### PR TITLE
Fixes Language button not looking good in light theme on site

### DIFF
--- a/site/components/ChangeLanguageButton/styles.ts
+++ b/site/components/ChangeLanguageButton/styles.ts
@@ -27,6 +27,18 @@ export const changeLanguageButton = css`
   ${breakpoints.medium} {
     top: 10.8rem;
   }
+  &:hover,
+  &:focus {
+    opacity: 0.7;
+  }
+  &:focus {
+    transform: scale(0.9);
+  }
+  &,
+  &:hover,
+  &:visited {
+    color: var(--font-01); /* same in darkmode */
+  }
 `;
 
 export const tooltip = css`
@@ -45,7 +57,7 @@ export const tooltip = css`
 
 export const menuItem = css`
   ${typography.button};
-  color: white !important;
+  color: var(--font-02) !important;
   &:hover {
     color: var(--klima-green) !important;
   }


### PR DESCRIPTION
## Description

Fixes Language Button not looking good in light theme on site

## Related Ticket

https://github.com/KlimaDAO/klimadao/issues/157


## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/63291640/162812655-ca8dc36d-4411-4612-b1c6-b410c37f3db6.png) |![image](https://user-images.githubusercontent.com/63291640/162812541-63e6d2cf-309f-4e5e-848d-792202cb0e91.png)|
-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
