### PR TITLE
App: Fix stake and wrap input placeholder language switch

### DIFF
--- a/app/components/views/Stake/index.tsx
+++ b/app/components/views/Stake/index.tsx
@@ -49,7 +49,7 @@ export const Stake = (props: Props) => {
   const locale = useSelector(selectLocale);
 
   const dispatch = useAppDispatch();
-  const [view, setView] = useState("stake");
+  const [view, setView] = useState<"stake" | "unstake">("stake");
   const fullStatus: AppNotificationStatus | null = useSelector(
     selectNotificationStatus
   );
@@ -190,22 +190,6 @@ export const Stake = (props: Props) => {
     }
   };
 
-  const getInputPlaceholder = (): string => {
-    if (view === "stake") {
-      return t({
-        id: "stake.inputplaceholder.stake",
-        message: "Amount to stake",
-      });
-    } else if (view === "unstake") {
-      return t({
-        id: "stake.inputplaceholder.unstake",
-        message: "Amount to unstake",
-      });
-    } else {
-      return t({ id: "shared.error", message: "ERROR" });
-    }
-  };
-
   const showSpinner =
     props.isConnected &&
     (status === "userConfirmation" ||
@@ -268,16 +252,21 @@ export const Stake = (props: Props) => {
               </button>
             </div>
             <div className={styles.stakeInput}>
-              <input
-                className={styles.stakeInput_input}
-                value={quantity}
-                onChange={(e) => {
-                  setQuantity(e.target.value);
-                  setStatus(null);
-                }}
-                type="number"
-                placeholder={getInputPlaceholder()}
-                min="0"
+              <Trans
+                id={`stake.inputplaceholder.${view}`}
+                render={({ translation }) => (
+                  <input
+                    className={styles.stakeInput_input}
+                    value={quantity}
+                    onChange={(e) => {
+                      setQuantity(e.target.value);
+                      setStatus(null);
+                    }}
+                    type="number"
+                    placeholder={translation as string}
+                    min="0"
+                  />
+                )}
               />
               <button
                 className={styles.stakeInput_max}

--- a/app/components/views/Wrap/index.tsx
+++ b/app/components/views/Wrap/index.tsx
@@ -158,10 +158,8 @@ export const Wrap: FC<Props> = (props) => {
     return `${Number(quantity) * Number(currentIndex)} ${suffix}`;
   };
 
-  const inputPlaceholder =
-    view === "wrap"
-      ? t({ id: "wrap.sklima_to_wrap", message: "sKLIMA to wrap" })
-      : t({ id: "wrap.wsklima_to_unwrap", message: "wsKLIMA to unwrap" });
+  const inputPlaceholderMessageID =
+    view === "wrap" ? "wrap.sklima_to_wrap" : "wrap.wsklima_to_unwrap";
 
   return (
     <>
@@ -226,13 +224,18 @@ export const Wrap: FC<Props> = (props) => {
               </button>
             </div>
             <div className={styles.stakeInput}>
-              <input
-                className={styles.stakeInput_input}
-                value={quantity}
-                onChange={(e) => setQuantity(e.target.value)}
-                type="number"
-                placeholder={inputPlaceholder}
-                min="0"
+              <Trans
+                id={inputPlaceholderMessageID}
+                render={({ translation }) => (
+                  <input
+                    className={styles.stakeInput_input}
+                    value={quantity}
+                    onChange={(e) => setQuantity(e.target.value)}
+                    type="number"
+                    placeholder={translation as string}
+                    min="0"
+                  />
+                )}
               />
               <button
                 className={styles.stakeInput_max}


### PR DESCRIPTION
## Description

This PR ensures that when switching the language in App the stake and wrap input placeholders do change too.

**Please test! Thanks**

**BEFORE:** https://staging-dapp.klimadao.finance/#/wrap
=> when changing the language **the input placeholder does not change**

**AFTER:** https://klimadao-app-git-fix-stake-input-placeholder-klimadao.vercel.app/#/wrap

---


**BEFORE:** https://staging-dapp.klimadao.finance/#/stake
=> when changing the language **the input placeholder does not change**

**AFTER:** https://klimadao-app-git-fix-stake-input-placeholder-klimadao.vercel.app/#/stake

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
