### PR TITLE
Makes the language swither redirect to the same page in the other language

### DIFF
--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/router";
  */
 export const ChangeLanguageButton: FC = () => {
   const [showMenu, setShowMenu] = useState(false);
-  const { locale } = useRouter();
+  const router = useRouter();
 
   const labels: { [key: string]: string } = {
     en: "English",
@@ -36,14 +36,14 @@ export const ChangeLanguageButton: FC = () => {
       {Object.keys(locales).map((localeKey) => (
         <Link
           key={localeKey}
-          href="/"
+          href={router.pathname}
           locale={localeKey}
           /** don't want to prefetch all locales */
           prefetch={false}
           replace={true}
         >
           <a
-            data-active={locale == localeKey ? "true" : "false"}
+            data-active={router.locale == localeKey ? "true" : "false"}
             className={styles.menuItem}
           >
             {labels[localeKey as keyof typeof labels]}


### PR DESCRIPTION
## Description

Makes the language swither redirect to the same page in the other language

## Related Ticket

Resolves #420

## Changes

NA

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
