### PR TITLE
Offset tool: Support query parameters

### DIFF
--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -60,6 +60,7 @@ import NBO from "public/icons/NBO.png";
 
 import * as styles from "./styles";
 import { cx } from "@emotion/css";
+import { useOffsetParams } from "lib/hooks/useOffsetParams";
 
 interface ButtonProps {
   label: React.ReactElement | string;
@@ -98,7 +99,7 @@ export const Offset = (props: Props) => {
   const dispatch = useAppDispatch();
   const balances = useSelector(selectBalances);
   const allowances = useSelector(selectCarbonRetiredAllowance);
-
+  const params = useOffsetParams();
   // local state
   const [isRetireTokenModalOpen, setRetireTokenModalOpen] = useState(false);
   const [isInputTokenModalOpen, setInputTokenModalOpen] = useState(false);
@@ -128,6 +129,32 @@ export const Offset = (props: Props) => {
     if (!statusType) return dispatch(setAppState({ notificationStatus: null }));
     dispatch(setAppState({ notificationStatus: { statusType, message } }));
   };
+
+  /** Initialize input from params after they are extracted, validated & stripped */
+  useEffect(() => {
+    if (params?.inputToken) {
+      setSelectedInputToken(params.inputToken);
+    }
+    if (params?.retirementToken) {
+      setSelectedRetirementToken(params.retirementToken);
+    }
+    if (params?.message) {
+      setRetirementMessage(params.message);
+    }
+    if (params?.beneficiary) {
+      setBeneficiary(params.beneficiary);
+    }
+    if (params?.beneficiaryAddress) {
+      setBeneficiaryAddress(params.beneficiaryAddress);
+    }
+    if (params?.projectTokens) {
+      setSpecificAddresses(params.projectTokens);
+    }
+    if (params?.quantity) {
+      setQuantity(params.quantity);
+      setDebouncedQuantity(params.quantity);
+    }
+  }, [params]);
 
   useEffect(() => {
     if (props.isConnected && props.address) {
@@ -649,7 +676,15 @@ const AdvancedTextInput: FC<{
   value: string[];
   onChange: (val: string[]) => void;
 }> = (props) => {
-  const [isOpen, toggleIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const concatValue = props.value.join("");
+
+  /** when query params are loaded we force the toggle open */
+  useEffect(() => {
+    if (!isOpen && concatValue.length > 1) {
+      setIsOpen(true);
+    }
+  }, [concatValue]);
 
   const handleEdit = (i: number) => (e: ChangeEvent<HTMLInputElement>) => {
     const newValue = [
@@ -673,7 +708,7 @@ const AdvancedTextInput: FC<{
     <>
       <button
         onClick={() => {
-          toggleIsOpen((prev) => !prev);
+          setIsOpen((prev) => !prev);
         }}
         className={styles.advancedButton}
       >

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -132,25 +132,25 @@ export const Offset = (props: Props) => {
 
   /** Initialize input from params after they are extracted, validated & stripped */
   useEffect(() => {
-    if (params?.inputToken) {
+    if (params.inputToken) {
       setSelectedInputToken(params.inputToken);
     }
-    if (params?.retirementToken) {
+    if (params.retirementToken) {
       setSelectedRetirementToken(params.retirementToken);
     }
-    if (params?.message) {
+    if (params.message) {
       setRetirementMessage(params.message);
     }
-    if (params?.beneficiary) {
+    if (params.beneficiary) {
       setBeneficiary(params.beneficiary);
     }
-    if (params?.beneficiaryAddress) {
+    if (params.beneficiaryAddress) {
       setBeneficiaryAddress(params.beneficiaryAddress);
     }
-    if (params?.projectTokens) {
+    if (params.projectTokens) {
       setSpecificAddresses(params.projectTokens);
     }
-    if (params?.quantity) {
+    if (params.quantity) {
       setQuantity(params.quantity);
       setDebouncedQuantity(params.quantity);
     }

--- a/app/lib/hooks/useOffsetParams.ts
+++ b/app/lib/hooks/useOffsetParams.ts
@@ -14,7 +14,7 @@ const inputParams = [
   "beneficiary",
   "beneficiaryAddress",
   "message",
-  "projectToken",
+  "projectTokens",
 ] as const;
 
 interface OffsetParams {
@@ -39,8 +39,8 @@ const isValidToken = <T extends readonly string[]>(
  *   ?quantity=123
  *   &inputToken=klima
  *   &retirementToken=mco2
- *   &projectToken=0x1234
- *   &projectToken=0x5678
+ *   &projectTokens=0x1234
+ *   &projectTokens=0x5678
  *   &beneficiary=The%20Devs
  *   &beneficiaryAddress=0x123&message=Thanks%20devs!
  * */
@@ -51,9 +51,9 @@ export const useOffsetParams = (): OffsetParams => {
   useEffect(() => {
     const data: OffsetParams = {};
     inputParams.forEach((param) => {
-      if (param === "projectToken") {
-        // NOTE: input is singular because of how query params work: `projectToken=0x123&projectToken=0x456`
-        data.projectTokens = params.getAll("projectToken") || undefined;
+      if (param === "projectTokens") {
+        const arr = params.getAll("projectTokens");
+        data.projectTokens = arr.length ? arr : undefined;
       } else if (param === "inputToken") {
         const tkn = params.get("inputToken")?.toLowerCase() || undefined;
         data[param] = tkn && isValidToken(tkn, inputTokens) ? tkn : undefined;

--- a/app/lib/hooks/useOffsetParams.ts
+++ b/app/lib/hooks/useOffsetParams.ts
@@ -27,18 +27,11 @@ interface OffsetParams {
   projectTokens?: string[];
 }
 
-/** Type guard */
-const isValidInputToken = (str: string | undefined): str is InputToken => {
-  if (typeof str === "undefined") return true;
-  return !!inputTokens.includes(str.toLocaleLowerCase() as InputToken);
-};
-/** Type guard */
-const isValidRetirementToken = (
-  str: string | undefined
-): str is RetirementToken => {
-  if (typeof str === "undefined") return true;
-  return !!retirementTokens.includes(str.toLowerCase() as RetirementToken);
-};
+/** Type guard to correctly infer the typed string e.g. "mco2" | "bct" */
+const isValidToken = <T extends readonly string[]>(
+  str: string,
+  arr: T
+): str is T[number] => arr.includes(str);
 
 /**
  * For the Offset view in the app. On mount, validates, extracts and strips the search params from the url and returns them as a typed object.
@@ -63,10 +56,11 @@ export const useOffsetParams = (): OffsetParams => {
         data.projectTokens = params.getAll("projectToken") || undefined;
       } else if (param === "inputToken") {
         const tkn = params.get("inputToken")?.toLowerCase() || undefined;
-        data[param] = isValidInputToken(tkn) ? tkn : undefined;
+        data[param] = tkn && isValidToken(tkn, inputTokens) ? tkn : undefined;
       } else if (param === "retirementToken") {
         const tkn = params.get("retirementToken")?.toLowerCase() || undefined;
-        data[param] = isValidRetirementToken(tkn) ? tkn : undefined;
+        data[param] =
+          tkn && isValidToken(tkn, retirementTokens) ? tkn : undefined;
       } else {
         data[param] = params.get(param) || undefined;
       }

--- a/app/lib/hooks/useOffsetParams.ts
+++ b/app/lib/hooks/useOffsetParams.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  InputToken,
+  inputTokens,
+  RetirementToken,
+  retirementTokens,
+} from "@klimadao/lib/constants";
+
+const inputParams = [
+  "quantity",
+  "inputToken",
+  "retirementToken",
+  "beneficiary",
+  "beneficiaryAddress",
+  "message",
+  "projectToken",
+] as const;
+
+interface OffsetParams {
+  quantity?: string;
+  inputToken?: InputToken;
+  retirementToken?: RetirementToken;
+  beneficiary?: string;
+  beneficiaryAddress?: string;
+  message?: string;
+  projectTokens?: string[];
+}
+
+/** Type guard */
+const isValidInputToken = (str: string | undefined): str is InputToken => {
+  if (typeof str === "undefined") return true;
+  return !!inputTokens.includes(str.toLocaleLowerCase() as InputToken);
+};
+/** Type guard */
+const isValidRetirementToken = (
+  str: string | undefined
+): str is RetirementToken => {
+  if (typeof str === "undefined") return true;
+  return !!retirementTokens.includes(str.toLowerCase() as RetirementToken);
+};
+
+/**
+ * For the Offset view in the app. On mount, validates, extracts and strips the search params from the url and returns them as a typed object.
+ * @example http://app.klimadao.finance/#/offset
+ *   ?quantity=123
+ *   &inputToken=klima
+ *   &retirementToken=mco2
+ *   &projectToken=0x1234
+ *   &projectToken=0x5678
+ *   &beneficiary=The%20Devs
+ *   &beneficiaryAddress=0x123&message=Thanks%20devs!
+ * */
+export const useOffsetParams = (): OffsetParams | undefined => {
+  const [params, setParams] = useSearchParams();
+  const [state, setState] = useState<OffsetParams>();
+
+  useEffect(() => {
+    const data: OffsetParams = {};
+    inputParams.forEach((param) => {
+      if (param === "projectToken") {
+        // NOTE: input is singular because of how query params work: `projectToken=0x123&projectToken=0x456`
+        data.projectTokens = params.getAll("projectToken") || undefined;
+      } else if (param === "inputToken") {
+        const tkn = params.get("inputToken")?.toLowerCase() || undefined;
+        data[param] = isValidInputToken(tkn) ? tkn : undefined;
+      } else if (param === "retirementToken") {
+        const tkn = params.get("retirementToken")?.toLowerCase() || undefined;
+        data[param] = isValidRetirementToken(tkn) ? tkn : undefined;
+      } else {
+        data[param] = params.get(param) || undefined;
+      }
+    });
+    setState(data);
+    setParams({});
+  }, []);
+  return state;
+};

--- a/app/lib/hooks/useOffsetParams.ts
+++ b/app/lib/hooks/useOffsetParams.ts
@@ -51,9 +51,9 @@ const isValidRetirementToken = (
  *   &beneficiary=The%20Devs
  *   &beneficiaryAddress=0x123&message=Thanks%20devs!
  * */
-export const useOffsetParams = (): OffsetParams | undefined => {
+export const useOffsetParams = (): OffsetParams => {
   const [params, setParams] = useSearchParams();
-  const [state, setState] = useState<OffsetParams>();
+  const [state, setState] = useState<OffsetParams>({});
 
   useEffect(() => {
     const data: OffsetParams = {};

--- a/app/lib/hooks/useOffsetParams.ts
+++ b/app/lib/hooks/useOffsetParams.ts
@@ -65,7 +65,9 @@ export const useOffsetParams = (): OffsetParams => {
         data[param] = params.get(param) || undefined;
       }
     });
+    // set state to trigger re-render in parent component
     setState(data);
+    // strip the params from the browser url
     setParams({});
   }, []);
   return state;

--- a/app/lib/hooks/useOffsetParams.ts
+++ b/app/lib/hooks/useOffsetParams.ts
@@ -65,10 +65,15 @@ export const useOffsetParams = (): OffsetParams => {
         data[param] = params.get(param) || undefined;
       }
     });
+
     // set state to trigger re-render in parent component
     setState(data);
     // strip the params from the browser url
-    setParams({});
+    const strippedParams = Object.fromEntries(params.entries());
+    for (const key of inputParams) {
+      delete strippedParams[key];
+    }
+    setParams(strippedParams);
   }, []);
   return state;
 };


### PR DESCRIPTION
## Description

You can pre-fill the app offset tool using URL search parameters. This is useful for connecting your carbon calculator or other third-party app.

Every field can be pre-filled, including selective retirement.

```ts
  quantity, // 1.23
  inputToken, // "bct" | "nct" | "mco2" | "usdc" | "klima" | "sklima" | "wsklima";
  retirementToken, // "bct" | "nct" | "mco2";
  beneficiary, // John Doe
  beneficiaryAddress, // 0x12345678912345678912345678912345678912345
  message, // Hello world
  projectTokens  // 0x12345678912345678912345678912345678912345
```
You can provide multiple arguments for `projectToken` and these will be automatically filled into the selective retirement fields (and the 'advanced' dropdown will open itself to reveal them)

Example URL with all fields filled, and 2 selective project tokens:
```
http://app.klimadao.finance/#/offset
  ?quantity=123
  &inputToken=klima
  &retirementToken=mco2
  &projectTokens=0x1234
  &projectTokens=0x5678
  &beneficiary=The%20Devs
  &beneficiaryAddress=0x123&message=Thanks%20devs!
```
Resolves #291 

## Checklist
- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
