### PR TITLE
Fix language switch for dynamic pages

### DIFF
--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -36,7 +36,10 @@ export const ChangeLanguageButton: FC = () => {
       {Object.keys(locales).map((localeKey) => (
         <Link
           key={localeKey}
-          href={router.pathname}
+          href={{
+            pathname: router.pathname,
+            query: { ...router.query },
+          }}
           locale={localeKey}
           /** don't want to prefetch all locales */
           prefetch={false}

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useState } from "react";
-import Link from "next/link";
 import Tippy from "@tippyjs/react";
 import { t } from "@lingui/macro";
 import Language from "@mui/icons-material/Language";
@@ -15,6 +14,7 @@ import { useRouter } from "next/router";
 export const ChangeLanguageButton: FC = () => {
   const [showMenu, setShowMenu] = useState(false);
   const router = useRouter();
+  const { pathname, asPath, query, locale } = router;
 
   const labels: { [key: string]: string } = {
     en: "English",
@@ -34,24 +34,17 @@ export const ChangeLanguageButton: FC = () => {
   const content = (
     <div className={styles.menuItemContainer}>
       {Object.keys(locales).map((localeKey) => (
-        <Link
+        <button
           key={localeKey}
-          href={{
-            pathname: router.pathname,
-            query: { ...router.query },
+          type="button"
+          data-active={locale == localeKey ? "true" : "false"}
+          className={styles.menuItem}
+          onClick={() => {
+            router.push({ pathname, query }, asPath, { locale: localeKey });
           }}
-          locale={localeKey}
-          /** don't want to prefetch all locales */
-          prefetch={false}
-          replace={true}
         >
-          <a
-            data-active={router.locale == localeKey ? "true" : "false"}
-            className={styles.menuItem}
-          >
-            {labels[localeKey as keyof typeof labels]}
-          </a>
-        </Link>
+          {labels[localeKey as keyof typeof labels]}
+        </button>
       ))}
     </div>
   );


### PR DESCRIPTION
## Description

This PR is a fix for this PR: https://github.com/KlimaDAO/klimadao/pull/451

When changing the language on **_dynamic pages_** the `Link` component needs the query data too.
Otherwise the dynamic pages can not be created for the new language.

On production nothing happens when trying to change the language on dynamic pages.
On localhost this error appears:
https://nextjs.org/docs/messages/href-interpolation-failed

Test yourself the bug here and **try to change the language:**
- [Blog Subpage on Staging](https://staging-site.klimadao.finance/fr/blog/response-to-verra-comments-on-crypto-instruments-and-tokens)
- [Retirement Page on Staging](https://staging-site.klimadao.finance/de/retirements/0x087a7afb6975a2837453be685eb6272576c0bc06)

=> nothing happens, no routing is created

**Test the fix:**

- [Blog Subpage with the Fix](https://klimadao-site-git-fix-routing-subpages-klimadao.vercel.app/fr/blog/response-to-verra-comments-on-crypto-instruments-and-tokens)
- [Retirement Page with the Fix](https://klimadao-site-git-fix-routing-subpages-klimadao.vercel.app/de/retirements/0x087a7afb6975a2837453be685eb6272576c0bc06)

=> When changing the language, the same page with new translations is rendered

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Follow-up on https://github.com/KlimaDAO/klimadao/issues/420

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
