### PR TITLE
Request resized images from the CDN for og image meta tags

### DIFF
--- a/app/components/PageHead.tsx
+++ b/app/components/PageHead.tsx
@@ -1,7 +1,9 @@
 import Head from "next/head";
 import React from "react";
+
 import { useSelector } from "react-redux";
 import { selectLocale } from "state/selectors";
+import { getOgImageSrc } from "@klimadao/lib/utils";
 export interface PageHeadProps {
   production: boolean;
   /** <title> tag */
@@ -17,6 +19,8 @@ export interface PageHeadProps {
 export const PageHead = (props: PageHeadProps) => {
   const locale = useSelector(selectLocale);
   const noRobots = props.doNotIndex || !props.production;
+  const mediaImageSrc = getOgImageSrc(props.mediaImageSrc);
+
   return (
     <Head>
       {noRobots && <meta name="robots" content="noindex" />}
@@ -31,18 +35,16 @@ export const PageHead = (props: PageHeadProps) => {
       <meta name="description" content={props.metaDescription} />
       <meta property="og:description" content={props.metaDescription} />
       <meta property="og:title" content={props.mediaTitle} />
-      {props.mediaImageSrc && (
-        <meta property="og:image" content={props.mediaImageSrc} />
-      )}
+      <meta property="og:image" content={mediaImageSrc} />
+
       <meta property="og:type" content="website" />
       <meta property="og:locale" content={locale || "en"} />
 
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={props.mediaTitle} />
       <meta name="twitter:description" content={props.metaDescription} />
-      {props.mediaImageSrc && (
-        <meta name="twitter:image" content={props.mediaImageSrc} />
-      )}
+      <meta name="twitter:image" content={mediaImageSrc} />
+
       <link
         rel="apple-touch-icon"
         sizes="180x180"

--- a/lib/utils/getOgImageSrc/index.ts
+++ b/lib/utils/getOgImageSrc/index.ts
@@ -1,0 +1,13 @@
+import { urls } from "@klimadao/lib/constants";
+
+/*
+Returns an appropriate url for og media image tag
+*/
+export const getOgImageSrc = (imageSrc: string | undefined) => {
+  // Return default image if none is provided
+  if (imageSrc === undefined || imageSrc.length == 0) return urls.mediaImage;
+  // Returned a URL to a resized version of the image if it is coming from the CDN
+  if (imageSrc.indexOf("cdn.sanity.io") >= 0) return `${imageSrc}?h=1000`;
+  // Return the URL as is in other cases
+  return imageSrc;
+};

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -23,6 +23,7 @@ export { fetchBlockRate } from "./fetchBlockRate";
 export { getTokenDecimals } from "./getTokenDecimals";
 export { getIsValidAddress } from "./getIsValidAddress";
 export { getRetirementTokenByAddress } from "./getRetirementTokenByAddress";
+export { getOgImageSrc } from "./getOgImageSrc";
 export {
   queryKlimaRetireByIndex,
   queryKlimaRetiresByAddress,

--- a/site/components/PageHead/index.tsx
+++ b/site/components/PageHead/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
 import React from "react";
-import { urls } from "@klimadao/lib/constants";
+import { getOgImageSrc } from "@klimadao/lib/utils";
 
 import { IS_PRODUCTION } from "lib/constants";
 
@@ -26,7 +26,7 @@ export const PageHead = (props: PageHeadProps) => {
   const relativePath = router.asPath.split(/[#,?]/)[0];
   const canonicalUrl =
     props.canonicalUrl || `https://www.klimadao.finance${relativePath}`;
-
+  const mediaImageSrc = getOgImageSrc(props.mediaImageSrc);
   return (
     <Head>
       {noRobots && <meta name="robots" content="noindex" />}
@@ -51,17 +51,8 @@ export const PageHead = (props: PageHeadProps) => {
       <meta name="twitter:title" content={props.mediaTitle} />
       <meta name="twitter:description" content={props.metaDescription} />
 
-      {props.mediaImageSrc ? (
-        <>
-          <meta property="og:image" content={props.mediaImageSrc} />
-          <meta name="twitter:image" content={props.mediaImageSrc} />
-        </>
-      ) : (
-        <>
-          <meta property="og:image" content={urls.mediaImage} />
-          <meta name="twitter:image" content={urls.mediaImage} />
-        </>
-      )}
+      <meta property="og:image" content={mediaImageSrc} />
+      <meta name="twitter:image" content={mediaImageSrc} />
 
       {props.isArticle && <meta property="og:type" content="article" />}
 


### PR DESCRIPTION
## Description

Sends an URL of a resized version of the CDN images for og image tags

I choose completly arbitrarily an height of 1000px 

## Related Ticket

Resolves #448

## Changes

When tweeting a post

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/11857992/173441110-f6774188-8f04-4aeb-bd23-93788f77d9bd.png) |![image](https://user-images.githubusercontent.com/11857992/173441188-28d1af64-d2ee-4097-b687-d31d47c575f6.png)|


## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
