### PR TITLE
Render meta tags with current locale language tag

### DIFF
--- a/app/components/PageHead.tsx
+++ b/app/components/PageHead.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import React from "react";
-
+import { useSelector } from "react-redux";
+import { selectLocale } from "state/selectors";
 export interface PageHeadProps {
   production: boolean;
   /** <title> tag */
@@ -14,6 +15,7 @@ export interface PageHeadProps {
 }
 
 export const PageHead = (props: PageHeadProps) => {
+  const locale = useSelector(selectLocale);
   const noRobots = props.doNotIndex || !props.production;
   return (
     <Head>
@@ -33,7 +35,7 @@ export const PageHead = (props: PageHeadProps) => {
         <meta property="og:image" content={props.mediaImageSrc} />
       )}
       <meta property="og:type" content="website" />
-      <meta property="og:locale" content="en" />
+      <meta property="og:locale" content={locale || "en"} />
       <link
         rel="apple-touch-icon"
         sizes="180x180"

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -46,7 +46,7 @@ import { Image } from "components/Image";
 import { ImageCard } from "components/ImageCard";
 
 export function prettyVestingPeriod(
-  locale: string,
+  locale = "en",
   currentBlock: number,
   vestingBlock: number,
   blockRate: number

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -16,20 +16,18 @@ export async function getStaticProps() {
 }
 const HomePage: NextPage = () => {
   return (
-    <>
-      <PageHead
-        production={IS_PRODUCTION}
-        title="KlimaDAO | Official App"
-        mediaTitle="KlimaDAO | Official App"
-        metaDescription="Use the KLIMA web app to bond, stake and earn rewards."
-        mediaImageSrc="/og-media.png"
-      />
-      <WithRedux>
-        <WithIsomorphicRouter location="/#">
-          <Home />
-        </WithIsomorphicRouter>
-      </WithRedux>
-    </>
+    <WithRedux>
+      <WithIsomorphicRouter location="/#">
+        <PageHead
+          production={IS_PRODUCTION}
+          title="KlimaDAO | Official App"
+          mediaTitle="KlimaDAO | Official App"
+          metaDescription="Use the KLIMA web app to bond, stake and earn rewards."
+          mediaImageSrc="/og-media.png"
+        />
+        <Home />
+      </WithIsomorphicRouter>
+    </WithRedux>
   );
 };
 

--- a/app/state/selectors/index.ts
+++ b/app/state/selectors/index.ts
@@ -43,5 +43,5 @@ export const selectNotificationStatus = createSelector(
 );
 export const selectLocale = createSelector(
   selectAppState,
-  (rootState) => rootState.locale || "en"
+  (rootState) => rootState.locale
 );

--- a/lib/utils/prettifySeconds/index.ts
+++ b/lib/utils/prettifySeconds/index.ts
@@ -1,7 +1,7 @@
 /*
  * Transforms seconds into a localized and readable format.
  */
-export function prettifySeconds(seconds: number, locale: string) {
+export function prettifySeconds(seconds: number, locale = "en") {
   const then = new Date();
   then.setSeconds(then.getSeconds() + seconds);
   return then.toLocaleString(locale, {

--- a/lib/utils/trimWithPlaceholder/index.ts
+++ b/lib/utils/trimWithPlaceholder/index.ts
@@ -2,7 +2,7 @@
 export const trimWithPlaceholder = (
   number: string | number | undefined,
   precision: number,
-  locale: string
+  locale = "en"
 ) => {
   if (typeof number === "undefined" || Number.isNaN(number)) {
     return "Loading... ";

--- a/site/components/PageHead/index.tsx
+++ b/site/components/PageHead/index.tsx
@@ -21,6 +21,7 @@ export const PageHead = (props: PageHeadProps) => {
   const router = useRouter();
   const relativePath = router.asPath.split(/[#,?]/)[0];
   const canonicalUrl = `https://www.klimadao.finance${relativePath}`;
+
   return (
     <Head>
       {noRobots && <meta name="robots" content="noindex" />}
@@ -38,7 +39,7 @@ export const PageHead = (props: PageHeadProps) => {
       <meta property="og:description" content={props.metaDescription} />
 
       <meta property="og:type" content="website" />
-      <meta property="og:locale" content="en" />
+      <meta property="og:locale" content={router.locale || "en"} />
       <meta property="og:site_name" content="KlimaDAO" />
 
       {props.mediaImageSrc && (


### PR DESCRIPTION
## Description

This PR does:

Site:
- render meta locale according to the router locale

App:
- render meta locale according to the locale in redux state (Client only, Server will always be "en")
- refactor state selector and remove the "en" fallback

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/293

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
