### PR TITLE
Add Korean and Spanish

### DIFF
--- a/app/components/ChangeLanguageButton/index.tsx
+++ b/app/components/ChangeLanguageButton/index.tsx
@@ -40,6 +40,8 @@ export const ChangeLanguageButton: FC = () => {
 
   // enable 'pseudo' locale only for Staging environment
   if (!IS_PRODUCTION) {
+    labels["es"] = "Español";
+    labels["ko"] = "한국어";
     labels["en-pseudo"] = "Pseudo";
   }
 

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { i18n } from "@lingui/core";
-import { en, fr, de, ru, zh } from "make-plural/plurals";
+import { en, fr, de, ru, zh, ko, es } from "make-plural/plurals";
 import { IS_PRODUCTION, IS_LOCAL_DEVELOPMENT } from "lib/constants";
 
 // TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
@@ -24,6 +24,8 @@ const locales: ILocales = {
 
 // Add pseudo locale only in development
 if (!IS_PRODUCTION) {
+  locales["es"] = { plurals: es, time: "es-ES" };
+  locales["ko"] = { plurals: ko, time: "ko-KR" };
   locales["en-pseudo"] = { plurals: en, time: "en-US" };
 }
 

--- a/app/locale/es/messages.po
+++ b/app/locale/es/messages.po
@@ -1,0 +1,841 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2022-05-13 12:47+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: es\n"
+
+#: components/views/Offset/index.tsx:643
+msgid "Beneficiary Address"
+msgstr ""
+
+#: components/views/Offset/index.tsx:663
+msgid "Download certificate"
+msgstr ""
+
+#: components/views/Offset/index.tsx:651
+msgid "Message"
+msgstr ""
+
+#: components/views/Offset/index.tsx:637
+msgid "Name"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:39
+msgid "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
+msgstr ""
+
+#: components/views/Offset/index.tsx:631
+msgid "Retirement Successful"
+msgstr ""
+
+#: components/views/Offset/index.tsx:671
+msgid "Share retirement"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:89
+msgid "Switch to Polygon"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:75
+msgid "This app only works on Polygon Mainnet."
+msgstr ""
+
+#: components/views/Offset/index.tsx:657
+msgid "Tonnes Retired"
+msgstr ""
+
+#: components/views/Offset/index.tsx:678
+msgid "View on <0>polygonscan.com</0>"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:72
+msgid "Wrong Network"
+msgstr ""
+
+#: components/views/Offset/index.tsx:666
+#: components/views/Offset/index.tsx:674
+msgid "[coming soon]"
+msgstr ""
+
+#: components/views/Offset/index.tsx:748
+msgid "advanced"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:743
+msgid "bond.all_demand_has_been_filled"
+msgstr ""
+
+#: components/views/Bond/index.tsx:486
+msgid "bond.balance"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:490
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:351
+#: components/views/Bond/index.tsx:433
+msgid "bond.bond"
+msgstr ""
+
+#: components/views/Bond/index.tsx:509
+msgid "bond.bond_price"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:513
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. Bond {0}
+#: components/views/Bond/index.tsx:413
+msgid "bond.bond_token"
+msgstr ""
+
+#: components/views/Bond/index.tsx:703
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#: components/views/Bond/index.tsx:708
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:600
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:604
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:541
+msgid "bond.discount"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:545
+msgid "bond.discount.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:373
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#: components/views/Bond/index.tsx:378
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#: components/views/Bond/index.tsx:525
+msgid "bond.market_price"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:529
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:581
+msgid "bond.maximum"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:585
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:329
+msgid "bond.not_redeemable"
+msgstr ""
+
+#: components/views/Bond/index.tsx:357
+#: components/views/Bond/index.tsx:443
+msgid "bond.redeem"
+msgstr ""
+
+#: components/views/Bond/index.tsx:670
+msgid "bond.redeemable"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:673
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. should autostake?
+#: components/views/Bond/index.tsx:773
+msgid "bond.should_autostake"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:732
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#: components/views/Bond/index.tsx:641
+msgid "bond.unredeemed"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:644
+msgid "bond.unredeemed.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:620
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:624
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:557
+msgid "bond.you_will_get"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:561
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#: components/views/Buy/index.tsx:44
+msgid "buy.buy_klima"
+msgstr ""
+
+#. Long sentence
+#: components/views/Buy/index.tsx:108
+msgid "buy.connect_wallet"
+msgstr ""
+
+#. Long sentence
+#: components/views/Buy/index.tsx:55
+msgid "buy.data_disclaimer"
+msgstr ""
+
+#. Long sentence
+#: components/views/Buy/index.tsx:47
+msgid "buy.how_to_buy"
+msgstr ""
+
+#: components/views/Buy/index.tsx:105
+msgid "buy.not_connected"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:77
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:163
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. Long sentence
+#: components/views/ChooseBond/index.tsx:166
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:190
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:85
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:81
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:73
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:93
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:69
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:193
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:215
+msgid "choose_bond.sold_out"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:180
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:65
+msgid "choose_bond.ubo.description"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:89
+msgid "choose_bond.usdc_lp.bct_usdc_sushiswap_liquidity"
+msgstr ""
+
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:130
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:137
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:144
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:122
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:151
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:117
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:105
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#: components/views/Info/index.tsx:102
+msgid "info.info_and_faq"
+msgstr ""
+
+#: components/views/Info/index.tsx:165
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#: components/NavMenu/index.tsx:148
+msgid "menu.bond_carbon"
+msgstr ""
+
+#: components/NavMenu/index.tsx:132
+msgid "menu.buy_klima"
+msgstr ""
+
+#: components/NavMenu/index.tsx:172
+msgid "menu.info"
+msgstr ""
+
+#: components/NavMenu/index.tsx:177
+msgid "menu.just_for_you"
+msgstr ""
+
+#: components/NavMenu/index.tsx:120
+msgid "menu.not_connected"
+msgstr ""
+
+#: components/NavMenu/index.tsx:164
+msgid "menu.offset"
+msgstr ""
+
+#: components/NavMenu/index.tsx:140
+msgid "menu.stake_klima"
+msgstr ""
+
+#: components/NavMenu/index.tsx:114
+msgid "menu.wallet_address"
+msgstr ""
+
+#: components/NavMenu/index.tsx:156
+msgid "menu.wrap_klima"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#: components/views/Bond/index.tsx:398
+msgid "nav.back"
+msgstr ""
+
+#: components/views/Offset/index.tsx:545
+msgid "offset.aggregation_fee_tooltip"
+msgstr ""
+
+#: components/views/Offset/index.tsx:426
+msgid "offset.amount_in_tonnes"
+msgstr ""
+
+#: components/CarbonTonnesBreakdownCard/index.tsx:41
+msgid "offset.breakdown"
+msgstr ""
+
+#: components/views/Offset/index.tsx:513
+msgid "offset.default_retirement_address"
+msgstr ""
+
+#: components/views/Offset/index.tsx:452
+msgid "offset.dropdown_payWith.label"
+msgstr ""
+
+#: components/views/Offset/index.tsx:467
+msgid "offset.dropdown_retire.label"
+msgstr ""
+
+#: components/CarbonTonnesBreakdownCard/index.tsx:53
+msgid "offset.empty"
+msgstr ""
+
+#: components/views/Offset/index.tsx:507
+#: components/views/Offset/index.tsx:777
+msgid "offset.enter_address"
+msgstr ""
+
+#: components/views/Offset/index.tsx:403
+msgid "offset.go_carbon_neutral"
+msgstr ""
+
+#: components/views/Offset/index.tsx:382
+msgid "offset.incompatible"
+msgstr ""
+
+#: components/views/Offset/index.tsx:453
+msgid "offset.modal_payWith.title"
+msgstr ""
+
+#: components/views/Offset/index.tsx:471
+msgid "offset.modal_retire.title"
+msgstr ""
+
+#: components/CarbonTonnesRetiredCard/index.tsx:37
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#: components/views/Offset/index.tsx:443
+msgid "offset.offset_quantity"
+msgstr ""
+
+#: components/views/Offset/index.tsx:400
+msgid "offset.retire_carbon"
+msgstr ""
+
+#: components/views/Offset/index.tsx:755
+msgid "offset.retire_specific"
+msgstr ""
+
+#: components/views/Offset/index.tsx:761
+msgid "offset.retire_specific_tooltip"
+msgstr ""
+
+#: components/views/Offset/index.tsx:496
+msgid "offset.retirement_beneficiary"
+msgstr ""
+
+#: components/views/Offset/index.tsx:488
+msgid "offset.retirement_credit"
+msgstr ""
+
+#: components/views/Offset/index.tsx:522
+msgid "offset.retirement_message"
+msgstr ""
+
+#: components/views/Offset/index.tsx:531
+msgid "offset.retirement_purpose"
+msgstr ""
+
+#: components/views/Offset/index.tsx:563
+msgid "offset.retiring"
+msgstr ""
+
+#: components/CarbonTonnesRetiredCard/index.tsx:29
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#: components/CarbonTonnesRetiredCard/index.tsx:20
+msgid "offset.you_have_retired"
+msgstr ""
+
+#: components/views/Offset/index.tsx:541
+msgid "offset_cost"
+msgstr ""
+
+#: components/views/Offset/index.tsx:574
+msgid "offset_disclaimer"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:151
+msgid "pklima.approve_bct"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:146
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#: components/views/PKlima/index.tsx:169
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:156
+msgid "pklima.exercise"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:185
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:253
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. Long sentence
+#: components/views/PKlima/index.tsx:256
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:201
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:182
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:241
+msgid "pklima.redeemed"
+msgstr ""
+
+#. Long sentence
+#: components/views/PKlima/index.tsx:244
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:225
+msgid "pklima.supply_limit"
+msgstr ""
+
+#. Long sentence
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
+
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
+#: components/views/Offset/index.tsx:689
+msgid "retirementSuccessModal.viewOnKlimadao"
+msgstr ""
+
+#: components/views/Bond/index.tsx:344
+#: components/views/Offset/index.tsx:311
+#: components/views/Stake/index.tsx:164
+#: components/views/Stake/index.tsx:170
+msgid "shared.approve"
+msgstr ""
+
+#: components/BalancesCard/index.tsx:49
+msgid "shared.balances"
+msgstr ""
+
+#: components/ChangeLanguageButton/index.tsx:73
+msgid "shared.change_language"
+msgstr ""
+
+#: components/views/Bond/index.tsx:338
+#: components/views/PKlima/index.tsx:140
+#: components/views/Stake/index.tsx:158
+msgid "shared.confirming"
+msgstr ""
+
+#: components/views/Bond/index.tsx:311
+#: components/views/Buy/index.tsx:113
+#: components/views/Offset/index.tsx:285
+#: components/views/PKlima/index.tsx:125
+#: components/views/Stake/index.tsx:143
+#: components/views/Wrap/index.tsx:129
+msgid "shared.connect_wallet"
+msgstr ""
+
+#: components/views/Buy/index.tsx:76
+msgid "shared.copy_wallet_address"
+msgstr ""
+
+#: components/views/Stake/index.tsx:179
+#: components/views/Stake/index.tsx:189
+msgid "shared.enter_amount"
+msgstr ""
+
+#: components/views/Bond/index.tsx:323
+#: components/views/Offset/index.tsx:297
+msgid "shared.enter_quantity"
+msgstr ""
+
+#: components/views/Bond/index.tsx:364
+#: components/views/Bond/index.tsx:383
+#: components/views/Stake/index.tsx:197
+msgid "shared.error"
+msgstr ""
+
+#: components/views/Offset/index.tsx:304
+msgid "shared.insufficient_balance"
+msgstr ""
+
+#: components/CarbonTonnesBreakdownCard/index.tsx:48
+#: components/RebaseCard/index.tsx:58
+#: components/RebaseCard/index.tsx:69
+#: components/views/Bond/index.tsx:317
+#: components/views/Loading/index.tsx:11
+#: components/views/Offset/index.tsx:291
+#: components/views/Offset/index.tsx:368
+#: components/views/PKlima/index.tsx:131
+#: components/views/Stake/index.tsx:149
+#: components/views/Stake/index.tsx:346
+#: components/views/Stake/index.tsx:353
+#: components/views/Stake/index.tsx:360
+#: components/views/Wrap/index.tsx:135
+msgid "shared.loading"
+msgstr ""
+
+#: components/views/Bond/index.tsx:471
+#: components/views/PKlima/index.tsx:212
+#: components/views/Stake/index.tsx:287
+#: components/views/Wrap/index.tsx:255
+msgid "shared.max"
+msgstr ""
+
+#: components/views/Offset/index.tsx:317
+msgid "shared.retire"
+msgstr ""
+
+#: components/views/Bond/index.tsx:305
+msgid "shared.sold_out"
+msgstr ""
+
+#: components/views/Buy/index.tsx:83
+msgid "shared.wallet_address_copied"
+msgstr ""
+
+#: components/views/Stake/index.tsx:300
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#: components/views/Stake/index.tsx:303
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#: components/views/Stake/index.tsx:316
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#: components/views/Stake/index.tsx:319
+msgid "stake.akr.tooltip"
+msgstr ""
+
+#. Long sentence
+#. Long sentence
+#: components/views/Buy/index.tsx:124
+#: components/views/Stake/index.tsx:215
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. Long sentence
+#: components/views/Stake/index.tsx:230
+msgid "stake.hold_stake_and_compound"
+msgstr ""
+
+#: components/views/Stake/index.tsx:330
+msgid "stake.index"
+msgstr ""
+
+#. Long sentence
+#: components/views/Stake/index.tsx:333
+msgid "stake.index.tooltip"
+msgstr ""
+
+#: components/views/Stake/index.tsx:49
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#: components/views/Stake/index.tsx:53
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#: components/views/Stake/index.tsx:250
+msgid "stake.stake"
+msgstr ""
+
+#: components/views/Stake/index.tsx:177
+#: components/views/Stake/index.tsx:227
+msgid "stake.stake_klima"
+msgstr ""
+
+#: components/views/Stake/index.tsx:262
+msgid "stake.unstake"
+msgstr ""
+
+#: components/views/Stake/index.tsx:187
+msgid "stake.unstake_klima"
+msgstr ""
+
+#: actions/utils.ts:21
+msgid "status.done"
+msgstr ""
+
+#: actions/utils.ts:16
+msgid "status.error"
+msgstr ""
+
+#: actions/utils.ts:28
+msgid "status.network_confirmation"
+msgstr ""
+
+#: actions/utils.ts:23
+msgid "status.user_confirmation"
+msgstr ""
+
+#: actions/utils.ts:10
+msgid "status.user_rejected"
+msgstr ""
+
+#: components/NavMenu/index.tsx:184
+msgid "token.pKLIMA"
+msgstr ""
+
+#: components/ConnectButton/index.tsx:20
+msgid "wallet.connect"
+msgstr ""
+
+#: components/ConnectButton/index.tsx:24
+msgid "wallet.disconnect"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:283
+msgid "wrap.balance"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:178
+msgid "wrap.balances_tooltip"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:270
+msgid "wrap.index"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:273
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:39
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:233
+msgid "wrap.unwrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:222
+msgid "wrap.wrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:188
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:200
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:191
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:43
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:286
+msgid "wrap.you_will_get"
+msgstr ""
+
+#: components/BalancesCard/index.tsx:35
+msgid "wsklima.unwrapped.label"
+msgstr ""

--- a/app/locale/ko/messages.po
+++ b/app/locale/ko/messages.po
@@ -1,0 +1,841 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2022-05-13 12:47+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: ko\n"
+
+#: components/views/Offset/index.tsx:643
+msgid "Beneficiary Address"
+msgstr ""
+
+#: components/views/Offset/index.tsx:663
+msgid "Download certificate"
+msgstr ""
+
+#: components/views/Offset/index.tsx:651
+msgid "Message"
+msgstr ""
+
+#: components/views/Offset/index.tsx:637
+msgid "Name"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:39
+msgid "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
+msgstr ""
+
+#: components/views/Offset/index.tsx:631
+msgid "Retirement Successful"
+msgstr ""
+
+#: components/views/Offset/index.tsx:671
+msgid "Share retirement"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:89
+msgid "Switch to Polygon"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:75
+msgid "This app only works on Polygon Mainnet."
+msgstr ""
+
+#: components/views/Offset/index.tsx:657
+msgid "Tonnes Retired"
+msgstr ""
+
+#: components/views/Offset/index.tsx:678
+msgid "View on <0>polygonscan.com</0>"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:72
+msgid "Wrong Network"
+msgstr ""
+
+#: components/views/Offset/index.tsx:666
+#: components/views/Offset/index.tsx:674
+msgid "[coming soon]"
+msgstr ""
+
+#: components/views/Offset/index.tsx:748
+msgid "advanced"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:743
+msgid "bond.all_demand_has_been_filled"
+msgstr ""
+
+#: components/views/Bond/index.tsx:486
+msgid "bond.balance"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:490
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:351
+#: components/views/Bond/index.tsx:433
+msgid "bond.bond"
+msgstr ""
+
+#: components/views/Bond/index.tsx:509
+msgid "bond.bond_price"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:513
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. Bond {0}
+#: components/views/Bond/index.tsx:413
+msgid "bond.bond_token"
+msgstr ""
+
+#: components/views/Bond/index.tsx:703
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#: components/views/Bond/index.tsx:708
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:600
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:604
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:541
+msgid "bond.discount"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:545
+msgid "bond.discount.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:373
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#: components/views/Bond/index.tsx:378
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#: components/views/Bond/index.tsx:525
+msgid "bond.market_price"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:529
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:581
+msgid "bond.maximum"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:585
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:329
+msgid "bond.not_redeemable"
+msgstr ""
+
+#: components/views/Bond/index.tsx:357
+#: components/views/Bond/index.tsx:443
+msgid "bond.redeem"
+msgstr ""
+
+#: components/views/Bond/index.tsx:670
+msgid "bond.redeemable"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:673
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. should autostake?
+#: components/views/Bond/index.tsx:773
+msgid "bond.should_autostake"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:732
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#: components/views/Bond/index.tsx:641
+msgid "bond.unredeemed"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:644
+msgid "bond.unredeemed.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:620
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:624
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#: components/views/Bond/index.tsx:557
+msgid "bond.you_will_get"
+msgstr ""
+
+#. Long sentence
+#: components/views/Bond/index.tsx:561
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#: components/views/Buy/index.tsx:44
+msgid "buy.buy_klima"
+msgstr ""
+
+#. Long sentence
+#: components/views/Buy/index.tsx:108
+msgid "buy.connect_wallet"
+msgstr ""
+
+#. Long sentence
+#: components/views/Buy/index.tsx:55
+msgid "buy.data_disclaimer"
+msgstr ""
+
+#. Long sentence
+#: components/views/Buy/index.tsx:47
+msgid "buy.how_to_buy"
+msgstr ""
+
+#: components/views/Buy/index.tsx:105
+msgid "buy.not_connected"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:77
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:163
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. Long sentence
+#: components/views/ChooseBond/index.tsx:166
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:190
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:85
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:81
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:73
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:93
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:69
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:193
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:215
+msgid "choose_bond.sold_out"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:180
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:65
+msgid "choose_bond.ubo.description"
+msgstr ""
+
+#: components/views/ChooseBond/index.tsx:89
+msgid "choose_bond.usdc_lp.bct_usdc_sushiswap_liquidity"
+msgstr ""
+
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:130
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:137
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:144
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:122
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:151
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:117
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. Long sentence
+#: components/views/Info/index.tsx:105
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#: components/views/Info/index.tsx:102
+msgid "info.info_and_faq"
+msgstr ""
+
+#: components/views/Info/index.tsx:165
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#: components/NavMenu/index.tsx:148
+msgid "menu.bond_carbon"
+msgstr ""
+
+#: components/NavMenu/index.tsx:132
+msgid "menu.buy_klima"
+msgstr ""
+
+#: components/NavMenu/index.tsx:172
+msgid "menu.info"
+msgstr ""
+
+#: components/NavMenu/index.tsx:177
+msgid "menu.just_for_you"
+msgstr ""
+
+#: components/NavMenu/index.tsx:120
+msgid "menu.not_connected"
+msgstr ""
+
+#: components/NavMenu/index.tsx:164
+msgid "menu.offset"
+msgstr ""
+
+#: components/NavMenu/index.tsx:140
+msgid "menu.stake_klima"
+msgstr ""
+
+#: components/NavMenu/index.tsx:114
+msgid "menu.wallet_address"
+msgstr ""
+
+#: components/NavMenu/index.tsx:156
+msgid "menu.wrap_klima"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#: components/views/Bond/index.tsx:398
+msgid "nav.back"
+msgstr ""
+
+#: components/views/Offset/index.tsx:545
+msgid "offset.aggregation_fee_tooltip"
+msgstr ""
+
+#: components/views/Offset/index.tsx:426
+msgid "offset.amount_in_tonnes"
+msgstr ""
+
+#: components/CarbonTonnesBreakdownCard/index.tsx:41
+msgid "offset.breakdown"
+msgstr ""
+
+#: components/views/Offset/index.tsx:513
+msgid "offset.default_retirement_address"
+msgstr ""
+
+#: components/views/Offset/index.tsx:452
+msgid "offset.dropdown_payWith.label"
+msgstr ""
+
+#: components/views/Offset/index.tsx:467
+msgid "offset.dropdown_retire.label"
+msgstr ""
+
+#: components/CarbonTonnesBreakdownCard/index.tsx:53
+msgid "offset.empty"
+msgstr ""
+
+#: components/views/Offset/index.tsx:507
+#: components/views/Offset/index.tsx:777
+msgid "offset.enter_address"
+msgstr ""
+
+#: components/views/Offset/index.tsx:403
+msgid "offset.go_carbon_neutral"
+msgstr ""
+
+#: components/views/Offset/index.tsx:382
+msgid "offset.incompatible"
+msgstr ""
+
+#: components/views/Offset/index.tsx:453
+msgid "offset.modal_payWith.title"
+msgstr ""
+
+#: components/views/Offset/index.tsx:471
+msgid "offset.modal_retire.title"
+msgstr ""
+
+#: components/CarbonTonnesRetiredCard/index.tsx:37
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#: components/views/Offset/index.tsx:443
+msgid "offset.offset_quantity"
+msgstr ""
+
+#: components/views/Offset/index.tsx:400
+msgid "offset.retire_carbon"
+msgstr ""
+
+#: components/views/Offset/index.tsx:755
+msgid "offset.retire_specific"
+msgstr ""
+
+#: components/views/Offset/index.tsx:761
+msgid "offset.retire_specific_tooltip"
+msgstr ""
+
+#: components/views/Offset/index.tsx:496
+msgid "offset.retirement_beneficiary"
+msgstr ""
+
+#: components/views/Offset/index.tsx:488
+msgid "offset.retirement_credit"
+msgstr ""
+
+#: components/views/Offset/index.tsx:522
+msgid "offset.retirement_message"
+msgstr ""
+
+#: components/views/Offset/index.tsx:531
+msgid "offset.retirement_purpose"
+msgstr ""
+
+#: components/views/Offset/index.tsx:563
+msgid "offset.retiring"
+msgstr ""
+
+#: components/CarbonTonnesRetiredCard/index.tsx:29
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#: components/CarbonTonnesRetiredCard/index.tsx:20
+msgid "offset.you_have_retired"
+msgstr ""
+
+#: components/views/Offset/index.tsx:541
+msgid "offset_cost"
+msgstr ""
+
+#: components/views/Offset/index.tsx:574
+msgid "offset_disclaimer"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:151
+msgid "pklima.approve_bct"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:146
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#: components/views/PKlima/index.tsx:169
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:156
+msgid "pklima.exercise"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:185
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:253
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. Long sentence
+#: components/views/PKlima/index.tsx:256
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:201
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:182
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:241
+msgid "pklima.redeemed"
+msgstr ""
+
+#. Long sentence
+#: components/views/PKlima/index.tsx:244
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#: components/views/PKlima/index.tsx:225
+msgid "pklima.supply_limit"
+msgstr ""
+
+#. Long sentence
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
+
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
+#: components/views/Offset/index.tsx:689
+msgid "retirementSuccessModal.viewOnKlimadao"
+msgstr ""
+
+#: components/views/Bond/index.tsx:344
+#: components/views/Offset/index.tsx:311
+#: components/views/Stake/index.tsx:164
+#: components/views/Stake/index.tsx:170
+msgid "shared.approve"
+msgstr ""
+
+#: components/BalancesCard/index.tsx:49
+msgid "shared.balances"
+msgstr ""
+
+#: components/ChangeLanguageButton/index.tsx:73
+msgid "shared.change_language"
+msgstr ""
+
+#: components/views/Bond/index.tsx:338
+#: components/views/PKlima/index.tsx:140
+#: components/views/Stake/index.tsx:158
+msgid "shared.confirming"
+msgstr ""
+
+#: components/views/Bond/index.tsx:311
+#: components/views/Buy/index.tsx:113
+#: components/views/Offset/index.tsx:285
+#: components/views/PKlima/index.tsx:125
+#: components/views/Stake/index.tsx:143
+#: components/views/Wrap/index.tsx:129
+msgid "shared.connect_wallet"
+msgstr ""
+
+#: components/views/Buy/index.tsx:76
+msgid "shared.copy_wallet_address"
+msgstr ""
+
+#: components/views/Stake/index.tsx:179
+#: components/views/Stake/index.tsx:189
+msgid "shared.enter_amount"
+msgstr ""
+
+#: components/views/Bond/index.tsx:323
+#: components/views/Offset/index.tsx:297
+msgid "shared.enter_quantity"
+msgstr ""
+
+#: components/views/Bond/index.tsx:364
+#: components/views/Bond/index.tsx:383
+#: components/views/Stake/index.tsx:197
+msgid "shared.error"
+msgstr ""
+
+#: components/views/Offset/index.tsx:304
+msgid "shared.insufficient_balance"
+msgstr ""
+
+#: components/CarbonTonnesBreakdownCard/index.tsx:48
+#: components/RebaseCard/index.tsx:58
+#: components/RebaseCard/index.tsx:69
+#: components/views/Bond/index.tsx:317
+#: components/views/Loading/index.tsx:11
+#: components/views/Offset/index.tsx:291
+#: components/views/Offset/index.tsx:368
+#: components/views/PKlima/index.tsx:131
+#: components/views/Stake/index.tsx:149
+#: components/views/Stake/index.tsx:346
+#: components/views/Stake/index.tsx:353
+#: components/views/Stake/index.tsx:360
+#: components/views/Wrap/index.tsx:135
+msgid "shared.loading"
+msgstr ""
+
+#: components/views/Bond/index.tsx:471
+#: components/views/PKlima/index.tsx:212
+#: components/views/Stake/index.tsx:287
+#: components/views/Wrap/index.tsx:255
+msgid "shared.max"
+msgstr ""
+
+#: components/views/Offset/index.tsx:317
+msgid "shared.retire"
+msgstr ""
+
+#: components/views/Bond/index.tsx:305
+msgid "shared.sold_out"
+msgstr ""
+
+#: components/views/Buy/index.tsx:83
+msgid "shared.wallet_address_copied"
+msgstr ""
+
+#: components/views/Stake/index.tsx:300
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#: components/views/Stake/index.tsx:303
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#: components/views/Stake/index.tsx:316
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#: components/views/Stake/index.tsx:319
+msgid "stake.akr.tooltip"
+msgstr ""
+
+#. Long sentence
+#. Long sentence
+#: components/views/Buy/index.tsx:124
+#: components/views/Stake/index.tsx:215
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. Long sentence
+#: components/views/Stake/index.tsx:230
+msgid "stake.hold_stake_and_compound"
+msgstr ""
+
+#: components/views/Stake/index.tsx:330
+msgid "stake.index"
+msgstr ""
+
+#. Long sentence
+#: components/views/Stake/index.tsx:333
+msgid "stake.index.tooltip"
+msgstr ""
+
+#: components/views/Stake/index.tsx:49
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#: components/views/Stake/index.tsx:53
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#: components/views/Stake/index.tsx:250
+msgid "stake.stake"
+msgstr ""
+
+#: components/views/Stake/index.tsx:177
+#: components/views/Stake/index.tsx:227
+msgid "stake.stake_klima"
+msgstr ""
+
+#: components/views/Stake/index.tsx:262
+msgid "stake.unstake"
+msgstr ""
+
+#: components/views/Stake/index.tsx:187
+msgid "stake.unstake_klima"
+msgstr ""
+
+#: actions/utils.ts:21
+msgid "status.done"
+msgstr ""
+
+#: actions/utils.ts:16
+msgid "status.error"
+msgstr ""
+
+#: actions/utils.ts:28
+msgid "status.network_confirmation"
+msgstr ""
+
+#: actions/utils.ts:23
+msgid "status.user_confirmation"
+msgstr ""
+
+#: actions/utils.ts:10
+msgid "status.user_rejected"
+msgstr ""
+
+#: components/NavMenu/index.tsx:184
+msgid "token.pKLIMA"
+msgstr ""
+
+#: components/ConnectButton/index.tsx:20
+msgid "wallet.connect"
+msgstr ""
+
+#: components/ConnectButton/index.tsx:24
+msgid "wallet.disconnect"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:283
+msgid "wrap.balance"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:178
+msgid "wrap.balances_tooltip"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:270
+msgid "wrap.index"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:273
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:39
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:233
+msgid "wrap.unwrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:222
+msgid "wrap.wrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:188
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:200
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. Long sentence
+#: components/views/Wrap/index.tsx:191
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:43
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#: components/views/Wrap/index.tsx:286
+msgid "wrap.you_will_get"
+msgstr ""
+
+#: components/BalancesCard/index.tsx:35
+msgid "wsklima.unwrapped.label"
+msgstr ""

--- a/lingui.config.js
+++ b/lingui.config.js
@@ -4,7 +4,7 @@
 
 /** @type {Config} */
 const config = {
-  locales: ["en", "zh-CN", "en-pseudo", "fr", "de", "ru"],
+  locales: ["en", "zh-CN", "en-pseudo", "fr", "de", "ru", "es", "ko"],
   sourceLocale: "en",
   fallbackLocales: {
     default: "en",

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -26,6 +26,8 @@ export const ChangeLanguageButton: FC = () => {
 
   // enable 'pseudo' locale only for Staging environment
   if (!IS_PRODUCTION) {
+    labels["es"] = "Español";
+    labels["ko"] = "한국어";
     labels["en-pseudo"] = "Pseudo";
   }
 

--- a/site/lib/i18n.ts
+++ b/site/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { i18n } from "@lingui/core";
-import { en, fr, de, ru, zh } from "make-plural/plurals";
+import { en, fr, de, ru, zh, ko, es } from "make-plural/plurals";
 import { IS_LOCAL_DEVELOPMENT, IS_PRODUCTION } from "lib/constants";
 
 // TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
@@ -22,6 +22,8 @@ const locales: ILocales = {
 };
 // Add pseudo locale only in development
 if (!IS_PRODUCTION) {
+  locales["es"] = { plurals: es, time: "es-ES" };
+  locales["ko"] = { plurals: ko, time: "ko-KR" };
   locales["en-pseudo"] = { plurals: en, time: "en-US" };
 }
 

--- a/site/locale/es/messages.po
+++ b/site/locale/es/messages.po
@@ -1,0 +1,832 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2022-05-13 12:47+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: es\n"
+
+#: components/pages/Blog/index.tsx:35
+msgid "Articles"
+msgstr ""
+
+#: components/ChangeLanguageButton/index.tsx:66
+msgid "Change language"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:276
+msgid "Enter App"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Blog/Post/index.tsx:95
+msgid "blog.disclaimer.description"
+msgstr ""
+
+#: components/pages/Blog/Post/index.tsx:92
+msgid "blog.disclaimer.title"
+msgstr ""
+
+#: components/pages/Blog/index.tsx:19
+msgid "blog.head.description"
+msgstr ""
+
+#: components/pages/Blog/index.tsx:18
+msgid "blog.head.headline"
+msgstr ""
+
+#: components/pages/Blog/index.tsx:17
+#: components/pages/Blog/index.tsx:24
+msgid "blog.head.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/CopyURLButton/index.tsx:29
+msgid "button.copyURL.copied"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/CopyURLButton/index.tsx:31
+msgid "button.copyURL.copy"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:135
+#: components/pages/Buy/index.tsx:254
+msgid "buy.advanced"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:90
+#: components/pages/Buy/index.tsx:176
+msgid "buy.beginner"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:14
+msgid "buy.beginner_01.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:10
+msgid "buy.beginner_01.title"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:29
+msgid "buy.beginner_02.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:37
+msgid "buy.beginner_02.description_02"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:25
+msgid "buy.beginner_02.title"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:51
+msgid "buy.beginner_03.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:57
+msgid "buy.beginner_03.description_2"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:47
+msgid "buy.beginner_03.title"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:72
+msgid "buy.beginner_04.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:79
+msgid "buy.beginner_04.description_02"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:68
+msgid "buy.beginner_04.title"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:97
+msgid "buy.beginner_05.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:93
+msgid "buy.beginner_05.title"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:132
+#: components/pages/Buy/index.tsx:257
+msgid "buy.bonding"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:260
+msgid "buy.bonding.description_01"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:268
+msgid "buy.bonding.description_02"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:87
+#: components/pages/Buy/index.tsx:179
+msgid "buy.credit_card"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:182
+msgid "buy.credit_card.summary"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:108
+msgid "buy.decentralized_exchange"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:210
+msgid "buy.dex"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:241
+msgid "buy.dex.how_zapper"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:214
+msgid "buy.dex.summary_01"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:221
+msgid "buy.dex.summary_02"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:146
+msgid "buy.disclaimer"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:151
+msgid "buy.disclaimer_01"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:161
+msgid "buy.disclaimer_02"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:48
+#: components/pages/Buy/index.tsx:49
+msgid "buy.head.title"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:113
+#: components/pages/Buy/index.tsx:207
+msgid "buy.intermediate"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:65
+msgid "buy.subtitle"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:62
+msgid "buy.title"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:13
+msgid "buy.zapper_01.description_01"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:19
+msgid "buy.zapper_01.description_02"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:9
+msgid "buy.zapper_01.title"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:36
+msgid "buy.zapper_02.description_02"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:32
+msgid "buy.zapper_02.title"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:49
+msgid "buy.zapper_03.description_01"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:45
+msgid "buy.zapper_03.title"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:97
+msgid "community.become_a_partner"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:170
+msgid "community.bigcowg_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:159
+msgid "community.blockchainforclimatefondation_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:333
+msgid "community.come_on_in"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:236
+msgid "community.deltawave_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:288
+msgid "community.digitalcharityart_logo"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Community/index.tsx:348
+msgid "community.discord_is_where_we_share"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:258
+msgid "community.dovu_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:266
+msgid "community.eco_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:247
+msgid "community.etcgroup_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:381
+msgid "community.get_in_touch"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:203
+msgid "community.gitcoin_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:75
+msgid "community.head.headline"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:76
+msgid "community.head.subline"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:74
+#: components/pages/Resources/Community/index.tsx:81
+msgid "community.head.title"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Community/index.tsx:384
+msgid "community.if_you_ve_got_questions"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:336
+msgid "community.join_our_discord"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:323
+msgid "community.join_the_klima_community"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:94
+#: components/pages/Resources/Community/index.tsx:378
+msgid "community.lets_work_together"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:137
+msgid "community.moss_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:192
+msgid "community.oceandrop_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:277
+msgid "community.offsetra_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:214
+msgid "community.olympusdao_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:225
+msgid "community.openearth_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:130
+msgid "community.our_partners"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:181
+msgid "community.polygon_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:148
+msgid "community.toucan_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:299
+msgid "community.toughtforfood_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:113
+msgid "community.tree_grove"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Community/index.tsx:100
+msgid "community.we_work_with_traditionnal"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:64
+msgid "concat.careers"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:141
+msgid "contact.bug_reports"
+msgstr ""
+
+#. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
+#: components/pages/Resources/Contact/index.tsx:144
+msgid "contact.bug_reports.to_file_a_bug_report"
+msgstr ""
+
+#. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
+#: components/pages/Resources/Contact/index.tsx:67
+msgid "contact.careers.we_re_hiring"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:18
+msgid "contact.head.headline"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:19
+msgid "contact.head.subline"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:17
+#: components/pages/Resources/Contact/index.tsx:24
+msgid "contact.head.title"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:106
+msgid "contact.media"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Contact/index.tsx:109
+msgid "contact.media.if_you_are_a_journalist"
+msgstr ""
+
+#. Use this <0>Media Request Form</0>.
+#: components/pages/Resources/Contact/index.tsx:118
+msgid "contact.media.use_this_media_request_form"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:86
+msgid "contact.partnerships"
+msgstr ""
+
+#. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
+#: components/pages/Resources/Contact/index.tsx:89
+msgid "contact.partnerships.until_we_finish_building"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:36
+msgid "contact.quest_and_support"
+msgstr ""
+
+#. Join our <0>community</0>
+#: components/pages/Resources/Contact/index.tsx:39
+msgid "contact.quest_and_support.join_our_community"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Contact/index.tsx:47
+msgid "contact.quest_and_support.join_our_discord_server"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:72
+msgid "disclaimer.1_an_offer_or_sollicitation"
+msgstr ""
+
+#: components/pages/Disclaimer/index.tsx:119
+msgid "disclaimer.1_meet_your_requirements"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:124
+msgid "disclaimer.2_be_available_on_an_uninterrupted"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:82
+msgid "disclaimer.2_financial_investment_or_trading_advice"
+msgstr ""
+
+#: components/pages/Disclaimer/index.tsx:133
+msgid "disclaimer.3_be_reliable_complete_legal_or_safe"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:40
+msgid "disclaimer.all_information_on_this_website"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:167
+msgid "disclaimer.any_action_you_take_upon_the_information"
+msgstr ""
+
+#: components/pages/Disclaimer/index.tsx:36
+msgid "disclaimer.disclaimer"
+msgstr ""
+
+#: components/pages/Disclaimer/index.tsx:19
+#: components/pages/Disclaimer/index.tsx:28
+msgid "disclaimer.head.title"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:110
+msgid "disclaimer.klimadao_and_its_suppliers"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:51
+msgid "disclaimer.klimadao_is_a_platform"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:138
+msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:186
+msgid "disclaimer.nothing_in_this_disclaimer"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:64
+msgid "disclaimer.nothing_in_this_platform"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:91
+msgid "disclaimer.the_service_available"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:197
+msgid "disclaimer.we_recommend_that_you_visit"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:152
+msgid "disclaimer.you_bear_full_responsibility"
+msgstr ""
+
+#: components/pages/errors/Custom404.tsx:39
+msgid "error.404.page.text"
+msgstr ""
+
+#: components/pages/errors/Custom404.tsx:36
+msgid "error.404.page.title"
+msgstr ""
+
+#: components/pages/errors/Custom500.tsx:41
+msgid "error.500.page.text"
+msgstr ""
+
+#: components/pages/errors/Custom500.tsx:36
+msgid "error.500.page.title"
+msgstr ""
+
+#: components/pages/errors/Custom404.tsx:21
+msgid "error.page.404.head.title"
+msgstr ""
+
+#: components/pages/errors/Custom404.tsx:17
+msgid "error.page.404.title"
+msgstr ""
+
+#: components/pages/errors/Custom500.tsx:21
+msgid "error.page.500.head.title"
+msgstr ""
+
+#: components/pages/errors/Custom500.tsx:17
+msgid "error.page.500.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:207
+msgid "home.backed_by_carbon"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:165
+msgid "home.by_increasing_access"
+msgstr ""
+
+#: components/pages/Home/index.tsx:298
+msgid "home.cars_annual"
+msgstr ""
+
+#: components/pages/Home/index.tsx:267
+msgid "home.equivalent_to"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:382
+msgid "home.every_klima_token_is_backed"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:105
+msgid "home.fight_climate_change"
+msgstr ""
+
+#: components/pages/Home/index.tsx:433
+msgid "home.get_exposure_to_the_growing_carbon_economy"
+msgstr ""
+
+#: components/pages/Home/index.tsx:430
+msgid "home.get_klima"
+msgstr ""
+
+#: components/pages/Home/index.tsx:281
+msgid "home.hectares_of_forest"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:150
+msgid "home.klima_is_a_black_hole"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:411
+msgid "home.klima_tokens_are_minted"
+msgstr ""
+
+#: components/pages/Home/index.tsx:81
+msgid "home.latest_news"
+msgstr ""
+
+#: components/pages/Home/index.tsx:136
+msgid "home.learn_more"
+msgstr ""
+
+#: components/pages/Home/index.tsx:313
+msgid "home.liters_if_gasoline"
+msgstr ""
+
+#: components/pages/Home/index.tsx:243
+msgid "home.massive impact"
+msgstr ""
+
+#: components/pages/Home/index.tsx:181
+msgid "home.mechanics"
+msgstr ""
+
+#: components/pages/Home/index.tsx:462
+msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:470
+msgid "home.newletter.get_the_latest_updates"
+msgstr ""
+
+#: components/pages/Home/index.tsx:487
+msgid "home.newletter.never_shared_never_spammed"
+msgstr ""
+
+#: components/pages/Home/index.tsx:481
+msgid "home.newletter.sign_up"
+msgstr ""
+
+#: components/pages/Home/index.tsx:467
+msgid "home.newsletter"
+msgstr ""
+
+#. <0>Reserve Asset</0><1>Of the carbon economy</1>
+#: components/pages/Home/index.tsx:370
+msgid "home.reserve_asset_of_the_carbon_economy"
+msgstr ""
+
+#: components/pages/Home/index.tsx:440
+msgid "home.see_tutorial"
+msgstr ""
+
+#: components/pages/Home/index.tsx:328
+msgid "home.source"
+msgstr ""
+
+#: components/pages/Home/index.tsx:225
+msgid "home.strong_incentives"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:184
+msgid "home.the_dao_sell_bonds"
+msgstr ""
+
+#. TONS OF <0>CARBON ABSORBED</0> BY KLIMADAO
+#: components/pages/Home/index.tsx:254
+msgid "home.tons_of_carbon_absorbed_by_klimadao"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:157
+msgid "home.we_ve_kickstarted"
+msgstr ""
+
+#. <0>{0}% WEEKLY REWARDS</0><1>FOR TOKEN HOLDERS</1>
+#: components/pages/Home/index.tsx:399
+msgid "home.weekly_rewards_for_token_holders"
+msgstr ""
+
+#. <0>WELCOME TO</0><1>KlimaDAO</1>
+#: components/pages/Home/index.tsx:92
+msgid "home.welcome_to_klimadao"
+msgstr ""
+
+#: components/pages/Home/index.tsx:355
+msgid "invest_in_the_future"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:59
+msgid "retirement.button.buy"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:63
+msgid "retirement.button.learnMore"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:28
+msgid "retirement.footer.aboutKlima.learnMore"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:20
+msgid "retirement.footer.aboutKlima.stake"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:15
+msgid "retirement.footer.aboutKlima.title"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:51
+msgid "retirement.footer.buyKlima.text"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:46
+msgid "retirement.footer.buyKlima.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:62
+msgid "retirement.head.metaDescription"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:56
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:52
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:103
+msgid "retirement.single.beneficiary.placeholder"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:97
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:111
+msgid "retirement.single.beneficiaryAddress.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:152
+msgid "retirement.single.description"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:72
+msgid "retirement.single.header.offset"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
+msgid "retirement.single.message.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:144
+msgid "retirement.single.retirementCertificate.link"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:139
+msgid "retirement.single.retirementCertificate.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:19
+msgid "retirement.single.retirementDate.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:82
+msgid "retirement.single.retirementMessage.placeholder"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:131
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
+msgid "retirement.single.value.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:171
+msgid "retirement.single.viewOnPolygon"
+msgstr ""
+
+#: components/pages/Retirements/index.tsx:31
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#: components/pages/Retirements/index.tsx:26
+msgid "retirement.totals.head.title"
+msgstr ""
+
+#: components/Footer/index.tsx:51
+#: components/pages/Resources/ResourcesHeader/index.tsx:29
+#: components/pages/Resources/ResourcesHeader/index.tsx:64
+msgid "shared.blog"
+msgstr ""
+
+#: components/Footer/index.tsx:44
+msgid "shared.bond"
+msgstr ""
+
+#: components/Footer/index.tsx:37
+#: components/Navigation/index.tsx:44
+#: components/Navigation/index.tsx:70
+msgid "shared.buy"
+msgstr ""
+
+#: components/pages/Resources/ResourcesHeader/index.tsx:40
+#: components/pages/Resources/ResourcesHeader/index.tsx:70
+msgid "shared.community"
+msgstr ""
+
+#: components/Footer/index.tsx:56
+#: components/pages/Resources/ResourcesHeader/index.tsx:76
+msgid "shared.contact"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:110
+#: components/pages/Resources/Community/index.tsx:394
+#: components/pages/Resources/ResourcesHeader/index.tsx:51
+msgid "shared.contact_us"
+msgstr ""
+
+#: components/Footer/index.tsx:61
+msgid "shared.disclaimer"
+msgstr ""
+
+#: components/Footer/index.tsx:47
+msgid "shared.docs"
+msgstr ""
+
+#: components/Navigation/index.tsx:37
+#: components/pages/Home/index.tsx:113
+msgid "shared.enter_app"
+msgstr ""
+
+#: components/pages/Blog/index.tsx:25
+#: components/pages/Buy/index.tsx:50
+#: components/pages/Disclaimer/index.tsx:23
+#: components/pages/Home/index.tsx:66
+#: components/pages/Resources/Community/index.tsx:82
+#: components/pages/Resources/Contact/index.tsx:25
+#: components/pages/Retirements/index.tsx:36
+#: components/pages/errors/Custom404.tsx:25
+#: components/pages/errors/Custom500.tsx:25
+msgid "shared.head.description"
+msgstr ""
+
+#: components/Footer/index.tsx:32
+msgid "shared.home"
+msgstr ""
+
+#: components/Navigation/index.tsx:53
+#: components/Navigation/index.tsx:78
+msgid "shared.loveletters"
+msgstr ""
+
+#: components/Navigation/index.tsx:57
+#: components/Navigation/index.tsx:82
+msgid "shared.resources"
+msgstr ""
+
+#: components/Footer/index.tsx:41
+#: components/Navigation/index.tsx:49
+#: components/Navigation/index.tsx:74
+msgid "shared.stake"
+msgstr ""

--- a/site/locale/ko/messages.po
+++ b/site/locale/ko/messages.po
@@ -1,0 +1,832 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2022-05-13 12:47+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: ko\n"
+
+#: components/pages/Blog/index.tsx:35
+msgid "Articles"
+msgstr ""
+
+#: components/ChangeLanguageButton/index.tsx:66
+msgid "Change language"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:276
+msgid "Enter App"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Blog/Post/index.tsx:95
+msgid "blog.disclaimer.description"
+msgstr ""
+
+#: components/pages/Blog/Post/index.tsx:92
+msgid "blog.disclaimer.title"
+msgstr ""
+
+#: components/pages/Blog/index.tsx:19
+msgid "blog.head.description"
+msgstr ""
+
+#: components/pages/Blog/index.tsx:18
+msgid "blog.head.headline"
+msgstr ""
+
+#: components/pages/Blog/index.tsx:17
+#: components/pages/Blog/index.tsx:24
+msgid "blog.head.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/CopyURLButton/index.tsx:29
+msgid "button.copyURL.copied"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/CopyURLButton/index.tsx:31
+msgid "button.copyURL.copy"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:135
+#: components/pages/Buy/index.tsx:254
+msgid "buy.advanced"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:90
+#: components/pages/Buy/index.tsx:176
+msgid "buy.beginner"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:14
+msgid "buy.beginner_01.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:10
+msgid "buy.beginner_01.title"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:29
+msgid "buy.beginner_02.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:37
+msgid "buy.beginner_02.description_02"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:25
+msgid "buy.beginner_02.title"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:51
+msgid "buy.beginner_03.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:57
+msgid "buy.beginner_03.description_2"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:47
+msgid "buy.beginner_03.title"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:72
+msgid "buy.beginner_04.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:79
+msgid "buy.beginner_04.description_02"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:68
+msgid "buy.beginner_04.title"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:97
+msgid "buy.beginner_05.description_01"
+msgstr ""
+
+#: components/pages/Buy/CreditCardTimeline/index.tsx:93
+msgid "buy.beginner_05.title"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:132
+#: components/pages/Buy/index.tsx:257
+msgid "buy.bonding"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:260
+msgid "buy.bonding.description_01"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:268
+msgid "buy.bonding.description_02"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:87
+#: components/pages/Buy/index.tsx:179
+msgid "buy.credit_card"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:182
+msgid "buy.credit_card.summary"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:108
+msgid "buy.decentralized_exchange"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:210
+msgid "buy.dex"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:241
+msgid "buy.dex.how_zapper"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:214
+msgid "buy.dex.summary_01"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:221
+msgid "buy.dex.summary_02"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:146
+msgid "buy.disclaimer"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:151
+msgid "buy.disclaimer_01"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:161
+msgid "buy.disclaimer_02"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:48
+#: components/pages/Buy/index.tsx:49
+msgid "buy.head.title"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:113
+#: components/pages/Buy/index.tsx:207
+msgid "buy.intermediate"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:65
+msgid "buy.subtitle"
+msgstr ""
+
+#: components/pages/Buy/index.tsx:62
+msgid "buy.title"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:13
+msgid "buy.zapper_01.description_01"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:19
+msgid "buy.zapper_01.description_02"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:9
+msgid "buy.zapper_01.title"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:36
+msgid "buy.zapper_02.description_02"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:32
+msgid "buy.zapper_02.title"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:49
+msgid "buy.zapper_03.description_01"
+msgstr ""
+
+#: components/pages/Buy/ZapperTimeline/index.tsx:45
+msgid "buy.zapper_03.title"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:97
+msgid "community.become_a_partner"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:170
+msgid "community.bigcowg_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:159
+msgid "community.blockchainforclimatefondation_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:333
+msgid "community.come_on_in"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:236
+msgid "community.deltawave_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:288
+msgid "community.digitalcharityart_logo"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Community/index.tsx:348
+msgid "community.discord_is_where_we_share"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:258
+msgid "community.dovu_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:266
+msgid "community.eco_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:247
+msgid "community.etcgroup_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:381
+msgid "community.get_in_touch"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:203
+msgid "community.gitcoin_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:75
+msgid "community.head.headline"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:76
+msgid "community.head.subline"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:74
+#: components/pages/Resources/Community/index.tsx:81
+msgid "community.head.title"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Community/index.tsx:384
+msgid "community.if_you_ve_got_questions"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:336
+msgid "community.join_our_discord"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:323
+msgid "community.join_the_klima_community"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:94
+#: components/pages/Resources/Community/index.tsx:378
+msgid "community.lets_work_together"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:137
+msgid "community.moss_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:192
+msgid "community.oceandrop_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:277
+msgid "community.offsetra_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:214
+msgid "community.olympusdao_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:225
+msgid "community.openearth_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:130
+msgid "community.our_partners"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:181
+msgid "community.polygon_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:148
+msgid "community.toucan_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:299
+msgid "community.toughtforfood_logo"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:113
+msgid "community.tree_grove"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Community/index.tsx:100
+msgid "community.we_work_with_traditionnal"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:64
+msgid "concat.careers"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:141
+msgid "contact.bug_reports"
+msgstr ""
+
+#. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
+#: components/pages/Resources/Contact/index.tsx:144
+msgid "contact.bug_reports.to_file_a_bug_report"
+msgstr ""
+
+#. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
+#: components/pages/Resources/Contact/index.tsx:67
+msgid "contact.careers.we_re_hiring"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:18
+msgid "contact.head.headline"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:19
+msgid "contact.head.subline"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:17
+#: components/pages/Resources/Contact/index.tsx:24
+msgid "contact.head.title"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:106
+msgid "contact.media"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Contact/index.tsx:109
+msgid "contact.media.if_you_are_a_journalist"
+msgstr ""
+
+#. Use this <0>Media Request Form</0>.
+#: components/pages/Resources/Contact/index.tsx:118
+msgid "contact.media.use_this_media_request_form"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:86
+msgid "contact.partnerships"
+msgstr ""
+
+#. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
+#: components/pages/Resources/Contact/index.tsx:89
+msgid "contact.partnerships.until_we_finish_building"
+msgstr ""
+
+#: components/pages/Resources/Contact/index.tsx:36
+msgid "contact.quest_and_support"
+msgstr ""
+
+#. Join our <0>community</0>
+#: components/pages/Resources/Contact/index.tsx:39
+msgid "contact.quest_and_support.join_our_community"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Resources/Contact/index.tsx:47
+msgid "contact.quest_and_support.join_our_discord_server"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:72
+msgid "disclaimer.1_an_offer_or_sollicitation"
+msgstr ""
+
+#: components/pages/Disclaimer/index.tsx:119
+msgid "disclaimer.1_meet_your_requirements"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:124
+msgid "disclaimer.2_be_available_on_an_uninterrupted"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:82
+msgid "disclaimer.2_financial_investment_or_trading_advice"
+msgstr ""
+
+#: components/pages/Disclaimer/index.tsx:133
+msgid "disclaimer.3_be_reliable_complete_legal_or_safe"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:40
+msgid "disclaimer.all_information_on_this_website"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:167
+msgid "disclaimer.any_action_you_take_upon_the_information"
+msgstr ""
+
+#: components/pages/Disclaimer/index.tsx:36
+msgid "disclaimer.disclaimer"
+msgstr ""
+
+#: components/pages/Disclaimer/index.tsx:19
+#: components/pages/Disclaimer/index.tsx:28
+msgid "disclaimer.head.title"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:110
+msgid "disclaimer.klimadao_and_its_suppliers"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:51
+msgid "disclaimer.klimadao_is_a_platform"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:138
+msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:186
+msgid "disclaimer.nothing_in_this_disclaimer"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:64
+msgid "disclaimer.nothing_in_this_platform"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:91
+msgid "disclaimer.the_service_available"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:197
+msgid "disclaimer.we_recommend_that_you_visit"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Disclaimer/index.tsx:152
+msgid "disclaimer.you_bear_full_responsibility"
+msgstr ""
+
+#: components/pages/errors/Custom404.tsx:39
+msgid "error.404.page.text"
+msgstr ""
+
+#: components/pages/errors/Custom404.tsx:36
+msgid "error.404.page.title"
+msgstr ""
+
+#: components/pages/errors/Custom500.tsx:41
+msgid "error.500.page.text"
+msgstr ""
+
+#: components/pages/errors/Custom500.tsx:36
+msgid "error.500.page.title"
+msgstr ""
+
+#: components/pages/errors/Custom404.tsx:21
+msgid "error.page.404.head.title"
+msgstr ""
+
+#: components/pages/errors/Custom404.tsx:17
+msgid "error.page.404.title"
+msgstr ""
+
+#: components/pages/errors/Custom500.tsx:21
+msgid "error.page.500.head.title"
+msgstr ""
+
+#: components/pages/errors/Custom500.tsx:17
+msgid "error.page.500.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:207
+msgid "home.backed_by_carbon"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:165
+msgid "home.by_increasing_access"
+msgstr ""
+
+#: components/pages/Home/index.tsx:298
+msgid "home.cars_annual"
+msgstr ""
+
+#: components/pages/Home/index.tsx:267
+msgid "home.equivalent_to"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:382
+msgid "home.every_klima_token_is_backed"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:105
+msgid "home.fight_climate_change"
+msgstr ""
+
+#: components/pages/Home/index.tsx:433
+msgid "home.get_exposure_to_the_growing_carbon_economy"
+msgstr ""
+
+#: components/pages/Home/index.tsx:430
+msgid "home.get_klima"
+msgstr ""
+
+#: components/pages/Home/index.tsx:281
+msgid "home.hectares_of_forest"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:150
+msgid "home.klima_is_a_black_hole"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:411
+msgid "home.klima_tokens_are_minted"
+msgstr ""
+
+#: components/pages/Home/index.tsx:81
+msgid "home.latest_news"
+msgstr ""
+
+#: components/pages/Home/index.tsx:136
+msgid "home.learn_more"
+msgstr ""
+
+#: components/pages/Home/index.tsx:313
+msgid "home.liters_if_gasoline"
+msgstr ""
+
+#: components/pages/Home/index.tsx:243
+msgid "home.massive impact"
+msgstr ""
+
+#: components/pages/Home/index.tsx:181
+msgid "home.mechanics"
+msgstr ""
+
+#: components/pages/Home/index.tsx:462
+msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:470
+msgid "home.newletter.get_the_latest_updates"
+msgstr ""
+
+#: components/pages/Home/index.tsx:487
+msgid "home.newletter.never_shared_never_spammed"
+msgstr ""
+
+#: components/pages/Home/index.tsx:481
+msgid "home.newletter.sign_up"
+msgstr ""
+
+#: components/pages/Home/index.tsx:467
+msgid "home.newsletter"
+msgstr ""
+
+#. <0>Reserve Asset</0><1>Of the carbon economy</1>
+#: components/pages/Home/index.tsx:370
+msgid "home.reserve_asset_of_the_carbon_economy"
+msgstr ""
+
+#: components/pages/Home/index.tsx:440
+msgid "home.see_tutorial"
+msgstr ""
+
+#: components/pages/Home/index.tsx:328
+msgid "home.source"
+msgstr ""
+
+#: components/pages/Home/index.tsx:225
+msgid "home.strong_incentives"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:184
+msgid "home.the_dao_sell_bonds"
+msgstr ""
+
+#. TONS OF <0>CARBON ABSORBED</0> BY KLIMADAO
+#: components/pages/Home/index.tsx:254
+msgid "home.tons_of_carbon_absorbed_by_klimadao"
+msgstr ""
+
+#. Long sentence
+#: components/pages/Home/index.tsx:157
+msgid "home.we_ve_kickstarted"
+msgstr ""
+
+#. <0>{0}% WEEKLY REWARDS</0><1>FOR TOKEN HOLDERS</1>
+#: components/pages/Home/index.tsx:399
+msgid "home.weekly_rewards_for_token_holders"
+msgstr ""
+
+#. <0>WELCOME TO</0><1>KlimaDAO</1>
+#: components/pages/Home/index.tsx:92
+msgid "home.welcome_to_klimadao"
+msgstr ""
+
+#: components/pages/Home/index.tsx:355
+msgid "invest_in_the_future"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:59
+msgid "retirement.button.buy"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:63
+msgid "retirement.button.learnMore"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:28
+msgid "retirement.footer.aboutKlima.learnMore"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:20
+msgid "retirement.footer.aboutKlima.stake"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:15
+msgid "retirement.footer.aboutKlima.title"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:51
+msgid "retirement.footer.buyKlima.text"
+msgstr ""
+
+#: components/pages/Retirements/Footer/index.tsx:46
+msgid "retirement.footer.buyKlima.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:62
+msgid "retirement.head.metaDescription"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:56
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:52
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:103
+msgid "retirement.single.beneficiary.placeholder"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:97
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:111
+msgid "retirement.single.beneficiaryAddress.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:152
+msgid "retirement.single.description"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:72
+msgid "retirement.single.header.offset"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
+msgid "retirement.single.message.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:144
+msgid "retirement.single.retirementCertificate.link"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:139
+msgid "retirement.single.retirementCertificate.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:19
+msgid "retirement.single.retirementDate.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:82
+msgid "retirement.single.retirementMessage.placeholder"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:131
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
+msgid "retirement.single.value.title"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:171
+msgid "retirement.single.viewOnPolygon"
+msgstr ""
+
+#: components/pages/Retirements/index.tsx:31
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#: components/pages/Retirements/index.tsx:26
+msgid "retirement.totals.head.title"
+msgstr ""
+
+#: components/Footer/index.tsx:51
+#: components/pages/Resources/ResourcesHeader/index.tsx:29
+#: components/pages/Resources/ResourcesHeader/index.tsx:64
+msgid "shared.blog"
+msgstr ""
+
+#: components/Footer/index.tsx:44
+msgid "shared.bond"
+msgstr ""
+
+#: components/Footer/index.tsx:37
+#: components/Navigation/index.tsx:44
+#: components/Navigation/index.tsx:70
+msgid "shared.buy"
+msgstr ""
+
+#: components/pages/Resources/ResourcesHeader/index.tsx:40
+#: components/pages/Resources/ResourcesHeader/index.tsx:70
+msgid "shared.community"
+msgstr ""
+
+#: components/Footer/index.tsx:56
+#: components/pages/Resources/ResourcesHeader/index.tsx:76
+msgid "shared.contact"
+msgstr ""
+
+#: components/pages/Resources/Community/index.tsx:110
+#: components/pages/Resources/Community/index.tsx:394
+#: components/pages/Resources/ResourcesHeader/index.tsx:51
+msgid "shared.contact_us"
+msgstr ""
+
+#: components/Footer/index.tsx:61
+msgid "shared.disclaimer"
+msgstr ""
+
+#: components/Footer/index.tsx:47
+msgid "shared.docs"
+msgstr ""
+
+#: components/Navigation/index.tsx:37
+#: components/pages/Home/index.tsx:113
+msgid "shared.enter_app"
+msgstr ""
+
+#: components/pages/Blog/index.tsx:25
+#: components/pages/Buy/index.tsx:50
+#: components/pages/Disclaimer/index.tsx:23
+#: components/pages/Home/index.tsx:66
+#: components/pages/Resources/Community/index.tsx:82
+#: components/pages/Resources/Contact/index.tsx:25
+#: components/pages/Retirements/index.tsx:36
+#: components/pages/errors/Custom404.tsx:25
+#: components/pages/errors/Custom500.tsx:25
+msgid "shared.head.description"
+msgstr ""
+
+#: components/Footer/index.tsx:32
+msgid "shared.home"
+msgstr ""
+
+#: components/Navigation/index.tsx:53
+#: components/Navigation/index.tsx:78
+msgid "shared.loveletters"
+msgstr ""
+
+#: components/Navigation/index.tsx:57
+#: components/Navigation/index.tsx:82
+msgid "shared.resources"
+msgstr ""
+
+#: components/Footer/index.tsx:41
+#: components/Navigation/index.tsx:49
+#: components/Navigation/index.tsx:74
+msgid "shared.stake"
+msgstr ""

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -87,7 +87,7 @@ const nextConfig = {
 if (!IS_PRODUCTION) {
   nextConfig.i18n = {
     ...nextConfig.i18n,
-    locales: [...nextConfig.i18n.locales, "en-pseudo"],
+    locales: [...nextConfig.i18n.locales, "ko", "es", "en-pseudo"],
   };
 }
 


### PR DESCRIPTION
## Description

This PRs includes Korean and Spanish translations (Staging only).
With the next sync these will be available on Translation.io too.

Please note that there are tons of different Spanish country codes.
See the full list [here](http://www.lingoes.net/en/translator/langcode.htm).
I decided now for "es-ES" which is Spain. 
Let's keep that in mind when we see problems with timezones.

## Related Ticket

Closes https://github.com/KlimaDAO/klimadao/issues/394


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
