### PR TITLE
Add Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Description
+
+<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
+<!-- Help us understand your motivation by explaining why you decided to make this change -->
+
+## Related Ticket
+
+<!-- If your changes are related to a github ticket, please provide the issue number: -->
+
+Resolves #<issue-number>
+
+## Checklist
+
+<!-- Check completed item: [X] -->
+
+- [ ] Building the site with `npm run build-site` works without errors
+- [ ] Building the app with `npm run build-app` works without errors
+- [ ] I formatted JS and TS files with running `npm run format-all`


### PR DESCRIPTION
## Description

This adds an initial version of a pull request template to allow contributors to submit code changes while following basic guidelines.

I saw that the script "next lint" as no effect during development.
This script only runs when building the site.
See also https://github.com/vercel/next.js/issues/9904

Therefore, to ensure that all files are linted correctly before opening a pull request, I added to the checklist that building both the app and the site works without errors.

For the future, it would be better to have the same eslint setup as for the "lib" folder, which then also runs in development mode and checks all files and folders ("eslint ."). This global script can then be integrated in CI on github actions later.
This would probably require to disable the default eslint set-up generated by nextJS. 
See also https://nextjs.org/docs/api-reference/next.config.js/ignoring-eslint

What do you think?
