### PR TITLE
Add Check URL banner

### DIFF
--- a/app/components/CheckURLBanner/index.module.css
+++ b/app/components/CheckURLBanner/index.module.css
@@ -1,0 +1,39 @@
+@value textButton from "@klimadao/lib/theme/common.module.css";
+
+.bg {
+  position: fixed;
+  background-color: rgba(0, 0, 0, 0.5);
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  cursor: not-allowed;
+  z-index: 99;
+}
+
+.banner {
+  cursor: default;
+  align-self: center;
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+  background-color: var(--primary-variant);
+  justify-items: center;
+  align-items: center;
+}
+
+.banner_text {
+  text-align: center;
+}
+
+.okButtonWrap {
+  display: flex;
+  justify-content: end;
+  gap: 0.8rem;
+}
+
+.okButton {
+  composes: textButton;
+  border: 2px solid var(--secondary);
+  justify-self: end;
+}

--- a/app/components/CheckURLBanner/index.tsx
+++ b/app/components/CheckURLBanner/index.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from "react";
+
+import styles from "./index.module.css";
+import t from "@klimadao/lib/theme/typography.module.css";
+
+interface Props {
+  onHide: () => void;
+}
+
+export const CheckURLBanner: FC<Props> = ({ onHide }) => {
+  return (
+    <div className={styles.bg}>
+      <div className={styles.banner}>
+        <div className={styles.banner_text}>
+          <p className={t.body1}>⚠️ Verify the URL and bookmark this page!</p>
+          <p className={t.body2}>
+            <strong>klimadao.finance</strong> is the only official domain
+          </p>
+        </div>
+        <div className={styles.okButtonWrap}>
+          <button onClick={onHide} className={styles.okButton}>
+            Got it
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -23,6 +23,7 @@ import { Wrap } from "components/views/Wrap";
 
 import { InvalidNetworkModal } from "components/InvalidNetworkModal";
 import { InvalidRPCModal } from "components/InvalidRPCModal";
+import { CheckURLBanner } from "components/CheckURLBanner";
 
 import styles from "./index.module.css";
 
@@ -124,6 +125,7 @@ export const Home: FC = () => {
   const dispatch = useAppDispatch();
   const [chainId, setChainId] = useState<number>();
   const [showRPCModal, setShowRPCModal] = useState(false);
+  const [showCheckURLBanner, setShowCheckURLBanner] = useState(true);
 
   const [provider, address, web3Modal, loadWeb3Modal] = useProvider();
   const { pathname } = useLocation();
@@ -457,6 +459,13 @@ export const Home: FC = () => {
         <InvalidRPCModal
           onHide={() => {
             setShowRPCModal(false);
+          }}
+        />
+      )}
+      {showCheckURLBanner && (
+        <CheckURLBanner
+          onHide={() => {
+            setShowCheckURLBanner(false);
           }}
         />
       )}


### PR DESCRIPTION
## Description

This PR adds a full-width top-page banner to DApp.

The banner is rendered by default on initial load.
The area below the banner is not clickable.
The button "Got it" closes the banner.

Closing the banner is not stored in a browser session cookie as mentioned [here](https://github.com/KlimaDAO/klimadao/issues/48#issuecomment-997192921).
Instead, the value is stored in the local React Component's state.
Therefore the banner is shown again as soon as the page is reloaded/revisited again.
I can imagine that this can be annoying for some users? WDYT?

As for the design, I went for a pretty catchy tone to grab the user's attention before they try to continue reading on the page. Let me know if there are any design guidelines I haven't seen yet.

See here some screenshots:

<p align="center">
<img width="600" alt="banner_desktop" src="https://user-images.githubusercontent.com/95881624/146679507-4336387b-d47d-4683-9dc6-8a0f41fa9b16.png">
<img width="300" alt="banner_mobile" src="https://user-images.githubusercontent.com/95881624/146679501-76af7506-ad75-4464-9d96-12b1c42337f3.png">
</p>

### Tickets
closes https://github.com/KlimaDAO/klimadao/issues/48

