### PR TITLE
Makes the `lingui:extract` command return an error if a file cannot be processed

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "start": "next start",
     "export": "next export",
     "lint": "next lint",
-    "lingui:extract": "NODE_ENV=test lingui extract --clean --overwrite",
+    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean --overwrite 2>&1 | grep 'Cannot process file'\"; if [[ $(eval $cmd) ]]; then exit 1; else exit 0; fi",
     "lingui:compile": "NODE_ENV=test lingui compile",
     "postinstall": "npm run lingui:compile"
   },

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
     "build": "prettier --check . && next build",
     "start": "next start",
     "lint": "next lint",
-    "lingui:extract": "NODE_ENV=test lingui extract --clean --overwrite",
+    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean --overwrite 2>&1 | grep 'Cannot process file'\"; if [[ $(eval $cmd) ]]; then exit 1; else exit 0; fi",
     "lingui:compile": "NODE_ENV=test lingui compile",
     "postinstall": "npm run lingui:compile"
   },


### PR DESCRIPTION
## Description

Makes the `lingui:extract` command return an error if a file cannot be processed

## Related Ticket

https://github.com/KlimaDAO/klimadao/issues/157

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
