### PR TITLE
i18n: Preload fallback messages

### DIFF
--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -2,6 +2,7 @@ import { i18n } from "@lingui/core";
 import { en, fr } from "make-plural/plurals";
 import { prettifySeconds as prettifySecondsLib } from "@klimadao/lib/utils";
 import { IS_PRODUCTION } from "lib/constants";
+import { messages as default_messages } from "../locale/en/messages";
 
 // TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
 
@@ -49,6 +50,11 @@ async function activate(locale: string) {
  * Initializes locale (retrieve current locale from localstorage if possible)
  */
 async function init() {
+  // Preload default locale
+  i18n.load("en", default_messages);
+  i18n.activate("en");
+
+  // Load user locale
   let locale = window.localStorage.getItem("locale") as string;
   if (!Object.keys(locales).includes(locale)) locale = "en";
   await load(locale);


### PR DESCRIPTION
## Description

Fixes message ids flashing when loading the application

https://github.com/KlimaDAO/klimadao/issues/157

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
