### PR TITLE
Fix resources nav buttons for smaller screens

### DIFF
--- a/site/components/pages/Resources/ResourcesHeader/styles.ts
+++ b/site/components/pages/Resources/ResourcesHeader/styles.ts
@@ -79,12 +79,12 @@ export const navigationDesktop = css`
 `;
 
 export const navigationMobile = css`
-  grid-column: full;
+  grid-column: main;
   padding: 0 1rem;
 
   display: flex;
-  gap: 2rem;
-  justify-content: space-between;
+  gap: 1rem;
+  justify-content: center;
 
   .navigationMobile_navItem {
     flex: 1;
@@ -95,6 +95,10 @@ export const navigationMobile = css`
     max-width: 10rem;
     height: 4.4rem;
     text-transform: none;
+  }
+
+  ${breakpoints.small} {
+    gap: 2rem;
   }
 
   ${breakpoints.medium} {


### PR DESCRIPTION
## Description

Give Resources Mobile Nav Buttons less space on smaller screens.
And prevent that the buttons take over the full width of tablets too, let´s keep them together.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Part of https://github.com/KlimaDAO/klimadao/issues/131

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
