### PR TITLE
Increase page revalidation times

### DIFF
--- a/site/pages/blog/[pid].tsx
+++ b/site/pages/blog/[pid].tsx
@@ -21,13 +21,13 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
         post,
         translation,
       },
-      revalidate: 120,
+      revalidate: 240,
     };
   } catch (e) {
     console.error("Failed to generate", e);
     return {
       notFound: true,
-      revalidate: 120,
+      revalidate: 240,
     };
   }
 };

--- a/site/pages/blog/index.tsx
+++ b/site/pages/blog/index.tsx
@@ -15,12 +15,12 @@ export async function getStaticProps(ctx: GetStaticPropsContext) {
         posts,
         translation,
       },
-      revalidate: 120,
+      revalidate: 240,
     };
   } catch (e) {
     return {
       notFound: true,
-      revalidate: 120,
+      revalidate: 240,
     };
   }
 }

--- a/site/pages/buy.tsx
+++ b/site/pages/buy.tsx
@@ -8,7 +8,6 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
     props: {
       translation,
     },
-    revalidate: 60,
   };
 };
 

--- a/site/pages/community.tsx
+++ b/site/pages/community.tsx
@@ -8,7 +8,6 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
     props: {
       translation,
     },
-    revalidate: 60,
   };
 };
 

--- a/site/pages/contact.tsx
+++ b/site/pages/contact.tsx
@@ -10,7 +10,6 @@ export const getStaticProps: GetStaticProps<Props> = async (ctx) => {
     props: {
       translation,
     },
-    revalidate: 60,
   };
 };
 

--- a/site/pages/disclaimer.tsx
+++ b/site/pages/disclaimer.tsx
@@ -10,7 +10,6 @@ export const getStaticProps: GetStaticProps<Props> = async (ctx) => {
     props: {
       translation,
     },
-    revalidate: 60,
   };
 };
 

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -27,7 +27,7 @@ export const getStaticProps: GetStaticProps<Props> = async (ctx) => {
       translation,
       weeklyStakingRewards,
     },
-    revalidate: 60,
+    revalidate: 600,
   };
 };
 


### PR DESCRIPTION
## Description

To stay within the Infura free tier I reduced the frequency at which the landing page refreshes itself. With all languages + dozens of contract calls, this was adding up quickly.

Also increased the blog revalidate time to reduce sanity.io bandwidth.
And removed `revalidate` from some static pages, to reduce vercel bandwidth.

Landing page: 1min -> 10min
Blog posts: 2min -> 4min
All static pages: remove revalidate and generate static pages at build time.

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
