### PR TITLE
Fix: change default bond quote

### DIFF
--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -12,8 +12,6 @@ import BondCalcContract from "@klimadao/lib/abi/BondCalcContract.json";
 import OhmDai from "@klimadao/lib/abi/OhmDai.json";
 import IERC20 from "@klimadao/lib/abi/IERC20.json";
 
-export const DEFAULT_QUOTE_SLP = "0.001"; // Use a realistic SLP ownership so we have a quote before the user inputs any value
-
 const getBondAddress = (params: { bond: Bond }): string => {
   return {
     klima_bct_lp: addresses["mainnet"].bond_klimaBctLp,
@@ -124,7 +122,7 @@ export const calcBondDetails = (params: {
   return async (dispatch) => {
     let amountInWei;
     if (!params.value || params.value === "") {
-      amountInWei = ethers.utils.parseEther(DEFAULT_QUOTE_SLP);
+      amountInWei = ethers.utils.parseEther("0");
     } else {
       amountInWei = ethers.utils.parseEther(params.value);
     }

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -13,7 +13,6 @@ import {
   redeemTransaction,
   calcBondDetails,
   calculateUserBondDetails,
-  DEFAULT_QUOTE_SLP,
 } from "actions/bonds";
 
 import typography from "@klimadao/lib/theme/typography";
@@ -122,7 +121,7 @@ export const Bond: FC<Props> = (props) => {
 
   const getBondMax = () => {
     if (!bondState?.bondQuote || !bondState?.maxBondPrice) return;
-    const quotedQuantity = quantity || DEFAULT_QUOTE_SLP;
+    const quotedQuantity = quantity || "0";
     const price = Number(quotedQuantity) / Number(bondState.bondQuote);
     const maxPayable = Number(bondState.maxBondPrice) * price;
     return Number(bondState?.balance) < Number(maxPayable)
@@ -430,7 +429,7 @@ export const Bond: FC<Props> = (props) => {
             }`}
             min="0"
             step={
-              view === "bond" && bondInfo.balanceUnit === "SLP" ? "1" : "0.0001"
+              view === "bond" && bondInfo.balanceUnit === "SLP" ? "0.0001" : "1"
             }
             disabled={view === "redeem"}
           />


### PR DESCRIPTION
## Description

* change default bond quote to 0 so the "you will get" value starts at 0
* update step count ternary on the "number" input

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
