### PR TITLE
OG meta properties fix for twitter

### DIFF
--- a/app/components/PageHead.tsx
+++ b/app/components/PageHead.tsx
@@ -37,11 +37,11 @@ export const PageHead = (props: PageHeadProps) => {
       <meta property="og:type" content="website" />
       <meta property="og:locale" content={locale || "en"} />
 
-      <meta property="twitter:card" content="summary_large_image" />
-      <meta property="twitter:title" content={props.mediaTitle} />
-      <meta property="twitter:description" content={props.metaDescription} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={props.mediaTitle} />
+      <meta name="twitter:description" content={props.metaDescription} />
       {props.mediaImageSrc && (
-        <meta property="twitter:image" content={props.mediaImageSrc} />
+        <meta name="twitter:image" content={props.mediaImageSrc} />
       )}
       <link
         rel="apple-touch-icon"

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -4,6 +4,7 @@ import { WithRedux } from "components/WithRedux";
 import { NextPage } from "next";
 import { PageHead } from "components/PageHead";
 import { IS_PRODUCTION } from "lib/constants";
+import { urls } from "@klimadao/lib/constants";
 import { messages as default_messages } from "../locale/en/messages";
 import { i18n } from "@lingui/core";
 
@@ -23,7 +24,7 @@ const HomePage: NextPage = () => {
           title="KlimaDAO | Official App"
           mediaTitle="KlimaDAO | Official App"
           metaDescription="Use the KLIMA web app to bond, stake and earn rewards."
-          mediaImageSrc="/og-media.png"
+          mediaImageSrc={urls.mediaImage}
         />
         <Home />
       </WithIsomorphicRouter>

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -128,6 +128,7 @@ export const urls = {
     "https://notionforms.io/forms/klimadao-request-for-collaboration",
   pressEmail: "mailto:press@klimadao.finance",
   loveletter: "https://loveletter.klimadao.finance",
+  mediaImage: "https://www.klimadao.finance/og-media.png",
 };
 
 export const polygonNetworks = {

--- a/site/components/PageHead/index.tsx
+++ b/site/components/PageHead/index.tsx
@@ -42,16 +42,16 @@ export const PageHead = (props: PageHeadProps) => {
       <meta property="og:locale" content={router.locale || "en"} />
       <meta property="og:site_name" content="KlimaDAO" />
 
-      <meta property="twitter:card" content="summary_large_image" />
-      <meta property="twitter:title" content={props.mediaTitle} />
-      <meta property="twitter:description" content={props.metaDescription} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={props.mediaTitle} />
+      <meta name="twitter:description" content={props.metaDescription} />
 
       {props.mediaImageSrc && (
         <meta property="og:image" content={props.mediaImageSrc} />
       )}
 
       {props.mediaImageSrc && (
-        <meta property="twitter:image" content={props.mediaImageSrc} />
+        <meta name="twitter:image" content={props.mediaImageSrc} />
       )}
 
       {props.isArticle && (

--- a/site/components/pages/Blog/Post/index.tsx
+++ b/site/components/pages/Blog/Post/index.tsx
@@ -11,6 +11,7 @@ import { Text } from "@klimadao/lib/components";
 
 import { Post } from "lib/queries";
 import { IS_PRODUCTION } from "lib/constants";
+import { urls } from "@klimadao/lib/constants";
 
 import { PageHead } from "components/PageHead";
 import { Footer } from "components/Footer";
@@ -50,7 +51,7 @@ export const PostPage = (props: PostProps) => {
         title={props.post.title}
         mediaTitle={props.post.title}
         metaDescription={props.post.summary}
-        mediaImageSrc={props.post.imageUrl || "/og-media.png"}
+        mediaImageSrc={props.post.imageUrl || urls.mediaImage}
         isArticle={true}
       />
 

--- a/site/components/pages/Blog/index.tsx
+++ b/site/components/pages/Blog/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { Trans, t } from "@lingui/macro";
 import { Text } from "@klimadao/lib/components";
-
+import { urls } from "@klimadao/lib/constants";
 import { AllPosts } from "lib/queries";
 import { Card } from "components/Card";
 import styles from "./index.module.css";
@@ -27,7 +27,7 @@ export const Blog: FC<Props> = (props) => (
       message:
         "Drive climate action and earn rewards with a carbon-backed digital currency.",
     })}
-    mediaImageSrc="/og-media.png"
+    mediaImageSrc={urls.mediaImage}
   >
     <div className={styles.container}>
       <section className={styles.cardsSection}>

--- a/site/components/pages/Disclaimer/index.tsx
+++ b/site/components/pages/Disclaimer/index.tsx
@@ -8,7 +8,7 @@ import { PageHead } from "components/PageHead";
 import { Footer } from "components/Footer";
 
 import { IS_PRODUCTION } from "lib/constants";
-
+import { urls } from "@klimadao/lib/constants";
 export type Props = HTMLHtmlElement;
 
 export const Disclaimer: NextPage<Props> = ({}) => {
@@ -26,7 +26,7 @@ export const Disclaimer: NextPage<Props> = ({}) => {
             "Drive climate action and earn rewards with a carbon-backed digital currency.",
         })}
         mediaTitle={t({ id: "disclaimer.head.title" })}
-        mediaImageSrc="/og-media.png"
+        mediaImageSrc={urls.mediaImage}
       />
       <Navigation activePage="Disclaimer" />
 

--- a/site/components/pages/Home/index.tsx
+++ b/site/components/pages/Home/index.tsx
@@ -68,7 +68,7 @@ export const Home: NextPage<Props> = (props) => {
           message:
             "Drive climate action and earn rewards with a carbon-backed digital currency.",
         })}
-        mediaImageSrc="/og-media.png"
+        mediaImageSrc={urls.mediaImage}
       />
 
       <Navigation activePage="Home" />

--- a/site/components/pages/Resources/Community/index.tsx
+++ b/site/components/pages/Resources/Community/index.tsx
@@ -84,7 +84,7 @@ export const Community: NextPage = () => (
       message:
         "Drive climate action and earn rewards with a carbon-backed digital currency.",
     })}
-    mediaImageSrc="/og-media.png"
+    mediaImageSrc={urls.mediaImage}
     headerElements={HeaderElements}
   >
     <Section style={{ paddingBottom: "unset" }}>

--- a/site/components/pages/Resources/Contact/index.tsx
+++ b/site/components/pages/Resources/Contact/index.tsx
@@ -27,7 +27,7 @@ export const Contact: NextPage<Props> = () => {
         message:
           "Drive climate action and earn rewards with a carbon-backed digital currency.",
       })}
-      mediaImageSrc="/og-media.png"
+      mediaImageSrc={urls.mediaImage}
     >
       <Section>
         <div className={styles.contactContainer}>

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -19,7 +19,7 @@ import { CopyURLButton } from "./CopyURLButton";
 import { IS_PRODUCTION } from "lib/constants";
 import { Trans, t } from "@lingui/macro";
 import * as styles from "./styles";
-
+import { urls } from "@klimadao/lib/constants";
 import { retirementTokenInfoMap } from "../../../../lib/getTokenInfo";
 
 type Props = {
@@ -63,7 +63,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
           id: "retirement.head.metaDescription",
           message: "Transparent, on-chain offsets powered by KlimaDAO.",
         })}
-        mediaImageSrc="/og-media.png"
+        mediaImageSrc={urls.mediaImage}
       />
       <Navigation activePage="Home" />
 

--- a/site/components/pages/Retirements/index.tsx
+++ b/site/components/pages/Retirements/index.tsx
@@ -11,6 +11,7 @@ import { RetirementFooter } from "./Footer";
 import { IS_PRODUCTION } from "lib/constants";
 import { t } from "@lingui/macro";
 import * as styles from "./styles";
+import { urls } from "@klimadao/lib/constants";
 
 type Props = {
   retirements: RetirementsTotalsAndBalances;
@@ -38,7 +39,7 @@ export const RetirementPage: NextPage<Props> = (props) => {
           message:
             "Drive climate action and earn rewards with a carbon-backed digital currency.",
         })}
-        mediaImageSrc="/og-media.png"
+        mediaImageSrc={urls.mediaImage}
       />
       <Navigation activePage="Home" />
 


### PR DESCRIPTION
## Description

To solve ticket #373 I initially used recommendations from a web site that generates og meta tags. This was not a good idea.
This time I read the documentation from twitter https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image and made the following changes:

- Use name instead of property attribute for twitter OG tags
- Use Fully qualified name for twitter:image OG tag

Twitter also has recommendations for the image size:
```A URL to a unique image representing the content of the page. You should not use a generic image such as your website logo, author photo, or other image that spans multiple pages. Images for this Card support an aspect ratio of 2:1 with minimum dimensions of 300x157 or maximum of 4096x4096 pixels. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported.```

## Related Ticket

Resolves #373

## Changes

NA

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
