### PR TITLE
Revert "build(deps): bump cross-fetch from 2.2.5 to 2.2.6 (#375)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3845,15 +3845,6 @@
       "version": "1.1.1",
       "license": "MIT"
     },
-    "node_modules/cross-fetch": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.6.tgz",
-      "integrity": "sha512-9JZz+vXCmfKUZ68zAptS7k4Nu8e2qcibe7WVZYps7sAgk5R8GYTc+T1WR0v1rlP9HxgARmOX1UTIJZFytajpNA==",
-      "dependencies": {
-        "node-fetch": "^2.6.7",
-        "whatwg-fetch": "^2.0.4"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "dev": true,
@@ -9366,9 +9357,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/web3-provider-engine/node_modules/cross-fetch": {
+      "version": "2.2.5",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "2.6.1",
+        "whatwg-fetch": "2.0.4"
+      }
+    },
     "node_modules/web3-provider-engine/node_modules/isarray": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "node_modules/web3-provider-engine/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
     },
     "node_modules/web3-provider-engine/node_modules/readable-stream": {
       "version": "2.3.7",
@@ -12172,15 +12178,6 @@
     },
     "create-require": {
       "version": "1.1.1"
-    },
-    "cross-fetch": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.6.tgz",
-      "integrity": "sha512-9JZz+vXCmfKUZ68zAptS7k4Nu8e2qcibe7WVZYps7sAgk5R8GYTc+T1WR0v1rlP9HxgARmOX1UTIJZFytajpNA==",
-      "requires": {
-        "node-fetch": "^2.6.7",
-        "whatwg-fetch": "^2.0.4"
-      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -15791,8 +15788,18 @@
         "clone": {
           "version": "2.1.2"
         },
+        "cross-fetch": {
+          "version": "2.2.5",
+          "requires": {
+            "node-fetch": "2.6.1",
+            "whatwg-fetch": "2.0.4"
+          }
+        },
         "isarray": {
           "version": "1.0.0"
+        },
+        "node-fetch": {
+          "version": "2.6.1"
         },
         "readable-stream": {
           "version": "2.3.7",


### PR DESCRIPTION
This reverts commit bf7ea53383b91f83197f9416d19a6e851f87337a.

## Description

Test for failing GH actions
