### PR TITLE
Script: Extract source "en" translations only for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,19 @@ A set of NPM Workspace commands are provided, and can be run from the root folde
 
 `npm run format-all`: Format all files with `prettier`.
 
+`npm run extract-strings:dev`: Extract translation files for the source language "en".
+
 ## Translations
+
+### For Developers
+
+This repo uses [lingui](https://lingui.js.org/tutorials/react.html) in combination with [translation.io](https://translation.io).
+
+We follow these rules:
+
+- always add an ID to each translation
+- extract the source translation with `npm run extract-strings:dev`
+- commit source language files "en" only
 
 ### For translators
 

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "start": "next start",
     "export": "next export",
     "lint": "next lint",
-    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean --overwrite 2>&1 | grep 'Cannot process file'\"; if [ -z \"$(eval $cmd)\" ]; then exit 0; else exit 1; fi",
+    "lingui:extract": "NODE_ENV=test npx lingui extract --clean --overwrite",
     "lingui:compile": "NODE_ENV=test lingui compile",
     "postinstall": "npm run lingui:compile"
   },

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "start": "next start",
     "export": "next export",
     "lint": "next lint",
-    "lingui:extract": "NODE_ENV=test npx lingui extract --clean --overwrite",
+    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean --overwrite 2>&1 | grep 'Cannot process file'\"; if [ -z \"$(eval $cmd)\" ]; then exit 0; else exit 1; fi",
     "lingui:compile": "NODE_ENV=test lingui compile",
     "lingui:extract:dev": "NODE_ENV=test npx lingui extract --clean --overwrite --locale=en",
     "postinstall": "npm run lingui:compile"

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "lingui:extract": "NODE_ENV=test npx lingui extract --clean --overwrite",
     "lingui:compile": "NODE_ENV=test lingui compile",
+    "lingui:extract:dev": "NODE_ENV=test npx lingui extract --clean --overwrite --locale=en",
     "postinstall": "npm run lingui:compile"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "deploy-cms": "cd ./cms && npm run deploy",
     "format-all": "prettier --write ./",
     "extract-strings": "npm run -w site lingui:extract && npm run -w app lingui:extract",
-    "compile-strings": "npm run extract-strings && npm run -w site lingui:compile && npm run -w app lingui:compile"
+    "compile-strings": "npm run extract-strings && npm run -w site lingui:compile && npm run -w app lingui:compile",
+    "extract-strings:dev": "npm run -w site lingui:extract:dev && npm run -w app lingui:extract:dev"
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
     "build": "prettier --check . && next build",
     "start": "next start",
     "lint": "next lint",
-    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean --overwrite 2>&1 | grep 'Cannot process file'\"; if [ -z \"$(eval $cmd)\" ]; then exit 0; else exit 1; fi",
+    "lingui:extract": "NODE_ENV=test npx lingui extract --clean --overwrite",
     "lingui:compile": "NODE_ENV=test lingui compile",
     "postinstall": "npm run lingui:compile"
   },

--- a/site/package.json
+++ b/site/package.json
@@ -8,6 +8,7 @@
     "lint": "next lint",
     "lingui:extract": "NODE_ENV=test npx lingui extract --clean --overwrite",
     "lingui:compile": "NODE_ENV=test lingui compile",
+    "lingui:extract:dev": "NODE_ENV=test npx lingui extract --clean --overwrite --locale=en",
     "postinstall": "npm run lingui:compile"
   },
   "dependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
     "build": "prettier --check . && next build",
     "start": "next start",
     "lint": "next lint",
-    "lingui:extract": "NODE_ENV=test npx lingui extract --clean --overwrite",
+    "lingui:extract": "cmd=\"NODE_ENV=test npx lingui extract --clean --overwrite 2>&1 | grep 'Cannot process file'\"; if [ -z \"$(eval $cmd)\" ]; then exit 0; else exit 1; fi",
     "lingui:compile": "NODE_ENV=test lingui compile",
     "lingui:extract:dev": "NODE_ENV=test npx lingui extract --clean --overwrite --locale=en",
     "postinstall": "npm run lingui:compile"


### PR DESCRIPTION
## Description

This PR does:
- add a new script `npm run extract-strings:dev` which extracts the source translations for "en" only
- ~remove the error catch for "can not process files" as this script runs on GH servers only!~
- => let´s keep this one for now to at least stop the github action workflow run if an error happens

This new script should help developers for local development and extract the source language only.
And should **prevent developers from pushing other language files** as these are handled by Github actions anyways.


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
