### PR TITLE
Add format-all with prettier script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ A set of NPM Workspace commands are provided, and can be run from the root folde
 `npm run dev-app`: run the app on localhost:3001
 
 `npm run dev-lib`: Watch for changes in `@klimadao/lib` and recompile on save. Alternatively, run `npm run build-lib` to compile once (this is already done automatically for the above two commands).
+
+`npm run format-all`: Format all files with `prettier`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
         "./app",
         "./lib"
       ],
-      "dependencies": {
-        "prettier": "^2.5.1"
-      },
       "engines": {
         "node": ">=14.18.1",
         "npm": ">=8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
         "./app",
         "./lib"
       ],
+      "dependencies": {
+        "prettier": "^2.5.1"
+      },
       "engines": {
         "node": ">=14.18.1",
         "npm": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "dev-lib": "npm run dev --workspace=lib",
     "dev-site": "npm run build-lib && npm run dev --workspace=site",
     "dev-app": "npm run build-lib && npm run dev --workspace=app"
+  },
+  "dependencies": {
+    "prettier": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,5 @@
     "dev-site": "npm run build-lib && npm run dev --workspace=site",
     "dev-app": "npm run build-lib && npm run dev --workspace=app",
     "format-all": "prettier --write ./"
-  },
-  "dependencies": {
-    "prettier": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "export-app": "cd ./lib && npm run build && cd ../app && npm run build && npm run export",
     "dev-lib": "npm run dev --workspace=lib",
     "dev-site": "npm run build-lib && npm run dev --workspace=site",
-    "dev-app": "npm run build-lib && npm run dev --workspace=app"
+    "dev-app": "npm run build-lib && npm run dev --workspace=app",
+    "format-all": "prettier --write ./"
   },
   "dependencies": {
     "prettier": "^2.5.1"


### PR DESCRIPTION
## Description

I saw that some files are not formatted yet with the bare VSCode formatting settings mentioned here: https://github.com/KlimaDAO/klimadao#requirements

Additionally, for people not using VSCode their code would probably be not formatted out-of-the-box when saving a file.

As it is recommended to run `prettier --write` on all files (see [this PR comment here](https://github.com/KlimaDAO/klimadao/pull/43#pullrequestreview-835702684)) I added a script on the root level which does exactly that.
~I also ran the script once and added all updated files.~
~Please take a closer look and let me know if this implementation can stay like that and I did not miss anything.~

If this script can stay like that it would make sense to add a default PR-template in which future devs are reminded to run this script once before opening a PR.


## Update

I rebased with staging again and saw that you added exactly that [2 days ago](https://github.com/KlimaDAO/klimadao/commit/d49b7e55a2487548df762cdd00d4b9386e35e851). 🦐 
=> running the script currently has no effect anymore, because now all files are already formatted correctly

Still, I think that adding a lint and format script on the root level for future PRs and mentioned this in a PR template would make sense. I left the script in the `package.json` and updated the README.

**Feel free to close this PR.**