### PR TITLE
[site] Fix padding for german, fix z-index conflict for language menu

### DIFF
--- a/site/components/pages/Home/index.tsx
+++ b/site/components/pages/Home/index.tsx
@@ -174,7 +174,7 @@ export const Home: NextPage<Props> = (props) => {
           <ParralaxWormhole />
         </div>
       </Section>
-      <Section variant="gray" fillViewport>
+      <Section variant="gray" fillViewport style={{ overflow: "hidden" }}>
         <div className={styles.mechanicsSection}>
           <div className="mechanics_textGroup">
             <Text t="h2" as="h2">

--- a/site/components/pages/Home/styles.ts
+++ b/site/components/pages/Home/styles.ts
@@ -44,7 +44,7 @@ export const heroSection = css`
     grid-template-rows: auto 1fr;
     grid-template-columns: inherit;
     grid-column: full;
-    z-index: 1;
+    z-index: 0;
   }
 
   .hero_whiteCard {
@@ -126,7 +126,6 @@ export const heroSection = css`
       grid-template-rows: unset;
       grid-template-columns: 1fr 1fr;
       grid-column: main;
-      z-index: 1;
       gap: 2.4rem;
     }
     .hero_whiteCard,

--- a/site/components/pages/Home/styles.ts
+++ b/site/components/pages/Home/styles.ts
@@ -270,7 +270,7 @@ export const mechanicsSection = css`
     animation: ${floatRight} 14s ease-in-out 1s infinite;
   }
   p.align-start {
-    margin-inline-start: -4.8rem;
+    margin-inline-start: -8.8rem;
     animation: ${floatLeft} 14s ease-in-out 2s infinite;
   }
   .mechanics_item:nth-child(1) {
@@ -454,7 +454,7 @@ export const sproutsSection = css`
     gap: 0.8rem;
   }
 
-  ${breakpoints.large} {
+  ${breakpoints.desktop} {
     grid-template-columns: 1fr 1fr;
     .sprouts_col2 > div {
       display: flex;


### PR DESCRIPTION
## Related Ticket

Resolves #351
Resolves #353 

## Checklist

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
