### PR TITLE
Retirements: Resolve KNS and ENS domains

### DIFF
--- a/lib/utils/ens/index.ts
+++ b/lib/utils/ens/index.ts
@@ -1,0 +1,16 @@
+import { getDefaultProvider } from "@ethersproject/providers";
+
+export const isENSDomain = (domain: string) =>
+  !!domain && domain.includes(".eth");
+
+export const ETHProvider = getDefaultProvider();
+
+export const getAddressByENS = async (domain: string) => {
+  try {
+    const address = await ETHProvider.resolveName(domain);
+    return address;
+  } catch (e) {
+    console.log("Error in getAddressByENS", e);
+    return Promise.reject(e);
+  }
+};

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -27,3 +27,9 @@ export {
   queryKlimaRetiresByAddress,
 } from "./subgraph/queryPolygonBridgedCarbon";
 export { getVerraProjectByID } from "./verra/getVerraProjects";
+
+// KNS
+export { isKNSDomain, KNSContract, getAddressByKNS } from "./kns";
+
+// ENS
+export { isENSDomain, ETHProvider, getAddressByENS } from "./ens";

--- a/lib/utils/kns/index.ts
+++ b/lib/utils/kns/index.ts
@@ -1,0 +1,36 @@
+import { ethers } from "ethers";
+import { addresses } from "../../constants";
+import PunkTLD from "../../abi/PunkTLD.json";
+import { getJsonRpcProvider } from "../getJsonRpcProvider";
+
+// https://www.kns.earth/#/
+export const isKNSDomain = (domain: string): boolean =>
+  !!domain && domain.toLowerCase().includes(".klima");
+
+// Use this import and overwrite your provider if needed with
+// import { KNSContract } from '...'
+// KNSContract.provider = myProvider;
+export const KNSContract = new ethers.Contract(
+  addresses["mainnet"].klimaNameService,
+  PunkTLD.abi,
+  getJsonRpcProvider()
+);
+
+// contract method getDomainHolder returns this address on not found
+const EMPTY_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const isValidAddress = (address: string) =>
+  !!address && address !== EMPTY_ADDRESS;
+
+export const getAddressByKNS = async (
+  domain: string
+): Promise<string | null> => {
+  try {
+    const strippedDomain = domain.replace(".klima", "");
+    const address = await KNSContract.getDomainHolder(strippedDomain);
+    return isValidAddress(address) ? address : null;
+  } catch (e) {
+    console.log("Error in getAddressByKNS", e);
+    return Promise.reject(e);
+  }
+};

--- a/site/components/PageHead/index.tsx
+++ b/site/components/PageHead/index.tsx
@@ -16,13 +16,16 @@ export interface PageHeadProps {
   mediaImageSrc?: string;
   /** displays some useful meta tags if current page is an article */
   isArticle?: boolean;
+  /** overwrite canonical for pages with duplicate content */
+  canonicalUrl?: string;
 }
 
 export const PageHead = (props: PageHeadProps) => {
   const noRobots = props.doNotIndex || !IS_PRODUCTION;
   const router = useRouter();
   const relativePath = router.asPath.split(/[#,?]/)[0];
-  const canonicalUrl = `https://www.klimadao.finance${relativePath}`;
+  const canonicalUrl =
+    props.canonicalUrl || `https://www.klimadao.finance${relativePath}`;
 
   return (
     <Head>

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -29,10 +29,11 @@ type Props = {
   retirement: KlimaRetire;
   retirementIndexInfo: RetirementIndexInfoResult;
   projectDetails?: VerraProjectDetails;
+  domain?: string;
 };
 
 export const SingleRetirementPage: NextPage<Props> = (props) => {
-  const { beneficiaryAddress, retirement, retirementIndexInfo } = props;
+  const { beneficiaryAddress, retirement, retirementIndexInfo, domain } = props;
   const { locale } = useRouter();
   const tokenData = retirementTokenInfoMap[retirementIndexInfo.typeOfToken];
   const amountWithoutWhiteSpace = retirementIndexInfo.amount.replace(
@@ -61,7 +62,9 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
         mediaTitle={t({
           id: "retirement.head.metaTitle",
           message: `${
-            retireData.beneficiaryName || concatAddress(beneficiaryAddress)
+            retireData.beneficiaryName ||
+            domain ||
+            concatAddress(beneficiaryAddress)
           } retired ${retireData.amount} Tonnes of carbon`,
         })}
         metaDescription={t({
@@ -124,9 +127,9 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
                 text={
                   <a
                     className="address"
-                    href={`${urls.retirements}/${beneficiaryAddress}`}
+                    href={`${urls.retirements}/${domain || beneficiaryAddress}`}
                   >
-                    {concatAddress(beneficiaryAddress)}
+                    {domain || concatAddress(beneficiaryAddress)}
                   </a>
                 }
               />

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -30,6 +30,7 @@ type Props = {
   retirementIndexInfo: RetirementIndexInfoResult;
   projectDetails?: VerraProjectDetails;
   domain?: string;
+  canonicalUrl?: string;
 };
 
 export const SingleRetirementPage: NextPage<Props> = (props) => {
@@ -71,6 +72,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
           id: "retirement.head.metaDescription",
           message: "Transparent, on-chain offsets powered by KlimaDAO.",
         })}
+        canonicalUrl={props.canonicalUrl}
       />
       <Navigation activePage="Home" />
 

--- a/site/components/pages/Retirements/index.tsx
+++ b/site/components/pages/Retirements/index.tsx
@@ -29,6 +29,7 @@ type Props = {
   klimaRetires: KlimaRetire[];
   beneficiaryAddress: string;
   domain?: string;
+  canonicalUrl?: string;
 };
 
 export const RetirementPage: NextPage<Props> = (props) => {
@@ -58,6 +59,7 @@ export const RetirementPage: NextPage<Props> = (props) => {
           message:
             "Drive climate action and earn rewards with a carbon-backed digital currency.",
         })}
+        canonicalUrl={props.canonicalUrl}
       />
       <Navigation activePage="Home" />
 

--- a/site/components/pages/Retirements/index.tsx
+++ b/site/components/pages/Retirements/index.tsx
@@ -28,10 +28,11 @@ type Props = {
   totalsAndBalances: RetirementsTotalsAndBalances;
   klimaRetires: KlimaRetire[];
   beneficiaryAddress: string;
+  domain?: string;
 };
 
 export const RetirementPage: NextPage<Props> = (props) => {
-  const { beneficiaryAddress, totalsAndBalances, klimaRetires } = props;
+  const { beneficiaryAddress, totalsAndBalances, klimaRetires, domain } = props;
   const { locale } = useRouter();
   const [copied, doCopy] = useCopyToClipboard();
 
@@ -42,13 +43,15 @@ export const RetirementPage: NextPage<Props> = (props) => {
       <PageHead
         title={t({
           id: "retirement.totals.head.title",
-          message: `KlimaDAO - Carbon Retirements for beneficiary ${concattedAddress}`,
-          values: { beneficiaryAddress },
+          message: `KlimaDAO - Carbon Retirements for beneficiary ${
+            domain || concattedAddress
+          }`,
         })}
         mediaTitle={t({
           id: "retirement.totals.head.metaTitle",
-          message: `KlimaDAO - Carbon Retirements for beneficiary ${concattedAddress}`,
-          values: { beneficiaryAddress },
+          message: `KlimaDAO - Carbon Retirements for beneficiary ${
+            domain || concattedAddress
+          }`,
         })}
         metaDescription={t({
           id: "shared.head.description",
@@ -70,9 +73,9 @@ export const RetirementPage: NextPage<Props> = (props) => {
               <Trans id="retirement.totals.page_subline">for beneficiary</Trans>
               <button
                 className={styles.copyButton}
-                onClick={() => doCopy(beneficiaryAddress)}
+                onClick={() => doCopy(domain || beneficiaryAddress)}
               >
-                {concattedAddress}
+                {domain || concattedAddress}
                 {copied ? (
                   <Check fontSize="large" />
                 ) : (

--- a/site/lib/getAddressByDomain.ts
+++ b/site/lib/getAddressByDomain.ts
@@ -1,0 +1,25 @@
+import {
+  isKNSDomain,
+  getAddressByKNS,
+  isENSDomain,
+  getAddressByENS,
+} from "@klimadao/lib/utils";
+
+export const getAddressByDomain = async (
+  domain: string
+): Promise<string | null> => {
+  try {
+    let address;
+    if (isKNSDomain(domain)) {
+      address = await getAddressByKNS(domain);
+    } else if (isENSDomain(domain)) {
+      address = await getAddressByENS(domain);
+    } else {
+      address = null;
+    }
+    return address;
+  } catch (e) {
+    console.log("Error in getAddressByDomain", e);
+    return Promise.reject(e);
+  }
+};

--- a/site/lib/getIsDomainInURL.ts
+++ b/site/lib/getIsDomainInURL.ts
@@ -1,0 +1,4 @@
+import { isKNSDomain, isENSDomain } from "@klimadao/lib/utils";
+
+export const getIsDomainInURL = (domain: string) =>
+  isKNSDomain(domain) || isENSDomain(domain);

--- a/site/pages/retirements/[beneficiary_address]/[retirement_index].tsx
+++ b/site/pages/retirements/[beneficiary_address]/[retirement_index].tsx
@@ -28,6 +28,7 @@ interface PageProps {
   retirementIndexInfo: RetirementIndexInfoResult;
   projectDetails: VerraProjectDetails | null;
   domain?: string;
+  canonicalUrl?: string;
 }
 
 // second param should always be a number
@@ -108,6 +109,9 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
         translation,
         projectDetails,
         domain: !!addressByDomain ? params.beneficiary_address : undefined,
+        canonicalUrl: !!addressByDomain
+          ? `https://www.klimadao.finance/${addressByDomain}/${params.retirement_index}`
+          : undefined,
       },
       revalidate: 240,
     };

--- a/site/pages/retirements/[beneficiary_address]/[retirement_index].tsx
+++ b/site/pages/retirements/[beneficiary_address]/[retirement_index].tsx
@@ -27,6 +27,7 @@ interface PageProps {
   retirement: KlimaRetire;
   retirementIndexInfo: RetirementIndexInfoResult;
   projectDetails: VerraProjectDetails | null;
+  domain?: string;
 }
 
 // second param should always be a number
@@ -106,6 +107,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
         retirementTotals: params.retirement_index,
         translation,
         projectDetails,
+        domain: !!addressByDomain ? params.beneficiary_address : undefined,
       },
       revalidate: 240,
     };

--- a/site/pages/retirements/[beneficiary_address]/index.tsx
+++ b/site/pages/retirements/[beneficiary_address]/index.tsx
@@ -3,13 +3,17 @@ import { ParsedUrlQuery } from "querystring";
 
 import { INFURA_ID } from "lib/constants";
 
-import { getRetirementTotalsAndBalances } from "@klimadao/lib/utils";
-import { queryKlimaRetiresByAddress } from "@klimadao/lib/utils";
+import {
+  getRetirementTotalsAndBalances,
+  queryKlimaRetiresByAddress,
+} from "@klimadao/lib/utils";
 import { RetirementsTotalsAndBalances } from "@klimadao/lib/types/offset";
 import { KlimaRetire } from "@klimadao/lib/types/subgraph";
 
 import { RetirementPage } from "components/pages/Retirements";
 import { loadTranslation } from "lib/i18n";
+import { getIsDomainInURL } from "lib/getIsDomainInURL";
+import { getAddressByDomain } from "lib/getAddressByDomain";
 
 interface Params extends ParsedUrlQuery {
   beneficiary_address: string;
@@ -31,12 +35,23 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
       throw new Error("No params found");
     }
 
+    let addressByDomain;
+    const isDomainInURL = getIsDomainInURL(params.beneficiary_address);
+    if (isDomainInURL) {
+      addressByDomain = await getAddressByDomain(params.beneficiary_address);
+    }
+
+    // Do not continue if KNS or ENS Domain can not be resolved
+    if (addressByDomain === null) {
+      throw new Error("No valid KNS or ENS domain holder address found !");
+    }
+
     const promises = [
       getRetirementTotalsAndBalances({
-        address: params.beneficiary_address as string,
+        address: addressByDomain || (params.beneficiary_address as string),
         infuraId: INFURA_ID,
       }),
-      queryKlimaRetiresByAddress(params.beneficiary_address),
+      queryKlimaRetiresByAddress(addressByDomain || params.beneficiary_address),
       loadTranslation(locale),
     ];
 

--- a/site/pages/retirements/[beneficiary_address]/index.tsx
+++ b/site/pages/retirements/[beneficiary_address]/index.tsx
@@ -23,6 +23,7 @@ interface PageProps {
   beneficiaryAddress: Params["beneficiary_address"];
   totalsAndBalances: RetirementsTotalsAndBalances;
   klimaRetires: KlimaRetire[];
+  domain?: string;
 }
 
 export const getStaticProps: GetStaticProps<PageProps, Params> = async (
@@ -67,6 +68,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
         totalsAndBalances,
         klimaRetires,
         beneficiaryAddress: params.beneficiary_address,
+        domain: !!addressByDomain ? params.beneficiary_address : undefined,
         translation,
       },
       revalidate: 240,

--- a/site/pages/retirements/[beneficiary_address]/index.tsx
+++ b/site/pages/retirements/[beneficiary_address]/index.tsx
@@ -24,6 +24,7 @@ interface PageProps {
   totalsAndBalances: RetirementsTotalsAndBalances;
   klimaRetires: KlimaRetire[];
   domain?: string;
+  canonicalUrl?: string;
 }
 
 export const getStaticProps: GetStaticProps<PageProps, Params> = async (
@@ -69,6 +70,9 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
         klimaRetires,
         beneficiaryAddress: params.beneficiary_address,
         domain: !!addressByDomain ? params.beneficiary_address : undefined,
+        canonicalUrl: !!addressByDomain
+          ? `https://www.klimadao.finance/${addressByDomain}`
+          : undefined,
         translation,
       },
       revalidate: 240,


### PR DESCRIPTION
## Description

This PR does:
- resolves KNS or ENS domains in the URL to the underlying address
- throw if no address could be resolved for the KNS or ENS domain
- use the resolved address for subgraph queries and retirementStorage contract methods
- show the domain instead of the beneficiary address on the pages
- ensure that the canonical URL is always the address (=> see [ticket](https://github.com/KlimaDAO/klimadao/issues/364) for explanation)

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/364


## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
