### PR TITLE
replaced emoji with utf8 code for emoji for linux bug

### DIFF
--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -744,8 +744,8 @@ export const Bond: FC<Props> = (props) => {
                 id="bond.all_demand_has_been_filled"
                 comment="Long sentence"
               >
-                🪧 SOLD OUT. All demand has been filled for this bond. Thank you,
-                Klimates!
+                &#U+1FAA7 SOLD OUT. All demand has been filled for this bond.
+                Thank you, Klimates!
               </Trans>
             </Text>
           )}

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -744,8 +744,8 @@ export const Bond: FC<Props> = (props) => {
                 id="bond.all_demand_has_been_filled"
                 comment="Long sentence"
               >
-                &#U+1FAA7 SOLD OUT. All demand has been filled for this bond.
-                Thank you, Klimates!
+                SOLD OUT. All demand has been filled for this bond. Thank you,
+                Klimates!
               </Trans>
             </Text>
           )}


### PR DESCRIPTION
## Description

I replaced the emoji with the code for the emoji to display on linux/ubuntu with brave. I have not tested this bc I dont run linux.

## Related Ticket
#384
<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #384 
#384
<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|
-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
