### PR TITLE
Show broken bonds as sold out

### DIFF
--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -185,6 +185,8 @@ export const calcBondDetails = (params: {
           params.bond === "klima_usdc_lp" ? 6 : 18
         ),
         marketPrice: marketPrice.toString(),
+        // format fee as # of tonnes
+        fee: parseInt(terms.fee) / 10000,
       })
     );
   };

--- a/app/components/views/ChooseBond/index.tsx
+++ b/app/components/views/ChooseBond/index.tsx
@@ -17,18 +17,27 @@ export const useBond = (bond: Bond) => {
     return state.bonds[bond];
   });
 
+  const bondPrice = bondState?.bondPrice;
+  const bondFee = bondState?.fee;
+
+  const disabledBonds = {
+    mco2: false,
+    bct: false,
+    klima_usdc_lp: false,
+    klima_bct_lp: false,
+    bct_usdc_lp: true,
+    klima_mco2_lp: false,
+    // future bond names go here
+  };
+  let disabled = disabledBonds[bond];
+  if (bondPrice && bondFee && parseFloat(bondPrice) < 1 + bondFee) {
+    disabled = true;
+  }
+
   return {
-    price: bondState?.bondPrice,
+    price: bondPrice,
     discount: bondState?.bondDiscount,
-    disabled: {
-      mco2: false,
-      bct: false,
-      klima_usdc_lp: false,
-      klima_bct_lp: false,
-      bct_usdc_lp: true,
-      klima_mco2_lp: false,
-      // future bond names go here
-    }[bond],
+    disabled: disabled,
     icon: {
       mco2: "/icons/MCO2.png",
       bct: "/icons/BCT.png",

--- a/app/state/bonds/index.ts
+++ b/app/state/bonds/index.ts
@@ -16,6 +16,7 @@ type BondState = {
     maxBondPrice?: string;
     bondPrice?: string;
     marketPrice?: string;
+    fee?: number;
   };
 };
 


### PR DESCRIPTION
## Description

When bond prices drop below `1 + fee` carbon tonne per KLIMA minted the treasury refuses to issue them because they would be unprofitable for the protocol.

As such, we need to account for this when displaying bonds on the frontend so that people don't think there is a juicy discount when in fact the bond cannot be claimed

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|
-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
