### PR TITLE
use relative path to call api/pledge

### DIFF
--- a/site/components/pages/Pledge/lib/putPledge.ts
+++ b/site/components/pages/Pledge/lib/putPledge.ts
@@ -1,4 +1,3 @@
-import { API_BASE_URL } from "lib/constants";
 import { PledgeFormValues } from "../types";
 
 export interface putPledgeParams {
@@ -8,7 +7,7 @@ export interface putPledgeParams {
 }
 
 export const putPledge = (params: putPledgeParams): Promise<Response> =>
-  fetch(`${API_BASE_URL}/api/pledge`, {
+  fetch("/api/pledge", {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Description

Use relative path in next api call to avoid CORS related issues

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
