### PR TITLE
Refactored CMS queries

### DIFF
--- a/site/lib/fetchCMSContent.ts
+++ b/site/lib/fetchCMSContent.ts
@@ -1,5 +1,7 @@
 import sanityClient from "@sanity/client";
 import { queries, QueryContent } from "./queries";
+import { IS_PRODUCTION } from "./constants";
+
 import {
   SANITY_STUDIO_API_PROJECT_ID,
   SANITY_STUDIO_API_DATASET,
@@ -11,7 +13,7 @@ const getSanityClient = () => {
     dataset: SANITY_STUDIO_API_DATASET,
     apiVersion: "2022-01-05",
     // token: 'sanity-auth-token', // or leave blank for unauthenticated usage
-    useCdn: true, // `false` if you want to ensure fresh data
+    useCdn: IS_PRODUCTION, // `false` if you want to ensure fresh data
   });
 };
 


### PR DESCRIPTION
## Description

This change 
- refactors the `site/lib/queries.ts` file. It removes a bit of code duplication.
- Removes the use of the CDN on staging.

There is a collateral impact:
- Currently on the staging environnement, the hidden posts are not shown in the list but we can see them by entering the URL directly.
- This change shows the hidden posts in the blog list on the staging environnement.

## Related Ticket

Initialy I made these changes on my environnement so I could work on #448
I can keep the refactoring and remove the collateral impacts depending on what is really expected.

## Changes

NA

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
