### PR TITLE
Better Logo size

### DIFF
--- a/lib/components/Logos/LogoWithClaim.tsx
+++ b/lib/components/Logos/LogoWithClaim.tsx
@@ -1,10 +1,12 @@
 import React, { FC } from "react";
+import * as styles from "./styles";
 
 export const LogoWithClaim: FC = () => {
   return (
     <svg
-      width="140"
-      height="23"
+      className={styles.logoWithClaim}
+      width="100%"
+      height="100%"
       viewBox="0 0 140 23"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/lib/components/Logos/styles.ts
+++ b/lib/components/Logos/styles.ts
@@ -1,0 +1,10 @@
+import { css } from "@emotion/css";
+import breakpoints from "../../theme/breakpoints";
+
+export const logoWithClaim = css`
+  max-width: 15rem;
+
+  ${breakpoints.medium} {
+    max-width: 20rem;
+  }
+`;

--- a/lib/components/Logos/styles.ts
+++ b/lib/components/Logos/styles.ts
@@ -7,4 +7,8 @@ export const logoWithClaim = css`
   ${breakpoints.medium} {
     max-width: 20rem;
   }
+
+  &:hover {
+    opacity: 0.7;
+  }
 `;


### PR DESCRIPTION
## Description

Logo should be the same height as the "Enter App" button.
I made it _almost the same height_ as this felt better. The exact same height was too much.

I also added a tiny hover effect on the Logo.

## Related Ticket

Part of https://github.com/KlimaDAO/klimadao/issues/131

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
