### PR TITLE
fix: carbon counter text for smaller screens

### DIFF
--- a/site/components/pages/Home/styles.ts
+++ b/site/components/pages/Home/styles.ts
@@ -368,8 +368,8 @@ export const carbonSection = css`
     gap: 1.6rem;
   }
   .carbon_counter {
-    font-size: 6rem;
-    line-height: 6rem;
+    font-size: 5rem;
+    line-height: 5rem;
     font-weight: 700;
     word-break: break-all;
   }


### PR DESCRIPTION
## Description

**Before:**
<img src="https://user-images.githubusercontent.com/95881624/154105000-80d6455f-7620-42b5-93a3-73968bd6a2e2.png" width="200" />

**After:**
<img src="https://user-images.githubusercontent.com/95881624/154105089-b6706329-176b-41c7-88d7-c9bb6f92752b.png" width="200" />



## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
