### PR TITLE
Release Spanish to Production

### DIFF
--- a/app/components/ChangeLanguageButton/index.tsx
+++ b/app/components/ChangeLanguageButton/index.tsx
@@ -36,11 +36,11 @@ export const ChangeLanguageButton: FC = () => {
     de: "Deutsch",
     ru: "Русский",
     "zh-CN": "中文",
+    es: "Español",
   };
 
   // enable 'pseudo' locale only for Staging environment
   if (!IS_PRODUCTION) {
-    labels["es"] = "Español";
     labels["ko"] = "한국어";
     labels["en-pseudo"] = "Pseudo";
   }

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -21,11 +21,11 @@ const locales: ILocales = {
   de: { plurals: de, time: "de-DE" },
   ru: { plurals: ru, time: "ru-RU" },
   "zh-CN": { plurals: zh, time: "zh-CN" },
+  es: { plurals: es, time: "es-ES" },
 };
 
 // Add pseudo locale only in development
 if (!IS_PRODUCTION) {
-  locales["es"] = { plurals: es, time: "es-ES" };
   locales["ko"] = { plurals: ko, time: "ko-KR" };
   locales["en-pseudo"] = { plurals: en, time: "en-US" };
 }

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -22,11 +22,11 @@ export const ChangeLanguageButton: FC = () => {
     de: "Deutsch",
     ru: "Русский",
     "zh-CN": "中文",
+    es: "Español",
   };
 
   // enable 'pseudo' locale only for Staging environment
   if (!IS_PRODUCTION) {
-    labels["es"] = "Español";
     labels["ko"] = "한국어";
     labels["en-pseudo"] = "Pseudo";
   }

--- a/site/lib/i18n.ts
+++ b/site/lib/i18n.ts
@@ -19,10 +19,10 @@ const locales: ILocales = {
   de: { plurals: de, time: "de-DE" },
   ru: { plurals: ru, time: "ru-RU" },
   "zh-CN": { plurals: zh, time: "zh-CN" },
+  es: { plurals: es, time: "es-ES" },
 };
 // Add pseudo locale only in development
 if (!IS_PRODUCTION) {
-  locales["es"] = { plurals: es, time: "es-ES" };
   locales["ko"] = { plurals: ko, time: "ko-KR" };
   locales["en-pseudo"] = { plurals: en, time: "en-US" };
 }

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -75,7 +75,7 @@ const nextConfig = {
     ];
   },
   i18n: {
-    locales: ["en", "fr", "de", "ru", "zh-CN"],
+    locales: ["en", "fr", "de", "ru", "zh-CN", "es"],
     defaultLocale: "en",
     localeDetection: true,
   },
@@ -87,7 +87,7 @@ const nextConfig = {
 if (!IS_PRODUCTION) {
   nextConfig.i18n = {
     ...nextConfig.i18n,
-    locales: [...nextConfig.i18n.locales, "ko", "es", "en-pseudo"],
+    locales: [...nextConfig.i18n.locales, "ko", "en-pseudo"],
   };
 }
 


### PR DESCRIPTION
## Description

This PR releases Spanish "es-ES" to Production.
Spanish will appear at the last language in the translation menu.
Let me know if I should change the order.

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/454

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
