### PR TITLE
Fix for rendering issue in Resources nav on mobile

### DIFF
--- a/site/components/Navigation/index.tsx
+++ b/site/components/Navigation/index.tsx
@@ -51,7 +51,7 @@ export const Navigation: FC<Props> = (props) => {
           name={t({ message: "Bond", id: "mainNav.bond" })}
         />
         <NavItemDesktop
-          url="/resources"
+          url="/blog"
           name={t`Resources`}
           link={Link}
           active={props.activePage === "Resources"}
@@ -59,8 +59,9 @@ export const Navigation: FC<Props> = (props) => {
       </HeaderDesktop>
       <HeaderMobile>
         <NavItemMobile
-          url={urls.home}
+          url={"/"}
           name={t({ message: "Home", id: "mainNav.home" })}
+          link={Link}
         />
         <NavItemMobile
           url={urls.tutorial}
@@ -76,7 +77,7 @@ export const Navigation: FC<Props> = (props) => {
           url={urls.bond}
           name={t({ message: "Bond", id: "mainNav.bond" })}
         />
-        <NavItemMobile url="/resources" name={t`Resources`} />
+        <NavItemMobile url="/blog" name={t`Resources`} link={Link} />
       </HeaderMobile>
     </>
   );

--- a/site/components/Navigation/index.tsx
+++ b/site/components/Navigation/index.tsx
@@ -61,7 +61,6 @@ export const Navigation: FC<Props> = (props) => {
         <NavItemMobile
           url={"/"}
           name={t({ message: "Home", id: "mainNav.home" })}
-          link={Link}
         />
         <NavItemMobile
           url={urls.tutorial}
@@ -77,7 +76,7 @@ export const Navigation: FC<Props> = (props) => {
           url={urls.bond}
           name={t({ message: "Bond", id: "mainNav.bond" })}
         />
-        <NavItemMobile url="/blog" name={t`Resources`} link={Link} />
+        <NavItemMobile url="/blog" name={t`Resources`} />
       </HeaderMobile>
     </>
   );

--- a/site/components/pages/Resources/ResourcesHeader/styles.ts
+++ b/site/components/pages/Resources/ResourcesHeader/styles.ts
@@ -25,6 +25,10 @@ export const resourcesHeader = css`
     text-transform: uppercase;
   }
 
+  .resourcesHeader_textGroup a {
+    display: none;
+  }
+
   ${breakpoints.medium} {
     grid-column: main;
 
@@ -39,6 +43,10 @@ export const resourcesHeader = css`
     .resourcesHeader_textGroup {
       padding: 0 2rem;
       grid-column: header_inner;
+    }
+
+    .resourcesHeader_textGroup a {
+      display: flex;
     }
   }
 `;
@@ -80,6 +88,13 @@ export const navigationMobile = css`
 
   .navigationMobile_navItem {
     flex: 1;
+  }
+
+  a {
+    width: 10rem;
+    max-width: 10rem;
+    height: 4.4rem;
+    text-transform: none;
   }
 
   ${breakpoints.medium} {


### PR DESCRIPTION
## Description

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

The widths of the nav buttons on mobile were bleeding off the right of the screen and creating a weird effect, as reported by @Atmosfearful. I've brought the buttons back in line with the design and I've hidden the Discord button on mobile.

Also changed the `Resources` button in the main nav to point to `/blog`. I had it pointing at `/resources` which redirected to `/resources/blog` but the directory structure changed and it looks like this didn't get updated.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
