### PR TITLE
feat: add web3context provider

### DIFF
--- a/site/hooks/useWeb3/index.tsx
+++ b/site/hooks/useWeb3/index.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useReducer, useCallback } from "react";
+import WalletConnectProvider from "@walletconnect/web3-provider";
+import { urls } from "@klimadao/lib/constants";
+import { ethers } from "ethers";
+import WalletLink from "walletlink";
+import Web3Modal from "web3modal";
+
+import {
+  Web3ProviderState,
+  Web3Action,
+  web3InitialState,
+  web3Reducer,
+} from "./reducers";
+
+const providerOptions = {
+  walletconnect: {
+    package: WalletConnectProvider,
+    options: {
+      rpc: { 137: urls.polygonMainnetRpc },
+    },
+  },
+  walletlink: {
+    package: WalletLink,
+    options: {
+      appName: "Official KlimaDAO App",
+      rpc: urls.polygonMainnetRpc,
+      chainId: 137,
+      appLogoUrl: null,
+      darkMode: false,
+    },
+  },
+};
+
+let web3Modal: Web3Modal | null;
+if (typeof window !== "undefined") {
+  web3Modal = new Web3Modal({
+    cacheProvider: true,
+    providerOptions,
+  });
+}
+
+export const useWeb3 = () => {
+  const [state, dispatch] = useReducer(web3Reducer, web3InitialState);
+  const { provider, web3Provider, address, network } = state;
+
+  const connect = useCallback(async () => {
+    if (web3Modal) {
+      try {
+        const provider = await web3Modal.connect();
+        const web3Provider = new ethers.providers.Web3Provider(provider);
+        const signer = web3Provider.getSigner();
+        const address = await signer.getAddress();
+        const network = await web3Provider.getNetwork();
+
+        dispatch({
+          type: "SET_WEB3_PROVIDER",
+          provider,
+          web3Provider,
+          address,
+          network,
+        } as Web3Action);
+      } catch (e) {
+        console.log("Connect error:", e);
+      }
+    } else {
+      console.error("No Web3Modal");
+    }
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    if (web3Modal) {
+      web3Modal.clearCachedProvider();
+      if (provider?.disconnect && typeof provider.disconnect === "function") {
+        await provider.disconnect();
+      }
+
+      dispatch({ type: "RESET_WEB3_PROVIDER" } as Web3Action);
+    } else {
+      console.error("No Web3Modal");
+    }
+  }, [provider]);
+
+  // Auto connect to the cached provider
+  useEffect(() => {
+    if (web3Modal && web3Modal.cachedProvider) {
+      connect();
+    }
+  }, [connect]);
+
+  // EIP-1193 events
+  useEffect(() => {
+    if (provider?.on) {
+      const handleAccountsChanged = (accounts: string[]) => {
+        dispatch({
+          type: "SET_ADDRESS",
+          address: accounts[0],
+        } as Web3Action);
+      };
+
+      // https://docs.ethers.io/v5/concepts/best-practices/#best-practices--network-changes
+      const handleChainChanged = (_hexChainId: string) => {
+        if (typeof window !== "undefined") {
+          console.log("Switched to chain...", _hexChainId);
+
+          window.location.reload();
+        } else {
+          console.log("Window is undefined");
+        }
+      };
+
+      const handleDisconnect = (error: { code: number; message: string }) => {
+        // eslint-disable-next-line no-console
+        console.log("disconnect", error);
+        disconnect();
+      };
+
+      provider.on("accountsChanged", handleAccountsChanged);
+      provider.on("chainChanged", handleChainChanged);
+      provider.on("disconnect", handleDisconnect);
+
+      // Subscription Cleanup
+      return () => {
+        if (provider.removeListener) {
+          provider.removeListener("accountsChanged", handleAccountsChanged);
+          provider.removeListener("chainChanged", handleChainChanged);
+          provider.removeListener("disconnect", handleDisconnect);
+        }
+      };
+    }
+  }, [provider, disconnect]);
+
+  return {
+    provider,
+    web3Provider,
+    address,
+    network,
+    connect,
+    disconnect,
+  } as Web3ProviderState;
+};

--- a/site/hooks/useWeb3/reducers.tsx
+++ b/site/hooks/useWeb3/reducers.tsx
@@ -1,0 +1,68 @@
+import { ethers } from "ethers";
+
+export type Web3ProviderState = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  provider: any;
+  web3Provider: ethers.providers.Web3Provider | null | undefined;
+  address: string | null | undefined;
+  network: ethers.providers.Network | null | undefined;
+  connect?: () => Promise<void>;
+  disconnect?: () => Promise<void>;
+};
+
+export const web3InitialState: Web3ProviderState = {
+  provider: null,
+  web3Provider: null,
+  address: null,
+  network: null,
+};
+
+export type Web3Action =
+  | {
+      type: "SET_WEB3_PROVIDER";
+      provider?: Web3ProviderState["provider"];
+      web3Provider?: Web3ProviderState["web3Provider"];
+      address?: Web3ProviderState["address"];
+      network?: Web3ProviderState["network"];
+    }
+  | {
+      type: "SET_ADDRESS";
+      address?: Web3ProviderState["address"];
+    }
+  | {
+      type: "SET_NETWORK";
+      network?: Web3ProviderState["network"];
+    }
+  | {
+      type: "RESET_WEB3_PROVIDER";
+    };
+
+export function web3Reducer(
+  state: Web3ProviderState,
+  action: Web3Action
+): Web3ProviderState {
+  switch (action.type) {
+    case "SET_WEB3_PROVIDER":
+      return {
+        ...state,
+        provider: action.provider,
+        web3Provider: action.web3Provider,
+        address: action.address,
+        network: action.network,
+      };
+    case "SET_ADDRESS":
+      return {
+        ...state,
+        address: action.address,
+      };
+    case "SET_NETWORK":
+      return {
+        ...state,
+        network: action.network,
+      };
+    case "RESET_WEB3_PROVIDER":
+      return web3InitialState;
+    default:
+      throw new Error();
+  }
+}

--- a/site/hooks/useWeb3/web3context.tsx
+++ b/site/hooks/useWeb3/web3context.tsx
@@ -1,0 +1,29 @@
+import React, { ReactChild, createContext, useContext } from "react";
+
+import { useWeb3 } from ".";
+import { Web3ProviderState, web3InitialState } from "./reducers";
+
+const Web3Context = createContext<Web3ProviderState>(web3InitialState);
+
+interface Props {
+  children: ReactChild;
+}
+
+export const Web3ContextProvider = ({ children }: Props) => {
+  const web3ProviderState = useWeb3();
+
+  return (
+    <Web3Context.Provider value={web3ProviderState}>
+      {children}
+    </Web3Context.Provider>
+  );
+};
+
+export const useWeb3Context = () => {
+  const context = useContext(Web3Context);
+  if (context === undefined) {
+    throw new Error("useWeb3 must be used within a Web3ContextProvider");
+  }
+
+  return context;
+};


### PR DESCRIPTION
## Description

### Introduces a Web3Context provider 🎉 

Wrapping the root level app component or a subset of pages with `<Web3ContextProvider />` will allow components further down the DOM tree to access key web3 objects and functions, namely the:
- `provider` object
- `address` connected
- `network` and
- wallet `connect()` and  `disconnect()` functions.

#### Why this pattern
Connecting and context of user's wallet is a core component to interacting with any dApp.
This is visibly evident in our app, every page requires the user's web3 context which is passed down as props to every page. Fortunately, our pages aren't too deeply nested so prop drilling it's not too much of an issue, however, it does prevent us from refactoring pages into smaller compositional components to simplify the app code without resorting to prop drilling.

Using the Context pattern will simplify how we access user's web3 context in our apps and will refer to a single source of truth. It will also enable code refactors to the app at some point to improve readability and workability (that bond page 👀)

### Example usage
In the root app component or a specific subset of pages
```ts
import { Web3ContextProvider } from "hooks/useWeb3/web3context";

function MyApp({ Component, pageProps, router }: AppProps) {
 // other code
return (
  <Web3ContextProvider>
    <Component {...pageProps} />
  </Web3ContextProvider>
)}

```

Web3 auth button
```ts
import React, { FC } from "react";
import { useWeb3 } from "hooks/useWeb3";

export const Web3Auth = () => {
  const { address, connect, disconnect } = useWeb3();
  const isConnected = Boolean(address);

  return (
    {isConnected ? (
      <ButtonPrimary label={address} onClick={disconnect} />
     ) : (
      <ButtonPrimary label="Connect" onClick={connect} />
    )}
  )
}

```

Full `useWeb3()` hook API
```ts
// will probably add isConnected boolean too instead of constructing it outside the hook.
const { provider, address, network, web3Provider, connect, disconnect } = useWeb3();
```

Credits to this [blog](https://betterprogramming.pub/adding-web3-to-our-nextjs-typescript-project-861e9ed5feaf) post. I tried to integrate what we had in `app/home` into a context provider but there was a bit of jank somewhere that made it difficult :) Super stoked to have come across that blog.

Will move this into `lib` at some point so we can share it across our monorepo. Keeping it local to `site` for now so I can actively develop on it whilst we build on the pledge dashboard.

Always open to feedback of course!

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
