### PR TITLE
fix: colors in Wrong Network modal

### DIFF
--- a/app/components/InvalidNetworkModal/index.tsx
+++ b/app/components/InvalidNetworkModal/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, FC } from "react";
 import styles from "./index.module.css";
 import t from "@klimadao/lib/theme/typography.module.css";
+import { Text } from "@klimadao/lib/components";
 import { polygonNetworks } from "@klimadao/lib/constants";
 import { providers } from "ethers";
 
@@ -67,11 +68,11 @@ export const InvalidNetworkModal: FC<Props> = ({ provider }) => {
       <div className={styles.bg}>
         <div className={styles.card}>
           <div className={styles.card_header}>
-            <h2 className={t.h4}>⚠ Wrong Network</h2>
-            <p className={t.body2}>
+            <Text t="h3">⚠ Wrong Network</Text>
+            <Text t="body3" color="lightest" style={{ fontWeight: "normal" }}>
               This dApp only works on Polygon Mainnet and Polygon Mumbai
               Testnet.
-            </p>
+            </Text>
           </div>
           <div
             style={{

--- a/app/components/InvalidNetworkModal/index.tsx
+++ b/app/components/InvalidNetworkModal/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, FC } from "react";
 import styles from "./index.module.css";
-import t from "@klimadao/lib/theme/typography.module.css";
 import { Text } from "@klimadao/lib/components";
 import { polygonNetworks } from "@klimadao/lib/constants";
 import { providers } from "ethers";


### PR DESCRIPTION
## Description

**BEFORE**
![Bildschirmfoto 2022-02-10 um 08 57 37](https://user-images.githubusercontent.com/95881624/153365445-1c4b1029-432c-4380-8f3b-5374f75d4519.png)

**AFTER**
![Bildschirmfoto 2022-02-10 um 09 12 46](https://user-images.githubusercontent.com/95881624/153365471-e30becb6-c68d-469d-8c2e-40b1bebb0bfe.png)




## Related Ticket

None

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
