### PR TITLE
dApp: Fix for the language button

### DIFF
--- a/app/components/ChangeLanguageButton/index.tsx
+++ b/app/components/ChangeLanguageButton/index.tsx
@@ -21,7 +21,7 @@ export const ChangeLanguageButton: FC = () => {
   const dispatch = useAppDispatch();
 
   const selectLocale = async (locale: string) => {
-    activate(locale);
+    await activate(locale);
     dispatch(setAppState({ locale }));
   };
 

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -65,7 +65,7 @@ async function load(locale: string) {
  * Stores the choice in localestorage
  */
 async function activate(locale: string) {
-  load(locale);
+  await load(locale);
   window.localStorage.setItem("locale", locale);
 }
 


### PR DESCRIPTION
## Description

The language button waits for the language to be loaded by lingui before commiting the change to the store.

## Related Ticket

Resolves #467


## Changes

NA

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
