### PR TITLE
Correctly pass params when redirecting to /stake

### DIFF
--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -1,6 +1,6 @@
 import { ethers, providers } from "ethers";
 import { FC, useRef, useState, useEffect } from "react";
-import { useNavigate, Route, useLocation } from "react-router-dom";
+import { Route, useLocation } from "react-router-dom";
 import WalletConnectProvider from "@walletconnect/web3-provider";
 import WalletLink from "walletlink";
 import Web3Modal from "web3modal";
@@ -152,7 +152,6 @@ export const Home: FC = () => {
   const localeFromURL = useLocaleFromParams();
 
   const { pathname } = useLocation();
-  const navigate = useNavigate();
   const [showCheckURLBanner, setShowCheckURLBanner] = useState(
     !skipCheckURLBanner()
   );
@@ -169,7 +168,7 @@ export const Home: FC = () => {
 
   useEffect(() => {
     if (pathname === "/") {
-      navigate("/stake");
+      window.location.replace(`/#/stake${window.location.search}`);
     }
   }, [pathname]);
 


### PR DESCRIPTION
## Description
When the user navigates to the app, we redirect them to a default view (/#/stake)

https://github.com/KlimaDAO/klimadao/blob/31e19ec9b0a91ea81b1914a6aa70661cf1342673/app/components/views/Home/index.tsx#L170-L174

React router `navigate()` was making wacky urls like `app.klimadao.finance/?locale=de#/stake`

Fixed by ditching `navigate()` and using browser native APIs