### PR TITLE
Fix Pledge Pages on Production

### DIFF
--- a/site/pages/pledge/[address].tsx
+++ b/site/pages/pledge/[address].tsx
@@ -8,10 +8,8 @@ import { IS_PRODUCTION } from "lib/constants";
 export const getStaticProps: GetStaticProps = async (ctx) => {
   if (IS_PRODUCTION) {
     return {
-      redirect: {
-        destination: "/",
-        permanent: false,
-      },
+      notFound: true,
+      revalidate: 180,
     };
   }
 

--- a/site/pages/pledge/index.tsx
+++ b/site/pages/pledge/index.tsx
@@ -9,10 +9,8 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
 
   if (IS_PRODUCTION) {
     return {
-      redirect: {
-        destination: "/",
-        permanent: false,
-      },
+      notFound: true,
+      revalidate: 180,
     };
   }
 


### PR DESCRIPTION
## Description

The latest automated Release from Staging to Production failed because the pages can not be generated:

```TS
Error: Export encountered errors on following paths:
--
17:47:11.732 | /pledge: /de/pledge
17:47:11.735 | /pledge: /en/pledge
17:47:11.735 | /pledge: /fr/pledge
Error: `redirect` can not be returned from getStaticProps during prerendering (/pledge)
```
Here is the failing build: => [Link to Vercel](https://vercel.com/klimadao/klimadao-site/5zxyAfEbBztmPtcnxnh4JFnKSkfw)


This PR fixes it with:
- if on Production => Return any URL with `/pledge` or `/fr/pledge` or `/de/pledge` **with a 404-Not Found**
- If not on Production => render the Pledge pages

**=> Page generation changed from a redirect to a 404 !**

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
