### PR TITLE
App: Fix tooltip re-render on language change

### DIFF
--- a/app/components/BalancesCard/index.tsx
+++ b/app/components/BalancesCard/index.tsx
@@ -14,7 +14,7 @@ type AssetLabels = { [key in Asset]: string };
 
 interface Props {
   assets: Asset[];
-  tooltip: string;
+  tooltip: React.ReactNode;
 }
 
 export const BalancesCard: FC<Props> = (props) => {

--- a/app/components/InfoButton/index.tsx
+++ b/app/components/InfoButton/index.tsx
@@ -4,7 +4,7 @@ import * as styles from "./styles";
 import { TextInfoTooltip } from "@klimadao/lib/components";
 
 interface Props {
-  content: string | React.ReactNode;
+  content: React.ReactNode;
 }
 
 export const InfoButton: FC<Props> = (props) => {

--- a/app/components/RebaseCard/index.tsx
+++ b/app/components/RebaseCard/index.tsx
@@ -6,7 +6,7 @@ import { selectAppState, selectBalances, selectLocale } from "state/selectors";
 import * as styles from "./styles";
 import { secondsUntilBlock, trimWithPlaceholder } from "@klimadao/lib/utils";
 import { FC } from "react";
-import { Trans, t } from "@lingui/macro";
+import { Trans } from "@lingui/macro";
 
 interface Props {
   isConnected?: boolean;
@@ -44,11 +44,12 @@ export const RebaseCard: FC<Props> = (props) => {
           <Trans id="stake.rebase">Rebase</Trans>
         </Text>
         <InfoButton
-          content={t({
-            id: "stake.rebase.info",
-            message:
-              "The protocol automatically mints and distributes rewards. Your payout is a percentage of your sKLIMA balance.",
-          })}
+          content={
+            <Trans id="stake.rebase.info">
+              The protocol automatically mints and distributes rewards. Your
+              payout is a percentage of your sKLIMA balance
+            </Trans>
+          }
         />
       </div>
       <div className="cardContent">

--- a/app/components/views/Buy/index.tsx
+++ b/app/components/views/Buy/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { providers } from "ethers";
 import { Link } from "react-router-dom";
-import { Trans, t } from "@lingui/macro";
+import { Trans } from "@lingui/macro";
 import Payment from "@mui/icons-material/Payment";
 import Check from "@mui/icons-material/Check";
 import ContentCopy from "@mui/icons-material/ContentCopy";
@@ -109,12 +109,12 @@ export const Buy = (props: Props) => {
       </div>
       <BalancesCard
         assets={["klima", "sklima"]}
-        tooltip={t({
-          id: "stake.balancescard.tooltip",
-          message:
-            "Stake your KLIMA tokens to receive sKLIMA. After every rebase, your sKLIMA balance will increase by the given percentage.",
-          comment: "Long sentence",
-        })}
+        tooltip={
+          <Trans id="stake.balancescard.tooltip" comment="Long sentence">
+            Stake your KLIMA tokens to receive sKLIMA. After every rebase, your
+            sKLIMA balance will increase by the given percentage.
+          </Trans>
+        }
       />
       <ImageCard />
     </>

--- a/app/components/views/PKlima/index.tsx
+++ b/app/components/views/PKlima/index.tsx
@@ -165,12 +165,15 @@ export const PKlima: FC<Props> = (props) => {
     <>
       <BalancesCard
         assets={["pklima", "bct"]}
-        tooltip={t({
-          id: "pklima.balances_card.make_sure_to_stake",
-          message:
-            "Make sure to stake your redeemed pKLIMA, and stay staked, until global GHG emissions have plateaued.",
-          comment: "Long sentence",
-        })}
+        tooltip={
+          <Trans
+            id="pklima.balances_card.make_sure_to_stake"
+            comment="Long sentence"
+          >
+            Make sure to stake your redeemed pKLIMA, and stay staked, until
+            global GHG emissions have plateaued.
+          </Trans>
+        }
       />
       <div className={styles.stakeCard} style={{ minHeight: "48rem" }}>
         <div className={styles.stakeCard_header}>

--- a/app/components/views/Stake/index.tsx
+++ b/app/components/views/Stake/index.tsx
@@ -216,12 +216,12 @@ export const Stake = (props: Props) => {
     <>
       <BalancesCard
         assets={["klima", "sklima"]}
-        tooltip={t({
-          id: "stake.balancescard.tooltip",
-          message:
-            "Stake your KLIMA tokens to receive sKLIMA. After every rebase, your sKLIMA balance will increase by the given percentage.",
-          comment: "Long sentence",
-        })}
+        tooltip={
+          <Trans id="stake.balancescard.tooltip" comment="Long sentence">
+            Stake your KLIMA tokens to receive sKLIMA. After every rebase, your
+            sKLIMA balance will increase by the given percentage.
+          </Trans>
+        }
       />
       <RebaseCard isConnected={props.isConnected} />
 

--- a/app/components/views/Wrap/index.tsx
+++ b/app/components/views/Wrap/index.tsx
@@ -167,10 +167,11 @@ export const Wrap: FC<Props> = (props) => {
     <>
       <BalancesCard
         assets={["sklima", "wsklima"]}
-        tooltip={t({
-          id: "wrap.balances_tooltip",
-          message: "Wrap sKLIMA to receive index-adjusted wrapped-staked-KLIMA",
-        })}
+        tooltip={
+          <Trans id="wrap.balances_tooltip">
+            Wrap sKLIMA to receive index-adjusted wrapped-staked-KLIMA
+          </Trans>
+        }
       />
 
       <div className={styles.stakeCard} style={{ minHeight: "74rem" }}>

--- a/lib/components/TextInfoTooltip/index.tsx
+++ b/lib/components/TextInfoTooltip/index.tsx
@@ -4,7 +4,7 @@ import styles from "./styles";
 
 interface Props extends TippyProps {
   /** String to be displayed in the tooltip. */
-  content: string | React.ReactNode;
+  content: React.ReactNode;
   /** Must be a focusable plain JSX element. Wrap with <span tabindex="0"> if needed. */
   children: JSX.Element;
 }


### PR DESCRIPTION
## Description

This PR replaces the lingui function `t` with the component `Trans` which handles the language change and the tooltip content is shown in the correct language.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves https://github.com/KlimaDAO/klimadao/issues/340


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
