### PR TITLE
Dynamic homepage staking rewards

### DIFF
--- a/lib/utils/getStakingRewards/index.ts
+++ b/lib/utils/getStakingRewards/index.ts
@@ -4,7 +4,7 @@ import { addresses, ESTIMATED_DAILY_REBASES } from "../../constants";
 import DistributorContractv4 from "../../abi/DistributorContractv4.json";
 import SKlima from "../../abi/sKlima.json";
 
-export const getStakingAPY = async (): Promise<number> => {
+export const getStakingRewards = async (days: number): Promise<number> => {
   const provider = getJsonRpcProvider();
   const distributorContract = new ethers.Contract(
     addresses.mainnet.distributor,
@@ -21,6 +21,9 @@ export const getStakingAPY = async (): Promise<number> => {
   const stakingReward = await distributorContract.nextRewardAt(info.rate);
 
   const stakingRebase = stakingReward / circSupply;
-  const stakingAPY = Math.pow(1 + stakingRebase, 365 * ESTIMATED_DAILY_REBASES);
-  return Math.floor(stakingAPY * 100);
+  const stakingRewards = Math.pow(
+    1 + stakingRebase,
+    days * ESTIMATED_DAILY_REBASES
+  );
+  return Math.floor((stakingRewards - 1) * 100);
 };

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -3,7 +3,7 @@ export { getKlimaSupply } from "./getKlimaSupply";
 export { getKlimaUsdcPrice } from "./getKlimaUsdcPrice";
 export { getJsonRpcProvider } from "./getJsonRpcProvider";
 export { getTreasuryBalance } from "./getTreasuryBalance";
-export { getStakingAPY } from "./getStakingAPY";
+export { getStakingRewards } from "./getStakingRewards";
 export { trimStringDecimals } from "./trimStringDecimals";
 export { secondsUntilBlock } from "./secondsUntilBlock";
 export { prettifySeconds } from "./prettifySeconds";

--- a/site/components/pages/Home/index.tsx
+++ b/site/components/pages/Home/index.tsx
@@ -29,6 +29,7 @@ import { ParralaxWormhole } from "./ParralaxWormhole";
 export interface Props {
   latestPost: LatestPost;
   treasuryBalance: number;
+  weeklyStakingRewards: number;
 }
 
 const hectaresForestPerTonne = 1 / 200;
@@ -366,7 +367,7 @@ export const Home: NextPage<Props> = (props) => {
               </Text>
               <div className="sprouts_col2_textGroup">
                 <Text t="h2" uppercase>
-                  6% WEEKLY YIELD
+                  {props.weeklyStakingRewards}% WEEKLY REWARDS
                 </Text>
                 <Text t="h4" color="lightest" uppercase>
                   FOR TOKEN HOLDERS

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -1,5 +1,5 @@
 import { GetStaticProps } from "next";
-import { getTreasuryBalance } from "@klimadao/lib/utils";
+import { getTreasuryBalance, getStakingRewards } from "@klimadao/lib/utils";
 import { Home, Props } from "components/pages/Home";
 import { fetchCMSContent } from "lib/fetchCMSContent";
 import { loadTranslation } from "lib/i18n";
@@ -8,12 +8,14 @@ export const getStaticProps: GetStaticProps<Props> = async (ctx) => {
   const treasuryBalance = await getTreasuryBalance();
   const latestPost = await fetchCMSContent("latestPost");
   const translation = await loadTranslation(ctx.locale);
+  const weeklyStakingRewards = await getStakingRewards(7);
 
   return {
     props: {
       latestPost,
       treasuryBalance,
       translation,
+      weeklyStakingRewards,
     },
     revalidate: 60,
   };


### PR DESCRIPTION
## Description

The `getStakingAPY` util is unused so I hijacked it and generalized it to support calculating staking rewards for a provided number of days - not sure if this should really be 7 day yield, went with 5 day for consistency with the Dapp

## Related Ticket

Resolves #188 

## Changes

### Before  
![image](https://user-images.githubusercontent.com/91024694/156000723-fed3c851-3887-41db-aa76-b4f5a1000c93.png)

### After
![image](https://user-images.githubusercontent.com/91024694/156000673-fcc28f61-52a2-4b8a-9586-383fd0252498.png)


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
