### PR TITLE
refactor: specify directories to lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo contains 3 packages: `@klimadao/site`, `@klimadao/app` and `@klimadao/
 
 **The DAO is looking for react/typescript devs as well as experienced Solidity devs!** Enjoy a flexible work schedule and work on something truly ambitious and meaningful. Monthly compensation available based on your level of experience and degree of contribution.
 
-If you'd like to just take a ticket or fix a big, go for it (always better to ask first, though).
+If you'd like to just take a ticket or fix a bug, go for it (always better to ask first, though).
 
 If you'd like to become a regular contributor to the DAO, [join the contributor discord](https://discord.gg/wuzAzUdcqW) and follow the application instructions.
 

--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -8,6 +8,7 @@
   ],
   "parser": "@typescript-eslint/parser",
   "plugins": ["react", "@typescript-eslint"],
+  "ignorePatterns": ["next.config.js"],
   "rules": {
     "react-hooks/exhaustive-deps": "off",
     "react/no-unescaped-entities": "off",

--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -1,11 +1,12 @@
 {
-  "parser": "@typescript-eslint/parser",
   "extends": [
+    "next",
     "next/core-web-vitals",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "prettier"
   ],
+  "parser": "@typescript-eslint/parser",
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
     "react-hooks/exhaustive-deps": "off",

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const config = {
+  eslint: {
+    dirs: ["actions", "components", "lib", "pages", "state"],
+  },
   reactStrictMode: true,
   async redirects() {
     return [

--- a/site/.eslintrc.json
+++ b/site/.eslintrc.json
@@ -1,15 +1,17 @@
 {
-  "parser": "@typescript-eslint/parser",
   "extends": [
+    "next",
     "next/core-web-vitals",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "prettier"
   ],
+  "parser": "@typescript-eslint/parser",
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
     "react-hooks/exhaustive-deps": "off",
     "react/no-unescaped-entities": "off",
+    "@next/next/no-img-element": "off",
     "@typescript-eslint/no-unused-vars": "error"
   }
 }


### PR DESCRIPTION
## Description

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Follow up on the previous PR.
[Next lint](https://nextjs.org/docs/basic-features/eslint#linting-custom-directories-and-files) will only run the linter against `pages/`, `components/` and `lib/` directories. 
Needed to specify `actions/` and `state/` for proper linting coverage. Something to bear in mind if we add new directories to the repos.

Also added the base eslint rulesets recommended by Next.js

Picked up on this when attempting to share common eslint config across all the repos as we discussed @Atmosfearful . Unfortunately, didn't have much luck with it. Shared config convention seems to be publishing a separate shared config module to npm, which seems overkill at this point in time 🤪 

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
