### PR TITLE
GH actions: Install packages without postinstall

### DIFF
--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -50,8 +50,8 @@ jobs:
           npm --version &&
           npm list -g --depth 0
 
-      - name: Install packages
-        run: npm install
+      - name: Install packages without postinstall
+        run: npm install --ignore-scripts
 
       - name: Extract Translation strings and sync with translation.io
         run: npm run extract-strings


### PR DESCRIPTION
## Description

Another test to fix the failing GH actions.

The workflow "Update Translations" runs `npm install` at some point.
Both App and Site do have a postinstall script which runs lingui:compile.
Lingui uses a config which checks if the secret for translation.io is present when running on GH servers.
At this point these secrets are not present yet. Which was never a problem so far 🤷 

This PR skips the postinstall scripts for GH actions as we do not need to compile translations at this point.
This is only needed for Vercel.
