### PR TITLE
Fix #432 - add better form validation for selective retirements

### DIFF
--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -166,63 +166,8 @@ export const input = css`
       cursor: default;
     }
   }
-`;
-
-export const inputError = css`
-  display: flex;
-  flex-direction: column;
-  gap: 0.8rem;
-
-  textarea {
-    width: 100%;
-    background-color: var(--surface-02);
-    border-radius: 0.8rem;
+  input[data-error="true"] {
     border: 0.2rem solid red;
-    padding-inline-start: 0.8rem;
-    min-height: 2.4rem;
-    color: var(--font-01);
-    resize: none;
-    padding-top: 0.8rem;
-    overflow-y: hidden;
-    min-height: 16rem;
-  }
-
-  input {
-    width: 100%;
-    background-color: var(--surface-02);
-    border-radius: 0.8rem;
-    border: 0.2rem solid red;
-    padding-inline-start: 0.8rem;
-    min-height: 4.8rem;
-    color: var(--font-01);
-  }
-
-  label {
-    display: flex;
-    gap: 0.8rem;
-    color: red;
-    align-items: center;
-  }
-
-  .number_input_container {
-    min-height: 4.8rem;
-    display: grid;
-    grid-template-columns: 1fr min-content;
-    z-index: 1; /* cover advanced-settings border */
-  }
-
-  .button_max {
-    ${common.iconButton};
-    ${typography.button};
-    padding: 0 1.6rem;
-    border-radius: 0 0.8rem 0.8rem 0;
-    &:hover:not(:disabled) {
-      background-color: var(--surface-03);
-    }
-    &:disabled {
-      opacity: 0.5;
-      cursor: default;
-    }
   }
 `;
 
@@ -294,9 +239,11 @@ export const advancedButtonInput = css`
   display: flex;
   align-items: center;
   gap: 0.8rem;
-  .inputError {
-    border-color: red;
+
+  input[data-error="true"] {
+    border: 0.2rem solid red;
   }
+
   .advancedButtonInput_iconAligner {
     display: flex;
     width: 100%;

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -168,6 +168,64 @@ export const input = css`
   }
 `;
 
+export const inputError = css`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+
+  textarea {
+    width: 100%;
+    background-color: var(--surface-02);
+    border-radius: 0.8rem;
+    border: 0.2rem solid red;
+    padding-inline-start: 0.8rem;
+    min-height: 2.4rem;
+    color: var(--font-01);
+    resize: none;
+    padding-top: 0.8rem;
+    overflow-y: hidden;
+    min-height: 16rem;
+  }
+
+  input {
+    width: 100%;
+    background-color: var(--surface-02);
+    border-radius: 0.8rem;
+    border: 0.2rem solid red;
+    padding-inline-start: 0.8rem;
+    min-height: 4.8rem;
+    color: var(--font-01);
+  }
+
+  label {
+    display: flex;
+    gap: 0.8rem;
+    color: red;
+    align-items: center;
+  }
+
+  .number_input_container {
+    min-height: 4.8rem;
+    display: grid;
+    grid-template-columns: 1fr min-content;
+    z-index: 1; /* cover advanced-settings border */
+  }
+
+  .button_max {
+    ${common.iconButton};
+    ${typography.button};
+    padding: 0 1.6rem;
+    border-radius: 0 0.8rem 0.8rem 0;
+    &:hover:not(:disabled) {
+      background-color: var(--surface-03);
+    }
+    &:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+  }
+`;
+
 export const retirementSuccessModal = css`
   position: fixed;
   background-color: rgba(0, 0, 0, 0.5);
@@ -236,6 +294,9 @@ export const advancedButtonInput = css`
   display: flex;
   align-items: center;
   gap: 0.8rem;
+  .inputError {
+    border-color: red;
+  }
   .advancedButtonInput_iconAligner {
     display: flex;
     width: 100%;


### PR DESCRIPTION
## Description
I used the ethers isAddress util to test the addresses and added an array of booleans to `specificAddresses` for conditional styles on the input. I left the :focused the same so it doesnt flash at the user while typing. One questio is for the button props what priority do we want thew address format error to be? before or after the "insufficient funds"and other errors?
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket
#432 
<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #432

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|
![image](https://user-images.githubusercontent.com/24912886/169873787-95f7734c-80d3-4920-adf8-1e167f70925f.png)
 |
![image](https://user-images.githubusercontent.com/24912886/169873702-4fa6a3ee-1964-48e5-87d9-bb2e390d7ae1.png)
|
-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
