### PR TITLE
Pass and read selected locale between App and Site

### DIFF
--- a/app/components/NavMenu/index.tsx
+++ b/app/components/NavMenu/index.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactElement, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import { selectBalances } from "state/selectors";
+import { selectBalances, selectLocale } from "state/selectors";
 import { Trans } from "@lingui/macro";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
@@ -28,6 +28,8 @@ import LibraryAddOutlined from "@mui/icons-material/LibraryAddOutlined";
 import ParkOutlined from "@mui/icons-material/ParkOutlined";
 import Payment from "@mui/icons-material/Payment";
 import SpaOutlined from "@mui/icons-material/SpaOutlined";
+
+import { createLinkWithLocaleSubPath } from "lib/i18n";
 
 import * as styles from "./styles";
 
@@ -92,6 +94,7 @@ interface Props {
 }
 
 export const NavMenu: FC<Props> = (props) => {
+  const locale = useSelector(selectLocale);
   const balances = useSelector(selectBalances);
   const { pathname } = useLocation();
 
@@ -101,7 +104,7 @@ export const NavMenu: FC<Props> = (props) => {
 
   return (
     <nav className={styles.container}>
-      <a href={urls.home}>
+      <a href={createLinkWithLocaleSubPath(urls.home, locale)}>
         <LogoWithClaim />
       </a>
       <div className="stack-12">

--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -7,10 +7,13 @@ import Web3Modal from "web3modal";
 import { useAppDispatch } from "state";
 import { bonds, urls } from "@klimadao/lib/constants";
 import { useSelector } from "react-redux";
+
+import { useLocaleFromParams } from "lib/hooks/useLocaleFromParams";
 import { selectAppState } from "state/selectors";
 import { loadAppDetails } from "actions/app";
 import { calcBondDetails } from "actions/bonds";
 import { loadAccountDetails } from "actions/user";
+
 import { Stake } from "components/views/Stake";
 import { PKlima } from "components/views/PKlima";
 import { Info } from "components/views/Info";
@@ -23,7 +26,7 @@ import { InvalidRPCModal } from "components/InvalidRPCModal";
 import { CheckURLBanner, skipCheckURLBanner } from "components/CheckURLBanner";
 import { NotificationModal } from "components/NotificationModal";
 
-import { init } from "lib/i18n";
+import { initLocale } from "lib/i18n";
 
 import styles from "./index.module.css";
 import { IS_PRODUCTION } from "lib/constants";
@@ -146,6 +149,8 @@ export const Home: FC = () => {
   const [showRPCModal, setShowRPCModal] = useState(false);
   const [showMobileMenu, setShowMobileMenu] = useState(false);
 
+  const localeFromURL = useLocaleFromParams();
+
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const [showCheckURLBanner, setShowCheckURLBanner] = useState(
@@ -156,11 +161,11 @@ export const Home: FC = () => {
 
   useEffect(() => {
     if (locale === undefined) {
-      init().then((init_locale: string) => {
+      initLocale(localeFromURL).then((init_locale: string) => {
         dispatch(setAppState({ locale: init_locale }));
       });
     }
-  }, []);
+  }, [localeFromURL]);
 
   useEffect(() => {
     if (pathname === "/") {

--- a/app/lib/hooks/useLocaleFromParams.ts
+++ b/app/lib/hooks/useLocaleFromParams.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { localeExists } from "lib/i18n";
+
+/**
+ * For the HOME view in the app. On mount, validates, extracts and strips the locale params from the url and returns the value from the locale param.
+ * @example https://app.klimadao.finance/#/stake?locale=fr => "fr" or https://app.klimadao.finance/#/stake?locale=not-supported-language => null
+ * */
+export const useLocaleFromParams = (): string | null => {
+  const [params, setParams] = useSearchParams();
+  const [state, setState] = useState<string | null>("");
+
+  useEffect(() => {
+    const languageParam = params.get("locale");
+    const validLocale =
+      (!!languageParam && localeExists(languageParam) && languageParam) || null;
+
+    // set state to trigger re-render in parent component
+    setState(validLocale);
+
+    // remove locale query from browser URL
+    if (!!languageParam) {
+      params.delete("locale");
+      setParams(params);
+    }
+  }, []);
+
+  return state;
+};

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -27,6 +27,10 @@ if (!IS_PRODUCTION) {
   locales["en-pseudo"] = { plurals: en, time: "en-US" };
 }
 
+// Validate locale language tag
+export const localeExists = (locale: string) =>
+  Object.keys(locales).includes(locale);
+
 // Load localedata
 for (const key in locales) {
   const locale = locales[key];
@@ -65,12 +69,12 @@ async function activate(locale: string) {
 /**
  * Initializes locale (retrieve current locale from localstorage if possible)
  */
-async function init() {
+async function initLocale(localeFromURL: string | null) {
   // Load user locale
-  let locale = window.localStorage.getItem("locale") as string;
-  if (!Object.keys(locales).includes(locale)) locale = "en";
+  let locale = localeFromURL || window.localStorage.getItem("locale");
+  if (!locale || (!!locale && !localeExists(locale))) locale = "en";
   await load(locale);
   return locale;
 }
 
-export { locales, activate, init };
+export { locales, activate, initLocale };

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -77,4 +77,9 @@ async function initLocale(localeFromURL: string | null) {
   return locale;
 }
 
+export const createLinkWithLocaleSubPath = (
+  url: string,
+  locale = "en"
+): string => `${url}/${locale}`;
+
 export { locales, activate, initLocale };

--- a/site/components/Footer/index.tsx
+++ b/site/components/Footer/index.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from "react";
 import { Trans } from "@lingui/macro";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { createLinkWithLocaleQuery } from "lib/i18n";
 
 import {
   Anchor as A,
@@ -18,78 +20,82 @@ import {
 import { urls } from "@klimadao/lib/constants";
 import * as styles from "./styles";
 
-export const Footer: FC = () => (
-  <footer className={styles.footer}>
-    <div className={styles.footer_content}>
-      <nav className={styles.footer_nav}>
-        <Link href="/">
-          <a>
-            <Trans id="shared.home">Home</Trans>
-          </a>
-        </Link>
-        <Link href="/buy">
-          <a>
-            <Trans id="shared.buy">Buy</Trans>
-          </a>
-        </Link>
-        <a href={urls.stake}>
-          <Trans id="shared.stake">Stake</Trans>
-        </a>
-        <a href={urls.app}>
-          <Trans id="shared.bond">App</Trans>
-        </a>
-        <A href={urls.officialDocs}>
-          <Trans id="shared.docs">Docs</Trans>
-        </A>
-        <Link href="/blog">
-          <a>
-            <Trans id="shared.blog">Blog</Trans>
-          </a>
-        </Link>
-        <Link href="/contact">
-          <a>
-            <Trans id="shared.contact">Contact</Trans>
-          </a>
-        </Link>
-        <Link href="/disclaimer">
-          <a>
-            <Trans id="shared.disclaimer">Disclaimer</Trans>
-          </a>
-        </Link>
-      </nav>
+export const Footer: FC = () => {
+  const { locale } = useRouter();
 
-      <nav className={styles.footer_icons}>
-        <A href={urls.twitter}>
-          <TwitterIcon />
-        </A>
-        <A href={urls.youtube}>
-          <YoutubeIcon />
-        </A>
-        <A href={urls.discordInvite}>
-          <DiscordIcon />
-        </A>
-        <A href={urls.reddit}>
-          <RedditIcon />
-        </A>
-        <A href={urls.twitch}>
-          <TwitchIcon />
-        </A>
-        <A href={urls.github}>
-          <GithubIcon />
-        </A>
-        <A href={urls.tiktok}>
-          <TiktokIcon />
-        </A>
-        <A href={urls.linkedIn}>
-          <LinkedInIcon />
-        </A>
-        <A href={urls.telegram}>
-          <TelegramIcon />
-        </A>
-        <A href={urls.podcast}>
-          <RSSIcon />
-        </A>
-      </nav>
-    </div>
-  </footer>
-);
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.footer_content}>
+        <nav className={styles.footer_nav}>
+          <Link href="/">
+            <a>
+              <Trans id="shared.home">Home</Trans>
+            </a>
+          </Link>
+          <Link href="/buy">
+            <a>
+              <Trans id="shared.buy">Buy</Trans>
+            </a>
+          </Link>
+          <a href={createLinkWithLocaleQuery(urls.stake, locale)}>
+            <Trans id="shared.stake">Stake</Trans>
+          </a>
+          <a href={createLinkWithLocaleQuery(urls.app, locale)}>
+            <Trans id="shared.bond">App</Trans>
+          </a>
+          <A href={urls.officialDocs}>
+            <Trans id="shared.docs">Docs</Trans>
+          </A>
+          <Link href="/blog">
+            <a>
+              <Trans id="shared.blog">Blog</Trans>
+            </a>
+          </Link>
+          <Link href="/contact">
+            <a>
+              <Trans id="shared.contact">Contact</Trans>
+            </a>
+          </Link>
+          <Link href="/disclaimer">
+            <a>
+              <Trans id="shared.disclaimer">Disclaimer</Trans>
+            </a>
+          </Link>
+        </nav>
+
+        <nav className={styles.footer_icons}>
+          <A href={urls.twitter}>
+            <TwitterIcon />
+          </A>
+          <A href={urls.youtube}>
+            <YoutubeIcon />
+          </A>
+          <A href={urls.discordInvite}>
+            <DiscordIcon />
+          </A>
+          <A href={urls.reddit}>
+            <RedditIcon />
+          </A>
+          <A href={urls.twitch}>
+            <TwitchIcon />
+          </A>
+          <A href={urls.github}>
+            <GithubIcon />
+          </A>
+          <A href={urls.tiktok}>
+            <TiktokIcon />
+          </A>
+          <A href={urls.linkedIn}>
+            <LinkedInIcon />
+          </A>
+          <A href={urls.telegram}>
+            <TelegramIcon />
+          </A>
+          <A href={urls.podcast}>
+            <RSSIcon />
+          </A>
+        </nav>
+      </div>
+    </footer>
+  );
+};

--- a/site/components/Navigation/index.tsx
+++ b/site/components/Navigation/index.tsx
@@ -2,6 +2,8 @@ import { FC } from "react";
 import dynamic from "next/dynamic";
 import { t } from "@lingui/macro";
 import { ButtonPrimary } from "@klimadao/lib/components";
+import { useRouter } from "next/router";
+import { createLinkWithLocaleQuery } from "lib/i18n";
 
 import { urls } from "@klimadao/lib/constants";
 import { HeaderDesktop } from "components/Header/HeaderDesktop";
@@ -21,63 +23,67 @@ export type Props = {
   activePage: PageName;
 };
 
-export const Navigation: FC<Props> = (props) => (
-  <>
-    <HeaderDesktop
-      buttons={(!IS_PRODUCTION
-        ? [<ChangeLanguageButton key="ChangeLanguageButton" />]
-        : []
-      ).concat([
-        <ThemeToggle key="ThemeToggle" />,
-        <ButtonPrimary
-          key="Enter App"
-          label={t({ message: "Enter App", id: "shared.enter_app" })}
-          href={urls.app}
-        />,
-      ])}
-    >
-      <NavItemDesktop
-        url={"/buy"}
-        name={t({ message: "Buy", id: "shared.buy" })}
-        active={props.activePage === "Buy"}
-      />
-      <NavItemDesktop
-        url={urls.stake}
-        name={t({ message: "Stake", id: "shared.stake" })}
-      />
-      <NavItemDesktop
-        url={urls.loveletter}
-        name={t({ message: "Love Letters", id: "shared.loveletters" })}
-      />
-      <NavItemDesktop
-        url="/blog"
-        name={t({ message: "Resources", id: "shared.resources" })}
-        active={props.activePage === "Resources"}
-      />
-    </HeaderDesktop>
+export const Navigation: FC<Props> = (props) => {
+  const { locale } = useRouter();
 
-    <HeaderMobile
-      buttons={(!IS_PRODUCTION
-        ? [<ChangeLanguageButton key="ChangeLanguageButton" />]
-        : []
-      ).concat([<ThemeToggle key="ThemeToggle" />])}
-    >
-      <NavItemMobile
-        url="/buy"
-        name={t({ message: "Buy", id: "shared.buy" })}
-      />
-      <NavItemMobile
-        url={urls.stake}
-        name={t({ message: "Stake", id: "shared.stake" })}
-      />
-      <NavItemMobile
-        url={urls.loveletter}
-        name={t({ message: "Love Letters", id: "shared.loveletters" })}
-      />
-      <NavItemMobile
-        url="/blog"
-        name={t({ message: "Resources", id: "shared.resources" })}
-      />
-    </HeaderMobile>
-  </>
-);
+  return (
+    <>
+      <HeaderDesktop
+        buttons={(!IS_PRODUCTION
+          ? [<ChangeLanguageButton key="ChangeLanguageButton" />]
+          : []
+        ).concat([
+          <ThemeToggle key="ThemeToggle" />,
+          <ButtonPrimary
+            key="Enter App"
+            label={t({ message: "Enter App", id: "shared.enter_app" })}
+            href={createLinkWithLocaleQuery(urls.app, locale)}
+          />,
+        ])}
+      >
+        <NavItemDesktop
+          url={"/buy"}
+          name={t({ message: "Buy", id: "shared.buy" })}
+          active={props.activePage === "Buy"}
+        />
+        <NavItemDesktop
+          url={createLinkWithLocaleQuery(urls.stake, locale)}
+          name={t({ message: "Stake", id: "shared.stake" })}
+        />
+        <NavItemDesktop
+          url={urls.loveletter}
+          name={t({ message: "Love Letters", id: "shared.loveletters" })}
+        />
+        <NavItemDesktop
+          url="/blog"
+          name={t({ message: "Resources", id: "shared.resources" })}
+          active={props.activePage === "Resources"}
+        />
+      </HeaderDesktop>
+
+      <HeaderMobile
+        buttons={(!IS_PRODUCTION
+          ? [<ChangeLanguageButton key="ChangeLanguageButton" />]
+          : []
+        ).concat([<ThemeToggle key="ThemeToggle" />])}
+      >
+        <NavItemMobile
+          url="/buy"
+          name={t({ message: "Buy", id: "shared.buy" })}
+        />
+        <NavItemMobile
+          url={createLinkWithLocaleQuery(urls.stake, locale)}
+          name={t({ message: "Stake", id: "shared.stake" })}
+        />
+        <NavItemMobile
+          url={urls.loveletter}
+          name={t({ message: "Love Letters", id: "shared.loveletters" })}
+        />
+        <NavItemMobile
+          url="/blog"
+          name={t({ message: "Resources", id: "shared.resources" })}
+        />
+      </HeaderMobile>
+    </>
+  );
+};

--- a/site/components/pages/Buy/index.tsx
+++ b/site/components/pages/Buy/index.tsx
@@ -1,6 +1,9 @@
 import { NextPage } from "next";
 import Image from "next/image";
 
+import { useRouter } from "next/router";
+import { createLinkWithLocaleQuery } from "lib/i18n";
+
 import {
   Anchor as A,
   Text,
@@ -29,6 +32,8 @@ import { t } from "@lingui/macro";
 export type Props = HTMLHtmlElement;
 
 export const Buy: NextPage<Props> = ({}) => {
+  const { locale } = useRouter();
+
   const begginerSectionRef = useRef<null | HTMLDivElement>(null);
   const intermediateSectionRef = useRef<null | HTMLDivElement>(null);
   const advancedSectionRef = useRef<null | HTMLDivElement>(null);
@@ -260,7 +265,7 @@ export const Buy: NextPage<Props> = ({}) => {
             </Text>
             <ButtonPrimary
               label="ENTER APP"
-              href={urls.bonds}
+              href={createLinkWithLocaleQuery(urls.bonds, locale)}
               target="_blank"
               rel="noopener noreferrer"
             />

--- a/site/components/pages/Home/index.tsx
+++ b/site/components/pages/Home/index.tsx
@@ -12,6 +12,7 @@ import { Footer } from "components/Footer";
 import { Navigation } from "components/Navigation";
 import { PageHead } from "components/PageHead";
 import { IS_PRODUCTION } from "lib/constants";
+import { createLinkWithLocaleQuery } from "lib/i18n";
 import { LatestPost } from "lib/queries";
 
 import forest from "public/forest.jpg";
@@ -110,7 +111,7 @@ export const Home: NextPage<Props> = (props) => {
                 <ButtonPrimary
                   key="Enter App"
                   label={t({ id: "shared.enter_app", message: "Enter App" })}
-                  href={urls.app}
+                  href={createLinkWithLocaleQuery(urls.app, locale)}
                 />
               </div>
             </div>

--- a/site/lib/i18n.ts
+++ b/site/lib/i18n.ts
@@ -43,4 +43,7 @@ async function loadTranslation(locale = "en") {
   return data.messages;
 }
 
+export const createLinkWithLocaleQuery = (url: string, locale = "en"): string =>
+  `${url}?locale=${locale}`;
+
 export { locales, loadTranslation };


### PR DESCRIPTION
## Description

This PR includes:
- All links from Site -> App have a locale param attached: `?locale=fr`
- App reads the locale params from the URL, validates the locale, removes the locales from URL and dispatches the locale to the state
- All links from App -> Site have the locale as a sub-path attached: `/fr`

## Test

- https://klimadao-app-git-pass-locale-as-queryparam-klimadao.vercel.app/#/stake?locale=de
=> should load german, remove query from URL, link to Site with `/de`

- https://klimadao-site-git-pass-locale-as-queryparam-klimadao.vercel.app/de
=> should load german, link to App with `?locale=de`

## Note

When linking to the Site with a sub-path and this sub-path does not exist the server responds with 404.
But there is no 404 page yet https://github.com/KlimaDAO/klimadao/issues/331

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/322

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
