### PR TITLE
i18n: a2. home, loading, checkurlbanner, basic notifications

### DIFF
--- a/app/components/CheckURLBanner/index.tsx
+++ b/app/components/CheckURLBanner/index.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 
 import styles from "./index.module.css";
 import { Text } from "@klimadao/lib/components";
+import { Trans } from "@lingui/macro";
 
 interface Props {
   onHide: () => void;
@@ -22,18 +23,23 @@ export const CheckURLBanner: FC<Props> = ({ onHide }) => {
       <div className={styles.banner}>
         <div className={styles.banner_text}>
           <Text t="h4" align="center">
-            ⚠️ Verify the URL and bookmark this page!
+            <Trans id="checkurlbanner.verify_url_and_bookmark">
+              ⚠️ Verify the URL and bookmark this page!
+            </Trans>
           </Text>
           <Text t="caption" color="lighter" align="center">
-            <strong>dapp.klimadao.finance</strong> is the only official domain.
+            <strong>dapp.klimadao.finance</strong>{" "}
+            <Trans id="checkurlbanner.is_the_only_official_domain">
+              is the only official domain.
+            </Trans>
           </Text>
         </div>
         <div className={styles.okButtonWrap}>
           <button onClick={onDontRemind} className={styles.dontButton}>
-            Don't Remind Me
+            <Trans id="checkurlbanner.dont_remind_me">Don't Remind Me</Trans>
           </button>
           <button onClick={onHide} className={styles.okButton}>
-            Got it
+            <Trans id="checkurlbanner.got_it">Got it</Trans>
           </button>
         </div>
       </div>

--- a/app/components/CheckURLBanner/index.tsx
+++ b/app/components/CheckURLBanner/index.tsx
@@ -28,9 +28,12 @@ export const CheckURLBanner: FC<Props> = ({ onHide }) => {
             </Trans>
           </Text>
           <Text t="caption" color="lighter" align="center">
-            <strong>dapp.klimadao.finance</strong>{" "}
-            <Trans id="checkurlbanner.is_the_only_official_domain">
-              is the only official domain.
+            <Trans
+              id="checkurlbanner.is_the_only_official_domain"
+              comment="Write '<0>dapp.klimadao.finance</0>' so it displays in bold"
+            >
+              <strong>dapp.klimadao.finance</strong> is the only official
+              domain.
             </Trans>
           </Text>
         </div>

--- a/app/components/ConnectButton/index.tsx
+++ b/app/components/ConnectButton/index.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react";
 import * as styles from "./styles";
+import { Trans } from "@lingui/macro";
 
 export interface Props {
   address?: string;
@@ -16,11 +17,11 @@ export const ConnectButton: FC<Props> = ({
 }) => {
   return !isConnected ? (
     <button type="button" className={styles.connect} onClick={loadWeb3Modal}>
-      Connect
+      <Trans id="wallet.connect">Connect</Trans>
     </button>
   ) : (
     <button type="button" className={styles.disconnect} onClick={disconnect}>
-      Disconnect
+      <Trans id="wallet.disconnect">Disconnect</Trans>
     </button>
   );
 };

--- a/app/components/NotificationModal/index.tsx
+++ b/app/components/NotificationModal/index.tsx
@@ -13,6 +13,7 @@ import { useAppDispatch } from "state";
 import { getStatusMessage } from "actions/utils";
 import { ClaimExceededModal } from "components/views/PKlima/ClaimExceededModal";
 import { Text } from "@klimadao/lib/components";
+import { Trans } from "@lingui/macro";
 
 interface ModalAssetTypes {
   [key: string]: {
@@ -22,10 +23,10 @@ interface ModalAssetTypes {
 
 const modalAssets: ModalAssetTypes = {
   header: {
-    done: "SUCCESS!",
-    error: "FAILURE!",
-    userConfirmation: "CONFIRMATION",
-    networkConfirmation: "PENDING",
+    done: <Trans id="modal.done">SUCCESS!</Trans>,
+    error: <Trans id="modal.error">FAILURE!</Trans>,
+    userConfirmation: <Trans id="modal.user_confirmation">CONFIRMATION</Trans>,
+    networkConfirmation: <Trans id="modal.pending">PENDING</Trans>,
   },
   iconStyle: {
     done: styles.icon_success,

--- a/app/components/views/Loading/index.tsx
+++ b/app/components/views/Loading/index.tsx
@@ -1,9 +1,14 @@
 import React, { FC } from "react";
+import { Trans } from "@lingui/macro";
 
 /**
  * Due to problems with react-router (needed for IPFS) and next.js isomorphic rendering,
  * return this placeholder view until the app mounts and the correct view can be resolved.
  */
 export const Loading: FC = () => {
-  return <div>Loading...</div>;
+  return (
+    <div>
+      <Trans id="home.loading">Loading...</Trans>
+    </div>
+  );
 };

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -254,6 +254,23 @@ msgid "choose_bond.bct.description"
 msgstr "Toucan Base Carbon Tonne"
 
 #: components/views/ChooseBond/index.tsx:126
+#: components/CheckURLBanner/index.tsx:34
+msgid "checkurlbanner.dont_remind_me"
+msgstr "Don't Remind Me"
+
+#: components/CheckURLBanner/index.tsx:37
+msgid "checkurlbanner.got_it"
+msgstr "Got it"
+
+#: components/CheckURLBanner/index.tsx:29
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr "is the only official domain."
+
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark"
+msgstr "⚠️ Verify the URL and bookmark this page!"
+
+#: components/views/ChooseBond/index.tsx:108
 msgid "choose_bond.caption"
 msgstr "The best way to buy KLIMA. Commit carbon to our treasury, and receive KLIMA at a discount. All bonds have a mandatory 5-day vesting period."
 
@@ -292,6 +309,25 @@ msgstr "Treasury Balance"
 #: components/views/ChooseBond/index.tsx:67
 msgid "choose_bond.usdc_lp.description"
 msgstr "BCT/USDC Sushiswap Liquidity"
+#: components/views/Loading/index.tsx:9
+msgid "home.loading"
+msgstr "Loading..."
+
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr "SUCCESS!"
+
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr "FAILURE!"
+
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr "PENDING"
+
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr "CONFIRMATION"
 
 #: components/NavMenu/index.tsx:142
 msgid "menu.bond_carbon"
@@ -380,6 +416,13 @@ msgstr "Please click 'confirm' in your wallet to continue."
 #: actions/utils.ts:10
 msgid "status.user_rejected"
 msgstr "You chose to reject the transaction"
+#: components/ConnectButton/index.tsx:20
+msgid "wallet.connect"
+msgstr "Connect"
+
+#: components/ConnectButton/index.tsx:24
+msgid "wallet.disconnect"
+msgstr "Disconnect"
 
 #: components/NavMenu/index.tsx:183
 msgid "token.pKLIMA"

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -249,28 +249,28 @@ msgstr "Stake"
 msgid "button.unstake"
 msgstr "Unstake"
 
-#: components/views/ChooseBond/index.tsx:55
-msgid "choose_bond.bct.description"
-msgstr "Toucan Base Carbon Tonne"
-
-#: components/views/ChooseBond/index.tsx:126
-#: components/CheckURLBanner/index.tsx:34
+#: components/CheckURLBanner/index.tsx:39
 msgid "checkurlbanner.dont_remind_me"
 msgstr "Don't Remind Me"
 
-#: components/CheckURLBanner/index.tsx:37
+#: components/CheckURLBanner/index.tsx:42
 msgid "checkurlbanner.got_it"
 msgstr "Got it"
 
-#: components/CheckURLBanner/index.tsx:29
+#. Write '<0>dapp.klimadao.finance</0>' so it displays in bold
+#: components/CheckURLBanner/index.tsx:31
 msgid "checkurlbanner.is_the_only_official_domain"
-msgstr "is the only official domain."
+msgstr "<0>dapp.klimadao.finance</0> is the only official domain."
 
 #: components/CheckURLBanner/index.tsx:26
 msgid "checkurlbanner.verify_url_and_bookmark"
 msgstr "⚠️ Verify the URL and bookmark this page!"
 
-#: components/views/ChooseBond/index.tsx:108
+#: components/views/ChooseBond/index.tsx:55
+msgid "choose_bond.bct.description"
+msgstr "Toucan Base Carbon Tonne"
+
+#: components/views/ChooseBond/index.tsx:126
 msgid "choose_bond.caption"
 msgstr "The best way to buy KLIMA. Commit carbon to our treasury, and receive KLIMA at a discount. All bonds have a mandatory 5-day vesting period."
 
@@ -309,7 +309,8 @@ msgstr "Treasury Balance"
 #: components/views/ChooseBond/index.tsx:67
 msgid "choose_bond.usdc_lp.description"
 msgstr "BCT/USDC Sushiswap Liquidity"
-#: components/views/Loading/index.tsx:9
+
+#: components/views/Loading/index.tsx:11
 msgid "home.loading"
 msgstr "Loading..."
 
@@ -416,6 +417,7 @@ msgstr "Please click 'confirm' in your wallet to continue."
 #: actions/utils.ts:10
 msgid "status.user_rejected"
 msgstr "You chose to reject the transaction"
+
 #: components/ConnectButton/index.tsx:20
 msgid "wallet.connect"
 msgstr "Connect"

--- a/app/locale/fr/messages.po
+++ b/app/locale/fr/messages.po
@@ -249,20 +249,16 @@ msgstr "Déposer"
 msgid "button.unstake"
 msgstr "Retirer"
 
-#: components/views/ChooseBond/index.tsx:55
-msgid "choose_bond.bct.description"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:126
-#: components/CheckURLBanner/index.tsx:34
+#: components/CheckURLBanner/index.tsx:39
 msgid "checkurlbanner.dont_remind_me"
 msgstr ""
 
-#: components/CheckURLBanner/index.tsx:37
+#: components/CheckURLBanner/index.tsx:42
 msgid "checkurlbanner.got_it"
 msgstr ""
 
-#: components/CheckURLBanner/index.tsx:29
+#. Write '<0>dapp.klimadao.finance</0>' so it displays in bold
+#: components/CheckURLBanner/index.tsx:31
 msgid "checkurlbanner.is_the_only_official_domain"
 msgstr ""
 
@@ -270,7 +266,11 @@ msgstr ""
 msgid "checkurlbanner.verify_url_and_bookmark"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:108
+#: components/views/ChooseBond/index.tsx:55
+msgid "choose_bond.bct.description"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:126
 msgid "choose_bond.caption"
 msgstr ""
 
@@ -308,7 +308,9 @@ msgstr ""
 
 #: components/views/ChooseBond/index.tsx:67
 msgid "choose_bond.usdc_lp.description"
-#: components/views/Loading/index.tsx:9
+msgstr ""
+
+#: components/views/Loading/index.tsx:11
 msgid "home.loading"
 msgstr ""
 
@@ -414,6 +416,8 @@ msgstr ""
 
 #: actions/utils.ts:10
 msgid "status.user_rejected"
+msgstr ""
+
 #: components/ConnectButton/index.tsx:20
 msgid "wallet.connect"
 msgstr ""

--- a/app/locale/fr/messages.po
+++ b/app/locale/fr/messages.po
@@ -254,6 +254,23 @@ msgid "choose_bond.bct.description"
 msgstr ""
 
 #: components/views/ChooseBond/index.tsx:126
+#: components/CheckURLBanner/index.tsx:34
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:37
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:29
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:108
 msgid "choose_bond.caption"
 msgstr ""
 
@@ -291,6 +308,24 @@ msgstr ""
 
 #: components/views/ChooseBond/index.tsx:67
 msgid "choose_bond.usdc_lp.description"
+#: components/views/Loading/index.tsx:9
+msgid "home.loading"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
 msgstr ""
 
 #: components/NavMenu/index.tsx:142
@@ -379,6 +414,12 @@ msgstr ""
 
 #: actions/utils.ts:10
 msgid "status.user_rejected"
+#: components/ConnectButton/index.tsx:20
+msgid "wallet.connect"
+msgstr ""
+
+#: components/ConnectButton/index.tsx:24
+msgid "wallet.disconnect"
 msgstr ""
 
 #: components/NavMenu/index.tsx:183

--- a/app/locale/pseudo/messages.po
+++ b/app/locale/pseudo/messages.po
@@ -249,20 +249,16 @@ msgstr ""
 msgid "button.unstake"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:55
-msgid "choose_bond.bct.description"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:126
-#: components/CheckURLBanner/index.tsx:34
+#: components/CheckURLBanner/index.tsx:39
 msgid "checkurlbanner.dont_remind_me"
 msgstr ""
 
-#: components/CheckURLBanner/index.tsx:37
+#: components/CheckURLBanner/index.tsx:42
 msgid "checkurlbanner.got_it"
 msgstr ""
 
-#: components/CheckURLBanner/index.tsx:29
+#. Write '<0>dapp.klimadao.finance</0>' so it displays in bold
+#: components/CheckURLBanner/index.tsx:31
 msgid "checkurlbanner.is_the_only_official_domain"
 msgstr ""
 
@@ -270,7 +266,11 @@ msgstr ""
 msgid "checkurlbanner.verify_url_and_bookmark"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:108
+#: components/views/ChooseBond/index.tsx:55
+msgid "choose_bond.bct.description"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:126
 msgid "choose_bond.caption"
 msgstr ""
 
@@ -308,7 +308,9 @@ msgstr ""
 
 #: components/views/ChooseBond/index.tsx:67
 msgid "choose_bond.usdc_lp.description"
-#: components/views/Loading/index.tsx:9
+msgstr ""
+
+#: components/views/Loading/index.tsx:11
 msgid "home.loading"
 msgstr ""
 
@@ -414,6 +416,8 @@ msgstr ""
 
 #: actions/utils.ts:10
 msgid "status.user_rejected"
+msgstr ""
+
 #: components/ConnectButton/index.tsx:20
 msgid "wallet.connect"
 msgstr ""

--- a/app/locale/pseudo/messages.po
+++ b/app/locale/pseudo/messages.po
@@ -254,6 +254,23 @@ msgid "choose_bond.bct.description"
 msgstr ""
 
 #: components/views/ChooseBond/index.tsx:126
+#: components/CheckURLBanner/index.tsx:34
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:37
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:29
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:108
 msgid "choose_bond.caption"
 msgstr ""
 
@@ -291,6 +308,24 @@ msgstr ""
 
 #: components/views/ChooseBond/index.tsx:67
 msgid "choose_bond.usdc_lp.description"
+#: components/views/Loading/index.tsx:9
+msgid "home.loading"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
 msgstr ""
 
 #: components/NavMenu/index.tsx:142
@@ -379,6 +414,12 @@ msgstr ""
 
 #: actions/utils.ts:10
 msgid "status.user_rejected"
+#: components/ConnectButton/index.tsx:20
+msgid "wallet.connect"
+msgstr ""
+
+#: components/ConnectButton/index.tsx:24
+msgid "wallet.disconnect"
 msgstr ""
 
 #: components/NavMenu/index.tsx:183


### PR DESCRIPTION
## Description

Added translation tags for home, loading, checkurlbanner, basic notifications components.

## Related Ticket

https://github.com/KlimaDAO/klimadao/issues/157

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
