### PR TITLE
Release Russian and Chinese translations

### DIFF
--- a/app/components/ChangeLanguageButton/index.tsx
+++ b/app/components/ChangeLanguageButton/index.tsx
@@ -34,12 +34,12 @@ export const ChangeLanguageButton: FC = () => {
     en: "English",
     fr: "Français",
     de: "Deutsch",
+    ru: "Русский",
+    "zh-CN": "中文",
   };
 
   // enable 'pseudo' locale only for Staging environment
   if (!IS_PRODUCTION) {
-    labels["ru"] = "Русский";
-    labels["zh-CN"] = "中文";
     labels["en-pseudo"] = "Pseudo";
   }
 

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -18,12 +18,12 @@ const locales: ILocales = {
   en: { plurals: en, time: "en-US" },
   fr: { plurals: fr, time: "fr-FR" },
   de: { plurals: de, time: "de-DE" },
+  ru: { plurals: ru, time: "ru-RU" },
+  "zh-CN": { plurals: zh, time: "zh-CN" },
 };
 
 // Add pseudo locale only in development
 if (!IS_PRODUCTION) {
-  locales["ru"] = { plurals: ru, time: "ru-RU" };
-  locales["zh-CN"] = { plurals: zh, time: "zh-CN" };
   locales["en-pseudo"] = { plurals: en, time: "en-US" };
 }
 

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -20,12 +20,12 @@ export const ChangeLanguageButton: FC = () => {
     en: "English",
     fr: "Français",
     de: "Deutsch",
+    ru: "Русский",
+    "zh-CN": "中文",
   };
 
   // enable 'pseudo' locale only for Staging environment
   if (!IS_PRODUCTION) {
-    labels["ru"] = "Русский";
-    labels["zh-CN"] = "中文";
     labels["en-pseudo"] = "Pseudo";
   }
 

--- a/site/lib/i18n.ts
+++ b/site/lib/i18n.ts
@@ -17,11 +17,11 @@ const locales: ILocales = {
   en: { plurals: en, time: "en-US" },
   fr: { plurals: fr, time: "fr-FR" },
   de: { plurals: de, time: "de-DE" },
+  ru: { plurals: ru, time: "ru-RU" },
+  "zh-CN": { plurals: zh, time: "zh-CN" },
 };
 // Add pseudo locale only in development
 if (!IS_PRODUCTION) {
-  locales["ru"] = { plurals: ru, time: "ru-RU" };
-  locales["zh-CN"] = { plurals: zh, time: "zh-CN" };
   locales["en-pseudo"] = { plurals: en, time: "en-US" };
 }
 

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -75,7 +75,7 @@ const nextConfig = {
     ];
   },
   i18n: {
-    locales: ["en", "fr", "de"],
+    locales: ["en", "fr", "de", "ru", "zh-CN"],
     defaultLocale: "en",
     localeDetection: true,
   },
@@ -87,7 +87,7 @@ const nextConfig = {
 if (!IS_PRODUCTION) {
   nextConfig.i18n = {
     ...nextConfig.i18n,
-    locales: ["en", "fr", "de", "ru", "zh-CN", "en-pseudo"],
+    locales: [...nextConfig.i18n.locales, "en-pseudo"],
   };
 }
 


### PR DESCRIPTION
## Description

According to these tickets I assume that both languages are ready for production:

https://github.com/KlimaDAO/klimadao/issues/386
https://github.com/KlimaDAO/klimadao/issues/387

This PR will make both languages available on Production for both Site and App 
according to the **current state of translation on Staging**.

### Please double check both languages on Staging:
- SITE: https://staging-site.klimadao.finance/
- App: https://staging-dapp.klimadao.finance/

## Related Ticket

Closes #386 
Closes #387 


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
