### PR TITLE
Retirements: Text improvements

### DIFF
--- a/site/components/pages/Retirements/Breakdown/index.tsx
+++ b/site/components/pages/Retirements/Breakdown/index.tsx
@@ -29,8 +29,8 @@ export const Breakdown: NextPage<Props> = (props) => {
     <div className={styles.breakdown}>
       <div className={styles.breakdownHeadline}>
         <Text t="h3" as="h3" align="center" className="title">
-          <Trans id="retirement.totals.assets_used_headline">
-            Assets used for retirements
+          <Trans id="retirement.totals_by_assets.headline">
+            Retirement Totals By Asset
           </Trans>
         </Text>
       </div>

--- a/site/components/pages/Retirements/Breakdown/index.tsx
+++ b/site/components/pages/Retirements/Breakdown/index.tsx
@@ -35,22 +35,30 @@ export const Breakdown: NextPage<Props> = (props) => {
         </Text>
       </div>
       <div className={styles.breakdownList}>
-        {breakdownTokens.map((tkn, index) => {
-          return (
-            <div className={styles.breakdownListItem} key={`${tkn}-${index}`}>
-              <Image
-                src={tkn.icon}
-                width={48}
-                height={48}
-                alt={`${tkn.label}-icon`}
-              />
-              <div className="content">
-                <Text>{trimWithLocale(tkn.amount, 5, locale)}</Text>
-                <Text color="lightest">{tkn.label}</Text>
+        {!!breakdownTokens.length &&
+          breakdownTokens.map((tkn, index) => {
+            return (
+              <div className={styles.breakdownListItem} key={`${tkn}-${index}`}>
+                <Image
+                  src={tkn.icon}
+                  width={48}
+                  height={48}
+                  alt={`${tkn.label}-icon`}
+                />
+                <div className="content">
+                  <Text>{trimWithLocale(tkn.amount, 5, locale)}</Text>
+                  <Text color="lightest">{tkn.label}</Text>
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        {!breakdownTokens.length && (
+          <Text align="center">
+            <Trans id="retirement.totals.breakdown_token_assets.empty">
+              No retirement assets found
+            </Trans>
+          </Text>
+        )}
       </div>
     </div>
   );

--- a/site/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
@@ -30,8 +30,7 @@ export const ProjectDetails: FC<Props> = (props) => {
           </Text>
           <Text t="body2">
             <Trans id="retirement.single.project_details.subline">
-              The following projects were retired. Click a project title to
-              learn more about it.
+              The tonne(s) retired originated from the following project(s).
             </Trans>
           </Text>
         </div>

--- a/site/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
@@ -33,6 +33,13 @@ export const ProjectDetails: FC<Props> = (props) => {
               The tonne(s) retired originated from the following project(s).
             </Trans>
           </Text>
+          {isVerraProject && (
+            <Text t="body2">
+              <Trans id="retirement.single.project_details.click_on_project">
+                Click on the project title to learn more.
+              </Trans>
+            </Text>
+          )}
         </div>
         {isVerraProject &&
           projectDetails.value.map((value) => (
@@ -49,8 +56,7 @@ export const ProjectDetails: FC<Props> = (props) => {
             projectLink={`${urls.carbonDashboard}/MCO2`}
             headline={t({
               id: "retirement.single.project_details.moss_headline",
-              message:
-                "Click here to learn more about the projects that back the MCO2 pools",
+              message: "Learn more about the projects that back the MCO2 pools",
             })}
             tokenAddress={offset.tokenAddress}
           />

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -1,5 +1,7 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
+import Link from "next/link";
+
 import { Text, Section, ButtonPrimary } from "@klimadao/lib/components";
 import { KlimaRetire } from "@klimadao/lib/types/subgraph";
 import { RetirementIndexInfoResult } from "@klimadao/lib/types/offset";
@@ -20,7 +22,6 @@ import { CopyURLButton } from "../CopyURLButton";
 
 import { Trans, t } from "@lingui/macro";
 import * as styles from "./styles";
-import { urls } from "@klimadao/lib/constants";
 import { retirementTokenInfoMap } from "lib/getTokenInfo";
 
 type Props = {
@@ -132,14 +133,16 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
                   </Trans>
                 }
                 text={
-                  <a
-                    className="address"
-                    href={`${urls.retirements}/${
+                  <Link
+                    href={`/retirements/${
                       nameserviceDomain || beneficiaryAddress
                     }`}
+                    passHref
                   >
-                    {nameserviceDomain || concatAddress(beneficiaryAddress)}
-                  </a>
+                    <a className="address">
+                      {nameserviceDomain || concatAddress(beneficiaryAddress)}
+                    </a>
+                  </Link>
                 }
               />
             </div>

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -722,7 +722,11 @@ msgstr ""
 msgid "retirement.single.message.title"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:51
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:38
+msgid "retirement.single.project_details.click_on_project"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:57
 msgid "retirement.single.project_details.moss_headline"
 msgstr ""
 
@@ -778,10 +782,6 @@ msgstr ""
 msgid "retirement.totals.all_retirements_list.headline"
 msgstr ""
 
-#: components/pages/Retirements/Breakdown/index.tsx:32
-msgid "retirement.totals.assets_used_headline"
-msgstr ""
-
 #: components/pages/Retirements/index.tsx:56
 msgid "retirement.totals.head.metaTitle"
 msgstr ""
@@ -812,6 +812,10 @@ msgstr ""
 
 #: components/pages/Retirements/index.tsx:121
 msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#: components/pages/Retirements/Breakdown/index.tsx:32
+msgid "retirement.totals_by_assets.headline"
 msgstr ""
 
 #: components/Footer/index.tsx:49

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -782,6 +782,10 @@ msgstr ""
 msgid "retirement.totals.all_retirements_list.headline"
 msgstr ""
 
+#: components/pages/Retirements/Breakdown/index.tsx:57
+msgid "retirement.totals.breakdown_token_assets.empty"
+msgstr ""
+
 #: components/pages/Retirements/index.tsx:56
 msgid "retirement.totals.head.metaTitle"
 msgstr ""

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -788,6 +788,10 @@ msgstr "No retirements found"
 msgid "retirement.totals.all_retirements_list.headline"
 msgstr "All Retirements"
 
+#: components/pages/Retirements/Breakdown/index.tsx:57
+msgid "retirement.totals.breakdown_token_assets.empty"
+msgstr "No retirement assets found"
+
 #: components/pages/Retirements/index.tsx:56
 msgid "retirement.totals.head.metaTitle"
 msgstr "KlimaDAO - Carbon Retirements for beneficiary {0}"

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -728,13 +728,17 @@ msgstr "CO2-Equivalent Emissions Offset (Metric Tonnes)"
 msgid "retirement.single.message.title"
 msgstr "Retirement Message"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:51
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:38
+msgid "retirement.single.project_details.click_on_project"
+msgstr "Click on the project title to learn more."
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:57
 msgid "retirement.single.project_details.moss_headline"
-msgstr "Click here to learn more about the projects that back the MCO2 pools"
+msgstr "Learn more about the projects that back the MCO2 pools"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:32
 msgid "retirement.single.project_details.subline"
-msgstr "The following projects were retired. Click a project title to learn more about it."
+msgstr "The tonne(s) retired originated from the following project(s)."
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
 msgid "retirement.single.project_details.title"
@@ -784,10 +788,6 @@ msgstr "No retirements found"
 msgid "retirement.totals.all_retirements_list.headline"
 msgstr "All Retirements"
 
-#: components/pages/Retirements/Breakdown/index.tsx:32
-msgid "retirement.totals.assets_used_headline"
-msgstr "Assets used for retirements"
-
 #: components/pages/Retirements/index.tsx:56
 msgid "retirement.totals.head.metaTitle"
 msgstr "KlimaDAO - Carbon Retirements for beneficiary {0}"
@@ -819,6 +819,10 @@ msgstr "Total Carbon Tonnes Retired"
 #: components/pages/Retirements/index.tsx:121
 msgid "retirement.totals.total_retirement_transactions"
 msgstr "Total Retirement Transactions"
+
+#: components/pages/Retirements/Breakdown/index.tsx:32
+msgid "retirement.totals_by_assets.headline"
+msgstr "Retirement Totals By Asset"
 
 #: components/Footer/index.tsx:49
 #: components/pages/Resources/ResourcesHeader/index.tsx:29


### PR DESCRIPTION
## Description

This PR changes:

**Retirements Totals Page:**
- New title "Retirement Totals By Asset"
- Placeholder for empty Assets list "No retirement assets found"

**Retirements Single Page:**
- New Project Details subline "The tonne(s) retired originated from the following project(s). Click on the project title to learn more."
- If a Moss Project => Remove "Click on the project title to learn more." from Project Details subline
- If a Moss Project change link text to "Learn more about the projects that back the MCO2 pools"

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/481

## Changes

<p align="center">

<img width="600" src="https://user-images.githubusercontent.com/95881624/173531897-8e6ce4a6-284e-4734-943d-13f73ec93166.png">

<img width="300"  src="https://user-images.githubusercontent.com/95881624/173531907-2b3e4882-c6ec-4cdb-a7c6-b092f87dc40f.png">

<img width="300" src="https://user-images.githubusercontent.com/95881624/173531910-7842ca9a-b7a3-4ea7-8993-e074f175cbc1.png">

</p>

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
