### PR TITLE
Switch partnerships form to Notion

### DIFF
--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -97,7 +97,7 @@ export const urls = {
   mediaRequestForm:
     "https://docs.google.com/forms/d/e/1FAIpQLSdIVolbOvbuw1LHGwT8ec9HHZTWxSluErInZ_TaiqKzAvG30w/viewform",
   partnerShipsContactForm:
-    "https://docs.google.com/forms/d/10ETkwPZyiiEz7BQSCEAxtXRSgQ9uTCO9LtaRqOVhoXk/viewform?chromeless=1&edit_requested=true",
+    "https://notionforms.io/forms/klimadao-request-for-collaboration",
 };
 
 export const INFURA_ID = "0f83eb63faea409abc1f440c9f077646";


### PR DESCRIPTION
## Description

We deployed the old Google partnerships form, just switches to the new Notion one

https://discord.com/channels/897616018602618880/941171473366798346/943384326752600075

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
