### PR TITLE
Fix footer alignment with new icon and disclaimer

### DIFF
--- a/site/components/Footer/styles.ts
+++ b/site/components/Footer/styles.ts
@@ -22,7 +22,7 @@ export const footer_content = css`
   align-items: center;
   flex: 1;
 
-  ${breakpoints.large} {
+  ${breakpoints.desktop} {
     text-align: center;
   }
 `;
@@ -44,10 +44,15 @@ export const footer_nav = css`
   }
 
   ${breakpoints.large} {
+    gap: 1.6rem 7rem;
+  }
+
+  ${breakpoints.desktop} {
     display: flex;
     flex-direction: row;
     justify-content: center;
     align-items: center;
+    gap: 1.6rem 3.2rem;
   }
 `;
 


### PR DESCRIPTION
## Description

New Discord Icon in Footer plus the new Disclaimer page broke the alignment on medium screens.

Here is the fix.

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
