### PR TITLE
Add German Translation

### DIFF
--- a/app/components/ChangeLanguageButton/index.tsx
+++ b/app/components/ChangeLanguageButton/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import Tippy from "@tippyjs/react";
 import { t } from "@lingui/macro";
 import Language from "@mui/icons-material/Language";
+import { IS_PRODUCTION } from "lib/constants";
 
 import { activate, locales } from "lib/i18n";
 import { selectAppState } from "state/selectors";
@@ -29,11 +30,16 @@ export const ChangeLanguageButton: FC = () => {
     setShowMenu(false);
   };
 
-  const labels = {
-    en: "English",
-    fr: "Français",
-    "en-pseudo": "Pseudo",
+  const labels: { [key: string]: string } = {
+    en: t`English`,
+    fr: t`French`,
+    de: t`German`,
   };
+
+  // enable 'pseudo' locale only for Staging environment
+  if (!IS_PRODUCTION) {
+    labels["en-pseudo"] = "Pseudo";
+  }
 
   const content = (
     <div>

--- a/app/components/ChangeLanguageButton/styles.ts
+++ b/app/components/ChangeLanguageButton/styles.ts
@@ -29,7 +29,11 @@ export const tooltip = css`
 
 export const menuItem = css`
   ${typography.button};
+  padding: 0.5rem 0;
   &:hover {
+    color: var(--klima-green);
+  }
+  &[data-active="true"] {
     color: var(--klima-green);
   }
 `;

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { i18n } from "@lingui/core";
-import { en, fr } from "make-plural/plurals";
+import { en, fr, de } from "make-plural/plurals";
 import { prettifySeconds as prettifySecondsLib } from "@klimadao/lib/utils";
 import { IS_PRODUCTION } from "lib/constants";
 
@@ -18,6 +18,7 @@ interface ILocales {
 const locales: ILocales = {
   en: { plurals: en, time: "en-US" },
   fr: { plurals: fr, time: "fr-FR" },
+  de: { plurals: de, time: "de-DE" },
 };
 
 // Add pseudo locale only in development

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -1,7 +1,7 @@
 import { i18n } from "@lingui/core";
 import { en, fr, de } from "make-plural/plurals";
 import { prettifySeconds as prettifySecondsLib } from "@klimadao/lib/utils";
-import { IS_PRODUCTION } from "lib/constants";
+import { IS_PRODUCTION, IS_LOCAL_DEVELOPMENT } from "lib/constants";
 
 // TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
 
@@ -31,8 +31,23 @@ for (const key in locales) {
   const locale = locales[key];
   i18n.loadLocaleData(key, { plurals: locale.plurals });
 }
+
+/**
+ * Loads a translation file
+ */
+async function loadTranslation(locale = "en") {
+  let data;
+  if (IS_LOCAL_DEVELOPMENT) {
+    // dynamic loading in dev https://lingui.js.org/ref/loader.html
+    data = await import(`@lingui/loader!../locale/${locale}/messages.po`);
+  } else {
+    data = await import(`../locale/${locale}/messages`);
+  }
+  return data.messages;
+}
+
 async function load(locale: string) {
-  const { messages } = await import(`../locale/${locale}/messages.js`);
+  const messages = await loadTranslation(locale);
   i18n.load(locale, messages);
   i18n.activate(locale);
 }

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -19,6 +19,7 @@ export const ChangeLanguageButton: FC = () => {
   const labels = {
     en: "English",
     fr: "Français",
+    de: "Deutsch",
     "en-pseudo": "Pseudo",
   };
 

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Tippy from "@tippyjs/react";
 import { t } from "@lingui/macro";
 import Language from "@mui/icons-material/Language";
-
+import { IS_PRODUCTION } from "lib/constants";
 import { locales } from "lib/i18n";
 
 import * as styles from "./styles";
@@ -21,6 +21,11 @@ export const ChangeLanguageButton: FC = () => {
     fr: t`French`,
     de: t`German`,
   };
+
+  // enable 'pseudo' locale only for Staging environment
+  if (!IS_PRODUCTION) {
+    labels["en-pseudo"] = "Pseudo";
+  }
 
   const content = (
     <div className={styles.menuItemContainer}>

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -16,11 +16,10 @@ export const ChangeLanguageButton: FC = () => {
   const [showMenu, setShowMenu] = useState(false);
   const { locale } = useRouter();
 
-  const labels = {
-    en: "English",
-    fr: "Français",
-    de: "Deutsch",
-    "en-pseudo": "Pseudo",
+  const labels: { [key: string]: string } = {
+    en: t`English`,
+    fr: t`French`,
+    de: t`German`,
   };
 
   const content = (

--- a/site/components/ChangeLanguageButton/styles.ts
+++ b/site/components/ChangeLanguageButton/styles.ts
@@ -61,6 +61,9 @@ export const menuItem = css`
   &:hover {
     color: var(--klima-green) !important;
   }
+  &[data-active="true"] {
+    color: var(--klima-green) !important;
+  }
 `;
 
 export const menuItemContainer = css`

--- a/site/lib/i18n.ts
+++ b/site/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { i18n } from "@lingui/core";
-import { en, fr } from "make-plural/plurals";
+import { en, fr, de } from "make-plural/plurals";
 import { IS_LOCAL_DEVELOPMENT, IS_PRODUCTION } from "lib/constants";
 
 // TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
@@ -16,6 +16,7 @@ interface ILocales {
 const locales: ILocales = {
   en: { plurals: en, time: "en-US" },
   fr: { plurals: fr, time: "fr-FR" },
+  de: { plurals: de, time: "de-DE" },
 };
 // Add pseudo locale only in development
 if (!IS_PRODUCTION) {

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 
-module.exports = {
+const IS_PRODUCTION = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+
+const nextConfig = {
   reactStrictMode: true,
   async redirects() {
     return [
@@ -80,3 +82,12 @@ module.exports = {
     domains: ["cdn.sanity.io"],
   },
 };
+
+if (!IS_PRODUCTION) {
+  nextConfig.i18n = {
+    ...nextConfig.i18n,
+    locales: ["en", "en-pseudo", "fr", "de"],
+  };
+}
+
+module.exports = nextConfig;

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -88,6 +88,7 @@ if (!IS_PRODUCTION) {
   nextConfig.i18n = {
     ...nextConfig.i18n,
     locales: ["en", "en-pseudo", "fr", "de"],
+    localeDetection: true,
   };
 }
 

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -77,6 +77,7 @@ const nextConfig = {
   i18n: {
     locales: ["en"],
     defaultLocale: "en",
+    localeDetection: false,
   },
   images: {
     domains: ["cdn.sanity.io"],

--- a/site/pages/_document.tsx
+++ b/site/pages/_document.tsx
@@ -7,7 +7,7 @@ import { WebFonts, InitializeTheme } from "@klimadao/lib/components";
 class MyDocument extends Document {
   render() {
     return (
-      <Html lang="en" className="theme-light">
+      <Html className="theme-light">
         <Head>
           <WebFonts />
         </Head>


### PR DESCRIPTION
## Description

This PR adds german to both site and app.

It also includes minor refactorings:
- re-enable translations on Site again for NextJS (FOR STAGING ONLY)
- autodetect locale for Site (FOR STAGING ONLY)
- load PO files if on development in App (Site does the same, better developer experience for local testing)
- ensure Pseudo is only shown when not on production
- Make Menu translatable
- Highlight current active locale in Menu
- Better Styles for Menu in App
- Let NextJS set the HTML language tag by itself

## Related Ticket

Part of https://github.com/KlimaDAO/klimadao/issues/157

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
