### PR TITLE
Remove material-ui/icons

### DIFF
--- a/app/components/views/Info/CopyAddressButton/index.tsx
+++ b/app/components/views/Info/CopyAddressButton/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import FileCopyOutlinedIcon from "@material-ui/icons/FileCopyOutlined";
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import styles from "./index.module.css";
 
 const CopyAddressButton = (params: { address: string; ariaLabel: string }) => {
@@ -28,7 +28,7 @@ const CopyAddressButton = (params: { address: string; ariaLabel: string }) => {
         onClick={handleCopy}
         className={styles.copyAddressButton}
       >
-        <FileCopyOutlinedIcon className={styles.copyAddressButtonIcon} />
+        <ContentCopyIcon className={styles.copyAddressButtonIcon} />
       </button>
     </div>
   ) : (

--- a/app/components/views/Info/CopyAddressButton/index.tsx
+++ b/app/components/views/Info/CopyAddressButton/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import styles from "./index.module.css";
 
 const CopyAddressButton = (params: { address: string; ariaLabel: string }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2980,171 +2980,6 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
-    "node_modules/@material-ui/core": {
-      "version": "4.12.3",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.4",
-        "@material-ui/system": "^4.12.1",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.2",
-        "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "1.16.1-lts",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0",
-        "react-transition-group": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/icons": {
-      "version": "4.11.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@material-ui/core": "^4.0.0",
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/styles": {
-      "version": "4.11.4",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.2",
-        "clsx": "^1.0.4",
-        "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.5.1",
-        "jss-plugin-camel-case": "^10.5.1",
-        "jss-plugin-default-unit": "^10.5.1",
-        "jss-plugin-global": "^10.5.1",
-        "jss-plugin-nested": "^10.5.1",
-        "jss-plugin-props-sort": "^10.5.1",
-        "jss-plugin-rule-value-function": "^10.5.1",
-        "jss-plugin-vendor-prefixer": "^10.5.1",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/styles/node_modules/csstype": {
-      "version": "2.6.19",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@material-ui/system": {
-      "version": "4.12.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.2",
-        "csstype": "^2.5.2",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/system/node_modules/csstype": {
-      "version": "2.6.19",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@material-ui/types": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@material-ui/utils": {
-      "version": "4.11.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
       "license": "ISC"
@@ -9229,15 +9064,6 @@
       "version": "1.1.2",
       "license": "MIT"
     },
-    "node_modules/css-vendor": {
-      "version": "2.0.8",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.8.3",
-        "is-in-browser": "^1.0.2"
-      }
-    },
     "node_modules/css-what": {
       "version": "3.4.2",
       "license": "BSD-2-Clause",
@@ -12678,11 +12504,6 @@
         "html-element": "^2.0.0"
       }
     },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.0.4",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "license": "MIT",
@@ -13237,11 +13058,6 @@
       "version": "0.1.8",
       "license": "MIT"
     },
-    "node_modules/is-in-browser": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "dev": true,
@@ -13762,88 +13578,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/jss": {
-      "version": "10.9.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "csstype": "^3.0.2",
-        "is-in-browser": "^1.1.3",
-        "tiny-warning": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/jss"
-      }
-    },
-    "node_modules/jss-plugin-camel-case": {
-      "version": "10.9.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "hyphenate-style-name": "^1.0.3",
-        "jss": "10.9.0"
-      }
-    },
-    "node_modules/jss-plugin-default-unit": {
-      "version": "10.9.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0"
-      }
-    },
-    "node_modules/jss-plugin-global": {
-      "version": "10.9.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0"
-      }
-    },
-    "node_modules/jss-plugin-nested": {
-      "version": "10.9.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-props-sort": {
-      "version": "10.9.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0"
-      }
-    },
-    "node_modules/jss-plugin-rule-value-function": {
-      "version": "10.9.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-vendor-prefixer": {
-      "version": "10.9.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.8",
-        "jss": "10.9.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -16199,11 +15933,6 @@
       "peerDependencies": {
         "@popperjs/core": "^2.2.0"
       }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1-lts",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
@@ -23462,7 +23191,6 @@
         "@emotion/server": "^11.4.0",
         "@lingui/core": "^3.13.0",
         "@lingui/react": "^3.13.0",
-        "@material-ui/icons": "^4.11.2",
         "@sanity/block-content-to-react": "^3.0.0",
         "@sanity/client": "^2.23.2",
         "ethers": "^5.5.2",
@@ -25034,7 +24762,6 @@
         "@lingui/loader": "^3.13.0",
         "@lingui/macro": "^3.13.0",
         "@lingui/react": "^3.13.0",
-        "@material-ui/icons": "^4.11.2",
         "@sanity/block-content-to-react": "^3.0.0",
         "@sanity/client": "^2.23.2",
         "@types/node": "16.11.12",
@@ -25222,88 +24949,6 @@
       "requires": {
         "@babel/runtime": "^7.11.2",
         "@lingui/core": "^3.13.2"
-      }
-    },
-    "@material-ui/core": {
-      "version": "4.12.3",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.4",
-        "@material-ui/system": "^4.12.1",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.2",
-        "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "1.16.1-lts",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0",
-        "react-transition-group": "^4.4.0"
-      }
-    },
-    "@material-ui/icons": {
-      "version": "4.11.2",
-      "requires": {
-        "@babel/runtime": "^7.4.4"
-      }
-    },
-    "@material-ui/styles": {
-      "version": "4.11.4",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.2",
-        "clsx": "^1.0.4",
-        "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.5.1",
-        "jss-plugin-camel-case": "^10.5.1",
-        "jss-plugin-default-unit": "^10.5.1",
-        "jss-plugin-global": "^10.5.1",
-        "jss-plugin-nested": "^10.5.1",
-        "jss-plugin-props-sort": "^10.5.1",
-        "jss-plugin-rule-value-function": "^10.5.1",
-        "jss-plugin-vendor-prefixer": "^10.5.1",
-        "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "2.6.19",
-          "peer": true
-        }
-      }
-    },
-    "@material-ui/system": {
-      "version": "4.12.1",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.2",
-        "csstype": "^2.5.2",
-        "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "2.6.19",
-          "peer": true
-        }
-      }
-    },
-    "@material-ui/types": {
-      "version": "5.1.0",
-      "peer": true,
-      "requires": {}
-    },
-    "@material-ui/utils": {
-      "version": "4.11.2",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
     "@metamask/safe-event-emitter": {
@@ -29408,14 +29053,6 @@
     "css-unit-converter": {
       "version": "1.1.2"
     },
-    "css-vendor": {
-      "version": "2.0.8",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.8.3",
-        "is-in-browser": "^1.0.2"
-      }
-    },
     "css-what": {
       "version": "3.4.2"
     },
@@ -31848,10 +31485,6 @@
         "html-element": "^2.0.0"
       }
     },
-    "hyphenate-style-name": {
-      "version": "1.0.4",
-      "peer": true
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "requires": {
@@ -32180,10 +31813,6 @@
     "is-hotkey": {
       "version": "0.1.8"
     },
-    "is-in-browser": {
-      "version": "1.1.3",
-      "peer": true
-    },
     "is-interactive": {
       "version": "1.0.0",
       "dev": true
@@ -32500,76 +32129,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
-      }
-    },
-    "jss": {
-      "version": "10.9.0",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "csstype": "^3.0.2",
-        "is-in-browser": "^1.1.3",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "jss-plugin-camel-case": {
-      "version": "10.9.0",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "hyphenate-style-name": "^1.0.3",
-        "jss": "10.9.0"
-      }
-    },
-    "jss-plugin-default-unit": {
-      "version": "10.9.0",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0"
-      }
-    },
-    "jss-plugin-global": {
-      "version": "10.9.0",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0"
-      }
-    },
-    "jss-plugin-nested": {
-      "version": "10.9.0",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "jss-plugin-props-sort": {
-      "version": "10.9.0",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0"
-      }
-    },
-    "jss-plugin-rule-value-function": {
-      "version": "10.9.0",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.9.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "jss-plugin-vendor-prefixer": {
-      "version": "10.9.0",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.8",
-        "jss": "10.9.0"
       }
     },
     "jsx-ast-utils": {
@@ -34163,10 +33722,6 @@
     "popper-max-size-modifier": {
       "version": "0.2.0",
       "requires": {}
-    },
-    "popper.js": {
-      "version": "1.16.1-lts",
-      "peer": true
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/site/package.json
+++ b/site/package.json
@@ -15,7 +15,6 @@
     "@emotion/server": "^11.4.0",
     "@lingui/core": "^3.13.0",
     "@lingui/react": "^3.13.0",
-    "@material-ui/icons": "^4.11.2",
     "@sanity/block-content-to-react": "^3.0.0",
     "@sanity/client": "^2.23.2",
     "ethers": "^5.5.2",


### PR DESCRIPTION
## Description

In order to finish the migration, last use of `@material-ui/icons` has been replaced for `@mui/icons-material`.
Also, all dependencies of `@material-ui/icons` have been removed.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #201 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|
-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
