### PR TITLE
feat: Fallback page

### DIFF
--- a/site/components/pages/Blog/Post/index.module.css
+++ b/site/components/pages/Blog/Post/index.module.css
@@ -48,3 +48,13 @@
   justify-content: center;
   margin: 2rem 0;
 }
+
+.fallbackContainer {
+  display: grid;
+  flex: auto;
+}
+
+.loadingArticle {
+  justify-self: center;
+  align-self: center;
+}

--- a/site/components/pages/Blog/Post/index.tsx
+++ b/site/components/pages/Blog/Post/index.tsx
@@ -22,18 +22,13 @@ interface PostProps {
 }
 
 export function PostPage(props: PostProps) {
-  if (!props.post) {
-    return <div>fallback page...</div>;
-  }
-  const date = new Date(props.post.publishedAt).toDateString();
-
   const serializers = {
     types: {
-      image: (props: any) => {
+      image: (params: any) => {
         return (
           <div className={styles.inlineImage}>
             <Image
-              src={props.node.asset.url}
+              src={params.node.asset.url}
               alt="inline image"
               objectFit="contain"
               width={320}
@@ -44,6 +39,34 @@ export function PostPage(props: PostProps) {
       },
     },
   };
+  const body = props.post ? (
+    <div className={styles.container}>
+      <div className={styles.banner}>
+        <div className={styles.bannerImage}>
+          <Image
+            src={props.post.imageUrl}
+            alt={props.post.title}
+            objectFit="cover"
+            layout="fill"
+          />
+        </div>
+      </div>
+      <section className={styles.blogContainer}>
+        <div className={styles.content}>
+          <h1 className={styles.title}>{props.post.title}</h1>
+          <p className={styles.date}>
+            Published {new Date(props.post.publishedAt).toDateString()}
+          </p>
+          <BlockContent blocks={props.post.body} serializers={serializers} />
+        </div>
+      </section>
+    </div>
+  ) : (
+    <div className={styles.fallbackContainer}>
+      <p className={styles.loadingArticle}>Loading article...</p>
+    </div>
+  );
+
   return (
     <>
       <PageHead
@@ -82,28 +105,7 @@ export function PostPage(props: PostProps) {
           <NavItemMobile url={urls.stake} name="Wrap" />
           <NavItemMobile url={urls.bond} name="Bond" />
         </HeaderMobile>
-        <div className={styles.container}>
-          <div className={styles.banner}>
-            <div className={styles.bannerImage}>
-              <Image
-                src={props.post.imageUrl}
-                alt={props.post.title}
-                objectFit="cover"
-                layout="fill"
-              />
-            </div>
-          </div>
-          <section className={styles.blogContainer}>
-            <div className={styles.content}>
-              <h1 className={styles.title}>{props.post.title}</h1>
-              <p className={styles.date}>Published {date}</p>
-              <BlockContent
-                blocks={props.post.body}
-                serializers={serializers}
-              />
-            </div>
-          </section>
-        </div>
+        {body}
         <Footer />
       </PageWrap>
     </>

--- a/site/components/pages/Blog/Post/index.tsx
+++ b/site/components/pages/Blog/Post/index.tsx
@@ -18,7 +18,7 @@ import { urls } from "@klimadao/lib/constants";
 import { IS_PRODUCTION } from "lib/constants";
 
 interface PostProps {
-  post: Post;
+  post?: Post;
 }
 
 export function PostPage(props: PostProps) {
@@ -69,13 +69,15 @@ export function PostPage(props: PostProps) {
 
   return (
     <>
-      <PageHead
-        production={IS_PRODUCTION}
-        title={props.post.title}
-        mediaTitle={props.post.title}
-        metaDescription={props.post.summary}
-        mediaImageSrc={props.post.imageUrl}
-      />
+      {props.post && (
+        <PageHead
+          production={IS_PRODUCTION}
+          title={props.post.title}
+          mediaTitle={props.post.title}
+          metaDescription={props.post.summary}
+          mediaImageSrc={props.post.imageUrl}
+        />
+      )}
       <PageWrap>
         <HeaderDesktop
           buttons={[


### PR DESCRIPTION
## Description

Add a fallback UI when nextJS is still fetching props
https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-true

## Related Ticket
#89 

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
