### PR TITLE
pledge dashboard v1 touchups

### DIFF
--- a/site/components/Modal/styles.ts
+++ b/site/components/Modal/styles.ts
@@ -30,7 +30,7 @@ export const modalContent = css`
   max-width: 55rem;
   height: fit-content;
   max-height: calc(100vh - 10rem);
-  overflow: scroll;
+  overflow-y: auto;
   border-radius: 1.2rem;
   background-color: var(--surface-01);
   pointer-events: fill;

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
@@ -76,7 +76,7 @@ export const FootprintCard: FC<Props> = (props) => {
         )}
         <div className={styles.footprintTotal}>
           <Text t="h1" uppercase>
-            {footprint.total}
+            {+footprint.total.toFixed(2)}
           </Text>
           <Text t="h3" color="lightest" uppercase>
             Tonnes
@@ -94,7 +94,7 @@ export const FootprintCard: FC<Props> = (props) => {
                 </Text>
                 <div className={styles.catergoryRow_values}>
                   <Text t="h4" uppercase>
-                    {category.quantity}{" "}
+                    {+category.quantity.toFixed(2)}{" "}
                     <span className={styles.categoryRow_divider}>|</span>{" "}
                     <span
                       className={styles.categoryRow_percentage}

--- a/site/components/pages/Pledge/PledgeDashboard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/index.tsx
@@ -104,7 +104,8 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
 
           <div className={styles.progressContainer}>
             <Text t="h4" color="lightest" align="center">
-              Pledged to offset <strong>{currentFootprint.total}</strong> Carbon
+              Pledged to offset{" "}
+              <strong>{+currentFootprint.total.toFixed(2)}</strong> Carbon
               Tonnes
             </Text>
 

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -36,7 +36,11 @@ const TotalFootprint = ({ control, setValue }: TotalFootprintProps) => {
   );
   setValue("footprint", totalFootprint);
 
-  return <Text t="h4">Total Footprint: {totalFootprint} Carbon Tonnes</Text>;
+  return (
+    <Text t="h4">
+      Total Footprint: {+totalFootprint.toFixed(2)} Carbon Tonnes
+    </Text>
+  );
 };
 
 type Props = {
@@ -127,7 +131,7 @@ export const PledgeForm: FC<Props> = (props) => {
         id="methodology"
         label="Methodology"
         rows={6}
-        placeholder="How will you meet your pledge?"
+        placeholder="What tools or methodologies did you use to determine your carbon footprint?"
         errors={formState.errors.methodology}
         {...register("methodology")}
       />

--- a/site/components/pages/Pledge/PledgeForm/styles.ts
+++ b/site/components/pages/Pledge/PledgeForm/styles.ts
@@ -95,6 +95,12 @@ export const categories_appendButton = css`
   border-radius: 1rem;
   background-color: var(--surface-02);
   border: 0.175rem solid var(--surface-03);
+  transition: border-color 0.2s ease-in;
+
+  &:focus,
+  &:hover {
+    border-color: var(--klima-green);
+  }
 
   ${breakpoints.medium} {
     width: 22rem;


### PR DESCRIPTION
## Description

- use overflow-y: auto on modal component
- methodology field placeholder text
- rounded total pledge tonnage to 2 decimal points

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
