### PR TITLE
Cleanup /blog and /[post] styles

### DIFF
--- a/cms/schemas/blockContent.js
+++ b/cms/schemas/blockContent.js
@@ -22,9 +22,8 @@ export default {
       // use your content.
       styles: [
         { title: "Normal", value: "normal" },
+        { title: "H1", value: "h1" },
         { title: "H2", value: "h2" },
-        { title: "H3", value: "h3" },
-        { title: "H4", value: "h4" },
         { title: "Quote", value: "blockquote" },
       ],
       lists: [{ title: "Bullet", value: "bullet" }],

--- a/lib/components/Text/index.tsx
+++ b/lib/components/Text/index.tsx
@@ -12,6 +12,7 @@ export type TypographyStyle =
   | "h5"
   | "body1"
   | "body2"
+  | "body3"
   | "caption"
   | "button";
 

--- a/lib/theme/typography.ts
+++ b/lib/theme/typography.ts
@@ -65,6 +65,15 @@ export const body1 = css`
   }
 `;
 export const body2 = css`
+  font-size: 2rem;
+  line-height: 2.8rem;
+  font-weight: 400;
+  ${breakpoints.medium} {
+    font-size: 2.4rem;
+    line-height: 3.2rem;
+  }
+`;
+export const body3 = css`
   font-size: 1.6rem;
   line-height: 2.4rem;
   font-weight: 600;

--- a/lib/theme/variables.css
+++ b/lib/theme/variables.css
@@ -3,8 +3,6 @@
   --klima-blue: #0ba1ff;
   --gray: rgb(160, 160, 160);
   --white: #ffffff;
-  --surface-04: #767676;
-  --surface-05: #a1a1a1;
   --font-family: Inter, sans-serif;
   --border-radius: 0.4rem;
   --header-height: 4.8rem;

--- a/lib/theme/variables.css
+++ b/lib/theme/variables.css
@@ -12,6 +12,7 @@
   --shadow-04: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
   --shadow-05: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
   --shadow-06: 0px 4.2px 37px rgba(0, 0, 0, 0.08);
+  --shadow-07: 0 4px 28px 0 rgba(0, 0, 0, 0.06);
 }
 
 :root.theme-light {

--- a/lib/theme/variables.css
+++ b/lib/theme/variables.css
@@ -3,6 +3,8 @@
   --klima-blue: #0ba1ff;
   --gray: rgb(160, 160, 160);
   --white: #ffffff;
+  --surface-04: #767676;
+  --surface-05: #a1a1a1;
   --font-family: Inter, sans-serif;
   --border-radius: 0.4rem;
   --header-height: 4.8rem;

--- a/site/components/BlockContentRenderer/index.module.css
+++ b/site/components/BlockContentRenderer/index.module.css
@@ -6,6 +6,21 @@
   margin: 2rem 0;
 }
 
+.blockQuote {
+  border-left: 1rem solid var(--klima-green);
+  margin: 1.5em 1rem;
+  padding: 0.5em 1rem;
+  quotes: "\201C""\201D""\2018""\2019";
+}
+.blockQuote:before {
+  color: var(--klima-green);
+  content: open-quote;
+  font-size: 4rem;
+  line-height: 1rem;
+  margin-right: 0.25rem;
+  vertical-align: -0.4rem;
+}
+
 .inlineImage {
   display: flex;
   justify-content: center;

--- a/site/components/BlockContentRenderer/index.module.css
+++ b/site/components/BlockContentRenderer/index.module.css
@@ -36,7 +36,7 @@
   color: var(--klima-blue);
 }
 
-.li_content {
+.liContent {
   display: inline;
 }
 

--- a/site/components/BlockContentRenderer/index.tsx
+++ b/site/components/BlockContentRenderer/index.tsx
@@ -18,33 +18,40 @@ interface BlockContentRendererProps {
 }
 
 const BlockRenderer = (params: {
-  node: { style: "h1" | "h2" | "h3" | "h4" | "normal" | "quote" };
+  node: { style: "h1" | "h2" | "h3" | "h4" | "normal" | "blockquote" };
   children: JSX.Element;
 }) => {
   const { style } = params.node;
-  if (style === "normal") {
-    return (
-      <Text t="body1" className={styles.paragraph}>
-        {params.children}
-      </Text>
-    );
-  }
-  if (style === "quote") {
-    // Fall back to default handling https://www.sanity.io/docs/portable-text-to-react#customizing-the-default-serializer-for
-    return BlockContent.defaultSerializers.types.block(params);
-  }
   if (style === "h1") {
     return (
-      <Text t="h2" as="h2" className={styles.heading}>
+      <Text t="h3" as="h2" className={styles.heading}>
         {params.children}
       </Text>
     );
   }
-  return (
-    <Text t={style} as={style} className={styles.heading}>
-      {params.children}
-    </Text>
-  );
+  if (style === "h2" || style === "h3" || style === "h4") {
+    return (
+      <Text t="h4" as="h3" className={styles.heading}>
+        {params.children}
+      </Text>
+    );
+  }
+  if (style === "normal") {
+    return (
+      <Text t="body2" className={styles.paragraph}>
+        {params.children}
+      </Text>
+    );
+  }
+  if (style === "blockquote") {
+    return (
+      <Text t="body2" className={styles.blockQuote}>
+        {params.children}
+      </Text>
+    );
+  }
+  // Fall back to default handling https://www.sanity.io/docs/portable-text-to-react#customizing-the-default-serializer-for
+  return BlockContent.defaultSerializers.types.block(params);
 };
 
 const serializers: BlockContentProps["serializers"] = {
@@ -66,7 +73,7 @@ const serializers: BlockContentProps["serializers"] = {
   listItem: (params) => {
     return (
       <li className={styles.li}>
-        <Text t="body1" className={styles.li_content}>
+        <Text t="body2" className={styles.li_content}>
           {/* content of current list item */}
           {params.children[0]}
         </Text>
@@ -79,7 +86,12 @@ const serializers: BlockContentProps["serializers"] = {
     link: ({ children, mark }) => {
       const { href } = mark;
       return (
-        <a className={styles.link} href={href}>
+        <a
+          className={styles.link}
+          href={href}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
           {children}
         </a>
       );

--- a/site/components/BlockContentRenderer/index.tsx
+++ b/site/components/BlockContentRenderer/index.tsx
@@ -71,14 +71,12 @@ const serializers: BlockContentProps["serializers"] = {
     );
   },
   listItem: (params) => {
+    // TODO: fix DOM nested list warning in console
     return (
       <li className={styles.li}>
-        <Text t="body2" className={styles.li_content}>
-          {/* content of current list item */}
-          {params.children[0]}
+        <Text t="body2" className={styles.liContent}>
+          {params.children}
         </Text>
-        {/* nested list items if any */}
-        {params.children?.[1]}
       </li>
     );
   },

--- a/site/components/Card/index.module.css
+++ b/site/components/Card/index.module.css
@@ -6,47 +6,52 @@
   grid-template-areas:
     "image"
     "content";
-  border-radius: 1rem;
   background-color: white;
-  color: #a1a1a1 !important;
   overflow: hidden;
-  transition: 200ms transform ease-in-out;
   grid-column: main;
-}
-.card:hover {
-  transform: scale(1.025);
+  border-radius: 1.2rem;
+  box-shadow: var(--shadow-07);
 }
 
 .content {
   margin: 2.4rem;
   grid-area: content;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
 }
-.content .date {
-  line-height: 3rem;
-  margin-bottom: 1.6rem;
-}
-.content h2 {
-  margin-bottom: 0.4rem;
-  color: black;
-}
-.content .body {
+.content .summary {
   display: none;
 }
-
+.content .read_more,
+.content .date {
+  color: var(--surface-05);
+}
 .image {
   position: relative;
   grid-area: image;
-  min-height: 20rem;
+  min-height: 24rem;
 }
 
 @media bp-medium {
   .card {
     grid-template-areas: "content image";
     grid-template-columns: 1fr 1fr;
-    height: 25rem;
+    height: 28rem;
   }
-  .content .body {
+  .content .summary {
     display: flex;
+    color: var(--surface-04);
+    font-size: 1.6rem;
+    line-height: 1.8rem;
+    max-height: 7rem;
+    /* CSS magic to limit lines shown to 3 https://stackoverflow.com/questions/3922739/limit-text-length-to-n-lines-using-css */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3; /* number of lines to show */
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
   }
   .image {
     min-height: unset;

--- a/site/components/Card/index.module.css
+++ b/site/components/Card/index.module.css
@@ -25,7 +25,7 @@
 }
 .content .read_more,
 .content .date {
-  color: var(--surface-05);
+  color: var(--font-03);
 }
 .image {
   position: relative;
@@ -41,7 +41,7 @@
   }
   .content .summary {
     display: flex;
-    color: var(--surface-04);
+    color: var(--font-02);
     font-size: 1.6rem;
     line-height: 1.8rem;
     max-height: 7rem;

--- a/site/components/Card/index.tsx
+++ b/site/components/Card/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Link from "next/link";
 import Image from "next/image";
 
+import { Text } from "@klimadao/lib/components";
 import defaultImage from "public/og-media.jpg";
 import { PostDetails } from "lib/queries";
 
@@ -17,9 +18,16 @@ export function Card(props: CardProps) {
     <Link href={`/blog/${props.post.slug}`}>
       <a className={styles.card}>
         <div className={styles.content}>
-          <span className={styles.date}>{date}</span>
-          <h2>{props.post.title}</h2>
-          <p className={styles.body}>{props.post.summary}</p>
+          <Text t="body3" className={styles.date}>
+            {date}
+          </Text>
+          <Text t="body1">{props.post.title}</Text>
+          <Text t="body2" className={styles.summary}>
+            {props.post.summary}
+          </Text>
+          <Text t="caption" className={styles.read_more}>
+            Read more
+          </Text>
         </div>
         <div className={styles.image}>
           <Image
@@ -27,6 +35,7 @@ export function Card(props: CardProps) {
             alt={props.post.title}
             objectFit="cover"
             layout="fill"
+            sizes="50vw"
           />
         </div>
       </a>

--- a/site/components/pages/Blog/Post/index.module.css
+++ b/site/components/pages/Blog/Post/index.module.css
@@ -2,7 +2,7 @@
 
 .container {
   grid-column: full;
-  background-color: var(--surface-01);
+  background-color: var(--surface-02);
   color: black;
 }
 

--- a/site/components/pages/Blog/Post/index.tsx
+++ b/site/components/pages/Blog/Post/index.tsx
@@ -42,10 +42,10 @@ export function PostPage(props: PostProps) {
       </div>
       <section className={styles.blogContainer}>
         <div className={styles.content}>
-          <Text t="h1" as="h1">
+          <Text t="h2" as="h1" className={styles.title}>
             {props.post.title}
           </Text>
-          <Text className={styles.date}>
+          <Text t="h5" as="p" className={styles.date}>
             Published {new Date(props.post.publishedAt).toDateString()}
           </Text>
           <BlockContentRenderer blocks={props.post.body} />

--- a/site/components/pages/Blog/index.module.css
+++ b/site/components/pages/Blog/index.module.css
@@ -1,6 +1,6 @@
 .container {
   grid-column: full;
-  background-color: #f5f5f7;
+  background-color: var(--surface-02);
   color: #313131;
   font-family: Arial, Helvetica, sans-serif;
   display: grid;
@@ -12,20 +12,6 @@
   grid-gap: 3.2rem;
 }
 
-.headerSection {
-  display: grid;
-  grid-column: main;
-  grid-gap: 0.8rem;
-  text-align: center;
-  max-width: 42rem;
-  justify-self: center;
-  margin-bottom: 4rem;
-}
-
-.headerSection h1 {
-  text-transform: uppercase;
-}
-
 .cardsSection {
   display: grid;
   grid-template-columns: inherit;
@@ -34,7 +20,7 @@
   row-gap: 2.4rem;
 }
 
-.cardsSection h3 {
+.articles {
   grid-column: main;
   text-transform: uppercase;
 }

--- a/site/components/pages/Blog/index.tsx
+++ b/site/components/pages/Blog/index.tsx
@@ -3,6 +3,7 @@ import React, { PropsWithChildren, ReactNode } from "react";
 import { AllPosts } from "lib/queries";
 
 import { Card } from "components/Card";
+import { Text } from "@klimadao/lib/components";
 
 import { t } from "@lingui/macro";
 
@@ -28,7 +29,10 @@ export function Blog(props: BlogProps) {
     >
       <div className={styles.container}>
         <section className={styles.cardsSection}>
-          <h3>Articles</h3>
+          <Text t="h4" className={styles.articles}>
+            {/* TODO: translate */}
+            Articles
+          </Text>
           <div className={styles.cards}>
             {props.posts.map((post) => (
               <Card key={post.slug} post={post} />

--- a/site/components/pages/Redesign/index.tsx
+++ b/site/components/pages/Redesign/index.tsx
@@ -69,7 +69,7 @@ export const Home: NextPage<Props> = (props) => {
                   KlimaDAO
                 </Text>
               </div>
-              <Text t="body2">
+              <Text t="body3">
                 <Trans>
                   Fight climate change and earn rewards with KLIMA, a digital
                   currency backed by real carbon assets.
@@ -109,7 +109,7 @@ export const Home: NextPage<Props> = (props) => {
               </Trans>
             </Text>
             <div className="blackHole_columns">
-              <Text t="body2" color="lighter">
+              <Text t="body3" color="lighter">
                 <Trans>
                   We’ve kickstarted a{" "}
                   <span>decentralized and open market for carbon</span>. Our
@@ -117,7 +117,7 @@ export const Home: NextPage<Props> = (props) => {
                   participate in and govern this new economy.
                 </Trans>
               </Text>
-              <Text t="body2" color="lighter">
+              <Text t="body3" color="lighter">
                 <Trans>
                   By increasing access and demand for carbon offsets, we make
                   pro-climate projects more profitable, while forcing companies
@@ -136,7 +136,7 @@ export const Home: NextPage<Props> = (props) => {
             <Text t="h2" as="h2">
               <Trans>MECHANICS</Trans>
             </Text>
-            <Text t="body2">
+            <Text t="body3">
               <Trans>
                 The DAO sells bonds and distributes profits to KLIMA holders.
                 Every bond we sell adds to an ever-growing green treasury, or
@@ -320,7 +320,7 @@ export const Home: NextPage<Props> = (props) => {
                 <Text t="h4" color="lightest" uppercase>
                   Of the carbon economy
                 </Text>
-                <Text t="body2" color="lighter">
+                <Text t="body3" color="lighter">
                   Every KLIMA token is backed by a real-world carbon asset.
                   Tokens are used to offset carbon emissions, interact with DeFi
                   applications, and get exposure to the rapidly growing global
@@ -339,7 +339,7 @@ export const Home: NextPage<Props> = (props) => {
                 <Text t="h4" color="lightest" uppercase>
                   FOR TOKEN HOLDERS
                 </Text>
-                <Text t="body2" color="lighter">
+                <Text t="body3" color="lighter">
                   KLIMA tokens are minted and distributed automatically every ~7
                   hours to staked KLIMA holders. Grow your KLIMA holdings as we
                   usher in a more sustainable future together.
@@ -356,7 +356,7 @@ export const Home: NextPage<Props> = (props) => {
             <Text t="h2" as="h2">
               <Trans>GET KLIMA</Trans>
             </Text>
-            <Text t="body2" color="lighter">
+            <Text t="body3" color="lighter">
               <Trans>
                 Get exposure to the growing carbon economy today. Acquire,
                 stake, and get rewarded. Financial activism for the climate.
@@ -386,7 +386,7 @@ export const Home: NextPage<Props> = (props) => {
             <Text t="h2" as="h2" uppercase>
               <Trans>Newsletter</Trans>
             </Text>
-            <Text t="body2" color="lighter">
+            <Text t="body3" color="lighter">
               <Trans>
                 Get the latest updates on Klima, as we build the future of the
                 carbon economy.

--- a/site/components/pages/Redesign/index.tsx
+++ b/site/components/pages/Redesign/index.tsx
@@ -148,7 +148,7 @@ export const Home: NextPage<Props> = (props) => {
           <div className="mechanics_itemGroup">
             <div className="mechanics_item">
               <Image
-                className="mechanics_img shadow-03"
+                className="mechanics_img"
                 src={windmills}
                 alt="Windmills"
                 width={240}
@@ -166,7 +166,7 @@ export const Home: NextPage<Props> = (props) => {
             </div>
             <div className="mechanics_item">
               <Image
-                className="mechanics_img shadow-04"
+                className="mechanics_img"
                 src={steams}
                 alt="Windmills"
                 width={240}
@@ -184,7 +184,7 @@ export const Home: NextPage<Props> = (props) => {
             </div>
             <div className="mechanics_item">
               <Image
-                className="mechanics_img shadow-05"
+                className="mechanics_img"
                 src={oceans}
                 alt="an ocean"
                 width={240}

--- a/site/components/pages/Redesign/styles.ts
+++ b/site/components/pages/Redesign/styles.ts
@@ -244,18 +244,10 @@ export const mechanicsSection = css`
   .mechanics_item > span {
     overflow: visible !important;
   }
-  .shadow-03 {
-    box-shadow: var(--shadow-03);
-  }
-  .shadow-04 {
-    box-shadow: var(--shadow-04);
-  }
-  .shadow-05 {
-    box-shadow: var(--shadow-05);
-  }
   .mechanics_img {
     border-radius: 1.6rem;
     overflow: visible;
+    box-shadow: var(--shadow-07);
   }
   ${breakpoints.small} {
     p.align-end {

--- a/site/components/pages/Resources/Community/index.tsx
+++ b/site/components/pages/Resources/Community/index.tsx
@@ -150,11 +150,16 @@ export const Community: NextPage<Props> = ({}) => {
           </div>
         </div>
         <div className={styles.joinDiscord}>
-          <div className="joinDiscord_col1">
-            <Text t="h2" as="h2">
+          <div className="joinDiscord_row1">
+            <Text t="h2" as="h2" align="center">
               <Trans>Discord</Trans>
             </Text>
-            <Text t="body2" color="lighter">
+            <Text
+              t="body2"
+              color="lighter"
+              align="center"
+              className="padding20"
+            >
               <Trans>
                 KlimaDAO harnesses the power of cryptocurrency, blockchain and
                 smart contracts to create
@@ -162,7 +167,7 @@ export const Community: NextPage<Props> = ({}) => {
             </Text>
             <DiscordButton />
           </div>
-          <div className="joinDiscord_col2">
+          <div className="joinDiscord_row2">
             <div className="joinDiscord_dummy">
               <Image
                 src={screenShotDesktop}

--- a/site/components/pages/Resources/Community/index.tsx
+++ b/site/components/pages/Resources/Community/index.tsx
@@ -59,7 +59,7 @@ export const Community: NextPage<Props> = ({}) => {
             <Text t="h2" as="h2" align="center">
               <Trans>BECOME A PARTNER</Trans>
             </Text>
-            <Text t="body2" align="center">
+            <Text t="body3" align="center">
               <Trans>
                 KlimaDAO harnesses the power of cryptocurrency, blockchain and
                 smart contracts to create
@@ -155,7 +155,7 @@ export const Community: NextPage<Props> = ({}) => {
               <Trans>Discord</Trans>
             </Text>
             <Text
-              t="body2"
+              t="body3"
               color="lighter"
               align="center"
               className="padding20"
@@ -190,7 +190,7 @@ export const Community: NextPage<Props> = ({}) => {
             <Text t="h2" as="h2">
               <Trans>Get in touch?</Trans>
             </Text>
-            <Text t="body2" color="lighter" align="center">
+            <Text t="body3" color="lighter" align="center">
               <Trans>
                 KlimaDAO harnesses the power of cryptocurrency, blockchain and
                 smart contracts to create

--- a/site/components/pages/Resources/Community/styles.ts
+++ b/site/components/pages/Resources/Community/styles.ts
@@ -76,22 +76,26 @@ export const joinDiscord = css`
   display: grid;
   grid-column: main;
   grid-template-rows: 1fr 1fr;
-  column-gap: 6.4rem;
   padding: 3.2rem;
   background-color: var(--surface-01);
   box-shadow: var(--shadow-06);
   border-radius: 1.6rem;
   overflow: hidden;
 
-  .joinDiscord_col1 {
-    display: grid;
-    align-self: flex-start;
-    gap: 1.6rem;
-    justify-items: start;
+  ${breakpoints.medium} {
+    .padding20 {
+      padding: 0 20rem;
+    }
   }
 
-  .joinDiscord_col2 {
+  .joinDiscord_row1 {
     display: grid;
+    align-self: center;
+    justify-items: center;
+    gap: 1.6rem;
+  }
+
+  .joinDiscord_row2 {
     position: relative;
   }
 
@@ -106,21 +110,12 @@ export const joinDiscord = css`
     overflow: hidden;
     border-radius: 2.4rem;
   }
-
-  ${breakpoints.medium} {
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: unset;
-    padding: 6.4rem;
-
-    .joinDiscord_dummy {
-      top: 2.4rem;
-    }
-  }
 `;
 
 export const page_discordButton = css`
   display: flex;
   flex-direction: row;
+  justify-self: center;
   align-items: center;
   justify-content: space-between;
   background: linear-gradient(180deg, #7780f0 0%, #5c65ed 100%);

--- a/site/components/pages/Resources/Contact/index.tsx
+++ b/site/components/pages/Resources/Contact/index.tsx
@@ -28,12 +28,12 @@ export const Contact: NextPage<Props> = () => {
             <Text t="h2" as="h2" align="center">
               <Trans>Questions & Support</Trans>
             </Text>
-            <Text t="body2" align="center">
+            <Text t="body3" align="center">
               <Trans>
                 Join our <Link href={"/community"}>community</Link>.
               </Trans>
             </Text>
-            <Text t="body2" align="center" color="lighter">
+            <Text t="body3" align="center" color="lighter">
               <Trans>
                 Discord server and ask in the #questions channel. We have
                 thousands of friendly, knowledgeable community members ready and
@@ -50,7 +50,7 @@ export const Contact: NextPage<Props> = () => {
             <Text t="h2" as="h2" color="lighter">
               <Trans>Careers</Trans>
             </Text>
-            <Text t="body2" align="center">
+            <Text t="body3" align="center">
               <Trans>
                 We're hiring! Until we finish building out our careers page, you
                 can submit a resume by joining our{" "}
@@ -71,7 +71,7 @@ export const Contact: NextPage<Props> = () => {
             <Text t="h2" as="h2">
               <Trans>Partnerships</Trans>
             </Text>
-            <Text t="body2" align="center">
+            <Text t="body3" align="center">
               <Trans>
                 Until we finish building out our partnerships page, we are
                 directing potential partnership and collaboration inquiries to{" "}
@@ -88,13 +88,13 @@ export const Contact: NextPage<Props> = () => {
             <Text t="h2" as="h2" color="lighter">
               <Trans>Media</Trans>
             </Text>
-            <Text t="body2" align="center">
+            <Text t="body3" align="center">
               <Trans>
                 If you are a journalist or content creator, our marketing team
                 would love to meet you.
               </Trans>
             </Text>
-            <Text t="body2" align="center">
+            <Text t="body3" align="center">
               <Trans>
                 Use this <a href={urls.mediaRequestForm}>Media Request Form</a>.
               </Trans>
@@ -109,7 +109,7 @@ export const Contact: NextPage<Props> = () => {
             <Text t="h2" as="h2">
               <Trans>Bug Reports</Trans>
             </Text>
-            <Text t="body2" align="center">
+            <Text t="body3" align="center">
               <Trans>
                 To file a bug report, join our community Discord server and ask
                 your question in the #bug-reports channel. Someone in our{" "}

--- a/site/components/pages/Resources/ResourcesHeader/index.tsx
+++ b/site/components/pages/Resources/ResourcesHeader/index.tsx
@@ -65,7 +65,7 @@ export const ResourcesHeader: FC<Props> = (props) => {
             <Text t="h2" as="h2">
               <Trans>{props.title}</Trans>
             </Text>
-            <Text align="center" t="body2" color="lighter">
+            <Text align="center" t="body3" color="lighter">
               <Trans>{props.subline}</Trans>
             </Text>
             {props.headerElements && <props.headerElements />}


### PR DESCRIPTION
## Description

*  update typography and colors of /blog and /post page to match designs
*  update join discord card styles to it doesn't get overlapped by the resources menu
*  remove h3 and h4 from sanity schema
*  add body3 to typography and --shadow-07, --surface-04, --surface-05 theme variables
*  add block quote styles to the blog

## Related Ticket

#124 

## Checklist

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
