### PR TITLE
Draft: Added translation tags to web3modal strings

### DIFF
--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -36,6 +36,7 @@ import { NavMenu } from "components/NavMenu";
 import Menu from "@mui/icons-material/Menu";
 import { IsomorphicRoutes } from "components/IsomorphicRoutes";
 import { Buy } from "../Buy";
+import { t } from "@lingui/macro";
 
 type EIP1139Provider = ethers.providers.ExternalProvider & {
   on: (e: "accountsChanged" | "chainChanged", cb: () => void) => void;
@@ -45,6 +46,8 @@ type EIP1139Provider = ethers.providers.ExternalProvider & {
 /** wrap in useEffect to skip on server-side render */
 const useWeb3Modal = () => {
   const ref = useRef<Web3Modal>();
+  const { locale } = useSelector(selectAppState);
+
   useEffect(() => {
     const modal = new Web3Modal({
       cacheProvider: true, // optional
@@ -53,6 +56,12 @@ const useWeb3Modal = () => {
           package: WalletConnectProvider, // required
           options: {
             rpc: { 137: urls.polygonMainnetRpc },
+          },
+          display: {
+            description: t({
+              id: "web3modal.walletconnect.description",
+              message: "Scan with WalletConnect to connect",
+            }),
           },
         },
         walletlink: {
@@ -64,11 +73,26 @@ const useWeb3Modal = () => {
             appLogoUrl: null, // Optional. Application logo image URL. favicon is used if unspecified
             darkMode: false, // Optional. Use dark theme, defaults to false
           },
+          display: {
+            description: t({
+              id: "web3modal.walletlink.description",
+              message: "Scan with Coinbase to connect",
+            }),
+          },
+        },
+        injected: {
+          display: {
+            description: t({
+              id: "web3modal.injected.description",
+              message: "Connect with your browser web3 provider",
+            }),
+          },
+          package: null,
         },
       },
     });
     ref.current = modal;
-  }, []);
+  }, [locale]);
   return ref.current;
 };
 


### PR DESCRIPTION
## Description

Added translation tags to web3modal strings

## Related Ticket

Resolves #397

## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/11857992/168682011-a4219a38-4385-4f29-8b02-7928702cf684.png) |![image](https://user-images.githubusercontent.com/11857992/168681934-38b5ff57-dc56-42c5-8029-4143f1d17f93.png)|

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`

## Notes

This does not work properly!

We have to make `useEffect` depend on `locale` so the modal can be translated when the locales are loaded.
But if we change the language after the modal is loaded once (not necessarily shown), somehow it gets bugged (impossible to open and close the modal).
I suspect it has something to do with the fact that it creates multiple instances of Web3Modal. I am digging into that but I think I need another pair of eyes.

Edit: If I add this test : `if (locale !== undefined && ref.current === undefined)` I can obtain a behavior where the language is correctly loaded at application startup but the Modal text won't change if the user changes the language until they reload the application.




