### PR TITLE
added checkbox for autostake on bond page and added param to redeem c…

### DIFF
--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -344,9 +344,11 @@ export const redeemTransaction = async (params: {
   bond: Bond;
   provider: providers.JsonRpcProvider;
   onStatus: OnStatusHandler;
+  shouldAutostake: boolean;
 }) => {
   try {
-    const autostake = false;
+    // update this line if we change prop to required
+    const autostake = params.shouldAutostake;
     const signer = params.provider.getSigner();
     const contractAddress = getBondAddress({ bond: params.bond });
     const contract = new ethers.Contract(

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -347,8 +347,6 @@ export const redeemTransaction = async (params: {
   shouldAutostake: boolean;
 }) => {
   try {
-    // update this line if we change prop to required
-    const autostake = params.shouldAutostake;
     const signer = params.provider.getSigner();
     const contractAddress = getBondAddress({ bond: params.bond });
     const contract = new ethers.Contract(
@@ -357,7 +355,7 @@ export const redeemTransaction = async (params: {
       signer
     );
     params.onStatus("userConfirmation", "");
-    const txn = await contract.redeem(params.address, autostake);
+    const txn = await contract.redeem(params.address, params.shouldAutostake);
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);
     params.onStatus("done", "Bond redeemed successfully");

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -39,6 +39,7 @@ import { RootState, useAppDispatch } from "state";
 import { setBondAllowance } from "state/user";
 import { redeemBond, setBond } from "state/bonds";
 import InfoOutlined from "@mui/icons-material/InfoOutlined";
+import { Box, Checkbox } from "@mui/material";
 
 import * as styles from "./styles";
 import { BondBalancesCard } from "components/BondBalancesCard";
@@ -125,6 +126,7 @@ export const Bond: FC<Props> = (props) => {
 
   const [view, setView] = useState("bond");
   const [quantity, setQuantity] = useState("");
+  const [shouldAutostake, setShouldAutostake] = useState(false);
   const debouncedQuantity = useDebounce(quantity, 500);
 
   const { currentBlock, blockRate } = useSelector(selectAppState);
@@ -222,6 +224,8 @@ export const Bond: FC<Props> = (props) => {
     }
   };
 
+  const handleAutostakeCheck = () => setShouldAutostake(!shouldAutostake)
+
   const handleBond = async () => {
     try {
       if (
@@ -276,6 +280,7 @@ export const Bond: FC<Props> = (props) => {
         bond: props.bond,
         provider: props.provider,
         onStatus: setStatus,
+        shouldAutostake,
       });
       dispatch(
         redeemBond({
@@ -749,10 +754,39 @@ export const Bond: FC<Props> = (props) => {
                 <Spinner />
               </div>
             ) : (
-              <ButtonPrimary
-                {...getButtonProps()}
-                className={styles.submitButton}
-              />
+              <Box
+                sx={{ display: "flex", flexDirection: "column", width: "100%" }}
+              >
+                <ButtonPrimary
+                  {...getButtonProps()}
+                  className={styles.submitButton}
+                />
+                {view === "redeem" && !showSpinner && (
+                  <Box
+                    sx={{
+                      display: "flex",
+                      width: "100%",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      paddingRight: "16px",
+                    }}
+                  >
+                    <Checkbox
+                      checked={shouldAutostake}
+                      onChange={handleAutostakeCheck}
+                      sx={{ color: "#fff" }}
+                    />{" "}
+                    <Text t="caption" align="center">
+                      <Trans
+                        id="bond.should_autostake"
+                        comment="should autostake?"
+                      >
+                        Autostake
+                      </Trans>
+                    </Text>
+                  </Box>
+                )}
+              </Box>
             )}
           </div>
         </div>

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -224,7 +224,7 @@ export const Bond: FC<Props> = (props) => {
     }
   };
 
-  const handleAutostakeCheck = () => setShouldAutostake(!shouldAutostake)
+  const handleAutostakeCheck = () => setShouldAutostake(!shouldAutostake);
 
   const handleBond = async () => {
     try {

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -39,8 +39,8 @@ import { RootState, useAppDispatch } from "state";
 import { setBondAllowance } from "state/user";
 import { redeemBond, setBond } from "state/bonds";
 import InfoOutlined from "@mui/icons-material/InfoOutlined";
-import { Box, Checkbox } from "@mui/material";
-
+import Box from "@mui/material/Box";
+import Checkbox from "@mui/material/Checkbox";
 import * as styles from "./styles";
 import { BondBalancesCard } from "components/BondBalancesCard";
 import { Image } from "components/Image";
@@ -224,7 +224,7 @@ export const Bond: FC<Props> = (props) => {
     }
   };
 
-  const handleAutostakeCheck = () => setShouldAutostake(!shouldAutostake);
+  const handleAutostakeCheck = (): void => setShouldAutostake(!shouldAutostake);
 
   const handleBond = async () => {
     try {
@@ -286,6 +286,7 @@ export const Bond: FC<Props> = (props) => {
         redeemBond({
           bond: props.bond,
           value: bondState.pendingPayout,
+          autostake: shouldAutostake,
         })
       );
     } catch (e) {
@@ -762,29 +763,21 @@ export const Bond: FC<Props> = (props) => {
                   className={styles.submitButton}
                 />
                 {view === "redeem" && !showSpinner && (
-                  <Box
-                    sx={{
-                      display: "flex",
-                      width: "100%",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      paddingRight: "16px",
-                    }}
-                  >
+                  <div className={styles.checkboxContainer}>
                     <Checkbox
                       checked={shouldAutostake}
                       onChange={handleAutostakeCheck}
-                      sx={{ color: "#fff" }}
+                      className={styles.checkbox}
                     />{" "}
                     <Text t="caption" align="center">
                       <Trans
                         id="bond.should_autostake"
                         comment="should autostake?"
                       >
-                        Autostake
+                        Automatically stake for sKLIMA
                       </Trans>
                     </Text>
-                  </Box>
+                  </div>
                 )}
               </Box>
             )}

--- a/app/components/views/Bond/styles.ts
+++ b/app/components/views/Bond/styles.ts
@@ -154,3 +154,15 @@ export const inputsContainer = css`
   display: grid;
   gap: 2rem;
 `;
+
+export const checkboxContainer = css`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  padding-right: 1.6rem;
+`;
+
+export const checkbox = css`
+  color: var(--font-01);
+`;

--- a/app/state/bonds/index.ts
+++ b/app/state/bonds/index.ts
@@ -38,7 +38,10 @@ export const bondsSlice = createSlice({
     setBond: (s, a: PayloadAction<BondPayload>) => {
       s[a.payload.bond] = { ...s[a.payload.bond], ...a.payload };
     },
-    redeemBond: (s, a: PayloadAction<{ bond: Bond; value: string }>) => {
+    redeemBond: (
+      s,
+      a: PayloadAction<{ bond: Bond; value: string; autostake?: boolean }>
+    ) => {
       s[a.payload.bond]!.pendingPayout = safeSub(
         s[a.payload.bond]!.pendingPayout!,
         a.payload.value

--- a/app/state/user/index.ts
+++ b/app/state/user/index.ts
@@ -220,10 +220,11 @@ export const userSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(redeemBond, (s, a) => {
       if (!s.balance) return;
-      s.balance.klima = safeAdd(
-        a.payload.autostake ? s.balance.sklima : s.balance.klima,
-        a.payload.value
-      );
+      if (a.payload.autostake) {
+        s.balance.sklima = safeAdd(s.balance.sklima, a.payload.value);
+      } else {
+        s.balance.klima = safeAdd(s.balance.klima, a.payload.value);
+      }
     });
   },
 });

--- a/app/state/user/index.ts
+++ b/app/state/user/index.ts
@@ -220,7 +220,10 @@ export const userSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(redeemBond, (s, a) => {
       if (!s.balance) return;
-      s.balance.klima = safeAdd(s.balance.klima, a.payload.value);
+      s.balance.klima = safeAdd(
+        a.payload.autostake ? s.balance.sklima : s.balance.klima,
+        a.payload.value
+      );
     });
   },
 });


### PR DESCRIPTION
…ontract call

## Description
I added a checkbox to to bond page that will autostake upon redeeming a bond. It passes in a required prop to `redeemTransaction` and then passes that param to the `redeem` contract call. The check box will show as long as the view is "redeem" and loading is false. We may want to disable it if the bond is not claimable?

## Related Ticket

Issue #64 

Resolves #64 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/24912886/165827258-76bc5117-2bee-49f7-8273-2b8e41b1fb66.png) |
![image](https://user-images.githubusercontent.com/24912886/165827159-7e8a27d8-ec7d-4916-9ab4-ce4eacee451b.png)
|
-->

## Checklist

<!-- Check completed item: [X] -->

- [x ] Building the site with `npm run build-site` works without errors
- [x ] Building the app with `npm run build-app` works without errors
- [x ] I formatted JS and TS files with running `npm run format-all`
