### PR TITLE
Fix Safari pinned tabs favicon color

### DIFF
--- a/app/components/PageHead.tsx
+++ b/app/components/PageHead.tsx
@@ -33,6 +33,7 @@ export const PageHead = (props: PageHeadProps) => {
         <meta property="og:image" content={props.mediaImageSrc} />
       )}
       <meta property="og:type" content="website" />
+      <meta property="og:locale" content="en" />
       <link
         rel="apple-touch-icon"
         sizes="180x180"
@@ -51,9 +52,8 @@ export const PageHead = (props: PageHeadProps) => {
         href="/favicon-16x16.png"
       />
       <link rel="manifest" href="/site.webmanifest" />
-      <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+      <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#00cc33" />
       <meta name="theme-color" content="#ffffff" />
-      <meta property="og:locale" content="en" />
     </Head>
   );
 };

--- a/site/components/PageHead/index.tsx
+++ b/site/components/PageHead/index.tsx
@@ -37,6 +37,7 @@ export const PageHead = (props: PageHeadProps) => {
         <meta property="og:image" content={props.mediaImageSrc} />
       )}
       <meta property="og:type" content="website" />
+      <meta property="og:locale" content="en" />
       <link rel="canonical" href={canonicalUrl} />
       <link
         rel="apple-touch-icon"
@@ -56,9 +57,8 @@ export const PageHead = (props: PageHeadProps) => {
         href="/favicon-16x16.png"
       />
       <link rel="manifest" href="/site.webmanifest" />
-      <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+      <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#00cc33" />
       <meta name="theme-color" content="#ffffff" />
-      <meta property="og:locale" content="en" />
     </Head>
   );
 };


### PR DESCRIPTION
## Description

As reported from the Community the Favicon in Safari pinned tabs was not in the correct KlimaDAO green.
This is the fix.

## Changes

| Before  | After  |
|---------|--------|
| ![kl_before](https://user-images.githubusercontent.com/95881624/158352514-a10fd5a9-d164-48fc-97d1-8e78e835d920.png)|![kl_after](https://user-images.githubusercontent.com/95881624/158352460-3d81d569-98cb-4d87-aaca-be5d8b88ab57.png) |

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
