### PR TITLE
Site: Add 404 and 500 Error pages

### DIFF
--- a/lib/theme/variables.css
+++ b/lib/theme/variables.css
@@ -7,7 +7,6 @@
   --font-family: Inter, sans-serif;
   --border-radius: 0.4rem;
   --header-height: 4.8rem;
-  --footer-height: 15rem;
   --shadow-01: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
   --shadow-02: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   --shadow-03: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);

--- a/lib/theme/variables.css
+++ b/lib/theme/variables.css
@@ -7,6 +7,7 @@
   --font-family: Inter, sans-serif;
   --border-radius: 0.4rem;
   --header-height: 4.8rem;
+  --footer-height: 15rem;
   --shadow-01: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
   --shadow-02: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   --shadow-03: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);

--- a/site/components/Footer/styles.ts
+++ b/site/components/Footer/styles.ts
@@ -69,6 +69,7 @@ export const footer_icons = css`
   align-items: center;
   justify-content: center;
   gap: 1.6rem;
+  flex-wrap: wrap;
 
   & svg path {
     fill: var(--font-02);

--- a/site/components/pages/errors/Custom404.tsx
+++ b/site/components/pages/errors/Custom404.tsx
@@ -11,7 +11,7 @@ import * as styles from "./styles";
 
 export const Custom404 = () => {
   return (
-    <>
+    <div className={styles.errorPageWrapper}>
       <PageHead
         production={IS_PRODUCTION}
         title={t({
@@ -30,7 +30,7 @@ export const Custom404 = () => {
       />
       <Navigation activePage="Home" />
 
-      <Section variant="gray" className={styles.fullheight}>
+      <Section variant="gray">
         <div className={styles.textGroup}>
           <Text t="h2" as="h2" align="center">
             <Trans id="error.404.page.title">404 - Page Not Found</Trans>
@@ -47,6 +47,6 @@ export const Custom404 = () => {
         </div>
       </Section>
       <Footer />
-    </>
+    </div>
   );
 };

--- a/site/components/pages/errors/Custom404.tsx
+++ b/site/components/pages/errors/Custom404.tsx
@@ -1,0 +1,52 @@
+import { Text, Section } from "@klimadao/lib/components";
+
+import { Navigation } from "components/Navigation";
+import { PageHead } from "components/PageHead";
+import { Footer } from "components/Footer";
+
+import { IS_PRODUCTION } from "lib/constants";
+import { urls } from "@klimadao/lib/constants";
+import { t, Trans } from "@lingui/macro";
+import * as styles from "./styles";
+
+export const Custom404 = () => {
+  return (
+    <>
+      <PageHead
+        production={IS_PRODUCTION}
+        title={t({
+          id: "error.page.404.title",
+          message: "404 - Page Not Found",
+        })}
+        mediaTitle={t({
+          id: "error.page.404.head.title",
+          message: "404 - Page Not Found",
+        })}
+        metaDescription={t({
+          id: "shared.head.description",
+          message:
+            "Drive climate action and earn rewards with a carbon-backed digital currency.",
+        })}
+      />
+      <Navigation activePage="Home" />
+
+      <Section variant="gray" className={styles.fullheight}>
+        <div className={styles.textGroup}>
+          <Text t="h2" as="h2" align="center">
+            <Trans id="error.404.page.title">404 - Page Not Found</Trans>
+          </Text>
+          <Text align="center">
+            <Trans id="error.404.page.text">
+              Sorry, looks like we sent you the wrong way. <br />
+              Let us guide you back to the Start Page:
+            </Trans>
+          </Text>
+          <Text>
+            <a href={urls.home}>{urls.home}</a>
+          </Text>
+        </div>
+      </Section>
+      <Footer />
+    </>
+  );
+};

--- a/site/components/pages/errors/Custom500.tsx
+++ b/site/components/pages/errors/Custom500.tsx
@@ -1,0 +1,55 @@
+import { Text, Section } from "@klimadao/lib/components";
+
+import { Navigation } from "components/Navigation";
+import { PageHead } from "components/PageHead";
+import { Footer } from "components/Footer";
+
+import { IS_PRODUCTION } from "lib/constants";
+import { urls } from "@klimadao/lib/constants";
+import { t, Trans } from "@lingui/macro";
+import * as styles from "./styles";
+
+export const Custom500 = () => {
+  return (
+    <>
+      <PageHead
+        production={IS_PRODUCTION}
+        title={t({
+          id: "error.page.500.title",
+          message: "500 - Page Not Found",
+        })}
+        mediaTitle={t({
+          id: "error.page.500.head.title",
+          message: "500 - Page Not Found",
+        })}
+        metaDescription={t({
+          id: "shared.head.description",
+          message:
+            "Drive climate action and earn rewards with a carbon-backed digital currency.",
+        })}
+      />
+      <Navigation activePage="Home" />
+
+      <Section variant="gray" className={styles.fullheight}>
+        <div className={styles.textGroup}>
+          <Text t="h2" as="h2" align="center">
+            <Trans id="error.500.page.title">
+              500 - Server-side error occurred
+            </Trans>
+          </Text>
+          <Text align="center">
+            <Trans id="error.500.page.text">
+              Sorry, something bad happened.
+              <br />
+              Try to go back to the Start Page:
+            </Trans>
+          </Text>
+          <Text>
+            <a href={urls.home}>{urls.home}</a>
+          </Text>
+        </div>
+      </Section>
+      <Footer />
+    </>
+  );
+};

--- a/site/components/pages/errors/Custom500.tsx
+++ b/site/components/pages/errors/Custom500.tsx
@@ -11,7 +11,7 @@ import * as styles from "./styles";
 
 export const Custom500 = () => {
   return (
-    <>
+    <div className={styles.errorPageWrapper}>
       <PageHead
         production={IS_PRODUCTION}
         title={t({
@@ -30,7 +30,7 @@ export const Custom500 = () => {
       />
       <Navigation activePage="Home" />
 
-      <Section variant="gray" className={styles.fullheight}>
+      <Section variant="gray">
         <div className={styles.textGroup}>
           <Text t="h2" as="h2" align="center">
             <Trans id="error.500.page.title">
@@ -50,6 +50,6 @@ export const Custom500 = () => {
         </div>
       </Section>
       <Footer />
-    </>
+    </div>
   );
 };

--- a/site/components/pages/errors/styles.ts
+++ b/site/components/pages/errors/styles.ts
@@ -1,13 +1,15 @@
 import { css } from "@emotion/css";
 import breakpoints from "@klimadao/lib/theme/breakpoints";
 
-export const fullheight = css`
-  min-height: calc(
-    100vh - (var(--footer-height) / 2 + var(--header-height) / 2)
-  );
+export const errorPageWrapper = css`
+  display: grid;
+  grid-column: full;
+  grid-template-columns: inherit;
+  min-height: 100vh;
+  grid-template-rows: 1fr auto;
 
   ${breakpoints.large} {
-    min-height: calc(100vh - (var(--footer-height) + var(--header-height)));
+    grid-template-rows: auto 1fr auto;
   }
 `;
 

--- a/site/components/pages/errors/styles.ts
+++ b/site/components/pages/errors/styles.ts
@@ -1,0 +1,20 @@
+import { css } from "@emotion/css";
+import breakpoints from "@klimadao/lib/theme/breakpoints";
+
+export const fullheight = css`
+  min-height: calc(
+    100vh - (var(--footer-height) / 2 + var(--header-height) / 2)
+  );
+
+  ${breakpoints.large} {
+    min-height: calc(100vh - (var(--footer-height) + var(--header-height)));
+  }
+`;
+
+export const textGroup = css`
+  grid-column: main;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 2.8rem;
+`;

--- a/site/pages/404.tsx
+++ b/site/pages/404.tsx
@@ -8,7 +8,6 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
     props: {
       translation,
     },
-    revalidate: 60,
   };
 };
 

--- a/site/pages/404.tsx
+++ b/site/pages/404.tsx
@@ -1,0 +1,15 @@
+import { GetStaticProps } from "next";
+import { Custom404 } from "components/pages/errors/Custom404";
+import { loadTranslation } from "lib/i18n";
+
+export const getStaticProps: GetStaticProps = async (ctx) => {
+  const translation = await loadTranslation(ctx.locale);
+  return {
+    props: {
+      translation,
+    },
+    revalidate: 60,
+  };
+};
+
+export default Custom404;

--- a/site/pages/500.tsx
+++ b/site/pages/500.tsx
@@ -8,7 +8,6 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
     props: {
       translation,
     },
-    revalidate: 60,
   };
 };
 

--- a/site/pages/500.tsx
+++ b/site/pages/500.tsx
@@ -1,0 +1,15 @@
+import { GetStaticProps } from "next";
+import { Custom500 } from "components/pages/errors/Custom500";
+import { loadTranslation } from "lib/i18n";
+
+export const getStaticProps: GetStaticProps = async (ctx) => {
+  const translation = await loadTranslation(ctx.locale);
+  return {
+    props: {
+      translation,
+    },
+    revalidate: 60,
+  };
+};
+
+export default Custom500;


### PR DESCRIPTION
## Description

This PR does:
- add simple 404 page to Site => [Test URL](https://klimadao-site-git-add-error-pages-klimadao.vercel.app/asdasdasdasd)
- add simple 500 page to Site
- see https://nextjs.org/docs/advanced-features/custom-error-page
- **Small fix: let Footer icons break on small devices**

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves https://github.com/KlimaDAO/klimadao/issues/331


## Changes

| Before  | After  |
|---------|--------|
| ![footer_before](https://user-images.githubusercontent.com/95881624/165081487-6a9fb113-77c3-4256-96ad-91c15cd31ff1.png) | ![footer_after](https://user-images.githubusercontent.com/95881624/165081483-57fea4c8-7695-4183-9428-d55051a9a3ed.png) |


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
