### PR TITLE
Run the workflow via UI

### DIFF
--- a/.github/workflows/schedule_auto_merge.yml
+++ b/.github/workflows/schedule_auto_merge.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # At 16:00 UTC (9am PDT) on every day-of-week from Monday through Thursday.
-    - cron: "0 16 * * 1-4"
+    - cron: "0 16 * * 1,2,3,4"
 
 jobs:
   call_update_translations:

--- a/.github/workflows/schedule_auto_merge.yml
+++ b/.github/workflows/schedule_auto_merge.yml
@@ -1,5 +1,6 @@
 name: Schedule Auto Merge
 on:
+  workflow_dispatch:
   schedule:
     # At 16:00 UTC (9am PDT) on every day-of-week from Monday through Thursday.
     - cron: "0 16 * * 1-4"


### PR DESCRIPTION
## Description

The scheduled cron job for the staging release workflow is not always triggered reliable.

In order to make it easier to trigger the workflow via Github UI this event is added: `workflow_dispatch`
You can then run the workflow from the actions tab.
See the docs: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
