### PR TITLE
Fix extract strings with same message ID

### DIFF
--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/views/Offset/index.tsx:636
+#: components/views/Offset/index.tsx:643
 msgid "Beneficiary Address"
 msgstr "Beneficiary Address"
 
-#: components/views/Offset/index.tsx:656
+#: components/views/Offset/index.tsx:663
 msgid "Download certificate"
 msgstr "Download certificate"
 
-#: components/views/Offset/index.tsx:644
+#: components/views/Offset/index.tsx:651
 msgid "Message"
 msgstr "Message"
 
-#: components/views/Offset/index.tsx:630
+#: components/views/Offset/index.tsx:637
 msgid "Name"
 msgstr "Name"
 
@@ -33,11 +33,11 @@ msgstr "Name"
 msgid "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
 msgstr "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
 
-#: components/views/Offset/index.tsx:624
+#: components/views/Offset/index.tsx:631
 msgid "Retirement Successful"
 msgstr "Retirement Successful"
 
-#: components/views/Offset/index.tsx:664
+#: components/views/Offset/index.tsx:671
 msgid "Share retirement"
 msgstr "Share retirement"
 
@@ -49,11 +49,11 @@ msgstr "Switch to Polygon"
 msgid "This app only works on Polygon Mainnet."
 msgstr "This app only works on Polygon Mainnet."
 
-#: components/views/Offset/index.tsx:650
+#: components/views/Offset/index.tsx:657
 msgid "Tonnes Retired"
 msgstr "Tonnes Retired"
 
-#: components/views/Offset/index.tsx:671
+#: components/views/Offset/index.tsx:678
 msgid "View on <0>polygonscan.com</0>"
 msgstr "View on <0>polygonscan.com</0>"
 
@@ -61,147 +61,152 @@ msgstr "View on <0>polygonscan.com</0>"
 msgid "Wrong Network"
 msgstr "Wrong Network"
 
-#: components/views/Offset/index.tsx:659
-#: components/views/Offset/index.tsx:667
+#: components/views/Offset/index.tsx:666
+#: components/views/Offset/index.tsx:674
 msgid "[coming soon]"
 msgstr "[coming soon]"
 
-#: components/views/Offset/index.tsx:728
+#: components/views/Offset/index.tsx:746
 msgid "advanced"
 msgstr "ADVANCED"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:737
+#: components/views/Bond/index.tsx:743
 msgid "bond.all_demand_has_been_filled"
 msgstr "🪧 SOLD OUT. All demand has been filled for this bond. Thank you, Klimates!"
 
-#: components/views/Bond/index.tsx:480
+#: components/views/Bond/index.tsx:486
 msgid "bond.balance"
 msgstr "Balance"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:484
+#: components/views/Bond/index.tsx:490
 msgid "bond.balance.tooltip"
 msgstr "Balance available for bonding"
 
-#: components/views/Bond/index.tsx:345
-#: components/views/Bond/index.tsx:427
+#: components/views/Bond/index.tsx:351
+#: components/views/Bond/index.tsx:433
 msgid "bond.bond"
 msgstr "Bond"
 
-#: components/views/Bond/index.tsx:503
+#: components/views/Bond/index.tsx:509
 msgid "bond.bond_price"
 msgstr "Bond price"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:507
+#: components/views/Bond/index.tsx:513
 msgid "bond.bond_price.tooltip"
 msgstr "Discounted price. Total amount to bond 1 full KLIMA (fractional bonds are also allowed)"
 
 #. Bond {0}
-#: components/views/Bond/index.tsx:407
+#: components/views/Bond/index.tsx:413
 msgid "bond.bond_token"
 msgstr "Bond {0}"
 
-#: components/views/Bond/index.tsx:697
+#: components/views/Bond/index.tsx:703
 msgid "bond.date_of_full_vesting"
 msgstr "Date of full vesting"
 
-#: components/views/Bond/index.tsx:702
+#: components/views/Bond/index.tsx:708
 msgid "bond.date_of_full_vesting.tooltip"
 msgstr "Date when the entire bond value can be redeemed"
 
-#: components/views/Bond/index.tsx:594
+#: components/views/Bond/index.tsx:600
 msgid "bond.debt_ratio"
 msgstr "Debt ratio"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:598
+#: components/views/Bond/index.tsx:604
 msgid "bond.debt_ratio.tooltip"
 msgstr "Protocol's current ratio of supply to outstanding bonds"
 
-#: components/views/Bond/index.tsx:535
+#: components/views/Bond/index.tsx:541
 msgid "bond.discount"
 msgstr "Bond discount"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:539
+#: components/views/Bond/index.tsx:545
 msgid "bond.discount.tooltip"
 msgstr "Percentage discount (or premium if negative) on KLIMA received for this bond, relative to the market value of KLIMA."
 
-#: components/views/Bond/index.tsx:367
+#: components/views/Bond/index.tsx:373
 msgid "bond.inputplaceholder.amount_to_bond"
 msgstr "Amount to bond"
 
-#: components/views/Bond/index.tsx:372
+#: components/views/Bond/index.tsx:378
 msgid "bond.inputplaceholder.amount_to_redeem"
 msgstr "Amount to redeem"
 
-#: components/views/Bond/index.tsx:519
+#: components/views/Bond/index.tsx:525
 msgid "bond.market_price"
 msgstr "Market price"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:523
+#: components/views/Bond/index.tsx:529
 msgid "bond.market_price.tooltip"
 msgstr "Current trading price of KLIMA, without bond discount"
 
-#: components/views/Bond/index.tsx:575
+#: components/views/Bond/index.tsx:581
 msgid "bond.maximum"
 msgstr "Maximum"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:579
+#: components/views/Bond/index.tsx:585
 msgid "bond.maximum.tooltip"
 msgstr "Maximum amount of KLIMA you can acquire by bonding"
 
-#: components/views/Bond/index.tsx:323
+#: components/views/Bond/index.tsx:329
 msgid "bond.not_redeemable"
 msgstr "Not Redeemable"
 
-#: components/views/Bond/index.tsx:351
-#: components/views/Bond/index.tsx:437
+#: components/views/Bond/index.tsx:357
+#: components/views/Bond/index.tsx:443
 msgid "bond.redeem"
 msgstr "Redeem"
 
-#: components/views/Bond/index.tsx:664
+#: components/views/Bond/index.tsx:670
 msgid "bond.redeemable"
 msgstr "Redeemable"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:667
+#: components/views/Bond/index.tsx:673
 msgid "bond.redeemable.tooltip"
 msgstr "Amount of KLIMA that has already vested and can be redeemed"
 
+#. should autostake?
+#: components/views/Bond/index.tsx:773
+msgid "bond.should_autostake"
+msgstr "Automatically stake for sKLIMA"
+
 #. Long sentence
-#: components/views/Bond/index.tsx:726
+#: components/views/Bond/index.tsx:732
 msgid "bond.this_bond_price_is_inflated"
 msgstr "⚠️ Warning: this bond price is inflated because the current discount rate is negative."
 
-#: components/views/Bond/index.tsx:635
+#: components/views/Bond/index.tsx:641
 msgid "bond.unredeemed"
 msgstr "Unredeemed"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:638
+#: components/views/Bond/index.tsx:644
 msgid "bond.unredeemed.tooltip"
 msgstr "Remaining unredeemed value (vested and un-vested)"
 
-#: components/views/Bond/index.tsx:614
+#: components/views/Bond/index.tsx:620
 msgid "bond.vesting_term_end"
 msgstr "Vesting term end"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:618
+#: components/views/Bond/index.tsx:624
 msgid "bond.vesting_term_end.tooltip"
 msgstr "If you bond now, your vesting term ends at this date. Klima is slowly unlocked for redemption over the duration of this term."
 
-#: components/views/Bond/index.tsx:551
+#: components/views/Bond/index.tsx:557
 msgid "bond.you_will_get"
 msgstr "You will get"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:555
+#: components/views/Bond/index.tsx:561
 msgid "bond.you_will_get.tooltip"
 msgstr "Amount of bonded KLIMA you will get, at the provided input quantity"
 
@@ -405,15 +410,15 @@ msgstr "PENDING"
 msgid "modal.user_confirmation"
 msgstr "CONFIRMATION"
 
-#: components/views/Bond/index.tsx:392
+#: components/views/Bond/index.tsx:398
 msgid "nav.back"
 msgstr "BACK"
 
-#: components/views/Offset/index.tsx:540
+#: components/views/Offset/index.tsx:545
 msgid "offset.aggregation_fee_tooltip"
 msgstr "This cost includes slippage and the aggregation fee of 1%."
 
-#: components/views/Offset/index.tsx:421
+#: components/views/Offset/index.tsx:426
 msgid "offset.amount_in_tonnes"
 msgstr "How many tonnes of carbon would you like to offset?"
 
@@ -421,15 +426,15 @@ msgstr "How many tonnes of carbon would you like to offset?"
 msgid "offset.breakdown"
 msgstr "Breakdown"
 
-#: components/views/Offset/index.tsx:508
+#: components/views/Offset/index.tsx:513
 msgid "offset.default_retirement_address"
 msgstr "Defaults to the connected wallet address"
 
-#: components/views/Offset/index.tsx:447
+#: components/views/Offset/index.tsx:452
 msgid "offset.dropdown_payWith.label"
 msgstr "Pay with"
 
-#: components/views/Offset/index.tsx:462
+#: components/views/Offset/index.tsx:467
 msgid "offset.dropdown_retire.label"
 msgstr "Select carbon offset token to retire"
 
@@ -437,24 +442,24 @@ msgstr "Select carbon offset token to retire"
 msgid "offset.empty"
 msgstr "This address has not completed any retirements."
 
-#: components/views/Offset/index.tsx:502
-#: components/views/Offset/index.tsx:757
+#: components/views/Offset/index.tsx:507
+#: components/views/Offset/index.tsx:775
 msgid "offset.enter_address"
 msgstr "Enter 0x address"
 
-#: components/views/Offset/index.tsx:398
+#: components/views/Offset/index.tsx:403
 msgid "offset.go_carbon_neutral"
 msgstr "Go carbon neutral by retiring carbon and claiming the underlying environmental benefit of the carbon offset. Choose to retire <0>Moss Carbon Credits</0> (MCO2), <1>Base Carbon Tonnes</1> (BCT), or <2>Nature Carbon Tonnes</2> (NCT), with more coming soon."
 
-#: components/views/Offset/index.tsx:377
+#: components/views/Offset/index.tsx:382
 msgid "offset.incompatible"
 msgstr "INPUT TOKEN INCOMPATIBLE"
 
-#: components/views/Offset/index.tsx:448
+#: components/views/Offset/index.tsx:453
 msgid "offset.modal_payWith.title"
 msgstr "Select Token"
 
-#: components/views/Offset/index.tsx:466
+#: components/views/Offset/index.tsx:471
 msgid "offset.modal_retire.title"
 msgstr "Select Carbon Type"
 
@@ -462,39 +467,39 @@ msgstr "Select Carbon Type"
 msgid "offset.number_of_retirements"
 msgstr "Total retirements"
 
-#: components/views/Offset/index.tsx:438
+#: components/views/Offset/index.tsx:443
 msgid "offset.offset_quantity"
 msgstr "Enter quantity to offset"
 
-#: components/views/Offset/index.tsx:395
+#: components/views/Offset/index.tsx:400
 msgid "offset.retire_carbon"
 msgstr "Retire Carbon"
 
-#: components/views/Offset/index.tsx:735
+#: components/views/Offset/index.tsx:753
 msgid "offset.retire_specific"
 msgstr "Retire specific project tokens"
 
-#: components/views/Offset/index.tsx:741
+#: components/views/Offset/index.tsx:759
 msgid "offset.retire_specific_tooltip"
 msgstr "Subject to additional fee, determined by the selected pool and paid to the bridge provider."
 
-#: components/views/Offset/index.tsx:491
+#: components/views/Offset/index.tsx:496
 msgid "offset.retirement_beneficiary"
 msgstr "Name or organisation"
 
-#: components/views/Offset/index.tsx:483
+#: components/views/Offset/index.tsx:488
 msgid "offset.retirement_credit"
 msgstr "Who will this retirement be credited to?"
 
-#: components/views/Offset/index.tsx:517
+#: components/views/Offset/index.tsx:522
 msgid "offset.retirement_message"
 msgstr "Retirement message"
 
-#: components/views/Offset/index.tsx:526
+#: components/views/Offset/index.tsx:531
 msgid "offset.retirement_purpose"
 msgstr "Describe the purpose of this retirement"
 
-#: components/views/Offset/index.tsx:558
+#: components/views/Offset/index.tsx:563
 msgid "offset.retiring"
 msgstr "Retiring"
 
@@ -506,11 +511,11 @@ msgstr "Tonnes of carbon"
 msgid "offset.you_have_retired"
 msgstr "You've Retired"
 
-#: components/views/Offset/index.tsx:536
+#: components/views/Offset/index.tsx:541
 msgid "offset_cost"
 msgstr "Cost"
 
-#: components/views/Offset/index.tsx:569
+#: components/views/Offset/index.tsx:574
 msgid "offset_disclaimer"
 msgstr "Be careful not to expose any sensitive personal information. Your message can not be edited and will permanently exist on a public blockchain."
 
@@ -578,8 +583,8 @@ msgstr "A percent of total token supply. Your index-adjusted claim may not excee
 msgid "pklima.update"
 msgstr "The updated contract now assumes pKLIMA holders have staked and earned rewards on previously claimed tokens. Prior to the November fix, these staking rewards were not counted against your supply share limit, which meant your share of the total KLIMA supply could surpass the limit defined in your terms."
 
-#: components/views/Bond/index.tsx:338
-#: components/views/Offset/index.tsx:306
+#: components/views/Bond/index.tsx:344
+#: components/views/Offset/index.tsx:311
 #: components/views/Stake/index.tsx:164
 #: components/views/Stake/index.tsx:170
 msgid "shared.approve"
@@ -593,15 +598,15 @@ msgstr "Balances"
 msgid "shared.change_language"
 msgstr "Change language"
 
-#: components/views/Bond/index.tsx:332
+#: components/views/Bond/index.tsx:338
 #: components/views/PKlima/index.tsx:140
 #: components/views/Stake/index.tsx:158
 msgid "shared.confirming"
 msgstr "Confirming"
 
-#: components/views/Bond/index.tsx:305
+#: components/views/Bond/index.tsx:311
 #: components/views/Buy/index.tsx:113
-#: components/views/Offset/index.tsx:280
+#: components/views/Offset/index.tsx:285
 #: components/views/PKlima/index.tsx:125
 #: components/views/Stake/index.tsx:143
 #: components/views/Wrap/index.tsx:129
@@ -617,28 +622,28 @@ msgstr "Copy Address {0}"
 msgid "shared.enter_amount"
 msgstr "Enter Amount"
 
-#: components/views/Bond/index.tsx:317
-#: components/views/Offset/index.tsx:292
+#: components/views/Bond/index.tsx:323
+#: components/views/Offset/index.tsx:297
 msgid "shared.enter_quantity"
 msgstr "ENTER QUANTITY"
 
-#: components/views/Bond/index.tsx:358
-#: components/views/Bond/index.tsx:377
+#: components/views/Bond/index.tsx:364
+#: components/views/Bond/index.tsx:383
 #: components/views/Stake/index.tsx:197
 msgid "shared.error"
 msgstr "ERROR"
 
-#: components/views/Offset/index.tsx:299
+#: components/views/Offset/index.tsx:304
 msgid "shared.insufficient_balance"
 msgstr "INSUFFICIENT BALANCE"
 
 #: components/CarbonTonnesBreakdownCard/index.tsx:48
 #: components/RebaseCard/index.tsx:58
 #: components/RebaseCard/index.tsx:69
-#: components/views/Bond/index.tsx:311
+#: components/views/Bond/index.tsx:317
 #: components/views/Loading/index.tsx:11
-#: components/views/Offset/index.tsx:286
-#: components/views/Offset/index.tsx:363
+#: components/views/Offset/index.tsx:291
+#: components/views/Offset/index.tsx:368
 #: components/views/PKlima/index.tsx:131
 #: components/views/Stake/index.tsx:149
 #: components/views/Stake/index.tsx:346
@@ -648,18 +653,18 @@ msgstr "INSUFFICIENT BALANCE"
 msgid "shared.loading"
 msgstr "Loading..."
 
-#: components/views/Bond/index.tsx:465
+#: components/views/Bond/index.tsx:471
 #: components/views/PKlima/index.tsx:212
 #: components/views/Stake/index.tsx:287
 #: components/views/Wrap/index.tsx:255
 msgid "shared.max"
 msgstr "Max"
 
-#: components/views/Offset/index.tsx:312
+#: components/views/Offset/index.tsx:317
 msgid "shared.retire"
 msgstr "RETIRE CARBON"
 
-#: components/views/Bond/index.tsx:299
+#: components/views/Bond/index.tsx:305
 msgid "shared.sold_out"
 msgstr "Sold Out"
 

--- a/site/components/pages/Retirement/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirement/SingleRetirement/index.tsx
@@ -29,7 +29,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
           values: { retirementIndex, beneficiaryAddress },
         })}
         mediaTitle={t({
-          id: "retirement.head.title",
+          id: "retirement.head.metaTitle",
           message: `Your retirement number ${retirementIndex} for address: ${beneficiaryAddress}`,
           values: { retirementIndex, beneficiaryAddress },
         })}

--- a/site/components/pages/Retirement/index.tsx
+++ b/site/components/pages/Retirement/index.tsx
@@ -28,8 +28,8 @@ export const RetirementPage: NextPage<Props> = (props) => {
           values: { beneficiaryAddress },
         })}
         mediaTitle={t({
-          id: "retirement.totals.head.title",
-          message: `KlimaDao - Your total retirements for address: ${props.beneficiaryAddress}`,
+          id: "retirement.totals.head.metaTitle",
+          message: `KlimaDao - Your total retirements for address: ${beneficiaryAddress}`,
           values: { beneficiaryAddress },
         })}
         metaDescription={t({

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -338,12 +338,12 @@ msgstr "We work with traditional carbon market players, crypto platforms, corpor
 msgid "concat.careers"
 msgstr "Careers"
 
-#: components/pages/Resources/Contact/index.tsx:143
+#: components/pages/Resources/Contact/index.tsx:141
 msgid "contact.bug_reports"
 msgstr "Bug Reports"
 
 #. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
-#: components/pages/Resources/Contact/index.tsx:146
+#: components/pages/Resources/Contact/index.tsx:144
 msgid "contact.bug_reports.to_file_a_bug_report"
 msgstr "To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you."
 
@@ -365,26 +365,26 @@ msgstr "Questions, concerns, ideas? Here are a few ways you can get in touch. We
 msgid "contact.head.title"
 msgstr "Contact KlimaDAO"
 
-#: components/pages/Resources/Contact/index.tsx:108
+#: components/pages/Resources/Contact/index.tsx:106
 msgid "contact.media"
 msgstr "Media"
 
 #. Long sentence
-#: components/pages/Resources/Contact/index.tsx:111
+#: components/pages/Resources/Contact/index.tsx:109
 msgid "contact.media.if_you_are_a_journalist"
 msgstr "If you are a journalist or content creator, our marketing team would love to meet you."
 
 #. Use this <0>Media Request Form</0>.
-#: components/pages/Resources/Contact/index.tsx:120
+#: components/pages/Resources/Contact/index.tsx:118
 msgid "contact.media.use_this_media_request_form"
 msgstr "Use this <0>Media Request Form</0> or send an email to <1>press@klimadao.finance</1>"
 
-#: components/pages/Resources/Contact/index.tsx:88
+#: components/pages/Resources/Contact/index.tsx:86
 msgid "contact.partnerships"
 msgstr "Partnerships"
 
 #. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
-#: components/pages/Resources/Contact/index.tsx:91
+#: components/pages/Resources/Contact/index.tsx:89
 msgid "contact.partnerships.until_we_finish_building"
 msgstr "Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>."
 
@@ -652,6 +652,22 @@ msgstr "<0>WELCOME TO</0><1>KlimaDAO</1>"
 msgid "invest_in_the_future"
 msgstr "Invest in the future."
 
+#: components/pages/Retirement/SingleRetirement/index.tsx:31
+msgid "retirement.head.metaTitle"
+msgstr "Your retirement number {retirementIndex} for address: {beneficiaryAddress}"
+
+#: components/pages/Retirement/SingleRetirement/index.tsx:26
+msgid "retirement.head.title"
+msgstr "Your retirement number {retirementIndex} for address: {beneficiaryAddress}"
+
+#: components/pages/Retirement/index.tsx:30
+msgid "retirement.totals.head.metaTitle"
+msgstr "KlimaDao - Your total retirements for address: {beneficiaryAddress}"
+
+#: components/pages/Retirement/index.tsx:25
+msgid "retirement.totals.head.title"
+msgstr "KlimaDao - Your total retirements for address: {beneficiaryAddress}"
+
 #: components/Footer/index.tsx:51
 #: components/pages/Resources/ResourcesHeader/index.tsx:29
 #: components/pages/Resources/ResourcesHeader/index.tsx:64
@@ -703,6 +719,8 @@ msgstr "Enter App"
 #: components/pages/Home/index.tsx:66
 #: components/pages/Resources/Community/index.tsx:82
 #: components/pages/Resources/Contact/index.tsx:25
+#: components/pages/Retirement/SingleRetirement/index.tsx:36
+#: components/pages/Retirement/index.tsx:35
 #: components/pages/errors/Custom404.tsx:25
 #: components/pages/errors/Custom500.tsx:25
 msgid "shared.head.description"


### PR DESCRIPTION
## Description

See here that the latest GH actions are failing: https://github.com/KlimaDAO/klimadao/actions

Reason is [this PR](https://github.com/KlimaDAO/klimadao/pull/366) which introduced same translation message IDs in different places. In this case lingui "Cannot process file" which [is caught in the actual script](https://github.com/KlimaDAO/klimadao/blob/staging/site/package.json#L9) which runs on the GH servers and exits the action run.

This PR contains the fix for the same message IDs.
I ran `npm extract-strings:dev` too which we should include in a check for developers in general for the future.
=> see this [ticket](https://github.com/KlimaDAO/klimadao/issues/348)

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
