### PR TITLE
fix blog mobile container overflow

### DIFF
--- a/site/components/BlockContentRenderer/styles.ts
+++ b/site/components/BlockContentRenderer/styles.ts
@@ -8,6 +8,7 @@ export const heading = css`
 
 export const paragraph = css`
   margin: 2rem 0;
+  word-break: break-word;
 `;
 
 export const blockQuote = css`


### PR DESCRIPTION
https://www.klimadao.finance/blog/polygon-pos-emissions-analysis this blog was overflowing the container in mobile view because one of the addresses was such a long word so i added word-break break word so that long words that take up the whole container will break to next line