### PR TITLE
fix: correct text in staking input placeholder (#103)

### DIFF
--- a/app/components/views/Stake/index.tsx
+++ b/app/components/views/Stake/index.tsx
@@ -191,9 +191,9 @@ export const Stake = (props: Props) => {
   };
   const getAction = () => {
     if (view === "unstake") {
-      return `Amount to stake`;
-    } else {
       return `Amount to unstake`;
+    } else {
+      return `Amount to stake`;
     }
   };
 


### PR DESCRIPTION
## Description

When I tried to stake, the input placeholder text is confusing. It seems like it should be switched. See #103 

## Related Ticket

https://github.com/KlimaDAO/klimadao/issues/103

Resolves #103 

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [ x] Building the app with `npm run build-app` works without errors
- [ x] I formatted JS and TS files with running `npm run format-all`
