### PR TITLE
Release Totals Retirement page 🌳 

### DIFF
--- a/site/components/pages/Retirements/List/index.tsx
+++ b/site/components/pages/Retirements/List/index.tsx
@@ -40,6 +40,13 @@ export const AllRetirements: FC<Props> = (props) => {
               key={`${retirement}-${index}`}
             />
           ))}
+        {!klimaRetires.length && (
+          <Text align="center">
+            <Trans id="retirement.totals.all_retirements_list.empty">
+              No retirements found
+            </Trans>
+          </Text>
+        )}
       </div>
     </div>
   );

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -120,9 +120,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
                 text={
                   <a
                     className="address"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={`https://polygonscan.com/address/${beneficiaryAddress}`}
+                    href={`${urls.retirements}/${beneficiaryAddress}`}
                   >
                     {concatAddress(beneficiaryAddress)}
                   </a>

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -712,7 +712,7 @@ msgstr "Beneficiary"
 msgid "retirement.single.beneficiaryAddress.title"
 msgstr "Beneficiary Address"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:157
+#: components/pages/Retirements/SingleRetirement/index.tsx:155
 msgid "retirement.single.disclaimer"
 msgstr "This represents the permanent retirement of tokenized carbon assets on the Polygon blockchain. This retirement and the associated data are immutable public records."
 
@@ -732,11 +732,11 @@ msgstr "Retirement Message"
 msgid "retirement.single.quantity"
 msgstr "QUANTITY RETIRED"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:149
+#: components/pages/Retirements/SingleRetirement/index.tsx:147
 msgid "retirement.single.retirementCertificate.soon"
 msgstr "...coming soon!"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:144
+#: components/pages/Retirements/SingleRetirement/index.tsx:142
 msgid "retirement.single.retirementCertificate.title"
 msgstr "Certificate"
 
@@ -748,13 +748,17 @@ msgstr "Date"
 msgid "retirement.single.retirementMessage.placeholder"
 msgstr "No retirement message provided"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:136
+#: components/pages/Retirements/SingleRetirement/index.tsx:134
 msgid "retirement.single.timestamp.placeholder"
 msgstr "No retirement timestamp provided"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:174
+#: components/pages/Retirements/SingleRetirement/index.tsx:172
 msgid "retirement.single.view_on_polygon_scan"
 msgstr "View on Polygonscan"
+
+#: components/pages/Retirements/List/index.tsx:45
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr "No retirements found"
 
 #: components/pages/Retirements/List/index.tsx:25
 msgid "retirement.totals.all_retirements_list.headline"

--- a/site/pages/retirements/[beneficiary_address]/index.tsx
+++ b/site/pages/retirements/[beneficiary_address]/index.tsx
@@ -1,7 +1,7 @@
 import { GetStaticProps } from "next";
 import { ParsedUrlQuery } from "querystring";
 
-import { INFURA_ID, IS_PRODUCTION } from "lib/constants";
+import { INFURA_ID } from "lib/constants";
 
 import { getRetirementTotalsAndBalances } from "@klimadao/lib/utils";
 import { queryKlimaRetiresByAddress } from "@klimadao/lib/utils";
@@ -25,10 +25,6 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   ctx
 ) => {
   try {
-    if (IS_PRODUCTION) {
-      throw new Error("Not on Staging");
-    }
-
     const { params, locale } = ctx;
 
     if (!params || !params?.beneficiary_address) {


### PR DESCRIPTION
## Description

This PR releases the totals retirement page for a beneficiary address on Production.
And links from the Single Retirement pages back to the totals page too.

Additionally, if the address does not exist => renders proper placeholder for empty states
E.g. https://klimadao-site-git-release-totals-klimadao.vercel.app/retirements/0x293ed38530005620e4b28600f196a97e1125daee

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Related to #402 


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
