### PR TITLE
Change workflow schedule to monday-thursday

### DIFF
--- a/.github/workflows/schedule_auto_merge.yml
+++ b/.github/workflows/schedule_auto_merge.yml
@@ -1,8 +1,8 @@
 name: Schedule Auto Merge
 on:
   schedule:
-    # Runs on default branch every Monday and Wednesday at 15h (8am PCT)
-    - cron: "0 15 * * 1,3"
+    # At 16:00 UTC (9am PDT) on every day-of-week from Monday through Thursday.
+    - cron: "0 16 * * 1-4"
 
 jobs:
   call_update_translations:


### PR DESCRIPTION
## Description

The first live release with github actions worked:
https://github.com/KlimaDAO/klimadao/actions/runs/2065669708

Let's change the schedule to daily at 16h UTC (9am PDT) from Monday through Thursday

## Related Ticket

Related https://github.com/KlimaDAO/klimadao/issues/206


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
