### PR TITLE
Switch URL check banner to proper Dapp URL

### DIFF
--- a/app/components/CheckURLBanner/index.tsx
+++ b/app/components/CheckURLBanner/index.tsx
@@ -25,7 +25,7 @@ export const CheckURLBanner: FC<Props> = ({ onHide }) => {
             ⚠️ Verify the URL and bookmark this page!
           </Text>
           <Text t="caption" color="lighter" align="center">
-            <strong>klimadao.finance</strong> is the only official domain.
+            <strong>dapp.klimadao.finance</strong> is the only official domain.
           </Text>
         </div>
         <div className={styles.okButtonWrap}>


### PR DESCRIPTION
## Description

Requested by Reikuman since it's confusing to have a different URL in the banner than the user sees in their browser (i.e. without the `dapp.` subdomain)

https://discord.com/channels/897616018602618880/941171473366798346/943337491488981012

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
