### PR TITLE
i18n: a7. app/wrap

### DIFF
--- a/app/components/views/Wrap/index.tsx
+++ b/app/components/views/Wrap/index.tsx
@@ -26,7 +26,7 @@ import { BalancesCard } from "components/BalancesCard";
 import { useAppDispatch } from "state";
 
 import * as styles from "components/views/Stake/styles";
-import { Trans } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
 interface Props {
   provider: ethers.providers.JsonRpcProvider;
   address?: string;
@@ -112,7 +112,7 @@ export const Wrap: FC<Props> = (props) => {
     const value = Number(quantity || "0");
     if (!props.isConnected || !props.address) {
       return {
-        label: <Trans>Connect wallet</Trans>,
+        label: <Trans id="shared.connect_wallet">Connect wallet</Trans>,
         onClick: props.loadWeb3Modal,
         disabled: false,
       };
@@ -157,7 +157,9 @@ export const Wrap: FC<Props> = (props) => {
   };
 
   const inputPlaceholder =
-    view === "wrap" ? "sKLIMA to wrap" : "wsKLIMA to unwrap";
+    view === "wrap"
+      ? t({ id: "wrap.sklima_to_wrap", message: "sKLIMA to wrap" })
+      : t({ id: "wrap.wsklima_to_unwrap", message: "wsKLIMA to unwrap" });
 
   return (
     <>
@@ -169,16 +171,22 @@ export const Wrap: FC<Props> = (props) => {
         <div className={styles.stakeCard_header}>
           <Text t="h4" className={styles.stakeCard_header_title}>
             <FlipOutlined />
-            Wrap sKLIMA
+            <Trans id="wrap.wrap_sklima">Wrap sKLIMA</Trans>
           </Text>
           <Text t="caption" color="lightest">
-            <Trans>
+            <Trans
+              id="wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+              comment="Long sentence"
+            >
               Wrap sKLIMA to receive wsKLIMA. Unlike sKLIMA, your wsKLIMA
               balance will not increase over time.
             </Trans>
           </Text>
           <Text t="caption" color="lightest">
-            <Trans>
+            <Trans
+              id="wrap.wrap_sklima.some_find_this_useful"
+              comment="Long sentence"
+            >
               Some find this useful for accounting purposes, but the yield is
               exactly the same. Wrap and unwrap values are calculated based on
               the current index.
@@ -197,7 +205,7 @@ export const Wrap: FC<Props> = (props) => {
                 }}
                 data-active={view === "wrap"}
               >
-                Wrap
+                <Trans id="wrap.wrap">Wrap</Trans>
               </button>
               <button
                 className={styles.switchButton}
@@ -208,7 +216,7 @@ export const Wrap: FC<Props> = (props) => {
                 }}
                 data-active={view === "unwrap"}
               >
-                Unwrap
+                <Trans id="wrap.unwrap">Unwrap</Trans>
               </button>
             </div>
             <div className={styles.stakeInput}>
@@ -225,7 +233,7 @@ export const Wrap: FC<Props> = (props) => {
                 type="button"
                 onClick={setMax}
               >
-                <Trans id="button.max">Max</Trans>
+                <Trans id="shared.max">Max</Trans>
               </button>
             </div>
 
@@ -240,10 +248,10 @@ export const Wrap: FC<Props> = (props) => {
 
           <div className={styles.infoTable}>
             <div className={styles.infoTable_label}>
-              <Trans>Index</Trans>
+              <Trans id="wrap.index">Index</Trans>
               <TextInfoTooltip
                 content={
-                  <Trans>
+                  <Trans id="wrap.index.tooltip">
                     Amount of KLIMA you would have today if you staked 1 KLIMA
                     on launch day. Used to calculate wsKLIMA value.
                   </Trans>
@@ -253,10 +261,10 @@ export const Wrap: FC<Props> = (props) => {
               </TextInfoTooltip>
             </div>
             <div className={styles.infoTable_label}>
-              <Trans>Balance</Trans>
+              <Trans id="wrap.balance">Balance</Trans>
             </div>
             <div className={styles.infoTable_label}>
-              <Trans>You Will Get</Trans>
+              <Trans id="wrap.you_will_get">You Will Get</Trans>
             </div>
             <div className={styles.infoTable_value}>
               {currentIndex

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -13,14 +13,6 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/views/Wrap/index.tsx:246
-msgid "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Used to calculate wsKLIMA value."
-msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Used to calculate wsKLIMA value."
-
-#: components/views/Wrap/index.tsx:256
-msgid "Balance"
-msgstr "Balance"
-
 #: components/views/ChooseBond/index.tsx:123
 msgid "Bond Carbon."
 msgstr "Bond Carbon."
@@ -28,26 +20,6 @@ msgstr "Bond Carbon."
 #: components/ChangeLanguageButton/index.tsx:64
 msgid "Change language"
 msgstr "Change language"
-
-#: components/views/Wrap/index.tsx:115
-msgid "Connect wallet"
-msgstr "Connect wallet"
-
-#: components/views/Wrap/index.tsx:243
-msgid "Index"
-msgstr "Index"
-
-#: components/views/Wrap/index.tsx:181
-msgid "Some find this useful for accounting purposes, but the yield is exactly the same. Wrap and unwrap values are calculated based on the current index."
-msgstr "Some find this useful for accounting purposes, but the yield is exactly the same. Wrap and unwrap values are calculated based on the current index."
-
-#: components/views/Wrap/index.tsx:175
-msgid "Wrap sKLIMA to receive wsKLIMA. Unlike sKLIMA, your wsKLIMA balance will not increase over time."
-msgstr "Wrap sKLIMA to receive wsKLIMA. Unlike sKLIMA, your wsKLIMA balance will not increase over time."
-
-#: components/views/Wrap/index.tsx:259
-msgid "You Will Get"
-msgstr "You Will Get"
 
 #: components/views/Bond/index.tsx:466
 msgid "bond.balance"
@@ -162,10 +134,6 @@ msgstr "You will get"
 #: components/views/Bond/index.tsx:536
 msgid "bond.you_will_get.tooltip"
 msgstr "Amount of bonded KLIMA you will get, at the provided input quantity"
-
-#: components/views/Wrap/index.tsx:228
-msgid "button.max"
-msgstr "Max"
 
 #: components/CheckURLBanner/index.tsx:42
 msgid "checkurlbanner.dont_remind_me"
@@ -420,6 +388,7 @@ msgstr "Confirming"
 #: components/views/Bond/index.tsx:302
 #: components/views/PKlima/index.tsx:124
 #: components/views/Stake/index.tsx:129
+#: components/views/Wrap/index.tsx:115
 msgid "shared.connect_wallet"
 msgstr "Connect wallet"
 
@@ -453,6 +422,7 @@ msgstr "Loading..."
 #: components/views/Bond/index.tsx:451
 #: components/views/PKlima/index.tsx:207
 #: components/views/Stake/index.tsx:281
+#: components/views/Wrap/index.tsx:236
 msgid "shared.max"
 msgstr "Max"
 
@@ -568,6 +538,52 @@ msgstr "Connect"
 #: components/ConnectButton/index.tsx:24
 msgid "wallet.disconnect"
 msgstr "Disconnect"
+
+#: components/views/Wrap/index.tsx:264
+msgid "wrap.balance"
+msgstr "Balance"
+
+#: components/views/Wrap/index.tsx:251
+msgid "wrap.index"
+msgstr "Index"
+
+#: components/views/Wrap/index.tsx:254
+msgid "wrap.index.tooltip"
+msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Used to calculate wsKLIMA value."
+
+#: components/views/Wrap/index.tsx:161
+msgid "wrap.sklima_to_wrap"
+msgstr "sKLIMA to wrap"
+
+#: components/views/Wrap/index.tsx:219
+msgid "wrap.unwrap"
+msgstr "Unwrap"
+
+#: components/views/Wrap/index.tsx:208
+msgid "wrap.wrap"
+msgstr "Wrap"
+
+#: components/views/Wrap/index.tsx:174
+msgid "wrap.wrap_sklima"
+msgstr "Wrap sKLIMA"
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:186
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr "Some find this useful for accounting purposes, but the yield is exactly the same. Wrap and unwrap values are calculated based on the current index."
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:177
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr "Wrap sKLIMA to receive wsKLIMA. Unlike sKLIMA, your wsKLIMA balance will not increase over time."
+
+#: components/views/Wrap/index.tsx:162
+msgid "wrap.wsklima_to_unwrap"
+msgstr "wsKLIMA to unwrap"
+
+#: components/views/Wrap/index.tsx:267
+msgid "wrap.you_will_get"
+msgstr "You Will Get"
 
 #: components/views/Bond/index.tsx:703
 msgid "🪧 SOLD OUT. All demand has been filled for this bond. Thank you, Klimates!"

--- a/app/locale/fr/messages.po
+++ b/app/locale/fr/messages.po
@@ -13,40 +13,12 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/views/Wrap/index.tsx:246
-msgid "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Used to calculate wsKLIMA value."
-msgstr ""
-
-#: components/views/Wrap/index.tsx:256
-msgid "Balance"
-msgstr ""
-
 #: components/views/ChooseBond/index.tsx:123
 msgid "Bond Carbon."
 msgstr ""
 
 #: components/ChangeLanguageButton/index.tsx:64
 msgid "Change language"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:115
-msgid "Connect wallet"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:243
-msgid "Index"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:181
-msgid "Some find this useful for accounting purposes, but the yield is exactly the same. Wrap and unwrap values are calculated based on the current index."
-msgstr ""
-
-#: components/views/Wrap/index.tsx:175
-msgid "Wrap sKLIMA to receive wsKLIMA. Unlike sKLIMA, your wsKLIMA balance will not increase over time."
-msgstr ""
-
-#: components/views/Wrap/index.tsx:259
-msgid "You Will Get"
 msgstr ""
 
 #: components/views/Bond/index.tsx:466
@@ -162,10 +134,6 @@ msgstr ""
 #: components/views/Bond/index.tsx:536
 msgid "bond.you_will_get.tooltip"
 msgstr ""
-
-#: components/views/Wrap/index.tsx:228
-msgid "button.max"
-msgstr "Max"
 
 #: components/CheckURLBanner/index.tsx:42
 msgid "checkurlbanner.dont_remind_me"
@@ -420,6 +388,7 @@ msgstr ""
 #: components/views/Bond/index.tsx:302
 #: components/views/PKlima/index.tsx:124
 #: components/views/Stake/index.tsx:129
+#: components/views/Wrap/index.tsx:115
 msgid "shared.connect_wallet"
 msgstr ""
 
@@ -453,6 +422,7 @@ msgstr ""
 #: components/views/Bond/index.tsx:451
 #: components/views/PKlima/index.tsx:207
 #: components/views/Stake/index.tsx:281
+#: components/views/Wrap/index.tsx:236
 msgid "shared.max"
 msgstr ""
 
@@ -567,6 +537,52 @@ msgstr ""
 
 #: components/ConnectButton/index.tsx:24
 msgid "wallet.disconnect"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:264
+msgid "wrap.balance"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:251
+msgid "wrap.index"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:254
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:161
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:219
+msgid "wrap.unwrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:208
+msgid "wrap.wrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:174
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:186
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:177
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:162
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:267
+msgid "wrap.you_will_get"
 msgstr ""
 
 #: components/views/Bond/index.tsx:703

--- a/app/locale/pseudo/messages.po
+++ b/app/locale/pseudo/messages.po
@@ -13,40 +13,12 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/views/Wrap/index.tsx:246
-msgid "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Used to calculate wsKLIMA value."
-msgstr ""
-
-#: components/views/Wrap/index.tsx:256
-msgid "Balance"
-msgstr ""
-
 #: components/views/ChooseBond/index.tsx:123
 msgid "Bond Carbon."
 msgstr ""
 
 #: components/ChangeLanguageButton/index.tsx:64
 msgid "Change language"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:115
-msgid "Connect wallet"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:243
-msgid "Index"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:181
-msgid "Some find this useful for accounting purposes, but the yield is exactly the same. Wrap and unwrap values are calculated based on the current index."
-msgstr ""
-
-#: components/views/Wrap/index.tsx:175
-msgid "Wrap sKLIMA to receive wsKLIMA. Unlike sKLIMA, your wsKLIMA balance will not increase over time."
-msgstr ""
-
-#: components/views/Wrap/index.tsx:259
-msgid "You Will Get"
 msgstr ""
 
 #: components/views/Bond/index.tsx:466
@@ -161,10 +133,6 @@ msgstr ""
 
 #: components/views/Bond/index.tsx:536
 msgid "bond.you_will_get.tooltip"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:228
-msgid "button.max"
 msgstr ""
 
 #: components/CheckURLBanner/index.tsx:42
@@ -420,6 +388,7 @@ msgstr ""
 #: components/views/Bond/index.tsx:302
 #: components/views/PKlima/index.tsx:124
 #: components/views/Stake/index.tsx:129
+#: components/views/Wrap/index.tsx:115
 msgid "shared.connect_wallet"
 msgstr ""
 
@@ -453,6 +422,7 @@ msgstr ""
 #: components/views/Bond/index.tsx:451
 #: components/views/PKlima/index.tsx:207
 #: components/views/Stake/index.tsx:281
+#: components/views/Wrap/index.tsx:236
 msgid "shared.max"
 msgstr ""
 
@@ -567,6 +537,52 @@ msgstr ""
 
 #: components/ConnectButton/index.tsx:24
 msgid "wallet.disconnect"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:264
+msgid "wrap.balance"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:251
+msgid "wrap.index"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:254
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:161
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:219
+msgid "wrap.unwrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:208
+msgid "wrap.wrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:174
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:186
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:177
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:162
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:267
+msgid "wrap.you_will_get"
 msgstr ""
 
 #: components/views/Bond/index.tsx:703


### PR DESCRIPTION
## Description

Improved translation tags in the app/wrap page

## Related Ticket

https://github.com/KlimaDAO/klimadao/issues/157

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
