### PR TITLE
Retirements: Redirect to KNS or ENS url, if exists

### DIFF
--- a/lib/utils/ens/index.ts
+++ b/lib/utils/ens/index.ts
@@ -1,3 +1,4 @@
+import { providers } from "ethers";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
 import { getIsValidAddress } from "../getIsValidAddress";
 
@@ -23,7 +24,10 @@ export const getENSByAddress = async (
   providerUrl?: string
 ): Promise<string | null> => {
   try {
-    const provider = getJsonRpcProvider(providerUrl, "eth"); // fallback to "eth" if providerUrl is undefined
+    // fallback to getDefaultProvider on local development where secrets are not present
+    const provider = providerUrl
+      ? getJsonRpcProvider(providerUrl)
+      : providers.getDefaultProvider(1);
     const domain = await provider.lookupAddress(address);
     return domain;
   } catch (e) {

--- a/lib/utils/ens/index.ts
+++ b/lib/utils/ens/index.ts
@@ -24,6 +24,7 @@ export const getENSByAddress = async (
   providerUrl?: string
 ): Promise<string | null> => {
   try {
+    // ENS lookup on the serverside works only with providerUrl
     // fallback to getDefaultProvider on local development where secrets are not present
     const provider = providerUrl
       ? getJsonRpcProvider(providerUrl)

--- a/lib/utils/ens/index.ts
+++ b/lib/utils/ens/index.ts
@@ -17,3 +17,17 @@ export const getAddressByENS = async (domain: string, providerUrl?: string) => {
     return Promise.reject(e);
   }
 };
+
+export const getENSByAddress = async (
+  address: string,
+  providerUrl?: string
+): Promise<string | null> => {
+  try {
+    const provider = getJsonRpcProvider(providerUrl);
+    const domain = await provider.lookupAddress(address);
+    return domain;
+  } catch (e) {
+    console.error("Error in getENSByAddress", e);
+    return Promise.reject(e);
+  }
+};

--- a/lib/utils/ens/index.ts
+++ b/lib/utils/ens/index.ts
@@ -23,7 +23,7 @@ export const getENSByAddress = async (
   providerUrl?: string
 ): Promise<string | null> => {
   try {
-    const provider = getJsonRpcProvider(providerUrl);
+    const provider = getJsonRpcProvider(providerUrl, "eth"); // fallback to "eth" if providerUrl is undefined
     const domain = await provider.lookupAddress(address);
     return domain;
   } catch (e) {

--- a/lib/utils/getJsonRpcProvider/index.ts
+++ b/lib/utils/getJsonRpcProvider/index.ts
@@ -1,15 +1,9 @@
-import { ethers } from "ethers";
+import { providers } from "ethers";
 import { urls } from "../../constants";
 
-export const getJsonRpcProvider = (
-  providerUrl?: string,
-  network: "eth" | "matic" = "matic"
-) => {
+export const getJsonRpcProvider = (providerUrl?: string) => {
   if (providerUrl) {
-    return new ethers.providers.JsonRpcProvider(providerUrl);
+    return new providers.JsonRpcProvider(providerUrl);
   }
-
-  if (network === "eth") return ethers.providers.getDefaultProvider(1);
-
-  return new ethers.providers.JsonRpcProvider(urls.polygonMainnetRpc);
+  return new providers.JsonRpcProvider(urls.polygonMainnetRpc);
 };

--- a/lib/utils/getJsonRpcProvider/index.ts
+++ b/lib/utils/getJsonRpcProvider/index.ts
@@ -1,9 +1,15 @@
 import { ethers } from "ethers";
 import { urls } from "../../constants";
 
-export const getJsonRpcProvider = (providerUrl?: string) => {
+export const getJsonRpcProvider = (
+  providerUrl?: string,
+  network: "eth" | "matic" = "matic"
+) => {
   if (providerUrl) {
     return new ethers.providers.JsonRpcProvider(providerUrl);
   }
+
+  if (network === "eth") return ethers.providers.getDefaultProvider(1);
+
   return new ethers.providers.JsonRpcProvider(urls.polygonMainnetRpc);
 };

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -30,7 +30,12 @@ export {
 export { getVerraProjectByID } from "./verra/getVerraProjects";
 
 // KNS
-export { isKNSDomain, KNSContract, getAddressByKNS } from "./kns";
+export {
+  isKNSDomain,
+  KNSContract,
+  getAddressByKNS,
+  getKNSByAddress,
+} from "./kns";
 
 // ENS
 export { isENSDomain, getAddressByENS, getENSByAddress } from "./ens";

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -33,4 +33,4 @@ export { getVerraProjectByID } from "./verra/getVerraProjects";
 export { isKNSDomain, KNSContract, getAddressByKNS } from "./kns";
 
 // ENS
-export { isENSDomain, getAddressByENS } from "./ens";
+export { isENSDomain, getAddressByENS, getENSByAddress } from "./ens";

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -32,6 +32,7 @@ export { getVerraProjectByID } from "./verra/getVerraProjects";
 // KNS
 export {
   isKNSDomain,
+  createKNSDomainFromName,
   KNSContract,
   getAddressByKNS,
   getKNSByAddress,

--- a/lib/utils/kns/index.ts
+++ b/lib/utils/kns/index.ts
@@ -30,3 +30,15 @@ export const getAddressByKNS = async (domain: string): Promise<string> => {
     return Promise.reject(e);
   }
 };
+
+export const getKNSByAddress = async (
+  address: string
+): Promise<string | null> => {
+  try {
+    const domain = await KNSContract.defaultNames(address); // name without .klima
+    return domain;
+  } catch (e) {
+    console.error("Error in getKNSByAddress", e);
+    return Promise.reject(e);
+  }
+};

--- a/lib/utils/kns/index.ts
+++ b/lib/utils/kns/index.ts
@@ -8,6 +8,9 @@ import { getIsValidAddress } from "../getIsValidAddress";
 export const isKNSDomain = (domain: string): boolean =>
   !!domain && domain.toLowerCase().includes(".klima");
 
+export const createKNSDomainFromName = (name: string): string =>
+  `${name}.klima`;
+
 // Use this import and overwrite your provider if needed with
 // import { KNSContract } from '...'
 // KNSContract.provider = myProvider;

--- a/site/components/pages/Retirements/CopyAddressButton/index.tsx
+++ b/site/components/pages/Retirements/CopyAddressButton/index.tsx
@@ -1,0 +1,34 @@
+import { FC } from "react";
+import { cx } from "@emotion/css";
+import ContentCopy from "@mui/icons-material/ContentCopy";
+import Check from "@mui/icons-material/Check";
+
+import { useCopyToClipboard } from "hooks/useCopyToClipboard";
+import * as styles from "./styles";
+
+type Props = {
+  address: string;
+  label?: string;
+  size?: "medium" | "small";
+};
+
+export const CopyAddressButton: FC<Props> = ({
+  address,
+  label,
+  size = "medium",
+}) => {
+  const [copied, doCopy] = useCopyToClipboard();
+
+  const className = cx(styles.copyButton, styles[size]);
+
+  return (
+    <button className={className} onClick={() => doCopy(address)}>
+      {label || address}
+      {copied ? (
+        <Check fontSize="inherit" />
+      ) : (
+        <ContentCopy fontSize="inherit" />
+      )}
+    </button>
+  );
+};

--- a/site/components/pages/Retirements/CopyAddressButton/styles.ts
+++ b/site/components/pages/Retirements/CopyAddressButton/styles.ts
@@ -18,7 +18,6 @@ export const medium = css`
 `;
 
 export const small = css`
-  ${copyButton}
   ${typography.caption}
   color: var(--font-02);
 `;

--- a/site/components/pages/Retirements/CopyAddressButton/styles.ts
+++ b/site/components/pages/Retirements/CopyAddressButton/styles.ts
@@ -1,0 +1,24 @@
+import { css } from "@emotion/css";
+import * as typography from "@klimadao/lib/theme/typography";
+
+export const copyButton = css`
+  ${typography.body1}
+  justify-self: start;
+  gap: 0.4rem;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+export const medium = css`
+  ${typography.body1}
+`;
+
+export const small = css`
+  ${copyButton}
+  ${typography.caption}
+  color: var(--font-02);
+`;

--- a/site/components/pages/Retirements/index.tsx
+++ b/site/components/pages/Retirements/index.tsx
@@ -37,8 +37,8 @@ export const RetirementPage: NextPage<Props> = (props) => {
     klimaRetires,
     nameserviceDomain,
   } = props;
-  const { locale } = useRouter();
 
+  const { locale } = useRouter();
   const concattedAddress = concatAddress(beneficiaryAddress);
 
   return (
@@ -66,14 +66,14 @@ export const RetirementPage: NextPage<Props> = (props) => {
       <Navigation activePage="Home" />
 
       <Section variant="gray" className={styles.section}>
-        <div className={styles.pageHeadline}>
-          <div className="textGroup">
+        <div className={styles.pageHeader}>
+          <div className={styles.headline}>
             <Text t="h2" as="h2" align="center">
               <Trans id="retirement.totals.page_headline">
                 Carbon Retirements
               </Trans>
             </Text>
-            <div>
+            <div className={styles.subline}>
               <Text align="center" className={styles.address}>
                 <Trans id="retirement.totals.page_subline">
                   for beneficiary
@@ -84,7 +84,7 @@ export const RetirementPage: NextPage<Props> = (props) => {
                 />
               </Text>
               {nameserviceDomain && (
-                <Text align="center" className={styles.address2}>
+                <Text align="center" className={styles.address}>
                   <CopyAddressButton
                     address={beneficiaryAddress}
                     label={concattedAddress}

--- a/site/components/pages/Retirements/index.tsx
+++ b/site/components/pages/Retirements/index.tsx
@@ -9,8 +9,6 @@ import { Footer } from "components/Footer";
 import { RetirementsTotalsAndBalances } from "@klimadao/lib/types/offset";
 import { KlimaRetire } from "@klimadao/lib/types/subgraph";
 import { concatAddress } from "@klimadao/lib/utils";
-import ContentCopy from "@mui/icons-material/ContentCopy";
-import Check from "@mui/icons-material/Check";
 
 import ForestOutlinedIcon from "@mui/icons-material/ForestOutlined";
 import LocalFireDepartmentIcon from "@mui/icons-material/LocalFireDepartment";
@@ -19,7 +17,7 @@ import { Breakdown } from "./Breakdown";
 import { AllRetirements } from "./List";
 import { RetirementFooter } from "./Footer";
 import { CopyURLButton } from "./CopyURLButton";
-import { useCopyToClipboard } from "hooks/useCopyToClipboard";
+import { CopyAddressButton } from "./CopyAddressButton";
 
 import { Trans, t } from "@lingui/macro";
 import * as styles from "./styles";
@@ -40,7 +38,6 @@ export const RetirementPage: NextPage<Props> = (props) => {
     nameserviceDomain,
   } = props;
   const { locale } = useRouter();
-  const [copied, doCopy] = useCopyToClipboard();
 
   const concattedAddress = concatAddress(beneficiaryAddress);
 
@@ -76,20 +73,26 @@ export const RetirementPage: NextPage<Props> = (props) => {
                 Carbon Retirements
               </Trans>
             </Text>
-            <Text align="center" className={styles.address}>
-              <Trans id="retirement.totals.page_subline">for beneficiary</Trans>
-              <button
-                className={styles.copyButton}
-                onClick={() => doCopy(nameserviceDomain || beneficiaryAddress)}
-              >
-                {nameserviceDomain || concattedAddress}
-                {copied ? (
-                  <Check fontSize="large" />
-                ) : (
-                  <ContentCopy fontSize="large" />
-                )}
-              </button>
-            </Text>
+            <div>
+              <Text align="center" className={styles.address}>
+                <Trans id="retirement.totals.page_subline">
+                  for beneficiary
+                </Trans>
+                <CopyAddressButton
+                  address={nameserviceDomain || beneficiaryAddress}
+                  label={nameserviceDomain || concattedAddress}
+                />
+              </Text>
+              {nameserviceDomain && (
+                <Text align="center" className={styles.address2}>
+                  <CopyAddressButton
+                    address={beneficiaryAddress}
+                    label={concattedAddress}
+                    size="small"
+                  />
+                </Text>
+              )}
+            </div>
           </div>
         </div>
         <div className={styles.cards}>

--- a/site/components/pages/Retirements/styles.ts
+++ b/site/components/pages/Retirements/styles.ts
@@ -10,7 +10,7 @@ export const section = css`
   }
 `;
 
-export const pageHeadline = css`
+export const pageHeader = css`
   grid-column: main;
   display: grid;
   gap: 2.8rem;
@@ -18,16 +18,20 @@ export const pageHeadline = css`
   ${breakpoints.medium} {
     gap: 5.2rem;
   }
+`;
 
-  .textGroup {
-    display: flex;
-    align-items: center;
-    flex-direction: column;
-    gap: 2.8rem;
-    p {
-      max-width: 57rem;
-    }
-  }
+export const headline = css`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 2.8rem;
+`;
+
+export const subline = css`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 0.8rem;
 `;
 
 export const address = css`
@@ -36,10 +40,6 @@ export const address = css`
   gap: 0.8rem;
   align-items: center;
   justify-content: center;
-`;
-export const address2 = css`
-  ${address}
-  margin-top: 0.8rem;
 `;
 
 export const copyButton = css`

--- a/site/components/pages/Retirements/styles.ts
+++ b/site/components/pages/Retirements/styles.ts
@@ -54,12 +54,6 @@ export const copyButton = css`
   }
 `;
 
-export const copyButtonSmall = css`
-  ${copyButton}
-  ${typography.caption}
-  color: var(--font-02);
-`;
-
 export const cards = css`
   grid-column: main;
   display: grid;

--- a/site/components/pages/Retirements/styles.ts
+++ b/site/components/pages/Retirements/styles.ts
@@ -37,6 +37,10 @@ export const address = css`
   align-items: center;
   justify-content: center;
 `;
+export const address2 = css`
+  ${address}
+  margin-top: 0.8rem;
+`;
 
 export const copyButton = css`
   ${typography.body1}
@@ -48,6 +52,12 @@ export const copyButton = css`
   &:hover {
     opacity: 0.7;
   }
+`;
+
+export const copyButtonSmall = css`
+  ${copyButton}
+  ${typography.caption}
+  color: var(--font-02);
 `;
 
 export const cards = css`

--- a/site/lib/getDomainByAddress.ts
+++ b/site/lib/getDomainByAddress.ts
@@ -1,0 +1,20 @@
+import {
+  getKNSByAddress,
+  createKNSDomainFromName,
+  getENSByAddress,
+} from "@klimadao/lib/utils";
+import { getInfuraUrlEther } from "lib/getInfuraUrl";
+
+export const getDomainByAddress = async (
+  address: string
+): Promise<string | null> => {
+  try {
+    const knsName = await getKNSByAddress(address);
+    const kns = !!knsName && createKNSDomainFromName(knsName);
+    const ens = !kns && (await getENSByAddress(address, getInfuraUrlEther())); // Caution: needs to be InfuraUrl for Ether here
+    return kns || ens || null;
+  } catch (e) {
+    console.error("Error in getDomainByAddress", e);
+    return Promise.reject(e);
+  }
+};

--- a/site/lib/getDomainByAddress.ts
+++ b/site/lib/getDomainByAddress.ts
@@ -11,7 +11,6 @@ export const getDomainByAddress = async (
   try {
     const knsName = await getKNSByAddress(address);
     const kns = !!knsName && createKNSDomainFromName(knsName);
-    // ENS lookup on the serverside works only with providerUrl
     const ens = !kns && (await getENSByAddress(address, getInfuraUrlEther())); // Caution: needs to be InfuraUrl for Ether here
     return kns || ens || null;
   } catch (e) {

--- a/site/lib/getDomainByAddress.ts
+++ b/site/lib/getDomainByAddress.ts
@@ -11,6 +11,7 @@ export const getDomainByAddress = async (
   try {
     const knsName = await getKNSByAddress(address);
     const kns = !!knsName && createKNSDomainFromName(knsName);
+    // ENS lookup on the serverside works only with providerUrl
     const ens = !kns && (await getENSByAddress(address, getInfuraUrlEther())); // Caution: needs to be InfuraUrl for Ether here
     return kns || ens || null;
   } catch (e) {

--- a/site/pages/retirements/[beneficiary]/[retirement_index].tsx
+++ b/site/pages/retirements/[beneficiary]/[retirement_index].tsx
@@ -17,6 +17,7 @@ import { loadTranslation } from "lib/i18n";
 import { getInfuraUrlPolygon } from "lib/getInfuraUrl";
 import { getIsDomainInURL } from "lib/getIsDomainInURL";
 import { getAddressByDomain } from "lib/getAddressByDomain";
+import { getDomainByAddress } from "lib/getDomainByAddress";
 
 interface Params extends ParsedUrlQuery {
   /** Either an 0x or a nameservice domain like atmosfearful.klima */
@@ -62,6 +63,19 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
 
     if (!isDomainInURL && !isValidAddress) {
       throw new Error("Not a valid beneficiary address");
+    }
+
+    const nameserviceDomain =
+      !isDomainInURL && (await getDomainByAddress(beneficiaryInUrl));
+
+    // redirect now to this page again with nameserviceDomain in URL
+    if (nameserviceDomain) {
+      return {
+        redirect: {
+          destination: `/retirements/${nameserviceDomain}/${params.retirement_index}`,
+          statusCode: 301,
+        },
+      };
     }
 
     let beneficiaryAddress: string;

--- a/site/pages/retirements/[beneficiary]/index.tsx
+++ b/site/pages/retirements/[beneficiary]/index.tsx
@@ -16,6 +16,7 @@ import { RetirementPage } from "components/pages/Retirements";
 import { loadTranslation } from "lib/i18n";
 import { getIsDomainInURL } from "lib/getIsDomainInURL";
 import { getAddressByDomain } from "lib/getAddressByDomain";
+import { getDomainByAddress } from "lib/getDomainByAddress";
 
 interface Params extends ParsedUrlQuery {
   /** Either an 0x or a nameservice domain like atmosfearful.klima */
@@ -48,6 +49,19 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
 
     if (!isDomainInURL && !isValidAddress) {
       throw new Error("Not a valid beneficiary address");
+    }
+
+    const nameserviceDomain =
+      !isDomainInURL && (await getDomainByAddress(beneficiaryInUrl));
+
+    // redirect now to this page again with nameserviceDomain in URL
+    if (nameserviceDomain) {
+      return {
+        redirect: {
+          destination: `/retirements/${nameserviceDomain}`,
+          statusCode: 301,
+        },
+      };
     }
 
     let beneficiaryAddress: string;


### PR DESCRIPTION
## Description

This PR does:
- take the beneficiary data from the url
- if the data is an address => check if a KNS or ENS domain exist for this address
- if a KNS or ENS address exists => redirect to new URL with this domain
- show beneficiaryAddress below nameserviceDomain
- some refactorings

## Note !

ENS lookup does not work in local development  on the server if the `infura_id` is not present!
Therefore rendering retirement pages with an address which do not have KNS or ENS fails locally (404)!

Error:

```TS
{
  reason: 'network does not support ENS',
  code: 'UNSUPPORTED_OPERATION',
  operation: 'lookupAddress',
  network: 'matic'
}
```

**Solutions:**
- [x] ~Either disable the ENS lookup on the server for site on local development~
- [x] ~or let Nextjs result in a 404 for these pages in local development (current behavior)~
- [x] fallback to `getDefaultProvider(1)` if providerUrl is undefined ✅ 


## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/483

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
