### PR TITLE
Format numbers in current active locale

### DIFF
--- a/app/components/BalancesCard/index.tsx
+++ b/app/components/BalancesCard/index.tsx
@@ -3,7 +3,7 @@ import AccountBalanceOutlined from "@mui/icons-material/AccountBalanceOutlined";
 import { trimWithPlaceholder } from "@klimadao/lib/utils";
 import { useSelector } from "react-redux";
 import { InfoButton } from "components/InfoButton";
-import { selectBalances } from "state/selectors";
+import { selectBalances, selectLocale } from "state/selectors";
 import * as styles from "./styles";
 import { FC } from "react";
 import { RootState } from "state";
@@ -19,6 +19,8 @@ interface Props {
 
 export const BalancesCard: FC<Props> = (props) => {
   const balances = useSelector(selectBalances);
+  const locale = useSelector(selectLocale);
+
   const labels: AssetLabels = {
     bct: "BCT",
     aklima: "aKLIMA",
@@ -46,7 +48,7 @@ export const BalancesCard: FC<Props> = (props) => {
         {props.assets.map((asset) => (
           <div className="stack" key={asset}>
             <Text className="value">
-              {trimWithPlaceholder(balances?.[asset] ?? 0, 9)}
+              {trimWithPlaceholder(balances?.[asset] ?? 0, 9, locale)}
             </Text>
             <Text className="label" color="lightest">
               {labels[asset]}

--- a/app/components/BondBalancesCard/index.tsx
+++ b/app/components/BondBalancesCard/index.tsx
@@ -2,6 +2,7 @@ import { Text } from "@klimadao/lib/components";
 import AccountBalanceOutlined from "@mui/icons-material/AccountBalanceOutlined";
 import { trimWithPlaceholder } from "@klimadao/lib/utils";
 import { useSelector } from "react-redux";
+import { selectLocale } from "state/selectors";
 import * as styles from "./styles";
 import { FC } from "react";
 import { RootState } from "state";
@@ -16,6 +17,7 @@ interface Props {
 export const BondBalancesCard: FC<Props> = (props) => {
   const { name } = useBond(props.bond);
   const bondState = useSelector((state: RootState) => state.bonds[props.bond]);
+  const locale = useSelector(selectLocale);
 
   return (
     <div className={styles.card + " " + status}>
@@ -30,7 +32,7 @@ export const BondBalancesCard: FC<Props> = (props) => {
       <div className="cardContent">
         <div className="stack">
           <Text className="value">
-            {trimWithPlaceholder(bondState?.balance ?? 0, 9)}
+            {trimWithPlaceholder(bondState?.balance ?? 0, 9, locale)}
           </Text>
           <Text className="label" color="lightest">
             {name}
@@ -40,7 +42,8 @@ export const BondBalancesCard: FC<Props> = (props) => {
           <Text className="value">
             {trimWithPlaceholder(
               bondState?.pendingPayout ?? 0,
-              Number(bondState?.pendingPayout) < 1 ? 5 : 2
+              Number(bondState?.pendingPayout) < 1 ? 5 : 2,
+              locale
             )}
           </Text>
           <Text className="label" color="lightest">

--- a/app/components/RebaseCard/index.tsx
+++ b/app/components/RebaseCard/index.tsx
@@ -2,7 +2,7 @@ import { Text } from "@klimadao/lib/components";
 import Sync from "@mui/icons-material/Sync";
 import { useSelector } from "react-redux";
 import { InfoButton } from "components/InfoButton";
-import { selectAppState, selectBalances } from "state/selectors";
+import { selectAppState, selectBalances, selectLocale } from "state/selectors";
 import * as styles from "./styles";
 import { secondsUntilBlock, trimWithPlaceholder } from "@klimadao/lib/utils";
 import { FC } from "react";
@@ -14,6 +14,7 @@ interface Props {
 
 export const RebaseCard: FC<Props> = (props) => {
   const balances = useSelector(selectBalances);
+  const locale = useSelector(selectLocale);
   const { stakingRebase, currentBlock, rebaseBlock, blockRate } =
     useSelector(selectAppState);
   const nextRebasePercent = stakingRebase ? stakingRebase * 100 : 0;
@@ -62,7 +63,7 @@ export const RebaseCard: FC<Props> = (props) => {
         <div className="stack">
           <Text className="value">
             {stakingRebase ? (
-              `${trimWithPlaceholder(nextRebasePercent, 2)}%`
+              `${trimWithPlaceholder(nextRebasePercent, 2, locale)}%`
             ) : (
               <Trans id="shared.loading">Loading...</Trans>
             )}
@@ -74,7 +75,7 @@ export const RebaseCard: FC<Props> = (props) => {
         {props.isConnected && (
           <div className="stack">
             <Text className="value">
-              {trimWithPlaceholder(nextRebaseValue, 6)}
+              {trimWithPlaceholder(nextRebaseValue, 6, locale)}
             </Text>
             <Text className="label" color="lightest">
               <Trans id="stake.estimated_payout">Est. payout (sKLIMA)</Trans>

--- a/app/components/RebaseCard/index.tsx
+++ b/app/components/RebaseCard/index.tsx
@@ -27,7 +27,7 @@ export const RebaseCard: FC<Props> = (props) => {
     if (currentBlock && rebaseBlock) {
       const seconds = secondsUntilBlock(currentBlock, rebaseBlock, blockRate);
       // if less than 1 hour remaining, return minutes
-      const rtf = new Intl.RelativeTimeFormat("en");
+      const rtf = new Intl.RelativeTimeFormat(locale);
       if (seconds < 3600) {
         return rtf.format(Math.floor(seconds / 60), "minutes");
       } else {

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "actions/bonds";
 
 import { Trans, t } from "@lingui/macro";
-import { prettifySeconds } from "lib/i18n";
+import { prettifySeconds } from "@klimadao/lib/utils";
 
 import { useBond } from "../ChooseBond";
 import { Bond as BondType } from "@klimadao/lib/constants";
@@ -46,7 +46,7 @@ import { Image } from "components/Image";
 import { ImageCard } from "components/ImageCard";
 
 export function prettyVestingPeriod(
-  locale: string | undefined,
+  locale: string,
   currentBlock: number,
   vestingBlock: number,
   blockRate: number
@@ -59,7 +59,7 @@ export function prettyVestingPeriod(
   if (seconds < 0) {
     return "Fully Vested";
   }
-  return prettifySeconds(seconds);
+  return prettifySeconds(seconds, locale);
 }
 
 interface DataRowProps {
@@ -145,7 +145,7 @@ export const Bond: FC<Props> = (props) => {
     if (!bondState || !currentBlock || !bondState.vestingTerm) return;
     const vestingBlock = currentBlock + bondState.vestingTerm;
     const seconds = secondsUntilBlock(currentBlock, vestingBlock, blockRate);
-    return prettifySeconds(seconds);
+    return prettifySeconds(seconds, locale);
   };
 
   const vestingTime = () => {

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import LeftOutlined from "@mui/icons-material/KeyboardArrowLeftRounded";
 import { Link } from "react-router-dom";
 import { setAppState, AppNotificationStatus, TxnStatus } from "state/app";
-import { selectNotificationStatus } from "state/selectors";
+import { selectNotificationStatus, selectLocale } from "state/selectors";
 import { TippyProps } from "@tippyjs/react";
 import {
   changeApprovalTransaction,
@@ -108,6 +108,7 @@ interface Props {
 }
 
 export const Bond: FC<Props> = (props) => {
+  const locale = useSelector(selectLocale);
   const bondInfo = useBond(props.bond);
 
   const fullStatus: AppNotificationStatus | null = useSelector(
@@ -126,7 +127,7 @@ export const Bond: FC<Props> = (props) => {
   const [quantity, setQuantity] = useState("");
   const debouncedQuantity = useDebounce(quantity, 500);
 
-  const { currentBlock, locale, blockRate } = useSelector(selectAppState);
+  const { currentBlock, blockRate } = useSelector(selectAppState);
   const bondState = useSelector((state: RootState) => state.bonds[props.bond]);
   const allowance = useSelector(selectBondAllowance);
 
@@ -491,7 +492,8 @@ export const Bond: FC<Props> = (props) => {
                     ? 0
                     : trimWithPlaceholder(
                         bondState?.balance,
-                        Number(bondState?.balance) < 1 ? 18 : 2
+                        Number(bondState?.balance) < 1 ? 18 : 2,
+                        locale
                       )
                 }
                 warning={Number(quantity) > Number(bondState?.balance)}
@@ -509,7 +511,7 @@ export const Bond: FC<Props> = (props) => {
                   comment: "Long sentence",
                 })}
                 unit={bondInfo.priceUnit}
-                value={trimWithPlaceholder(bondState?.bondPrice, 2)}
+                value={trimWithPlaceholder(bondState?.bondPrice, 2, locale)}
                 warning={false}
               />
               <DataRow
@@ -525,7 +527,7 @@ export const Bond: FC<Props> = (props) => {
                   comment: "Long sentence",
                 })}
                 unit={bondInfo.priceUnit}
-                value={trimWithPlaceholder(bondState?.marketPrice, 2)}
+                value={trimWithPlaceholder(bondState?.marketPrice, 2, locale)}
                 warning={false}
               />
               <DataRow
@@ -541,7 +543,7 @@ export const Bond: FC<Props> = (props) => {
                   comment: "Long sentence",
                 })}
                 unit={"%"}
-                value={trimWithPlaceholder(bondState?.bondDiscount, 2)}
+                value={trimWithPlaceholder(bondState?.bondDiscount, 2, locale)}
                 warning={isBondDiscountNegative}
               />
               <DataRow
@@ -562,7 +564,8 @@ export const Bond: FC<Props> = (props) => {
                     ? 0
                     : trimWithPlaceholder(
                         isLoading ? NaN : bondState?.bondQuote,
-                        Number(bondState?.bondQuote) < 1 ? 5 : 2
+                        Number(bondState?.bondQuote) < 1 ? 5 : 2,
+                        locale
                       )
                 }
                 warning={false}
@@ -583,7 +586,7 @@ export const Bond: FC<Props> = (props) => {
                   !!bondState?.maxBondPrice &&
                   Number(bondState?.bondQuote) > Number(bondState?.maxBondPrice)
                 }
-                value={trimWithPlaceholder(bondState?.maxBondPrice, 2)}
+                value={trimWithPlaceholder(bondState?.maxBondPrice, 2, locale)}
                 unit="KLIMA"
               />
               <DataRow
@@ -599,7 +602,11 @@ export const Bond: FC<Props> = (props) => {
                   comment: "Long sentence",
                 })}
                 warning={false}
-                value={trimWithPlaceholder(Number(bondState?.debtRatio), 2)}
+                value={trimWithPlaceholder(
+                  Number(bondState?.debtRatio),
+                  2,
+                  locale
+                )}
                 unit="%"
               />
               <DataRow
@@ -646,7 +653,7 @@ export const Bond: FC<Props> = (props) => {
                     placeholder="NOT CONNECTED"
                   >
                     <span>
-                      {trimWithPlaceholder(bondState?.interestDue, 4)}
+                      {trimWithPlaceholder(bondState?.interestDue, 4, locale)}
                     </span>{" "}
                     KLIMA
                   </WithPlaceholder>
@@ -677,7 +684,8 @@ export const Bond: FC<Props> = (props) => {
                     <span>
                       {trimWithPlaceholder(
                         bondState?.pendingPayout,
-                        Number(bondState?.pendingPayout) < 1 ? 5 : 2
+                        Number(bondState?.pendingPayout) < 1 ? 5 : 2,
+                        locale
                       )}
                     </span>{" "}
                     KLIMA

--- a/app/components/views/ChooseBond/index.tsx
+++ b/app/components/views/ChooseBond/index.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
 import React from "react";
 import { RootState } from "state";
-import { selectAppState } from "state/selectors";
+import { selectAppState, selectLocale } from "state/selectors";
 import { Bond } from "@klimadao/lib/constants";
 import { trimWithPlaceholder } from "@klimadao/lib/utils";
 import { ImageCard } from "components/ImageCard";
@@ -112,6 +112,8 @@ export const useBond = (bond: Bond) => {
 };
 
 export function ChooseBond() {
+  const locale = useSelector(selectLocale);
+
   const bct = useBond("bct");
   const klimaBctLp = useBond("klima_bct_lp");
   const bctUsdcLp = useBond("bct_usdc_lp");
@@ -149,7 +151,7 @@ export function ChooseBond() {
               <Trans id="choose_bond.treasury_balance">Treasury Balance</Trans>
             </Text>
             <Text>
-              {trimWithPlaceholder(treasuryBalance, 0)}
+              {trimWithPlaceholder(treasuryBalance, 0, locale)}
               {treasuryBalance ? " T CO2" : ""}
             </Text>
           </div>
@@ -189,7 +191,7 @@ export function ChooseBond() {
                       className={styles.bondDiscount}
                       data-hide={!bond?.discount || bond.discount < 0}
                     >
-                      {trimWithPlaceholder(bond?.discount, 2)}
+                      {trimWithPlaceholder(bond?.discount, 2, locale)}
                       {bond.discount ? "%" : ""}
                     </Text>
                   )}

--- a/app/components/views/PKlima/index.tsx
+++ b/app/components/views/PKlima/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { providers } from "ethers";
 
-import { selectNotificationStatus } from "state/selectors";
+import { selectNotificationStatus, selectLocale } from "state/selectors";
 import { setAppState, AppNotificationStatus, TxnStatus } from "state/app";
 
 import {
@@ -56,6 +56,7 @@ export const PKlima: FC<Props> = (props) => {
 
   const [quantity, setQuantity] = useState("");
 
+  const locale = useSelector(selectLocale);
   const { currentIndex } = useSelector(selectAppState);
   const allowances = useSelector(selectExerciseAllowance);
   const terms = useSelector(selectPklimaTerms);
@@ -263,17 +264,17 @@ export const PKlima: FC<Props> = (props) => {
             </div>
             <div className={styles.infoTable_value}>
               {terms?.supplyShare
-                ? trimWithPlaceholder(terms?.supplyShare, 2) + "%"
+                ? trimWithPlaceholder(terms?.supplyShare, 2, locale) + "%"
                 : "loading..."}
             </div>
             <div className={styles.infoTable_value}>
               {terms?.claimed
-                ? trimWithPlaceholder(terms?.claimed, 4) + " KLIMA"
+                ? trimWithPlaceholder(terms?.claimed, 4, locale) + " KLIMA"
                 : "loading..."}
             </div>
             <div className={styles.infoTable_value}>
               {indexAdjustedClaim
-                ? trimWithPlaceholder(indexAdjustedClaim, 4) + " KLIMA"
+                ? trimWithPlaceholder(indexAdjustedClaim, 4, locale) + " KLIMA"
                 : "loading..."}
             </div>
           </div>

--- a/app/components/views/Stake/index.tsx
+++ b/app/components/views/Stake/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { providers } from "ethers";
-import { selectNotificationStatus } from "state/selectors";
+import { selectNotificationStatus, selectLocale } from "state/selectors";
 import { setAppState, AppNotificationStatus, TxnStatus } from "state/app";
 import InfoOutlined from "@mui/icons-material/InfoOutlined";
 import LibraryAddOutlined from "@mui/icons-material/LibraryAddOutlined";
@@ -46,6 +46,8 @@ interface Props {
 }
 
 export const Stake = (props: Props) => {
+  const locale = useSelector(selectLocale);
+
   const dispatch = useAppDispatch();
   const [view, setView] = useState("stake");
   const fullStatus: AppNotificationStatus | null = useSelector(
@@ -339,21 +341,21 @@ export const Stake = (props: Props) => {
             </div>
             <div className={styles.infoTable_value}>
               {fiveDayRatePercent ? (
-                trimWithPlaceholder(fiveDayRatePercent, 2) + "%"
+                trimWithPlaceholder(fiveDayRatePercent, 2, locale) + "%"
               ) : (
                 <Trans id="shared.loading">Loading...</Trans>
               )}
             </div>
             <div className={styles.infoTable_value}>
               {stakingAKR ? (
-                trimWithPlaceholder(stakingAKR, 0) + "%"
+                trimWithPlaceholder(stakingAKR, 0, locale) + "%"
               ) : (
                 <Trans id="shared.loading">Loading...</Trans>
               )}
             </div>
             <div className={styles.infoTable_value}>
               {currentIndex ? (
-                trimWithPlaceholder(currentIndex, 2) + " sKLIMA"
+                trimWithPlaceholder(currentIndex, 2, locale) + " sKLIMA"
               ) : (
                 <Trans id="shared.loading">Loading...</Trans>
               )}

--- a/app/components/views/Wrap/index.tsx
+++ b/app/components/views/Wrap/index.tsx
@@ -5,7 +5,7 @@ import InfoOutlined from "@mui/icons-material/InfoOutlined";
 import FlipOutlined from "@mui/icons-material/FlipOutlined";
 
 import { changeApprovalTransaction, wrapTransaction } from "actions/wrap";
-import { selectNotificationStatus } from "state/selectors";
+import { selectNotificationStatus, selectLocale } from "state/selectors";
 import { setAppState, AppNotificationStatus, TxnStatus } from "state/app";
 
 import {
@@ -35,6 +35,8 @@ interface Props {
 }
 
 export const Wrap: FC<Props> = (props) => {
+  const locale = useSelector(selectLocale);
+
   const dispatch = useAppDispatch();
   const fullStatus: AppNotificationStatus | null = useSelector(
     selectNotificationStatus
@@ -272,13 +274,15 @@ export const Wrap: FC<Props> = (props) => {
             </div>
             <div className={styles.infoTable_value}>
               {currentIndex
-                ? trimWithPlaceholder(currentIndex, 2)
+                ? trimWithPlaceholder(currentIndex, 2, locale)
                 : "loading..."}
             </div>
             <div className={styles.infoTable_value}>
               {view === "wrap"
-                ? trimWithPlaceholder(balances?.sklima ?? 0, 6) + " sKLIMA"
-                : trimWithPlaceholder(balances?.wsklima ?? 0, 6) + " wsKLIMA"}
+                ? trimWithPlaceholder(balances?.sklima ?? 0, 6, locale) +
+                  " sKLIMA"
+                : trimWithPlaceholder(balances?.wsklima ?? 0, 6, locale) +
+                  " wsKLIMA"}
             </div>
             <div className={styles.infoTable_value}>{youWillGet()}</div>
           </div>

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -1,6 +1,5 @@
 import { i18n } from "@lingui/core";
 import { en, fr, de } from "make-plural/plurals";
-import { prettifySeconds as prettifySecondsLib } from "@klimadao/lib/utils";
 import { IS_PRODUCTION, IS_LOCAL_DEVELOPMENT } from "lib/constants";
 
 // TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
@@ -72,12 +71,4 @@ async function init() {
   return locale;
 }
 
-/**
- * Localizes an amount of seconds
- * TODO: revert temp fix and pass locale back down to prettify
- */
-function prettifySeconds(seconds: number) {
-  return prettifySecondsLib(seconds);
-}
-
-export { locales, activate, init, prettifySeconds };
+export { locales, activate, init };

--- a/app/state/selectors/index.ts
+++ b/app/state/selectors/index.ts
@@ -41,3 +41,7 @@ export const selectNotificationStatus = createSelector(
   selectAppState,
   (rootState) => rootState.notificationStatus
 );
+export const selectLocale = createSelector(
+  selectAppState,
+  (rootState) => rootState.locale || "en"
+);

--- a/lib/utils/prettifySeconds/index.ts
+++ b/lib/utils/prettifySeconds/index.ts
@@ -1,10 +1,10 @@
 /*
  * Transforms seconds into a localized and readable format.
  */
-export function prettifySeconds(seconds: number) {
+export function prettifySeconds(seconds: number, locale: string) {
   const then = new Date();
   then.setSeconds(then.getSeconds() + seconds);
-  return then.toLocaleString("en", {
+  return then.toLocaleString(locale, {
     timeStyle: "short",
     dateStyle: "short",
   });

--- a/lib/utils/trimWithPlaceholder/index.ts
+++ b/lib/utils/trimWithPlaceholder/index.ts
@@ -1,12 +1,13 @@
 /** Returns localized string, or falls back to "loading..." if no number provided */
 export const trimWithPlaceholder = (
   number: string | number | undefined,
-  precision: number
+  precision: number,
+  locale: string
 ) => {
   if (typeof number === "undefined" || Number.isNaN(number)) {
     return "Loading... ";
   }
-  return Number(number).toLocaleString("en", {
+  return Number(number).toLocaleString(locale, {
     maximumFractionDigits: precision,
   });
 };

--- a/site/components/pages/Home/index.tsx
+++ b/site/components/pages/Home/index.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from "react";
 import { NextPage } from "next";
+import { useRouter } from "next/router";
 import Image from "next/image";
 import Link from "next/link";
 import { Trans, t } from "@lingui/macro";
@@ -37,16 +38,18 @@ const passengerVehiclesPerTonne = 1 / 4.6;
 const litersGasPerTonne = 1 / 0.03368173;
 
 export const Home: NextPage<Props> = (props) => {
-  const formattedTreasuryBalance = props.treasuryBalance.toLocaleString();
+  const { locale } = useRouter();
+
+  const formattedTreasuryBalance = props.treasuryBalance.toLocaleString(locale);
   const hectaresForest = Math.floor(
     props.treasuryBalance * hectaresForestPerTonne
-  ).toLocaleString();
+  ).toLocaleString(locale);
   const passengerVehicles = Math.floor(
     props.treasuryBalance * passengerVehiclesPerTonne
-  ).toLocaleString();
+  ).toLocaleString(locale);
   const litersGas = Math.floor(
     props.treasuryBalance * litersGasPerTonne
-  ).toLocaleString();
+  ).toLocaleString(locale);
 
   const scrollToRef = useRef<null | HTMLDivElement>(null);
   const scrollToNextSection = () =>


### PR DESCRIPTION
## Description

This PR passes the current active locale to:
- toLocaleString
- trimWithPlaceholder
- Intl.RelativeTimeFormat
- prettifySeconds

**Please check the formatting for "en".**
=> All numbers changed from 8.888.88,88 to 8,888,88.88 (from points to commas) which seems to be the official formatting scheme for US and UK.


## Ticket
Part of https://github.com/KlimaDAO/klimadao/issues/157

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
