### PR TITLE
Show connected address in connect button

### DIFF
--- a/app/components/views/Home/index.module.css
+++ b/app/components/views/Home/index.module.css
@@ -115,6 +115,7 @@ TEMP
 }
 .disconnectWalletButton {
   composes: textButton from "@klimadao/lib/theme/common.module.css";
+  text-transform: none;
   border: 2px dashed var(--surface-06);
   opacity: 0.7;
   justify-self: start;

--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -6,6 +6,7 @@ import Web3Modal from "web3modal";
 import { useAppDispatch } from "state";
 import { bonds, urls } from "@klimadao/lib/constants";
 import t from "@klimadao/lib/theme/typography.module.css";
+import { concatAddress } from "@klimadao/lib/utils";
 import { useSelector } from "react-redux";
 import { selectBalances } from "state/selectors";
 import { loadAppDetails } from "actions/app";
@@ -359,7 +360,7 @@ export const Home: FC = () => {
                 className={styles.disconnectWalletButton}
                 onClick={disconnect}
               >
-                DISCONNECT WALLET
+                {concatAddress(address)}
               </button>
             )}
           </header>


### PR DESCRIPTION
This is a UX improvement that catters to power users.
Personally I have been frustrated by having to look in
Metamask in order to figure out which address was connected
in the dapp. I haven't found the disconnect action to be of
much use elsewhere, though I understand it may be something
that newcomers expect to find in this whole Connect flow.