### PR TITLE
180 add ws klima to balances

### DIFF
--- a/app/components/BalancesCard/index.tsx
+++ b/app/components/BalancesCard/index.tsx
@@ -2,12 +2,12 @@ import { Text } from "@klimadao/lib/components";
 import AccountBalanceOutlined from "@mui/icons-material/AccountBalanceOutlined";
 import { trimWithPlaceholder } from "@klimadao/lib/utils";
 import { useSelector } from "react-redux";
-import { InfoButton }                                   from "components/InfoButton";
+import { InfoButton } from "components/InfoButton";
 import { selectAppState, selectBalances, selectLocale } from "state/selectors";
-import * as styles                                      from "./styles";
+import * as styles from "./styles";
 import { FC } from "react";
 import { RootState } from "state";
-import { Trans } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 
 type Asset = keyof NonNullable<RootState["user"]["balance"]>;
 type AssetLabels = { [key in Asset]: string };
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const BalancesCard: FC<Props> = (props) => {
-  const {currentIndex} = useSelector(selectAppState);
+  const { currentIndex } = useSelector(selectAppState);
   const balances = useSelector(selectBalances);
   const locale = useSelector(selectLocale);
 
@@ -30,7 +30,10 @@ export const BalancesCard: FC<Props> = (props) => {
     pklima: "pKLIMA",
     sklima: "sKLIMA",
     wsklima: "wsKLIMA",
-    wsklimaUnwrapped: "wsKLIMA (unwrapped)",
+    wsklimaUnwrapped:
+      "wsKLIMA (" +
+      t({ id: "wsklima.unwrapped.label", message: "unwrapped" }) +
+      ")",
     mco2: "MCO2",
     usdc: "USDC",
     nct: "NCT",
@@ -50,22 +53,20 @@ export const BalancesCard: FC<Props> = (props) => {
       <div className="cardContent">
         {props.assets.map((asset) => (
           <div className="stack" key={asset}>
-            {
-              asset !== "wsklimaUnwrapped" && (
-                <Text className="value">
-                  {trimWithPlaceholder(balances?.[asset] ?? 0, 9, locale)}
-                </Text>
-              )
-            }
-            {
-              asset === "wsklimaUnwrapped" &&
-              balances &&
-              currentIndex && (
-                <Text className="value">
-                  {trimWithPlaceholder((Number(balances["wsklima"]) * Number(currentIndex)) ?? 0, 9, locale)}
-                </Text>
-              )
-            }
+            {asset !== "wsklimaUnwrapped" && (
+              <Text className="value">
+                {trimWithPlaceholder(balances?.[asset] ?? 0, 9, locale)}
+              </Text>
+            )}
+            {asset === "wsklimaUnwrapped" && balances && currentIndex && (
+              <Text className="value">
+                {trimWithPlaceholder(
+                  Number(balances["wsklima"]) * Number(currentIndex) ?? 0,
+                  9,
+                  locale
+                )}
+              </Text>
+            )}
             <Text className="label" color="lightest">
               {labels[asset]}
             </Text>

--- a/app/components/BalancesCard/index.tsx
+++ b/app/components/BalancesCard/index.tsx
@@ -2,9 +2,9 @@ import { Text } from "@klimadao/lib/components";
 import AccountBalanceOutlined from "@mui/icons-material/AccountBalanceOutlined";
 import { trimWithPlaceholder } from "@klimadao/lib/utils";
 import { useSelector } from "react-redux";
-import { InfoButton } from "components/InfoButton";
-import { selectBalances, selectLocale } from "state/selectors";
-import * as styles from "./styles";
+import { InfoButton }                                   from "components/InfoButton";
+import { selectAppState, selectBalances, selectLocale } from "state/selectors";
+import * as styles                                      from "./styles";
 import { FC } from "react";
 import { RootState } from "state";
 import { Trans } from "@lingui/macro";
@@ -18,6 +18,7 @@ interface Props {
 }
 
 export const BalancesCard: FC<Props> = (props) => {
+  const {currentIndex} = useSelector(selectAppState);
   const balances = useSelector(selectBalances);
   const locale = useSelector(selectLocale);
 
@@ -29,12 +30,14 @@ export const BalancesCard: FC<Props> = (props) => {
     pklima: "pKLIMA",
     sklima: "sKLIMA",
     wsklima: "wsKLIMA",
+    wsklimaUnwrapped: "wsKLIMA (unwrapped)",
     mco2: "MCO2",
     usdc: "USDC",
     nct: "NCT",
     ubo: "UBO",
     nbo: "NBO",
   };
+
   return (
     <div className={styles.card + " " + status}>
       <div className="header">
@@ -47,9 +50,22 @@ export const BalancesCard: FC<Props> = (props) => {
       <div className="cardContent">
         {props.assets.map((asset) => (
           <div className="stack" key={asset}>
-            <Text className="value">
-              {trimWithPlaceholder(balances?.[asset] ?? 0, 9, locale)}
-            </Text>
+            {
+              asset !== "wsklimaUnwrapped" && (
+                <Text className="value">
+                  {trimWithPlaceholder(balances?.[asset] ?? 0, 9, locale)}
+                </Text>
+              )
+            }
+            {
+              asset === "wsklimaUnwrapped" &&
+              balances &&
+              currentIndex && (
+                <Text className="value">
+                  {trimWithPlaceholder((Number(balances["wsklima"]) * Number(currentIndex)) ?? 0, 9, locale)}
+                </Text>
+              )
+            }
             <Text className="label" color="lightest">
               {labels[asset]}
             </Text>

--- a/app/components/CarbonTonnesBreakdownCard/index.tsx
+++ b/app/components/CarbonTonnesBreakdownCard/index.tsx
@@ -1,6 +1,5 @@
 import { FC } from "react";
-import { Image } from "components/Image";
-import { StaticImageData } from "next/image";
+import { Image, StaticImageData } from "components/Image";
 import { Trans } from "@lingui/macro";
 import CloudOutlined from "@mui/icons-material/CloudOutlined";
 

--- a/app/components/DropdownWithModal/index.tsx
+++ b/app/components/DropdownWithModal/index.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { StaticImageData } from "next/image";
+import { StaticImageData } from "components/Image";
 import { Image } from "components/Image";
 
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";

--- a/app/components/Image/index.tsx
+++ b/app/components/Image/index.tsx
@@ -9,3 +9,12 @@ export const Image = (props: ImageProps) => {
   }
   return <NextImage {...props} />;
 };
+
+// FIXME: next/image doesn't export this interface so this is a temporary hack
+// Currently located in this file: node_modules/next/image-types/global.d.ts
+export interface StaticImageData {
+  src: string;
+  height: number;
+  width: number;
+  blurDataURL?: string;
+}

--- a/app/components/MiniTokenDisplay/index.tsx
+++ b/app/components/MiniTokenDisplay/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode } from "react";
-import { StaticImageData } from "next/image";
+import { StaticImageData } from "components/Image";
 import { Image } from "components/Image";
 
 import { Spinner, Text } from "@klimadao/lib/components";

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, FC, useEffect, useState } from "react";
-import { StaticImageData } from "next/image";
+import { StaticImageData } from "components/Image";
 
 import { useSelector } from "react-redux";
 import { providers } from "ethers";

--- a/app/components/views/Stake/index.tsx
+++ b/app/components/views/Stake/index.tsx
@@ -210,7 +210,7 @@ export const Stake = (props: Props) => {
   return (
     <>
       <BalancesCard
-        assets={["klima", "sklima"]}
+        assets={["klima", "sklima", "wsklima"]}
         tooltip={
           <Trans id="stake.balancescard.tooltip" comment="Long sentence">
             Stake your KLIMA tokens to receive sKLIMA. After every rebase, your

--- a/app/components/views/Wrap/index.tsx
+++ b/app/components/views/Wrap/index.tsx
@@ -173,7 +173,7 @@ export const Wrap: FC<Props> = (props) => {
   return (
     <>
       <BalancesCard
-        assets={["sklima", "wsklima"]}
+        assets={["sklima", "wsklima", "wsklimaUnwrapped"]}
         tooltip={
           <Trans id="wrap.balances_tooltip">
             Wrap sKLIMA to receive index-adjusted wrapped-staked-KLIMA

--- a/app/locale/de/messages.po
+++ b/app/locale/de/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:638
 msgid "Beneficiary Address"
@@ -585,7 +591,7 @@ msgstr "Der aktualisierte Vertrag geht davon aus, dass pKLIMA-Besitzer ehemals b
 msgid "shared.approve"
 msgstr "Bestätigen"
 
-#: components/BalancesCard/index.tsx:43
+#: components/BalancesCard/index.tsx:46
 msgid "shared.balances"
 msgstr "Guthaben"
 
@@ -832,3 +838,7 @@ msgstr "Zu unwrappendes wsKLIMA"
 #: components/views/Wrap/index.tsx:286
 msgid "wrap.you_will_get"
 msgstr "Du erhältst"
+
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""

--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:638
 msgid "Beneficiary Address"
@@ -579,7 +585,7 @@ msgstr ""
 msgid "shared.approve"
 msgstr ""
 
-#: components/BalancesCard/index.tsx:43
+#: components/BalancesCard/index.tsx:46
 msgid "shared.balances"
 msgstr ""
 
@@ -825,4 +831,8 @@ msgstr ""
 
 #: components/views/Wrap/index.tsx:286
 msgid "wrap.you_will_get"
+msgstr ""
+
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
 msgstr ""

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -585,7 +585,7 @@ msgstr "The updated contract now assumes pKLIMA holders have staked and earned r
 msgid "shared.approve"
 msgstr "Approve"
 
-#: components/BalancesCard/index.tsx:43
+#: components/BalancesCard/index.tsx:46
 msgid "shared.balances"
 msgstr "Balances"
 
@@ -832,3 +832,7 @@ msgstr "wsKLIMA to unwrap"
 #: components/views/Wrap/index.tsx:286
 msgid "wrap.you_will_get"
 msgstr "You Will Get"
+
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr "unwrapped"

--- a/app/locale/fr/messages.po
+++ b/app/locale/fr/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:638
 msgid "Beneficiary Address"
@@ -583,7 +589,7 @@ msgstr "Le nouveau contrat présuppose que les détenteurs de pKLIMA ont gagné 
 msgid "shared.approve"
 msgstr "Approuver"
 
-#: components/BalancesCard/index.tsx:43
+#: components/BalancesCard/index.tsx:46
 msgid "shared.balances"
 msgstr "Soldes"
 
@@ -830,3 +836,7 @@ msgstr "wsKLIMA à dés-encapsuler"
 #: components/views/Wrap/index.tsx:286
 msgid "wrap.you_will_get"
 msgstr "Vous obtiendrez"
+
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""

--- a/app/locale/ru/messages.po
+++ b/app/locale/ru/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ru\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:638
 msgid "Beneficiary Address"
@@ -583,7 +589,7 @@ msgstr "Обновленный контракт теперь предполаг�
 msgid "shared.approve"
 msgstr "Одобрить"
 
-#: components/BalancesCard/index.tsx:43
+#: components/BalancesCard/index.tsx:46
 msgid "shared.balances"
 msgstr "Балансы"
 
@@ -830,3 +836,7 @@ msgstr ""
 #: components/views/Wrap/index.tsx:286
 msgid "wrap.you_will_get"
 msgstr "Вы получете"
+
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""

--- a/app/locale/zh-CN/messages.po
+++ b/app/locale/zh-CN/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:638
 msgid "Beneficiary Address"
@@ -579,7 +585,7 @@ msgstr "更新后的合约，假设现在 pKLIMA 的持有者已经质押了之�
 msgid "shared.approve"
 msgstr "批准"
 
-#: components/BalancesCard/index.tsx:43
+#: components/BalancesCard/index.tsx:46
 msgid "shared.balances"
 msgstr "余额"
 
@@ -826,3 +832,7 @@ msgstr "待拆分的 wsKLIMA"
 #: components/views/Wrap/index.tsx:286
 msgid "wrap.you_will_get"
 msgstr "你将获得"
+
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""

--- a/app/state/user/index.ts
+++ b/app/state/user/index.ts
@@ -8,6 +8,7 @@ export interface UserState {
     klima: string;
     sklima: string;
     wsklima: string;
+    wsklimaUnwrapped: string;
     aklima: string;
     alklima: string;
     pklima: string;

--- a/site/locale/de/messages.po
+++ b/site/locale/de/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"

--- a/site/locale/fr/messages.po
+++ b/site/locale/fr/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"

--- a/site/locale/ru/messages.po
+++ b/site/locale/ru/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ru\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"

--- a/site/locale/zh-CN/messages.po
+++ b/site/locale/zh-CN/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"


### PR DESCRIPTION
## Description

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Added wsKLIMA balance to BalancesCard if connected wallet has > 0 wsKLIMA. Also added an 'unwrapped' view while on the Wrap page.

## Related Ticket

Resolves #180

<!-- If there are UI changes, please include a before and after screenshot in the following template: -->

## Changes

### Stake

#### Before


<img width="399" alt="Screen Shot 2022-04-22 at 6 16 40 AM" src="https://user-images.githubusercontent.com/978072/164721786-b17e2f73-eb9c-4d03-9b51-9ddd34498908.png">

#### After

<img width="412" alt="Screen Shot 2022-04-22 at 6 19 08 AM" src="https://user-images.githubusercontent.com/978072/164722161-f677aa64-1458-4cd8-9e59-c98b6163430c.png">

### Wrap

#### Before

 <img width="403" alt="Screen Shot 2022-04-22 at 6 16 10 AM" src="https://user-images.githubusercontent.com/978072/164721680-cdfdd8df-98f4-4bc1-a159-f3bcc04a3f0e.png">

#### After

<img width="396" alt="Screen Shot 2022-04-22 at 6 18 52 AM" src="https://user-images.githubusercontent.com/978072/164722121-022084ac-a0de-42cc-b6ac-6ce561acca19.png">


## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
