### PR TITLE
Fix dark colors on resources nav, align Footer width

### DIFF
--- a/lib/components/Buttons/styles.ts
+++ b/lib/components/Buttons/styles.ts
@@ -29,7 +29,7 @@ export const button_primary = css`
 `;
 
 export const button_gray = css`
-  background-color: var(--white);
+  background-color: var(--surface-01);
   color: var(--font-02);
 
   &,

--- a/lib/components/Header/styles.ts
+++ b/lib/components/Header/styles.ts
@@ -86,8 +86,10 @@ export const navMain_Buttons = css`
   align-items: center;
   gap: 1rem;
 
-  button,
-  a {
-    box-shadow: var(--shadow-light);
+  ${breakpoints.medium} {
+    button,
+    a {
+      box-shadow: var(--shadow-light);
+    }
   }
 `;

--- a/lib/components/Header/styles.ts
+++ b/lib/components/Header/styles.ts
@@ -85,4 +85,9 @@ export const navMain_Buttons = css`
   justify-content: flex-end;
   align-items: center;
   gap: 1rem;
+
+  button,
+  a {
+    box-shadow: var(--shadow-light);
+  }
 `;

--- a/lib/theme/variables.css
+++ b/lib/theme/variables.css
@@ -22,6 +22,7 @@ body[data-theme="theme-light"] {
   --font-01: #313131;
   --font-02: #767676;
   --font-03: #a1a1a1;
+  --shadow-light: var(--shadow-07);
 }
 
 body[data-theme="theme-dark"] {
@@ -30,4 +31,5 @@ body[data-theme="theme-dark"] {
   --font-01: #ffffff;
   --font-02: #dddddd;
   --font-03: #9c9c9c;
+  --shadow-light: var(--shadow-04);
 }

--- a/site/components/Card/index.module.css
+++ b/site/components/Card/index.module.css
@@ -6,7 +6,7 @@
   grid-template-areas:
     "image"
     "content";
-  background-color: white;
+  background-color: var(--surface-01);
   overflow: hidden;
   grid-column: main;
   border-radius: 1.2rem;

--- a/site/components/Footer/styles.ts
+++ b/site/components/Footer/styles.ts
@@ -7,11 +7,11 @@ export const footer = css`
   padding: 2rem 2.4rem;
   position: relative;
   grid-column: full;
-  display: grid;
-  grid-template-columns: inherit;
 
   ${breakpoints.medium} {
     padding: 4.8rem 2.4rem;
+    display: grid;
+    grid-template-columns: inherit;
   }
 `;
 

--- a/site/components/Footer/styles.ts
+++ b/site/components/Footer/styles.ts
@@ -11,13 +11,8 @@ export const footer = css`
   grid-template-columns: inherit;
 
   ${breakpoints.medium} {
-    display: flex;
-    align-items: center;
-    justify-content: space-around;
     padding: 4.8rem 2.4rem;
   }
-
-  margin-top: auto;
 `;
 
 export const footer_content = css`

--- a/site/components/pages/Resources/ResourcesHeader/styles.ts
+++ b/site/components/pages/Resources/ResourcesHeader/styles.ts
@@ -109,13 +109,13 @@ export const list = css`
   min-width: 16rem;
 
   list-style: none;
-  background-color: #ffffff;
+  background-color: var(--surface-01);
   border-radius: 8px;
   padding: 0.5rem;
-  box-shadow: 0 0.4rem 2.8rem rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-light);
 
   li[data-active="true"] {
-    background-color: #fafafa;
+    background-color: var(--surface-02);
     border-radius: 4px;
 
     a {


### PR DESCRIPTION
## Description

This PR fixes the dark theme colors for Resources SubNavigation and the Blog headers.

Additionally this PR aligns the footer width with the main grid and gives the DesktopButtons a tiny shadow according to the designs.


## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

part of https://github.com/KlimaDAO/klimadao/issues/131

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
