### PR TITLE
Retirement: Show project details 🏷️ 

### DIFF
--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -206,3 +206,10 @@ const SUBGRAPH_URL = "https://api.thegraph.com/subgraphs/name/klimadao";
 export const subgraphs = {
   polygonBridgedCarbon: `${SUBGRAPH_URL}/polygon-bridged-carbon`,
 };
+
+const VERRA_REGISTRY = "https://registry.verra.org";
+const VERRA_REGISTRY_API = `${VERRA_REGISTRY}/uiapi`;
+export const verra = {
+  projectSearch: `${VERRA_REGISTRY_API}/resource/resource/search?maxResults=2000&$count=true&$skip=0&$top=50`,
+  projectDetailPage: `${VERRA_REGISTRY}/app/projectDetail/VCS`, // add ID after VCS like /191
+};

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -106,6 +106,7 @@ export const urls = {
   community: "https://www.klimadao.finance/community",
   buy: "https://www.klimadao.finance/buy",
   buy_dapp: "https://app.klimadao.finance/#/buy",
+  carbonDashboard: "https://carbon.klimadao.finance",
   forum: "https://forum.klimadao.finance",
   snapshot: "https://snapshot.org/#/klimadao.eth",
   polygonMainnetRpc: "https://polygon-rpc.com",

--- a/lib/types/subgraph.ts
+++ b/lib/types/subgraph.ts
@@ -13,6 +13,13 @@ export interface KlimaRetire {
   offset: {
     id: string;
     tokenAddress: string;
+    totalRetired: string;
+    projectID: string; // starts with 'VCS-'
+    country: string;
+    region: string;
+    bridge: string;
+    registry: string;
+    standard: string;
   };
 }
 

--- a/lib/types/subgraph.ts
+++ b/lib/types/subgraph.ts
@@ -13,13 +13,13 @@ export interface KlimaRetire {
   offset: {
     id: string;
     tokenAddress: string;
-    totalRetired: string;
-    projectID: string; // starts with 'VCS-'
+    totalRetired: string; // "0" if bridge is "Moss"
+    projectID: string; // starts with 'VCS-' if registry is "Verra"
     country: string;
     region: string;
-    bridge: string;
-    registry: string;
-    standard: string;
+    bridge: string; // "Toucan", "Moss" or "C3"
+    registry: string; // "Verra" or "VCS"
+    standard: string; // "VCS" or "" for Moss
   };
 }
 

--- a/lib/types/verra.ts
+++ b/lib/types/verra.ts
@@ -1,0 +1,29 @@
+export interface Value {
+  program: string;
+  resourceIdentifier: string;
+  resourceName: string;
+  proponent: string;
+  operator: null | string;
+  designee: null | string;
+  protocolCategories: string;
+  protocolSubCategories: null | string;
+  protocols: string;
+  resourceStatus: string;
+  country: string;
+  estAnnualEmissionReductions: number;
+  region: string;
+  version: string;
+  compatibleProgramScenarioTypeName: null | string;
+  inputTypes: null | string;
+  programObjectives: null | string;
+  creditingPeriodStartDate: string;
+  creditingPeriodEndDate: string;
+  createDate: string;
+}
+
+export interface VerraProjectDetails {
+  totalCount: number;
+  countExceeded: boolean;
+  "@count": number;
+  value: Value[];
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -25,3 +25,4 @@ export {
   queryKlimaRetireByIndex,
   queryKlimaRetiresByAddress,
 } from "./subgraph/queryPolygonBridgedCarbon";
+export { getVerraProjectByID } from "./verra/getVerraProjects";

--- a/lib/utils/subgraph/queryPolygonBridgedCarbon.ts
+++ b/lib/utils/subgraph/queryPolygonBridgedCarbon.ts
@@ -32,6 +32,13 @@ export const queryKlimaRetireByIndex = async (
               offset {
                 id
                 tokenAddress
+                totalRetired
+                projectID
+                country
+                region 
+                bridge
+                registry 
+                standard
               }
             }
           }
@@ -73,6 +80,13 @@ export const queryKlimaRetiresByAddress = async (
               offset {
                 id
                 tokenAddress
+                totalRetired
+                projectID
+                country
+                region 
+                bridge
+                registry 
+                standard
               }
             }
           }

--- a/lib/utils/verra/getVerraProjects.ts
+++ b/lib/utils/verra/getVerraProjects.ts
@@ -1,0 +1,37 @@
+import { VerraProjectDetails } from "../../types/verra";
+
+import { verra } from "../../constants";
+
+export const getVerraProjectByID = async (
+  id: string
+): Promise<VerraProjectDetails> => {
+  try {
+    const result = await fetch(verra.projectSearch, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        program: "VCS",
+        resourceIdentifier: id,
+        resourceStatuses: [
+          "VCS_EX_CRD_PRD_VER_REQUESTED",
+          "VCS_EX_CRD_PRD_REQUESTED",
+          "VCS_EX_REGISTERED",
+          "VCS_EX_REG_VER_APPR_REQUESTED",
+          "VCS_EX_REGISTRATION_REQUESTED",
+          "VCS_EX_REJ",
+          "VCS_EX_UNDER_DEVELOPMENT_CLD",
+          "VCS_EX_UNDER_DEVELOPMENT_OPN",
+          "VCS_EX_UNDER_VALIDATION_CLD",
+          "VCS_EX_UNDER_VALIDATION_OPN",
+          "VCS_EX_CRED_TRANS_FRM_OTHER_PROG",
+          "VCS_EX_WITHDRAWN",
+        ],
+      }),
+    });
+    const json = await result.json();
+    return json;
+  } catch (e) {
+    console.error("Failed to getVerraProjectByID", e);
+    return Promise.reject(e);
+  }
+};

--- a/site/components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx
@@ -1,0 +1,61 @@
+import { FC } from "react";
+import { useRouter } from "next/router";
+import { Text, ButtonPrimary } from "@klimadao/lib/components";
+import { trimStringDecimals } from "@klimadao/lib/utils";
+
+import LaunchIcon from "@mui/icons-material/Launch";
+import { Trans, t } from "@lingui/macro";
+import * as styles from "./styles";
+
+type Props = {
+  tokenAddress: string;
+  projectLink: string;
+  headline: string;
+  totalRetired?: string;
+};
+
+export const ProjectDetail: FC<Props> = (props) => {
+  const { projectLink, headline, tokenAddress, totalRetired } = props;
+  const { locale } = useRouter();
+
+  const trimTotalRetired =
+    !!totalRetired &&
+    Number(trimStringDecimals(totalRetired, 6)).toLocaleString(locale);
+
+  return (
+    <div className={styles.listItem}>
+      <Text t="h4">
+        <a
+          className="link"
+          href={projectLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {headline}{" "}
+          <span className="svg">
+            <LaunchIcon fontSize="inherit" />
+          </span>
+        </a>
+      </Text>
+      {trimTotalRetired && (
+        <Text>
+          {trimTotalRetired}{" "}
+          <Trans id="retirement.single.project_details.tonnes">Tonnes</Trans>
+        </Text>
+      )}
+      <div className="button_link">
+        <ButtonPrimary
+          className="gray_button"
+          variant="gray"
+          href={`https://polygonscan.com/address/${tokenAddress}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          label={t({
+            id: "retirement.single.project_details.view_on_polygon_scan",
+            message: "View on Polygonscan",
+          })}
+        />
+      </div>
+    </div>
+  );
+};

--- a/site/components/pages/Retirements/SingleRetirement/ProjectDetails/List/styles.ts
+++ b/site/components/pages/Retirements/SingleRetirement/ProjectDetails/List/styles.ts
@@ -1,34 +1,6 @@
 import { css } from "@emotion/css";
-import breakpoints from "@klimadao/lib/theme/breakpoints";
 
-export const section = css`
-  padding-bottom: 4rem;
-  ${breakpoints.medium} {
-    padding-top: 9rem;
-    padding-bottom: 4rem;
-  }
-`;
-
-export const projectDetails = css`
-  background-color: var(--surface-01);
-  border-radius: 1.2rem;
-  grid-column: main;
-  display: grid;
-  gap: 2.8rem;
-  padding: 2.8rem 1.5rem;
-
-  ${breakpoints.medium} {
-    gap: 5.2rem;
-    padding: 5.2rem;
-  }
-`;
-
-export const title = css`
-  display: grid;
-  gap: 1.6rem;
-`;
-
-export const list = css`
+export const listItem = css`
   display: grid;
   gap: 1.2rem;
 

--- a/site/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
@@ -1,0 +1,82 @@
+import { FC } from "react";
+import { useRouter } from "next/router";
+import { Text, Section, ButtonPrimary } from "@klimadao/lib/components";
+import { KlimaRetire } from "@klimadao/lib/types/subgraph";
+import { VerraProjectDetails } from "@klimadao/lib/types/verra";
+import { trimStringDecimals } from "@klimadao/lib/utils";
+
+import LaunchIcon from "@mui/icons-material/Launch";
+import { Trans, t } from "@lingui/macro";
+import * as styles from "./styles";
+import { verra } from "@klimadao/lib/constants";
+
+type Props = {
+  offset: KlimaRetire["offset"];
+  projectDetails: VerraProjectDetails;
+};
+
+export const ProjectDetails: FC<Props> = (props) => {
+  const { offset, projectDetails } = props;
+  const { locale } = useRouter();
+
+  const totalRetired = Number(
+    trimStringDecimals(offset.totalRetired, 6)
+  ).toLocaleString(locale);
+
+  return (
+    <Section variant="gray" className={styles.section}>
+      <div className={styles.projectDetails}>
+        <div className={styles.title}>
+          <Text t="h3">
+            <Trans id="retirement.single.project_details.title">
+              Project Details
+            </Trans>
+          </Text>
+          <Text t="body2">
+            <Trans id="retirement.single.project_details.subline">
+              The following projects were retired. Click a project title to
+              learn more about it.
+            </Trans>
+          </Text>
+        </div>
+        {!!projectDetails.value.length &&
+          projectDetails.value.map((value) => (
+            <div className={styles.list} key={value.resourceIdentifier}>
+              <Text t="h4">
+                <a
+                  className="link"
+                  href={`${verra.projectDetailPage}/${value.resourceIdentifier}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {value.resourceName}{" "}
+                  <span className="svg">
+                    <LaunchIcon fontSize="inherit" />
+                  </span>
+                </a>
+              </Text>
+              <Text>
+                {totalRetired}{" "}
+                <Trans id="retirement.single.project_details.tonnes">
+                  Tonnes
+                </Trans>
+              </Text>
+              <div className="button_link">
+                <ButtonPrimary
+                  className="gray_button"
+                  variant="gray"
+                  href={`https://polygonscan.com/address/${offset.tokenAddress}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  label={t({
+                    id: "retirement.single.project_details.view_on_polygon_scan",
+                    message: "View on Polygonscan",
+                  })}
+                />
+              </div>
+            </div>
+          ))}
+      </div>
+    </Section>
+  );
+};

--- a/site/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
@@ -1,27 +1,23 @@
 import { FC } from "react";
-import { useRouter } from "next/router";
-import { Text, Section, ButtonPrimary } from "@klimadao/lib/components";
+import { Text, Section } from "@klimadao/lib/components";
 import { KlimaRetire } from "@klimadao/lib/types/subgraph";
 import { VerraProjectDetails } from "@klimadao/lib/types/verra";
-import { trimStringDecimals } from "@klimadao/lib/utils";
 
-import LaunchIcon from "@mui/icons-material/Launch";
 import { Trans, t } from "@lingui/macro";
+import { ProjectDetail } from "./List";
 import * as styles from "./styles";
-import { verra } from "@klimadao/lib/constants";
+import { verra, urls } from "@klimadao/lib/constants";
 
 type Props = {
   offset: KlimaRetire["offset"];
-  projectDetails: VerraProjectDetails;
+  projectDetails?: VerraProjectDetails;
 };
 
 export const ProjectDetails: FC<Props> = (props) => {
   const { offset, projectDetails } = props;
-  const { locale } = useRouter();
 
-  const totalRetired = Number(
-    trimStringDecimals(offset.totalRetired, 6)
-  ).toLocaleString(locale);
+  const isMossOffset = offset.bridge === "Moss";
+  const isVerraProject = !isMossOffset && !!projectDetails?.value.length;
 
   return (
     <Section variant="gray" className={styles.section}>
@@ -39,43 +35,27 @@ export const ProjectDetails: FC<Props> = (props) => {
             </Trans>
           </Text>
         </div>
-        {!!projectDetails.value.length &&
+        {isVerraProject &&
           projectDetails.value.map((value) => (
-            <div className={styles.list} key={value.resourceIdentifier}>
-              <Text t="h4">
-                <a
-                  className="link"
-                  href={`${verra.projectDetailPage}/${value.resourceIdentifier}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {value.resourceName}{" "}
-                  <span className="svg">
-                    <LaunchIcon fontSize="inherit" />
-                  </span>
-                </a>
-              </Text>
-              <Text>
-                {totalRetired}{" "}
-                <Trans id="retirement.single.project_details.tonnes">
-                  Tonnes
-                </Trans>
-              </Text>
-              <div className="button_link">
-                <ButtonPrimary
-                  className="gray_button"
-                  variant="gray"
-                  href={`https://polygonscan.com/address/${offset.tokenAddress}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  label={t({
-                    id: "retirement.single.project_details.view_on_polygon_scan",
-                    message: "View on Polygonscan",
-                  })}
-                />
-              </div>
-            </div>
+            <ProjectDetail
+              key={value.resourceIdentifier}
+              projectLink={`${verra.projectDetailPage}/${value.resourceIdentifier}`}
+              headline={value.resourceName}
+              tokenAddress={offset.tokenAddress}
+              totalRetired={offset.totalRetired}
+            />
           ))}
+        {isMossOffset && (
+          <ProjectDetail
+            projectLink={`${urls.carbonDashboard}/MCO2`}
+            headline={t({
+              id: "retirement.single.project_details.moss_headline",
+              message:
+                "Click here to learn more about the projects that back the MCO2 pools",
+            })}
+            tokenAddress={offset.tokenAddress}
+          />
+        )}
       </div>
     </Section>
   );

--- a/site/components/pages/Retirements/SingleRetirement/ProjectDetails/styles.ts
+++ b/site/components/pages/Retirements/SingleRetirement/ProjectDetails/styles.ts
@@ -1,0 +1,61 @@
+import { css } from "@emotion/css";
+import breakpoints from "@klimadao/lib/theme/breakpoints";
+
+export const section = css`
+  padding-bottom: 4rem;
+  ${breakpoints.medium} {
+    padding-top: 9rem;
+    padding-bottom: 4rem;
+  }
+`;
+
+export const projectDetails = css`
+  background-color: var(--surface-01);
+  border-radius: 0 0 1.2rem 1.2rem;
+  grid-column: main;
+  display: grid;
+  gap: 2.8rem;
+  padding: 2.8rem 1.5rem;
+
+  ${breakpoints.medium} {
+    gap: 5.2rem;
+    padding: 5.2rem;
+  }
+`;
+
+export const title = css`
+  display: grid;
+  gap: 1.6rem;
+`;
+
+export const list = css`
+  display: grid;
+  gap: 1.2rem;
+
+  .link {
+    color: var(--white);
+    &:hover {
+      text-decoration: underline;
+    }
+
+    .svg {
+      display: inline-flex;
+      align-self: center;
+      top: 0.125em; // em to perfectly align with inline breaks
+      position: relative;
+      left: 0.4rem;
+    }
+  }
+
+  .button_link {
+    align-items: flex-start;
+    display: flex;
+  }
+
+  .gray_button {
+    background-color: #4a4a4a;
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+`;

--- a/site/components/pages/Retirements/SingleRetirement/ProjectDetails/styles.ts
+++ b/site/components/pages/Retirements/SingleRetirement/ProjectDetails/styles.ts
@@ -11,7 +11,7 @@ export const section = css`
 
 export const projectDetails = css`
   background-color: var(--surface-01);
-  border-radius: 0 0 1.2rem 1.2rem;
+  border-radius: 1.2rem;
   grid-column: main;
   display: grid;
   gap: 2.8rem;
@@ -33,7 +33,7 @@ export const list = css`
   gap: 1.2rem;
 
   .link {
-    color: var(--white);
+    color: var(--font-01);
     &:hover {
       text-decoration: underline;
     }

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -178,12 +178,10 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
           )}
         </div>
       </Section>
-      {props.projectDetails && (
-        <ProjectDetails
-          projectDetails={props.projectDetails}
-          offset={props.retirement.offset}
-        />
-      )}
+      <ProjectDetails
+        projectDetails={props.projectDetails}
+        offset={props.retirement.offset}
+      />
       <RetirementFooter />
       <Footer />
     </>

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -3,6 +3,7 @@ import { NextPage } from "next";
 import { Text, Section, ButtonPrimary } from "@klimadao/lib/components";
 import { KlimaRetire } from "@klimadao/lib/types/subgraph";
 import { RetirementIndexInfoResult } from "@klimadao/lib/types/offset";
+import { VerraProjectDetails } from "@klimadao/lib/types/verra";
 import { concatAddress } from "@klimadao/lib/utils";
 
 import { Navigation } from "components/Navigation";
@@ -13,6 +14,7 @@ import { RetirementMessage } from "./RetirementMessage";
 import { RetirementValue } from "./RetirementValue";
 import { RetirementDate } from "./RetirementDate";
 import { TextGroup } from "./TextGroup";
+import { ProjectDetails } from "./ProjectDetails";
 import { RetirementFooter } from "../Footer";
 import { CopyURLButton } from "../CopyURLButton";
 
@@ -24,8 +26,9 @@ import { retirementTokenInfoMap } from "lib/getTokenInfo";
 type Props = {
   beneficiaryAddress: string;
   retirementTotals: string;
-  retirement?: KlimaRetire;
+  retirement: KlimaRetire;
   retirementIndexInfo: RetirementIndexInfoResult;
+  projectDetails?: VerraProjectDetails;
 };
 
 export const SingleRetirementPage: NextPage<Props> = (props) => {
@@ -40,8 +43,8 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
     tokenIcon: tokenData.icon,
     beneficiaryName: retirementIndexInfo.beneficiaryName,
     retirementMessage: retirementIndexInfo.retirementMessage,
-    timestamp: retirement?.timestamp,
-    transactionID: retirement?.transaction?.id,
+    timestamp: retirement.timestamp,
+    transactionID: retirement.transaction?.id,
   };
 
   return (
@@ -162,6 +165,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
           <CopyURLButton />
           {retireData.transactionID && (
             <ButtonPrimary
+              className="gray_button"
               variant="gray"
               href={`https://polygonscan.com/tx/${retireData.transactionID}`}
               target="_blank"
@@ -174,6 +178,12 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
           )}
         </div>
       </Section>
+      {props.projectDetails && (
+        <ProjectDetails
+          projectDetails={props.projectDetails}
+          offset={props.retirement.offset}
+        />
+      )}
       <RetirementFooter />
       <Footer />
     </>

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -688,39 +688,39 @@ msgstr "Use carbon-backed KLIMA tokens to govern, swap, and earn staking rewards
 msgid "retirement.footer.buy_klima.title"
 msgstr "Acquire, stake, and get rewarded."
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:60
+#: components/pages/Retirements/SingleRetirement/index.tsx:63
 msgid "retirement.head.metaDescription"
 msgstr "Transparent, on-chain offsets powered by KlimaDAO."
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:54
+#: components/pages/Retirements/SingleRetirement/index.tsx:57
 msgid "retirement.head.metaTitle"
 msgstr "{0} retired {1} Tonnes of carbon"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:50
+#: components/pages/Retirements/SingleRetirement/index.tsx:53
 msgid "retirement.head.title"
 msgstr "KlimaDAO | Carbon Retirement Receipt"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:105
+#: components/pages/Retirements/SingleRetirement/index.tsx:108
 msgid "retirement.single.beneficiary.placeholder"
 msgstr "No beneficiary name provided"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:99
+#: components/pages/Retirements/SingleRetirement/index.tsx:102
 msgid "retirement.single.beneficiary.title"
 msgstr "Beneficiary"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:113
+#: components/pages/Retirements/SingleRetirement/index.tsx:116
 msgid "retirement.single.beneficiaryAddress.title"
 msgstr "Beneficiary Address"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:152
+#: components/pages/Retirements/SingleRetirement/index.tsx:155
 msgid "retirement.single.disclaimer"
 msgstr "This represents the permanent retirement of tokenized carbon assets on the Polygon blockchain. This retirement and the associated data are immutable public records."
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:70
+#: components/pages/Retirements/SingleRetirement/index.tsx:73
 msgid "retirement.single.header.quantity"
 msgstr "{0} t"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:75
+#: components/pages/Retirements/SingleRetirement/index.tsx:78
 msgid "retirement.single.header.subline"
 msgstr "CO2-Equivalent Emissions Offset (Metric Tonnes)"
 
@@ -752,11 +752,11 @@ msgstr "View on Polygonscan"
 msgid "retirement.single.quantity"
 msgstr "QUANTITY RETIRED"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:144
+#: components/pages/Retirements/SingleRetirement/index.tsx:147
 msgid "retirement.single.retirementCertificate.soon"
 msgstr "...coming soon!"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:139
+#: components/pages/Retirements/SingleRetirement/index.tsx:142
 msgid "retirement.single.retirementCertificate.title"
 msgstr "Certificate"
 
@@ -764,15 +764,15 @@ msgstr "Certificate"
 msgid "retirement.single.retirementDate.title"
 msgstr "Date"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:84
+#: components/pages/Retirements/SingleRetirement/index.tsx:87
 msgid "retirement.single.retirementMessage.placeholder"
 msgstr "No retirement message provided"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:131
+#: components/pages/Retirements/SingleRetirement/index.tsx:134
 msgid "retirement.single.timestamp.placeholder"
 msgstr "No retirement timestamp provided"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:169
+#: components/pages/Retirements/SingleRetirement/index.tsx:173
 msgid "retirement.single.view_on_polygon_scan"
 msgstr "View on Polygonscan"
 

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -728,19 +728,23 @@ msgstr "CO2-Equivalent Emissions Offset (Metric Tonnes)"
 msgid "retirement.single.message.title"
 msgstr "Retirement Message"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:36
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:51
+msgid "retirement.single.project_details.moss_headline"
+msgstr "Click here to learn more about the projects that back the MCO2 pools"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:32
 msgid "retirement.single.project_details.subline"
 msgstr "The following projects were retired. Click a project title to learn more about it."
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
 msgid "retirement.single.project_details.title"
 msgstr "Project Details"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:60
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:43
 msgid "retirement.single.project_details.tonnes"
 msgstr "Tonnes"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:71
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:53
 msgid "retirement.single.project_details.view_on_polygon_scan"
 msgstr "View on Polygonscan"
 

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -728,6 +728,22 @@ msgstr "CO2-Equivalent Emissions Offset (Metric Tonnes)"
 msgid "retirement.single.message.title"
 msgstr "Retirement Message"
 
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:36
+msgid "retirement.single.project_details.subline"
+msgstr "The following projects were retired. Click a project title to learn more about it."
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.project_details.title"
+msgstr "Project Details"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:60
+msgid "retirement.single.project_details.tonnes"
+msgstr "Tonnes"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:71
+msgid "retirement.single.project_details.view_on_polygon_scan"
+msgstr "View on Polygonscan"
+
 #: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
 msgid "retirement.single.quantity"
 msgstr "QUANTITY RETIRED"


### PR DESCRIPTION
## Description

This PR does:
- extend the subgraph data to projectID and other offset data
- get information about a single VCS project ID from Verra
- render project details and link to Verra and Polygon
- render fallback for Moss offsets

**Preview URL:**
`https://klimadao-site-git-show-project-details-klimadao.vercel.app/retirements/<WALLET-ADDRESS>/<NUMBER-OF-RETIREMENT>`

## Open TODOS:
- [x] ~add fallback for bridge "Moss" data~ done
- [x] ~find an example on multiple projects (is this data coming from Verra directly or Subgraph?)~ Obsolete, see [comment](https://github.com/KlimaDAO/klimadao/issues/438#issuecomment-1138909061)

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/438

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
