### PR TITLE
Use --overwrite for lingui:extract command

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "start": "next start",
     "export": "next export",
     "lint": "next lint",
-    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean 2>&1 | grep 'Cannot process file'\"; if [ -z \"$(eval $cmd)\" ]; then exit 0; else exit 1; fi",
+    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean --overwrite 2>&1 | grep 'Cannot process file'\"; if [ -z \"$(eval $cmd)\" ]; then exit 0; else exit 1; fi",
     "lingui:compile": "NODE_ENV=test lingui compile",
     "postinstall": "npm run lingui:compile"
   },

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
     "build": "prettier --check . && next build",
     "start": "next start",
     "lint": "next lint",
-    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean 2>&1 | grep 'Cannot process file'\"; if [ -z \"$(eval $cmd)\" ]; then exit 0; else exit 1; fi",
+    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean --overwrite 2>&1 | grep 'Cannot process file'\"; if [ -z \"$(eval $cmd)\" ]; then exit 0; else exit 1; fi",
     "lingui:compile": "NODE_ENV=test lingui compile",
     "postinstall": "npm run lingui:compile"
   },


### PR DESCRIPTION
## Description

Use --overwrite for lingui:extract command

This syncs back the translations made in the code into the `en/messages.po`

## Related Ticket

https://github.com/KlimaDAO/klimadao/issues/157

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
