### PR TITLE
fix caret position for bottom tooltip #178

### DIFF
--- a/lib/components/TextInfoTooltip/styles.ts
+++ b/lib/components/TextInfoTooltip/styles.ts
@@ -38,19 +38,19 @@ const tooltip = css`
     }
   }
   &[data-placement^="bottom"] > .tippy-arrow {
-    bottom: 0;
+    top: -1.6rem;
 
     &::before,
     &::after {
       bottom: -0.8rem;
       left: -0.4rem;
-      border-width: 0.8rem 0.8rem 0;
-      border-top-color: var(--surface-01);
+      border-width: 0 0.8rem 0.8rem;
+      border-bottom-color: var(--surface-01);
       transform-origin: center top;
     }
     &::after {
-      bottom: -0.6rem;
-      border-top-color: var(--surface-03);
+      bottom: -1rem;
+      border-bottom-color: var(--surface-03);
     }
   }
   &[data-placement^="left"] > .tippy-arrow {


### PR DESCRIPTION
## Description

Fixes position for _bottom_ caret in tooltip component

![image](https://user-images.githubusercontent.com/88386270/154163479-dff2fed1-2596-4fb2-bfc4-ca8a3d951009.png)

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #178

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
