### PR TITLE
Release Retirement Page 💚 

### DIFF
--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -22,6 +22,7 @@ import {
   selectNotificationStatus,
   selectBalances,
   selectCarbonRetiredAllowance,
+  selectLocale,
 } from "state/selectors";
 import {
   changeApprovalTransaction,
@@ -63,6 +64,7 @@ import NBO from "public/icons/NBO.png";
 import * as styles from "./styles";
 import { cx } from "@emotion/css";
 import { useOffsetParams } from "lib/hooks/useOffsetParams";
+import { createLinkWithLocaleSubPath } from "lib/i18n";
 
 interface ButtonProps {
   label: React.ReactElement | string;
@@ -618,6 +620,7 @@ interface RetirementSuccessModalProps {
 }
 
 const RetirementSuccessModal = (props: RetirementSuccessModalProps) => {
+  const locale = useSelector(selectLocale);
   return (
     <div className={styles.retirementSuccessModal}>
       <div className="card">
@@ -689,7 +692,10 @@ const RetirementSuccessModal = (props: RetirementSuccessModalProps) => {
                 View your retirement details on{" "}
                 <A
                   target="_blank"
-                  href={`${urls.retirements}/${props.beneficiaryAddress}/${props.retirementTotals}`}
+                  href={createLinkWithLocaleSubPath(
+                    `${urls.retirements}/${props.beneficiaryAddress}/${props.retirementTotals}`,
+                    locale
+                  )}
                 >
                   klimadao.finance
                 </A>

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -621,6 +621,25 @@ interface RetirementSuccessModalProps {
 
 const RetirementSuccessModal = (props: RetirementSuccessModalProps) => {
   const locale = useSelector(selectLocale);
+  const retirementPageLink =
+    !!props.retirementTotals &&
+    createLinkWithLocaleSubPath(
+      `${urls.retirements}/${props.beneficiaryAddress}/${props.retirementTotals}`,
+      locale
+    );
+
+  useEffect(() => {
+    if (retirementPageLink) {
+      // show the modal shortly, open new window with URL to Site
+      const timer = setTimeout(() => {
+        window.open(retirementPageLink, "_blank");
+      }, 1500);
+      return () => {
+        !!timer && clearTimeout(timer);
+      };
+    }
+  }, [retirementPageLink]);
+
   return (
     <div className={styles.retirementSuccessModal}>
       <div className="card">
@@ -686,17 +705,11 @@ const RetirementSuccessModal = (props: RetirementSuccessModalProps) => {
               </A>
             </Trans>
           </Text>
-          {props.retirementTotals && (
+          {retirementPageLink && (
             <Text t="caption">
               <Trans id="offset.retirement_success_modal.view_on_klimadao">
                 View your retirement details on{" "}
-                <A
-                  target="_blank"
-                  href={createLinkWithLocaleSubPath(
-                    `${urls.retirements}/${props.beneficiaryAddress}/${props.retirementTotals}`,
-                    locale
-                  )}
-                >
+                <A target="_blank" href={retirementPageLink}>
                   klimadao.finance
                 </A>
               </Trans>

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -62,7 +62,6 @@ import NBO from "public/icons/NBO.png";
 
 import * as styles from "./styles";
 import { cx } from "@emotion/css";
-import { IS_PRODUCTION } from "lib/constants";
 import { useOffsetParams } from "lib/hooks/useOffsetParams";
 
 interface ButtonProps {
@@ -684,7 +683,7 @@ const RetirementSuccessModal = (props: RetirementSuccessModalProps) => {
               </A>
             </Trans>
           </Text>
-          {!IS_PRODUCTION && props.retirementTotals && (
+          {props.retirementTotals && (
             <Text t="caption">
               <Trans id="offset.retirement_success_modal.view_on_klimadao">
                 View your retirement details on{" "}

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -1,6 +1,7 @@
 import { i18n } from "@lingui/core";
 import { en, fr, de, ru, zh, ko, es } from "make-plural/plurals";
 import { IS_PRODUCTION, IS_LOCAL_DEVELOPMENT } from "lib/constants";
+import { urls } from "@klimadao/lib/constants";
 
 // TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
 
@@ -82,6 +83,13 @@ async function initLocale(localeFromURL: string | null) {
 export const createLinkWithLocaleSubPath = (
   url: string,
   locale = "en"
-): string => `${url}/${locale}`;
+): string => {
+  // ensure that the locale is added right after the main Site URL
+  // klimadao.finance/LOCALE/the/other/sub/page
+  if (url.startsWith(urls.home)) {
+    return url.replace(urls.home, `${urls.home}/${locale}`);
+  }
+  return `${url}/${locale}`;
+};
 
 export { locales, activate, initLocale };

--- a/site/pages/retirements/[beneficiary_address]/[retirement_index].tsx
+++ b/site/pages/retirements/[beneficiary_address]/[retirement_index].tsx
@@ -8,7 +8,6 @@ import { RetirementIndexInfoResult } from "@klimadao/lib/types/offset";
 
 import { SingleRetirementPage } from "components/pages/Retirements/SingleRetirement";
 import { loadTranslation } from "lib/i18n";
-import { IS_PRODUCTION } from "lib/constants";
 
 interface Params extends ParsedUrlQuery {
   beneficiary_address: string;
@@ -31,10 +30,6 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   ctx
 ) => {
   try {
-    if (IS_PRODUCTION) {
-      throw new Error("Not on Staging");
-    }
-
     const { params, locale } = ctx;
 
     if (


### PR DESCRIPTION
## Description

This PR removes the feature flag and enables:

- App: Offset Success Modal includes a Link to `https://www.klimadao.finance/retirements/0xs34..../1` 
- App: SuccessModal is shown for 1,5 seconds, then opens Retirement Page in a new window/tab (If the browser settings **do not block** new windows!))
- Site: Generates the corresponding page for `retirements/0xs34..../1`
- **Refactoring:** Pass the current **locale** between App to Site for **subpaths** too

Please note that maybe not all translations are available for these page yet?

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
