### PR TITLE
Fix BigNumber throws "overflow" error on Retirement pages

### DIFF
--- a/lib/types/offset.ts
+++ b/lib/types/offset.ts
@@ -86,6 +86,6 @@ export type Retirements = [
 
 export type RetirementsResult = {
   totalRetirements: ReturnType<Retirements[0]["toNumber"]>;
-  totalCarbonRetired: ReturnType<Retirements[1]["toNumber"]>;
-  totalClaimed: ReturnType<Retirements[2]["toNumber"]>;
+  totalCarbonRetired: string;
+  totalClaimed: string;
 };

--- a/lib/types/offset.ts
+++ b/lib/types/offset.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "ethers";
-
+import { InputToken } from "../constants";
 interface GasUsed {
   type: string;
   hex: string;
@@ -72,7 +72,8 @@ export type RetirementIndexInfo = [
 
 export type RetirementIndexInfoResult = {
   tokenAddress: RetirementIndexInfo[0];
-  amount: ReturnType<RetirementIndexInfo[1]["toNumber"]>;
+  typeOfToken?: InputToken;
+  amount: string;
   beneficiaryName: RetirementIndexInfo[2];
   retirementMessage: RetirementIndexInfo[3];
 };

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -30,8 +30,8 @@ export const getRetirements = async (
       await storageContract.retirements(beneficiaryAdress);
 
     const formattedTotalRetirements = totalRetirements.toNumber();
-    const formattedTotalCarbonRetired = totalCarbonRetired.toNumber();
-    const formattedTotalClaimed = totalClaimed.toNumber();
+    const formattedTotalCarbonRetired = formatUnits(totalCarbonRetired);
+    const formattedTotalClaimed = formatUnits(totalClaimed);
 
     return {
       totalRetirements: formattedTotalRetirements,

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -58,7 +58,7 @@ export const getRetirementIndexInfo = async (
       retirementMessage,
     ]: RetirementIndexInfo = await storageContract.getRetirementIndexInfo(
       beneficiaryAdress,
-      index
+      BigNumber.from(index)
     );
 
     return {

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -1,7 +1,12 @@
-import { ethers } from "ethers";
+import { ethers, BigNumber } from "ethers";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
 import KlimaRetirementStorage from "../../abi/KlimaRetirementStorage.json";
 import { addresses } from "../../constants";
+import {
+  getTypeofTokenByAddress,
+  formatUnits,
+  getTokenDecimals,
+} from "../../utils";
 
 import {
   Retirements,
@@ -61,14 +66,19 @@ export const getRetirementIndexInfo = async (
       BigNumber.from(index)
     );
 
+    const typeOfToken = getTypeofTokenByAddress(tokenAddress);
+    const tokenDecimals = getTokenDecimals(typeOfToken || "");
+    const formattedAmount = formatUnits(amount, tokenDecimals);
+
     return {
       tokenAddress,
-      amount: amount.toNumber(),
+      typeOfToken,
+      amount: formattedAmount,
       beneficiaryName,
       retirementMessage,
     };
   } catch (e) {
-    console.error(e);
+    console.error("getRetirementIndexInfo Error", e);
     return Promise.reject(e);
   }
 };

--- a/lib/utils/getTypeOfToken/index.ts
+++ b/lib/utils/getTypeOfToken/index.ts
@@ -1,0 +1,10 @@
+import { addresses, InputToken } from "../../constants";
+
+const { mainnet } = addresses;
+
+export const getTypeofTokenByAddress = (
+  tokenAddress: string
+): InputToken | undefined =>
+  Object.keys(mainnet).find(
+    (key) => mainnet[key as InputToken] === tokenAddress.toLowerCase()
+  ) as InputToken;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -16,3 +16,4 @@ export { safeSub } from "./safeSub";
 export { getEstimatedDailyRebases } from "./getEstimatedDailyRebases";
 export { fetchBlockRate } from "./fetchBlockRate";
 export { getTokenDecimals } from "./getTokenDecimals";
+export { getTypeofTokenByAddress } from "./getTypeOfToken";

--- a/site/components/pages/Retirement/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirement/SingleRetirement/index.tsx
@@ -51,6 +51,9 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
               tokenAddress: {props.retirementIndexInfo.tokenAddress}
             </Text>
             <Text align="center">
+              typeOfToken: {props.retirementIndexInfo.typeOfToken}
+            </Text>
+            <Text align="center">
               amount: {props.retirementIndexInfo.amount}
             </Text>
             <Text align="center">


### PR DESCRIPTION
## Description

[BigNumber.toNumber](https://docs.ethers.io/v5/api/utils/bignumber/#BigNumber--BigNumber--methods--conversion) method can not handle JavaScript numbers outside the safe range.
See the docs => https://docs.ethers.io/v5/troubleshooting/errors/#help-NUMERIC_FAULT-overflow

This the reason why the retirement pages can not be generated for some addresses.

Replacing `toNumber` with `ethers.utils.parseUnits` fixes the overflow error.
Thus, this PR introduces the correct formatting of the retirement amount according to the **type of token** too.


## How to test

You need to have some retirements done first.
You can do these here: https://app.klimadao.finance/#/offset

Then open the preview URL of this Pull Request and add your address and number of the retirement to the URL:

- `https://klimadao-site-git-fix-tonumber-overflow-error-klimadao.vercel.app/retirement/<YOUR-ADDRESS>/<NUMBER-OF-RETIREMENT>`

You can see the totals of your retirements too:  
- `https://klimadao-site-git-fix-tonumber-overflow-error-klimadao.vercel.app/retirement/<YOUR-ADDRESS>`


## Related Ticket

Part of https://github.com/KlimaDAO/klimadao/issues/345

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
