### PR TITLE
Fix Site Language Toggle, Fix Chinese Set-Up

### DIFF
--- a/app/components/ChangeLanguageButton/index.tsx
+++ b/app/components/ChangeLanguageButton/index.tsx
@@ -35,7 +35,7 @@ export const ChangeLanguageButton: FC = () => {
     fr: "Français",
     de: "Deutsch",
     ru: "Русский",
-    zh: "中文",
+    "zh-CN": "中文",
   };
 
   // enable 'pseudo' locale only for Staging environment

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -19,7 +19,7 @@ const locales: ILocales = {
   fr: { plurals: fr, time: "fr-FR" },
   de: { plurals: de, time: "de-DE" },
   ru: { plurals: ru, time: "ru-RU" },
-  zh: { plurals: zh, time: "zh-CN" },
+  "zh-CN": { plurals: zh, time: "zh-CN" },
 };
 
 // Add pseudo locale only in development

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -17,9 +17,11 @@ export const ChangeLanguageButton: FC = () => {
   const { locale } = useRouter();
 
   const labels: { [key: string]: string } = {
-    en: t`English`,
-    fr: t`French`,
-    de: t`German`,
+    en: "English",
+    fr: "Français",
+    de: "Deutsch",
+    ru: "Русский",
+    zh: "中文",
   };
 
   // enable 'pseudo' locale only for Staging environment

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -21,7 +21,7 @@ export const ChangeLanguageButton: FC = () => {
     fr: "Français",
     de: "Deutsch",
     ru: "Русский",
-    zh: "中文",
+    "zh-CN": "中文",
   };
 
   // enable 'pseudo' locale only for Staging environment

--- a/site/lib/i18n.ts
+++ b/site/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { i18n } from "@lingui/core";
-import { en, fr, de } from "make-plural/plurals";
+import { en, fr, de, ru, zh } from "make-plural/plurals";
 import { IS_LOCAL_DEVELOPMENT, IS_PRODUCTION } from "lib/constants";
 
 // TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
@@ -17,6 +17,8 @@ const locales: ILocales = {
   en: { plurals: en, time: "en-US" },
   fr: { plurals: fr, time: "fr-FR" },
   de: { plurals: de, time: "de-DE" },
+  ru: { plurals: ru, time: "ru-RU" },
+  zh: { plurals: zh, time: "zh-CN" },
 };
 // Add pseudo locale only in development
 if (!IS_PRODUCTION) {

--- a/site/lib/i18n.ts
+++ b/site/lib/i18n.ts
@@ -18,7 +18,7 @@ const locales: ILocales = {
   fr: { plurals: fr, time: "fr-FR" },
   de: { plurals: de, time: "de-DE" },
   ru: { plurals: ru, time: "ru-RU" },
-  zh: { plurals: zh, time: "zh-CN" },
+  "zh-CN": { plurals: zh, time: "zh-CN" },
 };
 // Add pseudo locale only in development
 if (!IS_PRODUCTION) {

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -87,7 +87,7 @@ const nextConfig = {
 if (!IS_PRODUCTION) {
   nextConfig.i18n = {
     ...nextConfig.i18n,
-    locales: ["en", "zh-CN", "en-pseudo", "fr", "de", "ru"],
+    locales: ["en", "fr", "de", "ru", "zh-CN", "en-pseudo"],
     localeDetection: true,
   };
 }


### PR DESCRIPTION
## Description

This PR fixes:
- do not translate Languages in Language Menu for Site
- show Russian and Chinese in Language Menu on Site 
- make Chinese work on Site and App properly with setting the correct Language Code "zh-CN" everywhere

## Related Ticket

Missing parts of https://github.com/KlimaDAO/klimadao/issues/324


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
