### PR TITLE
Sync translations on every push to staging

### DIFF
--- a/.github/workflows/push_to_staging.yml
+++ b/.github/workflows/push_to_staging.yml
@@ -1,0 +1,23 @@
+name: On Push to Staging
+on:
+  push:
+    branches:
+      - staging
+    paths-ignore:
+      - ".github/**"
+      # do not trigger again if translations have been pushed from this workflow
+      - "**/locale/**"
+
+jobs:
+  call_update_translations:
+    # ignore pushes from dependabot
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    uses: ./.github/workflows/update_translations.yml
+    with:
+      environment: Translation Sync
+      branch: staging
+    secrets:
+      PUSH_ACTOR_TOKEN: ${{ secrets.PUSH_ACTOR_TOKEN }}
+      PUSH_ACTOR: ${{ secrets.PUSH_ACTOR }}
+      TRANSLATIONIO_KEY_APP: ${{ secrets.TRANSLATIONIO_KEY_APP }}
+      TRANSLATIONIO_KEY_SITE: ${{ secrets.TRANSLATIONIO_KEY_SITE }}

--- a/.github/workflows/schedule_auto_merge.yml
+++ b/.github/workflows/schedule_auto_merge.yml
@@ -9,7 +9,7 @@ jobs:
   call_update_translations:
     uses: ./.github/workflows/update_translations.yml
     with:
-      environment: Release-staging
+      environment: Translation Sync
       branch: staging
     secrets:
       PUSH_ACTOR_TOKEN: ${{ secrets.PUSH_ACTOR_TOKEN }}


### PR DESCRIPTION
## Description

With this new workflow **every merged PR and every other commit** on branch **staging** will trigger "Update Translations".
"Update Translations" checks out staging, installs all dependencies and runs `npm run extract-strings`.

`npm run extract-strings` extracts and syncs (!) all translations with translation.io when running on Github servers.

This will now ensure that if any translations changed/have been added in the repo they will be synced with translation.io immediately.

If no PRs / commits have been pushed to staging during a day => the daily staging release will run "Update Translations" too! Therefore at least once per day the translation are synced with translation.io.
 
## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
