### PR TITLE
156 d app nav icons broken safari

### DIFF
--- a/lib/theme/common.ts
+++ b/lib/theme/common.ts
@@ -25,6 +25,10 @@ export const iconButton = css`
   border-radius: 0.8rem;
   svg {
     font-size: 2.4rem;
+
+    path {
+      fill: var(--font-01);
+    }
   }
   &:hover {
     opacity: 0.7rem;


### PR DESCRIPTION
## Description

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Icons should now be white on Safari. Didn't test on all other browsers, but seems like a safe fix to me.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #156

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
