### PR TITLE
feat: add discord icon to site footer

### DIFF
--- a/site/components/Footer/index.tsx
+++ b/site/components/Footer/index.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 import Link from "next/link";
 import * as styles from "./styles";
 
-import { TwitterIcon, GithubIcon } from "@klimadao/lib/components";
+import { TwitterIcon, GithubIcon, DiscordIcon } from "@klimadao/lib/components";
 
 import { urls } from "@klimadao/lib/constants";
 import { Trans } from "@lingui/macro";
@@ -49,6 +49,13 @@ export const Footer: FC = () => {
           </a>
           <a href={urls.github} target="_blank" rel="noreferrer noopener">
             <GithubIcon />
+          </a>
+          <a
+            href={urls.discordInvite}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            <DiscordIcon className="discordIcon" />
           </a>
         </nav>
       </div>

--- a/site/components/Footer/styles.ts
+++ b/site/components/Footer/styles.ts
@@ -54,6 +54,8 @@ export const footer_nav = css`
 export const footer_icons = css`
   display: flex;
   align-items: center;
+  flex-direction: column;
+  gap: 2rem;
 
   & a {
     margin: 0 1rem;
@@ -65,5 +67,15 @@ export const footer_icons = css`
 
   & svg:hover path {
     fill: var(--font-01);
+  }
+
+  & .discordIcon {
+    width: 2rem;
+    height: 2rem;
+  }
+
+  ${breakpoints.medium} {
+    flex-direction: row;
+    gap: 1rem;
   }
 `;


### PR DESCRIPTION
## Description

Requested that more social links should be added to the footer.
Right now we do only have the discord icon. Which is the most important IMO.
Let´s add more in the future.

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
