### PR TITLE
Change scheduled time and translation script for workflow

### DIFF
--- a/.github/workflows/schedule_auto_merge.yml
+++ b/.github/workflows/schedule_auto_merge.yml
@@ -2,8 +2,8 @@ name: Schedule Auto Merge
 on:
   workflow_dispatch:
   schedule:
-    # At 16:00 UTC (9am PDT) on every day-of-week from Monday through Thursday.
-    - cron: "0 16 * * 1,2,3,4"
+    # At 15:30 UTC (8.30am PDT) on every day-of-week from Monday through Thursday.
+    - cron: "30 15 * * 1,2,3,4"
 
 jobs:
   call_update_translations:

--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Install packages
         run: npm install
 
-      - name: Extract and Compile Translation strings
-        run: npm run compile-strings
+      - name: Extract Translation strings and sync with translation.io
+        run: npm run extract-strings
         env:
           TRANSLATIONIO_KEY_APP: ${{ secrets.TRANSLATIONIO_KEY_APP }}
           TRANSLATIONIO_KEY_SITE: ${{ secrets.TRANSLATIONIO_KEY_SITE }}


### PR DESCRIPTION
## Description

As discussed the **Update Translation** job does not need to run `lingui compile` (=> see [line](https://github.com/KlimaDAO/klimadao/blob/staging/.github/workflows/update_translations.yml#L57))
The script only needs to extract the translations with `npm run extract-strings`

The compile command is done on postinstall on Vercel later.

Also changed the scheduled time to be 30 minutes earlier as Github seems to need ~30 minutes to run a scheduled cron job.

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
