### PR TITLE
Fix Translation menu z-index issue

### DIFF
--- a/site/components/Header/styles.ts
+++ b/site/components/Header/styles.ts
@@ -11,7 +11,7 @@ export const headerDesktop = css`
   background: var(--surface-02);
   padding-top: 4.8rem;
   height: calc(var(--header-height) * 2);
-  z-index: 1; /* so the drop-shadow is visible over next section */
+  z-index: 10; /* so the drop-shadow is visible over next section, 10 to make opened Translation menu flow over main content */
   ${breakpoints.large} {
     display: grid;
   }


### PR DESCRIPTION
## Description

See the bug description in this ticket: https://github.com/KlimaDAO/klimadao/issues/410

With giving the HeaderDesktop an higher z-index (same as the HeaderMobile has btw), the opened Translation menu has enough z-index layers of space to render above any content which might have z-indexes too.

**BEFORE:**
https://staging-site.klimadao.finance/de/retirements/0x087a7afb6975a2837453be685eb6272576c0bc06/2

**AFTER**
https://klimadao-site-git-fix-z-index-klimadao.vercel.app/de/retirements/0x087a7afb6975a2837453be685eb6272576c0bc06/2

## Related Ticket

Resolves #410

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
