### PR TITLE
Fix #34 - Only reset bond quote quantity after bond txn success

### DIFF
--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -180,7 +180,6 @@ export const Bond: FC<Props> = (props) => {
       ) {
         return;
       }
-      setQuantity("");
       if (
         Number(bondState?.interestDue) > 0 ||
         Number(bondState?.pendingPayout) > 0
@@ -200,6 +199,7 @@ export const Bond: FC<Props> = (props) => {
         address: recipientAddress || props.address,
         onStatus: setStatus,
       });
+      setQuantity("");
       dispatch(
         setBond({
           bond: props.bond,


### PR DESCRIPTION
Prevent the "you will get" field from changing after they click "Bond"