### PR TITLE
refactor: dapp offset ui polish

### DIFF
--- a/app/components/BalancesCard/styles.ts
+++ b/app/components/BalancesCard/styles.ts
@@ -6,6 +6,7 @@ import * as typography from "@klimadao/lib/theme/typography";
 export const card = css`
   ${common.cardSurface};
   align-content: start;
+  grid-column: 1 / 3;
   grid-template-rows: min-content 1fr;
   gap: 0.8rem;
   .header {
@@ -41,6 +42,7 @@ export const card = css`
   }
 
   ${breakpoints.desktop} {
+    grid-column: 2 / 3;
     .value {
       ${typography.h4}
     }

--- a/app/components/BondBalancesCard/styles.ts
+++ b/app/components/BondBalancesCard/styles.ts
@@ -6,6 +6,7 @@ import * as typography from "@klimadao/lib/theme/typography";
 export const card = css`
   ${common.cardSurface};
   align-content: start;
+  grid-column: 1 / 3;
   grid-template-rows: min-content 1fr;
   gap: 0.8rem;
   .header {
@@ -41,6 +42,7 @@ export const card = css`
   }
 
   ${breakpoints.desktop} {
+    grid-column: 2 / 3;
     .value {
       ${typography.h4}
     }

--- a/app/components/DropdownWithModal/styles.ts
+++ b/app/components/DropdownWithModal/styles.ts
@@ -16,7 +16,7 @@ export const container = css`
     align-items: center;
     background-color: var(--surface-01);
     border-radius: 1rem;
-    padding: 0.5rem;
+    padding: 0.4rem 0.8rem;
     &:hover {
       background-color: var(--surface-03);
     }

--- a/app/components/ImageCard/styles.ts
+++ b/app/components/ImageCard/styles.ts
@@ -10,6 +10,7 @@ export const card = css`
   border-radius: 1.2rem;
   display: grid;
   align-content: space-between;
+  grid-column: 1 / 3;
   .header {
     display: grid;
     gap: 0.8rem;
@@ -21,13 +22,15 @@ export const card = css`
     margin-bottom: -0.8rem;
     justify-content: flex-end;
   }
+
   .footer svg {
     width: 4rem;
     height: 4rem;
     transform: scaleX(-1);
     color: var(--font-01);
   }
-  ${breakpoints.desktopLarge} {
-    padding: 3.2rem;
+
+  ${breakpoints.desktop} {
+    grid-column: 2 / 3;
   }
 `;

--- a/app/components/ImageCard/styles.ts
+++ b/app/components/ImageCard/styles.ts
@@ -32,5 +32,6 @@ export const card = css`
 
   ${breakpoints.desktop} {
     grid-column: 2 / 3;
+    min-height: 20rem;
   }
 `;

--- a/app/components/MiniTokenDisplay/index.tsx
+++ b/app/components/MiniTokenDisplay/index.tsx
@@ -29,6 +29,7 @@ export const MiniTokenDisplay: FC<Props> = (props) => {
         <div className="image">
           <Image src={props.icon} width={48} height={48} alt={props.name} />
         </div>
+
         {props.loading ? (
           <Spinner />
         ) : (

--- a/app/components/MiniTokenDisplay/styles.ts
+++ b/app/components/MiniTokenDisplay/styles.ts
@@ -10,10 +10,12 @@ export const container = css`
   .label {
     height: 2rem;
     text-transform: uppercase;
+
     ${breakpoints.medium} {
       justify-self: flex-start;
     }
   }
+
   .value.warn {
     color: var(--warn);
   }
@@ -28,9 +30,11 @@ export const card = css`
   height: 5.6rem;
   border-radius: 1rem;
   padding: 0.4rem 0.8rem;
+
   .image {
     min-width: 4.8rem;
   }
+  
   p {
     padding: 0 0.6rem;
   }

--- a/app/components/MiniTokenDisplay/styles.ts
+++ b/app/components/MiniTokenDisplay/styles.ts
@@ -4,18 +4,14 @@ import breakpoints from "@klimadao/lib/theme/breakpoints";
 export const container = css`
   display: grid;
   flex-direction: column;
+  width: 100%;
   gap: 0.5rem;
+
   .label {
+    height: 2rem;
     text-transform: uppercase;
-    justify-self: center;
-    ${breakpoints.small} {
-      justify-self: flex-start;
-    }
-  }
-  .label.alignEnd {
-    justify-self: center;
-    ${breakpoints.small} {
-      justify-self: flex-end;
+    ${breakpoints.medium} {
+      justify-self: flex-start; 
     }
   }
   .value.warn {
@@ -25,14 +21,17 @@ export const container = css`
 
 export const card = css`
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 0.8rem;
   background-color: var(--surface-01);
   color: var(--font-01);
   min-height: 4.8rem;
   border-radius: 1rem;
-  padding: 0.4rem 1.6rem 0.4rem 0.4rem;
+  padding: 0.4rem 0.8rem;
   .image {
     min-width: 4.8rem;
+  }
+  p {
+    padding: 0 1rem;
   }
 `;

--- a/app/components/MiniTokenDisplay/styles.ts
+++ b/app/components/MiniTokenDisplay/styles.ts
@@ -25,13 +25,13 @@ export const card = css`
   align-items: center;
   background-color: var(--surface-01);
   color: var(--font-01);
-  min-height: 4.8rem;
+  height: 5.6rem;
   border-radius: 1rem;
   padding: 0.4rem 0.8rem;
   .image {
     min-width: 4.8rem;
   }
   p {
-    padding: 0 1rem;
+    padding: 0 0.6rem;
   }
 `;

--- a/app/components/MiniTokenDisplay/styles.ts
+++ b/app/components/MiniTokenDisplay/styles.ts
@@ -34,7 +34,7 @@ export const card = css`
   .image {
     min-width: 4.8rem;
   }
-  
+
   p {
     padding: 0 0.6rem;
   }

--- a/app/components/MiniTokenDisplay/styles.ts
+++ b/app/components/MiniTokenDisplay/styles.ts
@@ -11,7 +11,7 @@ export const container = css`
     height: 2rem;
     text-transform: uppercase;
     ${breakpoints.medium} {
-      justify-self: flex-start; 
+      justify-self: flex-start;
     }
   }
   .value.warn {

--- a/app/components/NavMenu/index.tsx
+++ b/app/components/NavMenu/index.tsx
@@ -151,20 +151,20 @@ export const NavMenu: FC<Props> = (props) => {
         <Trans id="menu.wrap_klima">Wrap sKLIMA</Trans>
       </MenuButton>
       <MenuButton
-        isActive={pathname === "/info"}
-        href="/info"
-        icon={<InfoOutlined />}
-        onClick={handleHide}
-      >
-        <Trans id="menu.info">Info</Trans>
-      </MenuButton>
-      <MenuButton
         isActive={pathname === "/offset"}
         icon={<ParkOutlined />}
         href="/offset"
         onClick={handleHide}
       >
         <Trans id="menu.offset">Offset</Trans>
+      </MenuButton>
+      <MenuButton
+        isActive={pathname === "/info"}
+        href="/info"
+        icon={<InfoOutlined />}
+        onClick={handleHide}
+      >
+        <Trans id="menu.info">Info</Trans>
       </MenuButton>
       {!!Number(balances?.pklima) && (
         <div className="labelStack">

--- a/app/components/RebaseCard/styles.ts
+++ b/app/components/RebaseCard/styles.ts
@@ -5,6 +5,7 @@ import * as typography from "@klimadao/lib/theme/typography";
 
 export const card = css`
   ${common.cardSurface};
+  grid-column: 1 / 3;
   align-content: start;
   grid-template-rows: min-content 1fr;
   gap: 0.8rem;
@@ -39,6 +40,7 @@ export const card = css`
   }
 
   ${breakpoints.desktop} {
+    grid-column: 2 / 3;
     .value {
       ${typography.h4}
     }

--- a/app/components/views/Bond/styles.ts
+++ b/app/components/views/Bond/styles.ts
@@ -21,6 +21,7 @@ export const bondCard = css`
   padding: 2.4rem;
   gap: 2.4rem;
   align-content: start;
+  grid-column: 1 / 3;
   .hr {
     height: 2px;
     background-color: var(--surface-01);

--- a/app/components/views/ChooseBond/index.tsx
+++ b/app/components/views/ChooseBond/index.tsx
@@ -129,7 +129,7 @@ export function ChooseBond() {
         <div className={styles.chooseBondCard_header}>
           <Text t="h4" className={styles.chooseBondCard_header_title}>
             <SpaOutlined />
-            <Trans id="choose_bond.bond_carbon">Bond Carbon.</Trans>
+            <Trans id="choose_bond.bond_carbon">Bond Carbon</Trans>
           </Text>
           <Text t="caption" color="lightest">
             <Trans
@@ -142,6 +142,7 @@ export function ChooseBond() {
             </Trans>
           </Text>
         </div>
+
         <div className={styles.chooseBondCard_ui}>
           <div>
             <Text t="badge" color="lightest">
@@ -194,7 +195,10 @@ export function ChooseBond() {
           </div>
         </div>
       </div>
-      <ImageCard />
+
+      <div className={styles.columnRight}>
+        <ImageCard />
+      </div>
     </>
   );
 }

--- a/app/components/views/ChooseBond/styles.ts
+++ b/app/components/views/ChooseBond/styles.ts
@@ -33,7 +33,7 @@ export const chooseBondCard_header = css`
 export const chooseBondCard_ui = css`
   display: grid;
   gap: 2.4rem;
-  
+
   ${breakpoints.medium} {
     border: 2px solid var(--surface-01);
     padding: 2.4rem;

--- a/app/components/views/ChooseBond/styles.ts
+++ b/app/components/views/ChooseBond/styles.ts
@@ -1,21 +1,14 @@
 import { css } from "@emotion/css";
-// import * as typography from "@klimadao/lib/theme/typography";
-// import * as common from "@klimadao/lib/theme/common";
 import breakpoints from "@klimadao/lib/theme/breakpoints";
 
 export const chooseBondCard = css`
-  position: relative;
   display: grid;
   background-color: var(--surface-02);
   border-radius: 1.2rem;
   padding: 1.6rem;
   gap: 2.4rem;
   align-content: start;
-
-  .hr {
-    height: 2px;
-    background-color: var(--surface-01);
-  }
+  grid-column: 1 / 3;
 
   ${breakpoints.small} {
     padding: 2.4rem;
@@ -23,20 +16,11 @@ export const chooseBondCard = css`
 
   ${breakpoints.desktop} {
     grid-column: cardsleft;
-    grid-row: 2 / span 3;
-    grid-template-rows: 1fr 1fr 1fr;
     align-items: start;
-    /* hacky fix to keep grid-rows from collapsing on short screens */
-    /* if you add a new bond or refactor this view, make sure you test for overflow at the narrowest part of the breakpoint */
-    min-height: 117rem;
-    min-width: 45rem;
   }
 
   ${breakpoints.desktopLarge} {
     padding: 3.2rem;
-    /* hacky fix to keep grid-rows from collapsing on short screens */
-    /* if you add a new bond or refactor this view, make sure you test for overflow at the narrowest part of the breakpoint */
-    min-height: 99rem;
   }
 `;
 
@@ -49,17 +33,28 @@ export const chooseBondCard_header = css`
 export const chooseBondCard_ui = css`
   display: grid;
   gap: 2.4rem;
+  
   ${breakpoints.medium} {
     border: 2px solid var(--surface-01);
     padding: 2.4rem;
     border-radius: 1.2rem;
   }
+
   ${breakpoints.desktop} {
     gap: 3.2rem;
     padding: 3.2rem;
     max-width: 56rem;
     justify-self: center;
     width: 100%;
+  }
+`;
+
+export const columnRight = css`
+  grid-column: 1 / 3;
+
+  ${breakpoints.desktop} {
+    grid-column: 2 / 3;
+    grid-row: span 2;
   }
 `;
 
@@ -73,10 +68,12 @@ export const bondList = css`
   display: grid;
   gap: 1.2rem;
 `;
+
 export const bondList_columnTitle = css`
   display: flex;
   justify-content: space-between;
 `;
+
 export const bondLink = css`
   display: grid;
   gap: 1.6rem;

--- a/app/components/views/Home/index.module.css
+++ b/app/components/views/Home/index.module.css
@@ -97,7 +97,7 @@
 @media bp-medium {
   .cardGrid {
     gap: 2.4rem;
-    padding: 3.2rem;
+    padding: 2.4rem;
   }
 }
 

--- a/app/components/views/Home/index.module.css
+++ b/app/components/views/Home/index.module.css
@@ -39,6 +39,7 @@
   display: flex;
   justify-content: flex-end;
   gap: 1.6rem;
+  grid-column: 1 / 3;
 }
 .menuButton {
   background-color: var(--surface-02);
@@ -111,6 +112,7 @@
       [full-start] minmax(0px, 1fr)
       [full-end];
   }
+
   .cardGrid {
     overflow-y: auto;
     display: grid;
@@ -118,7 +120,6 @@
     grid-template-columns:
       [cardsleft] minmax(38rem, auto)
       [cardsright] minmax(auto, 38rem);
-    grid-template-rows: min-content 1fr 1fr 1fr;
     max-width: unset;
   }
   .controls {

--- a/app/components/views/Home/index.module.css
+++ b/app/components/views/Home/index.module.css
@@ -120,6 +120,7 @@
     grid-template-columns:
       [cardsleft] minmax(38rem, auto)
       [cardsright] minmax(auto, 38rem);
+    grid-template-rows: min-content 1fr 1fr 1fr;
     max-width: unset;
   }
   .controls {

--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -379,22 +379,16 @@ export const Home: FC = () => {
           </IsomorphicRoutes>
         </div>
       </div>
+
       <InvalidNetworkModal provider={provider} />
+      <NotificationModal />
+
       {showRPCModal && (
-        <InvalidRPCModal
-          onHide={() => {
-            setShowRPCModal(false);
-          }}
-        />
+        <InvalidRPCModal onHide={() => setShowRPCModal(false)} />
       )}
       {showCheckURLBanner && (
-        <CheckURLBanner
-          onHide={() => {
-            setShowCheckURLBanner(false);
-          }}
-        />
+        <CheckURLBanner onHide={() => setShowCheckURLBanner(false)} />
       )}
-      <NotificationModal />
     </>
   );
 };

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -547,8 +547,10 @@ export const Offset = (props: Props) => {
         </div>
       </div>
 
-      <CarbonTonnesRetiredCard />
-      <CarbonTonnesBreakdownCard />
+      <div className={styles.columnRight}>
+        <CarbonTonnesRetiredCard />
+        <CarbonTonnesBreakdownCard />
+      </div>
 
       {retirementTransactionHash && (
         <RetirementSuccessModal

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -357,7 +357,7 @@ export const Offset = (props: Props) => {
               environmental benefit of the carbon offset. Choose to retire{" "}
               <A href="https://docs.klimadao.finance/references/glossary#mco2">
                 Moss Carbon Credits
-              </A>
+              </A>{" "}
               (MCO2),{" "}
               <A href="https://docs.klimadao.finance/references/glossary#bct">
                 Base Carbon Tonnes

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -344,6 +344,11 @@ export const Offset = (props: Props) => {
 
   return (
     <>
+      <div className={styles.columnRight}>
+        <CarbonTonnesRetiredCard />
+        <CarbonTonnesBreakdownCard />
+      </div>
+
       <div className={styles.offsetCard}>
         <div className={styles.offsetCard_header}>
           <Text t="h4" className={styles.offsetCard_header_title}>
@@ -545,11 +550,6 @@ export const Offset = (props: Props) => {
             )}
           </div>
         </div>
-      </div>
-
-      <div className={styles.columnRight}>
-        <CarbonTonnesRetiredCard />
-        <CarbonTonnesBreakdownCard />
       </div>
 
       {retirementTransactionHash && (

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -5,7 +5,6 @@ import { providers } from "ethers";
 import { Trans, t } from "@lingui/macro";
 
 import ParkOutlined from "@mui/icons-material/ParkOutlined";
-import ArrowRightAlt from "@mui/icons-material/ArrowRightAlt";
 import InfoOutlined from "@mui/icons-material/InfoOutlined";
 import GppMaybeOutlined from "@mui/icons-material/GppMaybeOutlined";
 import CheckIcon from "@mui/icons-material/Check";
@@ -454,6 +453,7 @@ export const Offset = (props: Props) => {
             loading={cost === "loading"}
             warn={insufficientBalance}
           />
+
           <MiniTokenDisplay
             label={
               <Text t="caption" color="lightest">
@@ -546,8 +546,10 @@ export const Offset = (props: Props) => {
           </div>
         </div>
       </div>
+
       <CarbonTonnesRetiredCard />
       <CarbonTonnesBreakdownCard />
+
       {retirementTransactionHash && (
         <RetirementSuccessModal
           onSuccessModalClose={handleOnSuccessModalClose}

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -430,44 +430,42 @@ export const Offset = (props: Props) => {
               </button> */}
             </div>
           </div>
-          <div className="mini_token_display_row">
-            <MiniTokenDisplay
-              label={
-                <div className="mini_token_label">
-                  <Text t="caption" color="lightest">
-                    <Trans id="offset_cost">Cost</Trans>
-                  </Text>
-                  <TextInfoTooltip
-                    content={
-                      <Trans id="offset_aggregation_fee_tooltip">
-                        This cost includes slippage and the aggregation fee of
-                        1%.
-                      </Trans>
-                    }
-                  >
-                    <InfoOutlined />
-                  </TextInfoTooltip>
-                </div>
-              }
-              amount={cost}
-              icon={tokenInfo[selectedInputToken].icon}
-              name={selectedInputToken}
-              loading={cost === "loading"}
-              warn={insufficientBalance}
-            />
-            <ArrowRightAlt className="mini_token_display_icon" />
-            <MiniTokenDisplay
-              label={
+
+          <MiniTokenDisplay
+            label={
+              <div className="mini_token_label">
                 <Text t="caption" color="lightest">
-                  <Trans id="offset_retiring">Retiring</Trans>
+                  <Trans id="offset_cost">Cost</Trans>
                 </Text>
-              }
-              amount={quantity}
-              icon={tokenInfo[selectedRetirementToken].icon}
-              name={selectedRetirementToken}
-              labelAlignment="end"
-            />
-          </div>
+                <TextInfoTooltip
+                  content={
+                    <Trans id="offset_aggregation_fee_tooltip">
+                      This cost includes slippage and the aggregation fee of 1%.
+                    </Trans>
+                  }
+                >
+                  <InfoOutlined />
+                </TextInfoTooltip>
+              </div>
+            }
+            amount={cost}
+            icon={tokenInfo[selectedInputToken].icon}
+            name={selectedInputToken}
+            loading={cost === "loading"}
+            warn={insufficientBalance}
+          />
+          <MiniTokenDisplay
+            label={
+              <Text t="caption" color="lightest">
+                <Trans id="offset_retiring">Retiring</Trans>
+              </Text>
+            }
+            amount={quantity}
+            icon={tokenInfo[selectedRetirementToken].icon}
+            name={selectedRetirementToken}
+            labelAlignment="start"
+          />
+
           <div className={styles.input}>
             <label>
               <Text t="caption" color="lightest">

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -40,11 +40,14 @@ export const offsetCard_header = css`
 export const offsetCard_ui = css`
   display: grid;
   gap: 2.4rem;
+  overflow: none;
+
   ${breakpoints.medium} {
     border: 2px solid var(--surface-03);
     padding: 2.4rem;
     border-radius: 1.2rem;
   }
+
   ${breakpoints.desktop} {
     gap: 2.4rem;
     padding: 2.4rem;
@@ -52,32 +55,33 @@ export const offsetCard_ui = css`
     max-width: 48rem;
     width: 100%;
   }
-  .mini_token_display_row {
+
+  .mini_token_label {
+    color: var(--font-01);
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    flex-direction: column;
-    ${breakpoints.small} {
-      flex-direction: row;
-    }
-    .mini_token_label {
-      color: var(--font-01);
-      display: flex;
-      align-items: center;
-      gap: 0.4rem;
-    }
+    gap: 0.4rem;
   }
+
   .mini_token_display_icon {
     width: 4.8rem;
     height: 4.8rem;
     color: var(--font-01);
-    margin-top: 3.2rem;
+    transform: rotate(90deg);
+    margin-top: 0.8rem;
+    
+    ${breakpoints.medium} {
+      margin-top: 3.2rem;     
+      transform: rotate(0deg); 
+    }
   }
+
   .disclaimer {
     color: var(--font-01);
     display: flex;
-    gap: 0.4rem;
+    gap: 1.2rem;
   }
+
   .disclaimer svg {
     color: yellow;
     width: 3.2rem;
@@ -102,9 +106,11 @@ export const buttonRow_spinner = css`
   align-items: center;
   min-height: 4.8rem;
 `;
+
 export const submitButton = css`
   width: 100%;
 `;
+
 export const input = css`
   display: flex;
   flex-direction: column;
@@ -114,7 +120,7 @@ export const input = css`
     background-color: var(--surface-02);
     border-radius: 1rem;
     border: 0.2rem solid var(--surface-03);
-    padding-inline-start: 2rem;
+    padding-inline-start: 1rem;
     min-height: 2.4rem;
     color: var(--font-01);
     resize: none;
@@ -127,7 +133,7 @@ export const input = css`
     background-color: var(--surface-02);
     border-radius: 1rem;
     border: 0.2rem solid var(--surface-03);
-    padding-inline-start: 2rem;
+    padding-inline-start: 1rem;
     min-height: 4.8rem;
     color: var(--font-01);
   }

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -12,7 +12,7 @@ export const columnRight = css`
   ${breakpoints.desktop} {
     grid-column: 2 / 3;
   }
-`
+`;
 
 export const offsetCard = css`
   display: grid;

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -63,19 +63,6 @@ export const offsetCard_ui = css`
     gap: 0.4rem;
   }
 
-  .mini_token_display_icon {
-    width: 4.8rem;
-    height: 4.8rem;
-    color: var(--font-01);
-    transform: rotate(90deg);
-    margin-top: 0.8rem;
-
-    ${breakpoints.medium} {
-      margin-top: 3.2rem;
-      transform: rotate(0deg);
-    }
-  }
-
   .disclaimer {
     color: var(--font-01);
     display: flex;
@@ -115,6 +102,7 @@ export const input = css`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+
   textarea {
     width: 100%;
     background-color: var(--surface-02);
@@ -128,6 +116,7 @@ export const input = css`
     overflow-y: hidden;
     min-height: 16rem;
   }
+
   input {
     width: 100%;
     background-color: var(--surface-02);
@@ -137,12 +126,14 @@ export const input = css`
     min-height: 4.8rem;
     color: var(--font-01);
   }
+
   .number_input_container {
     min-height: 4.8rem;
     display: grid;
     grid-template-columns: 1fr min-content;
     z-index: 1; /* cover advanced-settings border */
   }
+
   .button_max {
     ${common.iconButton};
     ${typography.button};

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -4,7 +4,6 @@ import * as typography from "@klimadao/lib/theme/typography";
 import * as common from "@klimadao/lib/theme/common";
 
 export const columnRight = css`
-  grid-column: cardsright;
   display: grid;
   gap: 2.4rem;
   grid-column: 1 / 3;

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -5,7 +5,7 @@ import * as common from "@klimadao/lib/theme/common";
 
 export const offsetCard = css`
   display: grid;
-  align-content: start; 
+  align-content: start;
   background-color: var(--surface-02);
   border-radius: 1.2rem;
   padding: 2.4rem;
@@ -69,10 +69,10 @@ export const offsetCard_ui = css`
     color: var(--font-01);
     transform: rotate(90deg);
     margin-top: 0.8rem;
-    
+
     ${breakpoints.medium} {
-      margin-top: 3.2rem;     
-      transform: rotate(0deg); 
+      margin-top: 3.2rem;
+      transform: rotate(0deg);
     }
   }
 

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -24,14 +24,13 @@ export const offsetCard = css`
     align-items: start;
     min-height: 128rem;
   }
-  ${breakpoints.desktopLarge} {
-    min-height: 118rem;
-  }
 
   ${breakpoints.desktopLarge} {
+    min-height: 118rem;
     padding: 3.2rem;
   }
 `;
+
 export const offsetCard_header = css`
   display: grid;
   gap: 0.8rem;

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -3,6 +3,18 @@ import breakpoints from "@klimadao/lib/theme/breakpoints";
 import * as typography from "@klimadao/lib/theme/typography";
 import * as common from "@klimadao/lib/theme/common";
 
+export const columnRight = css`
+  grid-column: cardsright;
+  display: grid;
+  gap: 2.4rem;
+  grid-column: 1 / 3;
+  align-content: start;
+
+  ${breakpoints.desktop} {
+    grid-column: 2 / 3;
+  }
+`
+
 export const offsetCard = css`
   display: grid;
   align-content: start;
@@ -11,22 +23,15 @@ export const offsetCard = css`
   padding: 2.4rem;
   gap: 2.4rem;
   align-content: start;
-
-  ${breakpoints.medium} {
-    gap: 3.2rem;
-  }
+  grid-column: 1 / 3;
 
   ${breakpoints.desktop} {
     grid-column: cardsleft;
-    grid-row: 2 / span 3;
     gap: 4.8rem;
-    grid-template-rows: 1fr 1fr 1fr;
     align-items: start;
-    min-height: 128rem;
   }
 
   ${breakpoints.desktopLarge} {
-    min-height: 118rem;
     padding: 3.2rem;
   }
 `;

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -16,16 +16,16 @@ export const columnRight = css`
 
 export const offsetCard = css`
   display: grid;
-  align-content: start;
   background-color: var(--surface-02);
+  align-content: start;
   border-radius: 1.2rem;
   padding: 2.4rem;
   gap: 2.4rem;
-  align-content: start;
   grid-column: 1 / 3;
 
   ${breakpoints.desktop} {
     grid-column: cardsleft;
+    grid-row: 2 / auto;
     gap: 4.8rem;
     align-items: start;
   }

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -4,8 +4,8 @@ import * as typography from "@klimadao/lib/theme/typography";
 import * as common from "@klimadao/lib/theme/common";
 
 export const offsetCard = css`
-  position: relative;
   display: grid;
+  align-content: start; 
   background-color: var(--surface-02);
   border-radius: 1.2rem;
   padding: 2.4rem;

--- a/app/components/views/Stake/index.tsx
+++ b/app/components/views/Stake/index.tsx
@@ -220,6 +220,7 @@ export const Stake = (props: Props) => {
           comment: "Long sentence",
         })}
       />
+      <RebaseCard isConnected={props.isConnected} />
 
       <div className={styles.stakeCard}>
         <div className={styles.stakeCard_header}>
@@ -370,7 +371,6 @@ export const Stake = (props: Props) => {
         </div>
       </div>
 
-      <RebaseCard isConnected={props.isConnected} />
       <ImageCard />
     </>
   );

--- a/app/components/views/Stake/index.tsx
+++ b/app/components/views/Stake/index.tsx
@@ -220,6 +220,7 @@ export const Stake = (props: Props) => {
           comment: "Long sentence",
         })}
       />
+
       <div className={styles.stakeCard}>
         <div className={styles.stakeCard_header}>
           <Text t="h4" className={styles.stakeCard_header_title}>
@@ -368,6 +369,7 @@ export const Stake = (props: Props) => {
           </div>
         </div>
       </div>
+
       <RebaseCard isConnected={props.isConnected} />
       <ImageCard />
     </>

--- a/app/components/views/Stake/styles.ts
+++ b/app/components/views/Stake/styles.ts
@@ -221,4 +221,4 @@ export const columnRight = css`
   ${breakpoints.desktop} {
     grid-column: 2 / 3;
   }
-`
+`;

--- a/app/components/views/Stake/styles.ts
+++ b/app/components/views/Stake/styles.ts
@@ -11,6 +11,7 @@ export const stakeCard = css`
   padding: 2.4rem;
   gap: 2.4rem;
   align-content: start;
+  grid-column: 1 / 3;
 
   .hr {
     height: 2px;
@@ -210,3 +211,14 @@ export const buttonRow_spinner = css`
 export const submitButton = css`
   width: 100%;
 `;
+
+export const columnRight = css`
+  display: grid;
+  gap: 2.4rem;
+  grid-column: 1 / 3;
+  align-content: start;
+
+  ${breakpoints.desktop} {
+    grid-column: 2 / 3;
+  }
+`

--- a/app/components/views/Wrap/index.tsx
+++ b/app/components/views/Wrap/index.tsx
@@ -167,6 +167,7 @@ export const Wrap: FC<Props> = (props) => {
         assets={["sklima", "wsklima"]}
         tooltip="Wrap sKLIMA to recieve index-adjusted wrapped-staked-KLIMA"
       />
+
       <div className={styles.stakeCard} style={{ minHeight: "74rem" }}>
         <div className={styles.stakeCard_header}>
           <Text t="h4" className={styles.stakeCard_header_title}>
@@ -293,6 +294,7 @@ export const Wrap: FC<Props> = (props) => {
           </div>
         </div>
       </div>
+
       <ImageCard />
     </>
   );

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -208,7 +208,7 @@ msgstr "Toucan Base Carbon Tonne"
 
 #: components/views/ChooseBond/index.tsx:132
 msgid "choose_bond.bond_carbon"
-msgstr "Bond Carbon."
+msgstr "Bond Carbon"
 
 #. Long sentence
 #: components/views/ChooseBond/index.tsx:135


### PR DESCRIPTION
## Description

Small styling changes to polish the offset ui ux:
- consistent gaps around all cards
- move offset nav item above info
- **full width cost and retiring fields to remove input resizing on user input**
    - this change completely diverts from the original design, I can look into a solution if we wish to maintain the original design :)
- padding alignment on input and button elements
- standardised responsive styling across dapp

#### TODO
- [x] fix <OffsetCard /> content overflow
- [x] ~align `carbon tonnes` input to the right~ not implementing, ux looked too strange
- [x] Fix `/bond` page responsive style regressions

## Changes

| Before  | After  |
|---------|--------|
|<img width="1440" alt="image" src="https://user-images.githubusercontent.com/97446324/160029859-da8f3df2-2268-4e14-955c-a706202e4672.png">|<img width="1440" alt="image" src="https://user-images.githubusercontent.com/97446324/160030047-325a23ae-ba25-4e04-8a05-c239961cda6d.png">|

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
