### PR TITLE
Main „Enter App“ button does not include locale

### DIFF
--- a/site/components/Navigation/index.tsx
+++ b/site/components/Navigation/index.tsx
@@ -35,7 +35,7 @@ export const Navigation: FC<Props> = (props) => {
           <ButtonPrimary
             key="Enter App"
             label={t({ message: "Enter App", id: "shared.enter_app" })}
-            href={urls.app}
+            href={createLinkWithLocaleQuery(urls.app, locale)}
           />,
         ]}
       >


### PR DESCRIPTION
## Description

_Minor_ thing:
The main "Enter App" button does not link with the current chosen locale to the App.
This is the fix.

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
