### PR TITLE
Rebased dynamic block rate

### DIFF
--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -3,8 +3,12 @@ import { ethers, providers } from "ethers";
 import { Thunk } from "state";
 import { setAppState } from "state/app";
 
-import { getTreasuryBalance } from "@klimadao/lib/utils";
-import { addresses, ESTIMATED_DAILY_REBASES } from "@klimadao/lib/constants";
+import {
+  getEstimatedDailyRebases,
+  getTreasuryBalance,
+  fetchBlockRate,
+} from "@klimadao/lib/utils";
+import { addresses } from "@klimadao/lib/constants";
 import DistributorContractv4 from "@klimadao/lib/abi/DistributorContractv4.json";
 import SKlima from "@klimadao/lib/abi/sKlima.json";
 import IERC20 from "@klimadao/lib/abi/IERC20.json";
@@ -39,20 +43,28 @@ export const loadAppDetails = (params: {
         sKlimaContract.balanceOf("0x693aD12DbA5F6E07dE86FaA21098B691F60A1BEa"),
         getTreasuryBalance(),
         distributorContract.nextEpochBlock(),
+        fetchBlockRate(),
       ];
-      const [info, circSupply, currentIndex, treasuryBalance, rebaseBlock] =
-        await Promise.all(promises);
+      const [
+        info,
+        circSupply,
+        currentIndex,
+        treasuryBalance,
+        rebaseBlock,
+        blockRate,
+      ] = await Promise.all(promises);
 
       const promises2 = [distributorContract.nextRewardAt(info.rate)];
 
       const [stakingReward] = await Promise.all(promises2);
 
+      const estimatedDailyRebases = getEstimatedDailyRebases(blockRate);
       const stakingRebase = stakingReward / circSupply;
       const fiveDayRate =
-        Math.pow(1 + stakingRebase, 5 * ESTIMATED_DAILY_REBASES) - 1;
+        Math.pow(1 + stakingRebase, 5 * estimatedDailyRebases) - 1;
       const stakingAPY = Math.pow(
         1 + stakingRebase,
-        365 * ESTIMATED_DAILY_REBASES
+        365 * estimatedDailyRebases
       );
 
       dispatch(
@@ -64,6 +76,7 @@ export const loadAppDetails = (params: {
           stakingRebase,
           treasuryBalance,
           rebaseBlock: rebaseBlock.toNumber(),
+          blockRate,
         })
       );
     } catch (error: any) {

--- a/app/components/RebaseCard/index.tsx
+++ b/app/components/RebaseCard/index.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export const RebaseCard: FC<Props> = (props) => {
   const balances = useSelector(selectBalances);
-  const { stakingRebase, currentBlock, rebaseBlock } =
+  const { stakingRebase, currentBlock, rebaseBlock, blockRate } =
     useSelector(selectAppState);
   const nextRebasePercent = stakingRebase ? stakingRebase * 100 : 0;
   const nextRebaseValue =
@@ -24,7 +24,7 @@ export const RebaseCard: FC<Props> = (props) => {
 
   const timeUntilRebase = () => {
     if (currentBlock && rebaseBlock) {
-      const seconds = secondsUntilBlock(currentBlock, rebaseBlock);
+      const seconds = secondsUntilBlock(currentBlock, rebaseBlock, blockRate);
       // if less than 1 hour remaining, return minutes
       const rtf = new Intl.RelativeTimeFormat("en");
       if (seconds < 3600) {

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -48,13 +48,14 @@ import { BondBalancesCard } from "components/BondBalancesCard";
 export function prettyVestingPeriod(
   locale: string | undefined,
   currentBlock: number,
-  vestingBlock: number
+  vestingBlock: number,
+  blockRate: number
 ) {
   if (vestingBlock === 0) {
     return "";
   }
 
-  const seconds = secondsUntilBlock(currentBlock, vestingBlock);
+  const seconds = secondsUntilBlock(currentBlock, vestingBlock, blockRate);
   if (seconds < 0) {
     return "Fully Vested";
   }
@@ -125,7 +126,7 @@ export const Bond: FC<Props> = (props) => {
   const [quantity, setQuantity] = useState("");
   const debouncedQuantity = useDebounce(quantity, 500);
 
-  const { currentBlock, locale } = useSelector(selectAppState);
+  const { currentBlock, locale, blockRate } = useSelector(selectAppState);
   const bondState = useSelector((state: RootState) => state.bonds[props.bond]);
   const allowance = useSelector(selectBondAllowance);
 
@@ -142,7 +143,7 @@ export const Bond: FC<Props> = (props) => {
   const vestingPeriod = () => {
     if (!bondState || !currentBlock || !bondState.vestingTerm) return;
     const vestingBlock = currentBlock + bondState.vestingTerm;
-    const seconds = secondsUntilBlock(currentBlock, vestingBlock);
+    const seconds = secondsUntilBlock(currentBlock, vestingBlock, blockRate);
     return prettifySeconds(seconds);
   };
 
@@ -151,7 +152,8 @@ export const Bond: FC<Props> = (props) => {
     return prettyVestingPeriod(
       locale,
       currentBlock,
-      bondState.bondMaturationBlock
+      bondState.bondMaturationBlock,
+      blockRate
     );
   };
 

--- a/app/state/app/index.ts
+++ b/app/state/app/index.ts
@@ -1,5 +1,7 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
+import { FALLBACK_BLOCK_RATE } from "@klimadao/lib/constants";
+
 export type TxnStatus =
   | "userConfirmation"
   | "networkConfirmation"
@@ -20,6 +22,7 @@ interface AppState {
   stakingRebase: number | undefined;
   treasuryBalance: number | undefined;
   rebaseBlock: number | undefined;
+  blockRate: number;
   locale: string | undefined;
   notificationStatus: AppNotificationStatus | null;
 }
@@ -32,6 +35,7 @@ const initialState: AppState = {
   stakingRebase: undefined,
   treasuryBalance: undefined,
   rebaseBlock: undefined,
+  blockRate: FALLBACK_BLOCK_RATE,
   locale: undefined,
   notificationStatus: null,
 };

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -135,10 +135,9 @@ export const bonds = [
 export type Bond = typeof bonds[number];
 
 export const EPOCH_INTERVAL = 11520;
-// NOTE could get this from an outside source since it changes slightly over time
-export const BLOCK_RATE_SECONDS = 2.5;
+export const FALLBACK_BLOCK_RATE = 2.3;
 
-export const ESTIMATED_DAILY_REBASES = 3.28;
+export const API_BASE_URL = "https://www.klimadao.finance/api";
 
 /** CMS stuff  */
 export const SANITY_STUDIO_API_PROJECT_ID = "dk34t4vc";

--- a/lib/utils/fetchBlockRate/index.ts
+++ b/lib/utils/fetchBlockRate/index.ts
@@ -1,0 +1,13 @@
+import { API_BASE_URL, FALLBACK_BLOCK_RATE } from "../../constants";
+
+/** Fetch the 30 day moving average block rate from our API */
+export const fetchBlockRate = async () => {
+  try {
+    const response = await fetch(API_BASE_URL + "/block-rate");
+    const data = await response.json();
+    return data.blockRate30Day;
+  } catch (error) {
+    console.error(error);
+    return FALLBACK_BLOCK_RATE;
+  }
+};

--- a/lib/utils/getEstimatedDailyRebases/index.ts
+++ b/lib/utils/getEstimatedDailyRebases/index.ts
@@ -1,0 +1,9 @@
+import { EPOCH_INTERVAL } from "../../constants";
+
+// Calculates estimated daily rebases based on current block rate
+export function getEstimatedDailyRebases(blockRate: number) {
+  const rebaseRate = blockRate * EPOCH_INTERVAL;
+  const secondsInDay = 86400;
+  const rebasesPerDay = secondsInDay / rebaseRate;
+  return rebasesPerDay;
+}

--- a/lib/utils/getStakingRewards/index.ts
+++ b/lib/utils/getStakingRewards/index.ts
@@ -1,10 +1,14 @@
 import { ethers } from "ethers";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
-import { addresses, ESTIMATED_DAILY_REBASES } from "../../constants";
+import { addresses } from "../../constants";
+import { getEstimatedDailyRebases } from "..";
 import DistributorContractv4 from "../../abi/DistributorContractv4.json";
 import SKlima from "../../abi/sKlima.json";
 
-export const getStakingRewards = async (days: number): Promise<number> => {
+export const getStakingRewards = async (
+  days: number,
+  blockRate: number
+): Promise<number> => {
   const provider = getJsonRpcProvider();
   const distributorContract = new ethers.Contract(
     addresses.mainnet.distributor,
@@ -20,10 +24,12 @@ export const getStakingRewards = async (days: number): Promise<number> => {
   const info = await distributorContract.info(0);
   const stakingReward = await distributorContract.nextRewardAt(info.rate);
 
+  const estimatedDailyRebases = getEstimatedDailyRebases(blockRate);
+
   const stakingRebase = stakingReward / circSupply;
   const stakingRewards = Math.pow(
     1 + stakingRebase,
-    days * ESTIMATED_DAILY_REBASES
+    days * estimatedDailyRebases
   );
   return Math.floor((stakingRewards - 1) * 100);
 };

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -13,3 +13,5 @@ export { formatUnits } from "./formatUnits";
 export { useDebounce } from "./useDebounce";
 export { safeAdd } from "./safeAdd";
 export { safeSub } from "./safeSub";
+export { getEstimatedDailyRebases } from "./getEstimatedDailyRebases";
+export { fetchBlockRate } from "./fetchBlockRate";

--- a/lib/utils/secondsUntilBlock/index.ts
+++ b/lib/utils/secondsUntilBlock/index.ts
@@ -1,12 +1,16 @@
-import { BLOCK_RATE_SECONDS, EPOCH_INTERVAL } from "../../constants";
+import { EPOCH_INTERVAL } from "../../constants";
 
-export function secondsUntilBlock(startBlock: number, endBlock: number) {
+export function secondsUntilBlock(
+  startBlock: number,
+  endBlock: number,
+  blockRateSeconds: number
+) {
   if (startBlock % EPOCH_INTERVAL === 0) {
     return 0;
   }
 
   const blocksAway = endBlock - startBlock;
-  const secondsAway = blocksAway * BLOCK_RATE_SECONDS;
+  const secondsAway = blocksAway * blockRateSeconds;
 
   return secondsAway;
 }

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -1,5 +1,9 @@
 import { GetStaticProps } from "next";
-import { getTreasuryBalance, getStakingRewards } from "@klimadao/lib/utils";
+import {
+  fetchBlockRate,
+  getTreasuryBalance,
+  getStakingRewards,
+} from "@klimadao/lib/utils";
 import { Home, Props } from "components/pages/Home";
 import { fetchCMSContent } from "lib/fetchCMSContent";
 import { loadTranslation } from "lib/i18n";
@@ -8,7 +12,8 @@ export const getStaticProps: GetStaticProps<Props> = async (ctx) => {
   const treasuryBalance = await getTreasuryBalance();
   const latestPost = await fetchCMSContent("latestPost");
   const translation = await loadTranslation(ctx.locale);
-  const weeklyStakingRewards = await getStakingRewards(7);
+  const blockRate = await fetchBlockRate();
+  const weeklyStakingRewards = await getStakingRewards(7, blockRate);
 
   return {
     props: {


### PR DESCRIPTION
## Description

I took the `dynamic-block-rate` branch, rebased in the latest changes, moved the API itself to `site` instead of `app` and added caching

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #31 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|
-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
