### PR TITLE
Refactor: Move Contracts and Abi to lib 🧹 

### DIFF
--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -8,7 +8,7 @@ import {
   getTreasuryBalance,
   fetchBlockRate,
   getJsonRpcProvider,
-  getContractByToken,
+  getContract,
 } from "@klimadao/lib/utils";
 import { addresses } from "@klimadao/lib/constants";
 import SKlima from "@klimadao/lib/abi/sKlima.json";
@@ -19,11 +19,11 @@ export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
     try {
       const currentBlock = await provider.getBlockNumber();
 
-      const distributorContract = getContractByToken({
+      const distributorContract = getContract({
         token: "distributor",
         provider: provider,
       });
-      const sKlimaContract = getContractByToken({
+      const sKlimaContract = getContract({
         token: "sklima",
         provider: provider,
       });

--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -20,11 +20,11 @@ export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
       const currentBlock = await provider.getBlockNumber();
 
       const distributorContract = getContract({
-        token: "distributor",
+        contractName: "distributor",
         provider: provider,
       });
       const sKlimaContract = getContract({
-        token: "sklima",
+        contractName: "sklima",
         provider: provider,
       });
       const sKlimaMainContract = new ethers.Contract(

--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -11,7 +11,6 @@ import {
   getContractByToken,
 } from "@klimadao/lib/utils";
 import { addresses } from "@klimadao/lib/constants";
-import DistributorContractv4 from "@klimadao/lib/abi/DistributorContractv4.json";
 import SKlima from "@klimadao/lib/abi/sKlima.json";
 
 export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
@@ -20,11 +19,10 @@ export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
     try {
       const currentBlock = await provider.getBlockNumber();
 
-      const distributorContract = new ethers.Contract(
-        addresses["mainnet"].distributor,
-        DistributorContractv4.abi,
-        provider
-      );
+      const distributorContract = getContractByToken({
+        token: "distributor",
+        provider: provider,
+      });
       const sKlimaContract = getContractByToken({
         token: "sklima",
         provider: provider,

--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -8,11 +8,11 @@ import {
   getTreasuryBalance,
   fetchBlockRate,
   getJsonRpcProvider,
+  getContractByToken,
 } from "@klimadao/lib/utils";
 import { addresses } from "@klimadao/lib/constants";
 import DistributorContractv4 from "@klimadao/lib/abi/DistributorContractv4.json";
 import SKlima from "@klimadao/lib/abi/sKlima.json";
-import IERC20 from "@klimadao/lib/abi/IERC20.json";
 
 export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
   return async (dispatch) => {
@@ -25,11 +25,10 @@ export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
         DistributorContractv4.abi,
         provider
       );
-      const sKlimaContract = new ethers.Contract(
-        addresses["mainnet"].sklima,
-        IERC20.abi,
-        provider
-      );
+      const sKlimaContract = getContractByToken({
+        token: "sklima",
+        provider: provider,
+      });
       const sKlimaMainContract = new ethers.Contract(
         addresses["mainnet"].sklima,
         SKlima.abi,

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -93,7 +93,7 @@ export const changeApprovalTransaction = async (params: {
   try {
     const contract = getContractByToken({
       token: params.token,
-      provider: params.provider,
+      provider: params.provider.getSigner(),
     });
     const decimals = getTokenDecimals(params.token);
     const value = ethers.utils.parseUnits("1000000000", decimals);
@@ -190,7 +190,7 @@ export const retireCarbonTransaction = async (params: {
     // retire transaction
     const retireContract = getContractByToken({
       token: "retirementAggregator",
-      provider: params.provider,
+      provider: params.provider.getSigner(),
     });
 
     params.onStatus("userConfirmation");

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -16,7 +16,7 @@ import {
   getTokenDecimals,
   createRetirementStorageContract,
   getRetirementTotalsAndBalances,
-  getContractByToken,
+  getContract,
 } from "@klimadao/lib/utils";
 import { OnStatusHandler } from "./utils";
 
@@ -52,7 +52,7 @@ export const getRetirementAllowances = (params: {
     try {
       // create arr of promises, one for each of the above erc20s
       const promises = inputTokens.reduce((arr, val) => {
-        const contract = getContractByToken({
+        const contract = getContract({
           token: val,
           provider: params.provider,
         });
@@ -91,7 +91,7 @@ export const changeApprovalTransaction = async (params: {
   onStatus: OnStatusHandler;
 }): Promise<string> => {
   try {
-    const contract = getContractByToken({
+    const contract = getContract({
       token: params.token,
       provider: params.provider.getSigner(),
     });
@@ -125,7 +125,7 @@ export const getOffsetConsumptionCost = async (params: {
   amountInCarbon: boolean;
   getSpecific: boolean;
 }): Promise<[string, string]> => {
-  const retirementAggregatorContract = getContractByToken({
+  const retirementAggregatorContract = getContract({
     token: "retirementAggregator",
     provider: params.provider,
   });
@@ -188,7 +188,7 @@ export const retireCarbonTransaction = async (params: {
     const retirementTotals = formattedTotals + 1;
 
     // retire transaction
-    const retireContract = getContractByToken({
+    const retireContract = getContract({
       token: "retirementAggregator",
       provider: params.provider.getSigner(),
     });

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -6,7 +6,6 @@ import {
 } from "state/user";
 
 import KlimaRetirementAggregator from "@klimadao/lib/abi/KlimaRetirementAggregator.json";
-import IERC20 from "@klimadao/lib/abi/IERC20.json";
 import {
   addresses,
   InputToken,
@@ -18,6 +17,7 @@ import {
   getTokenDecimals,
   createRetirementStorageContract,
   getRetirementTotalsAndBalances,
+  getContractByToken,
 } from "@klimadao/lib/utils";
 import { OnStatusHandler } from "./utils";
 
@@ -53,11 +53,10 @@ export const getRetirementAllowances = (params: {
     try {
       // create arr of promises, one for each of the above erc20s
       const promises = inputTokens.reduce((arr, val) => {
-        const contract = new ethers.Contract(
-          addresses["mainnet"][val],
-          IERC20.abi,
-          params.provider
-        );
+        const contract = getContractByToken({
+          token: val,
+          provider: params.provider,
+        });
         arr.push(
           contract.allowance(
             params.address, // owner
@@ -93,11 +92,10 @@ export const changeApprovalTransaction = async (params: {
   onStatus: OnStatusHandler;
 }): Promise<string> => {
   try {
-    const contract = new ethers.Contract(
-      addresses["mainnet"][params.token],
-      IERC20.abi,
-      params.provider.getSigner()
-    );
+    const contract = getContractByToken({
+      token: params.token,
+      provider: params.provider,
+    });
     const decimals = getTokenDecimals(params.token);
     const value = ethers.utils.parseUnits("1000000000", decimals);
     params.onStatus("userConfirmation", "");

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -5,7 +5,6 @@ import {
   setCarbonRetiredBalances,
 } from "state/user";
 
-import KlimaRetirementAggregator from "@klimadao/lib/abi/KlimaRetirementAggregator.json";
 import {
   addresses,
   InputToken,
@@ -126,11 +125,10 @@ export const getOffsetConsumptionCost = async (params: {
   amountInCarbon: boolean;
   getSpecific: boolean;
 }): Promise<[string, string]> => {
-  const retirementAggregatorContract = new ethers.Contract(
-    addresses["mainnet"].retirementAggregator,
-    KlimaRetirementAggregator.abi,
-    params.provider
-  );
+  const retirementAggregatorContract = getContractByToken({
+    token: "retirementAggregator",
+    provider: params.provider,
+  });
   const parsed = ethers.utils.parseUnits(
     params.quantity,
     getTokenDecimals(params.retirementToken)
@@ -190,11 +188,10 @@ export const retireCarbonTransaction = async (params: {
     const retirementTotals = formattedTotals + 1;
 
     // retire transaction
-    const retireContract = new ethers.Contract(
-      addresses["mainnet"].retirementAggregator,
-      KlimaRetirementAggregator.abi,
-      params.provider.getSigner()
-    );
+    const retireContract = getContractByToken({
+      token: "retirementAggregator",
+      provider: params.provider,
+    });
 
     params.onStatus("userConfirmation");
 

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -53,7 +53,7 @@ export const getRetirementAllowances = (params: {
       // create arr of promises, one for each of the above erc20s
       const promises = inputTokens.reduce((arr, val) => {
         const contract = getContract({
-          token: val,
+          contractName: val,
           provider: params.provider,
         });
         arr.push(
@@ -92,7 +92,7 @@ export const changeApprovalTransaction = async (params: {
 }): Promise<string> => {
   try {
     const contract = getContract({
-      token: params.token,
+      contractName: params.token,
       provider: params.provider.getSigner(),
     });
     const decimals = getTokenDecimals(params.token);
@@ -126,7 +126,7 @@ export const getOffsetConsumptionCost = async (params: {
   getSpecific: boolean;
 }): Promise<[string, string]> => {
   const retirementAggregatorContract = getContract({
-    token: "retirementAggregator",
+    contractName: "retirementAggregator",
     provider: params.provider,
   });
   const parsed = ethers.utils.parseUnits(
@@ -189,7 +189,7 @@ export const retireCarbonTransaction = async (params: {
 
     // retire transaction
     const retireContract = getContract({
-      token: "retirementAggregator",
+      contractName: "retirementAggregator",
       provider: params.provider.getSigner(),
     });
 

--- a/app/actions/pklima.ts
+++ b/app/actions/pklima.ts
@@ -18,11 +18,10 @@ export const loadTerms = (params: {
 }): Thunk => {
   return async (dispatch) => {
     try {
-      const pExerciseContract = new ethers.Contract(
-        addresses["mainnet"].pklima_exercise,
-        ExercisePKlima.abi,
-        params.provider
-      );
+      const pExerciseContract = getContractByToken({
+        token: "pklima_exercise",
+        provider: params.provider,
+      });
       const pklimaRedeemBalance = await pExerciseContract.redeemableFor(
         params.address
       );
@@ -95,11 +94,10 @@ export const exerciseTransaction = async (params: {
   onStatus: OnStatusHandler;
 }) => {
   try {
-    const contract = new ethers.Contract(
-      addresses["mainnet"].pklima_exercise,
-      ExercisePKlima.abi,
-      params.provider.getSigner()
-    );
+    const contract = getContractByToken({
+      token: "pklima_exercise",
+      provider: params.provider,
+    });
     params.onStatus("userConfirmation", "");
     const txn = await contract.exercise(
       ethers.utils.parseUnits(params.value, "ether")

--- a/app/actions/pklima.ts
+++ b/app/actions/pklima.ts
@@ -60,9 +60,12 @@ export const changeApprovalTransaction = async (params: {
     const contract = {
       pklima: getContractByToken({
         token: "pklima",
-        provider: params.provider,
+        provider: params.provider.getSigner(),
       }),
-      bct: getContractByToken({ token: "bct", provider: params.provider }),
+      bct: getContractByToken({
+        token: "bct",
+        provider: params.provider.getSigner(),
+      }),
     }[params.action];
     const value = ethers.utils.parseUnits(
       "1000000000000000000000000000",
@@ -95,7 +98,7 @@ export const exerciseTransaction = async (params: {
   try {
     const contract = getContractByToken({
       token: "pklima_exercise",
-      provider: params.provider,
+      provider: params.provider.getSigner(),
     });
     params.onStatus("userConfirmation", "");
     const txn = await contract.exercise(

--- a/app/actions/pklima.ts
+++ b/app/actions/pklima.ts
@@ -7,7 +7,7 @@ import { setPklimaTerms } from "state/user";
 import {
   formatUnits,
   trimStringDecimals,
-  getContractByToken,
+  getContract,
 } from "@klimadao/lib/utils";
 
 export const loadTerms = (params: {
@@ -17,7 +17,7 @@ export const loadTerms = (params: {
 }): Thunk => {
   return async (dispatch) => {
     try {
-      const pExerciseContract = getContractByToken({
+      const pExerciseContract = getContract({
         token: "pklima_exercise",
         provider: params.provider,
       });
@@ -58,11 +58,11 @@ export const changeApprovalTransaction = async (params: {
 }) => {
   try {
     const contract = {
-      pklima: getContractByToken({
+      pklima: getContract({
         token: "pklima",
         provider: params.provider.getSigner(),
       }),
-      bct: getContractByToken({
+      bct: getContract({
         token: "bct",
         provider: params.provider.getSigner(),
       }),
@@ -96,7 +96,7 @@ export const exerciseTransaction = async (params: {
   onStatus: OnStatusHandler;
 }) => {
   try {
-    const contract = getContractByToken({
+    const contract = getContract({
       token: "pklima_exercise",
       provider: params.provider.getSigner(),
     });

--- a/app/actions/pklima.ts
+++ b/app/actions/pklima.ts
@@ -18,7 +18,7 @@ export const loadTerms = (params: {
   return async (dispatch) => {
     try {
       const pExerciseContract = getContract({
-        token: "pklima_exercise",
+        contractName: "pklima_exercise",
         provider: params.provider,
       });
       const pklimaRedeemBalance = await pExerciseContract.redeemableFor(
@@ -59,11 +59,11 @@ export const changeApprovalTransaction = async (params: {
   try {
     const contract = {
       pklima: getContract({
-        token: "pklima",
+        contractName: "pklima",
         provider: params.provider.getSigner(),
       }),
       bct: getContract({
-        token: "bct",
+        contractName: "bct",
         provider: params.provider.getSigner(),
       }),
     }[params.action];
@@ -97,7 +97,7 @@ export const exerciseTransaction = async (params: {
 }) => {
   try {
     const contract = getContract({
-      token: "pklima_exercise",
+      contractName: "pklima_exercise",
       provider: params.provider.getSigner(),
     });
     params.onStatus("userConfirmation", "");

--- a/app/actions/pklima.ts
+++ b/app/actions/pklima.ts
@@ -2,11 +2,14 @@ import { ethers, providers } from "ethers";
 
 import { addresses } from "@klimadao/lib/constants";
 import ExercisePKlima from "@klimadao/lib/abi/ExercisepKLIMA.json";
-import IERC20 from "@klimadao/lib/abi/IERC20.json";
 import { OnStatusHandler } from "./utils";
 import { Thunk } from "state";
 import { setPklimaTerms } from "state/user";
-import { formatUnits, trimStringDecimals } from "@klimadao/lib/utils";
+import {
+  formatUnits,
+  trimStringDecimals,
+  getContractByToken,
+} from "@klimadao/lib/utils";
 
 export const loadTerms = (params: {
   address: string;
@@ -57,16 +60,11 @@ export const changeApprovalTransaction = async (params: {
 }) => {
   try {
     const contract = {
-      pklima: new ethers.Contract(
-        addresses["mainnet"].pklima,
-        IERC20.abi,
-        params.provider.getSigner()
-      ),
-      bct: new ethers.Contract(
-        addresses["mainnet"].bct,
-        IERC20.abi,
-        params.provider.getSigner()
-      ),
+      pklima: getContractByToken({
+        token: "pklima",
+        provider: params.provider,
+      }),
+      bct: getContractByToken({ token: "bct", provider: params.provider }),
     }[params.action];
     const value = ethers.utils.parseUnits(
       "1000000000000000000000000000",

--- a/app/actions/pklima.ts
+++ b/app/actions/pklima.ts
@@ -1,7 +1,6 @@
 import { ethers, providers } from "ethers";
 
 import { addresses } from "@klimadao/lib/constants";
-import ExercisePKlima from "@klimadao/lib/abi/ExercisepKLIMA.json";
 import { OnStatusHandler } from "./utils";
 import { Thunk } from "state";
 import { setPklimaTerms } from "state/user";

--- a/app/actions/stake.ts
+++ b/app/actions/stake.ts
@@ -2,10 +2,9 @@ import { ethers, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
 import { addresses } from "@klimadao/lib/constants";
 
-import IERC20 from "@klimadao/lib/abi/IERC20.json";
 import KlimaStakingHelper from "@klimadao/lib/abi/KlimaStakingHelper.json";
 import KlimaStakingv2 from "@klimadao/lib/abi/KlimaStakingv2.json";
-import { formatUnits } from "@klimadao/lib/utils";
+import { formatUnits, getContractByToken } from "@klimadao/lib/utils";
 
 export const changeApprovalTransaction = async (params: {
   provider: providers.JsonRpcProvider;
@@ -14,16 +13,11 @@ export const changeApprovalTransaction = async (params: {
 }): Promise<string> => {
   try {
     const contract = {
-      stake: new ethers.Contract(
-        addresses["mainnet"].klima,
-        IERC20.abi,
-        params.provider.getSigner()
-      ),
-      unstake: new ethers.Contract(
-        addresses["mainnet"].sklima,
-        IERC20.abi,
-        params.provider.getSigner()
-      ),
+      stake: getContractByToken({ token: "klima", provider: params.provider }),
+      unstake: getContractByToken({
+        token: "sklima",
+        provider: params.provider,
+      }),
     }[params.action];
     const address = {
       stake: addresses["mainnet"].staking_helper,

--- a/app/actions/stake.ts
+++ b/app/actions/stake.ts
@@ -11,10 +11,13 @@ export const changeApprovalTransaction = async (params: {
 }): Promise<string> => {
   try {
     const contract = {
-      stake: getContractByToken({ token: "klima", provider: params.provider }),
+      stake: getContractByToken({
+        token: "klima",
+        provider: params.provider.getSigner(),
+      }),
       unstake: getContractByToken({
         token: "sklima",
-        provider: params.provider,
+        provider: params.provider.getSigner(),
       }),
     }[params.action];
     const address = {
@@ -49,11 +52,11 @@ export const changeStakeTransaction = async (params: {
     const contract = {
       stake: getContractByToken({
         token: "staking_helper",
-        provider: params.provider,
+        provider: params.provider.getSigner(),
       }),
       unstake: getContractByToken({
         token: "staking",
-        provider: params.provider,
+        provider: params.provider.getSigner(),
       }),
     }[params.action];
     params.onStatus("userConfirmation", "");

--- a/app/actions/stake.ts
+++ b/app/actions/stake.ts
@@ -2,7 +2,7 @@ import { ethers, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
 import { addresses } from "@klimadao/lib/constants";
 
-import { formatUnits, getContractByToken } from "@klimadao/lib/utils";
+import { formatUnits, getContract } from "@klimadao/lib/utils";
 
 export const changeApprovalTransaction = async (params: {
   provider: providers.JsonRpcProvider;
@@ -11,11 +11,11 @@ export const changeApprovalTransaction = async (params: {
 }): Promise<string> => {
   try {
     const contract = {
-      stake: getContractByToken({
+      stake: getContract({
         token: "klima",
         provider: params.provider.getSigner(),
       }),
-      unstake: getContractByToken({
+      unstake: getContract({
         token: "sklima",
         provider: params.provider.getSigner(),
       }),
@@ -50,11 +50,11 @@ export const changeStakeTransaction = async (params: {
   try {
     const parsedValue = ethers.utils.parseUnits(params.value, "gwei");
     const contract = {
-      stake: getContractByToken({
+      stake: getContract({
         token: "staking_helper",
         provider: params.provider.getSigner(),
       }),
-      unstake: getContractByToken({
+      unstake: getContract({
         token: "staking",
         provider: params.provider.getSigner(),
       }),

--- a/app/actions/stake.ts
+++ b/app/actions/stake.ts
@@ -12,11 +12,11 @@ export const changeApprovalTransaction = async (params: {
   try {
     const contract = {
       stake: getContract({
-        token: "klima",
+        contractName: "klima",
         provider: params.provider.getSigner(),
       }),
       unstake: getContract({
-        token: "sklima",
+        contractName: "sklima",
         provider: params.provider.getSigner(),
       }),
     }[params.action];
@@ -51,11 +51,11 @@ export const changeStakeTransaction = async (params: {
     const parsedValue = ethers.utils.parseUnits(params.value, "gwei");
     const contract = {
       stake: getContract({
-        token: "staking_helper",
+        contractName: "staking_helper",
         provider: params.provider.getSigner(),
       }),
       unstake: getContract({
-        token: "staking",
+        contractName: "staking",
         provider: params.provider.getSigner(),
       }),
     }[params.action];

--- a/app/actions/stake.ts
+++ b/app/actions/stake.ts
@@ -2,8 +2,6 @@ import { ethers, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
 import { addresses } from "@klimadao/lib/constants";
 
-import KlimaStakingHelper from "@klimadao/lib/abi/KlimaStakingHelper.json";
-import KlimaStakingv2 from "@klimadao/lib/abi/KlimaStakingv2.json";
 import { formatUnits, getContractByToken } from "@klimadao/lib/utils";
 
 export const changeApprovalTransaction = async (params: {
@@ -49,16 +47,14 @@ export const changeStakeTransaction = async (params: {
   try {
     const parsedValue = ethers.utils.parseUnits(params.value, "gwei");
     const contract = {
-      stake: new ethers.Contract(
-        addresses["mainnet"].staking_helper,
-        KlimaStakingHelper.abi,
-        params.provider.getSigner()
-      ),
-      unstake: new ethers.Contract(
-        addresses["mainnet"].staking,
-        KlimaStakingv2.abi,
-        params.provider.getSigner()
-      ),
+      stake: getContractByToken({
+        token: "staking_helper",
+        provider: params.provider,
+      }),
+      unstake: getContractByToken({
+        token: "staking",
+        provider: params.provider,
+      }),
     }[params.action];
     params.onStatus("userConfirmation", "");
     const txn =

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -5,7 +5,7 @@ import { addresses } from "@klimadao/lib/constants";
 import {
   formatUnits,
   trimStringDecimals,
-  getContractByToken,
+  getContract,
 } from "@klimadao/lib/utils";
 import {
   setBalance,
@@ -24,47 +24,47 @@ export const loadAccountDetails = (params: {
 }): Thunk => {
   return async (dispatch) => {
     try {
-      const bctContract = getContractByToken({
+      const bctContract = getContract({
         token: "bct",
         provider: params.provider,
       });
-      const nctContract = getContractByToken({
+      const nctContract = getContract({
         token: "nct",
         provider: params.provider,
       });
-      const mco2Contract = getContractByToken({
+      const mco2Contract = getContract({
         token: "mco2",
         provider: params.provider,
       });
-      const uboContract = getContractByToken({
+      const uboContract = getContract({
         token: "ubo",
         provider: params.provider,
       });
-      const nboContract = getContractByToken({
+      const nboContract = getContract({
         token: "nbo",
         provider: params.provider,
       });
-      const usdcContract = getContractByToken({
+      const usdcContract = getContract({
         token: "usdc",
         provider: params.provider,
       });
-      const klimaContract = getContractByToken({
+      const klimaContract = getContract({
         token: "klima",
         provider: params.provider,
       });
-      const sklimaContract = getContractByToken({
+      const sklimaContract = getContract({
         token: "sklima",
         provider: params.provider,
       });
-      const wsklimaContract = getContractByToken({
+      const wsklimaContract = getContract({
         token: "wsklima",
         provider: params.provider,
       });
-      const pKlimaContract = getContractByToken({
+      const pKlimaContract = getContract({
         token: "pklima",
         provider: params.provider,
       });
-      const klimaDomainContract = getContractByToken({
+      const klimaDomainContract = getContract({
         token: "klimaNameService",
         provider: params.provider,
       });

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -66,12 +66,10 @@ export const loadAccountDetails = (params: {
         token: "pklima",
         provider: params.provider,
       });
-      // remember to add this to addresses object
-      const klimaDomainContract = new ethers.Contract(
-        addresses["mainnet"].klimaNameService,
-        PunkTLD.abi,
-        params.provider
-      );
+      const klimaDomainContract = getContractByToken({
+        token: "klimaNameService",
+        provider: params.provider,
+      });
 
       //domains
       const knsDomain = await getKns({

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -1,7 +1,6 @@
 import { ethers, providers } from "ethers";
 import { Thunk } from "state";
 
-import wsKlima from "@klimadao/lib/abi/wsKlima.json";
 import PunkTLD from "@klimadao/lib/abi/PunkTLD.json";
 
 import { addresses } from "@klimadao/lib/constants";
@@ -27,11 +26,6 @@ export const loadAccountDetails = (params: {
 }): Thunk => {
   return async (dispatch) => {
     try {
-      const wsklimaContract = new ethers.Contract(
-        addresses["mainnet"].wsklima,
-        wsKlima.abi,
-        params.provider
-      );
       const bctContract = getContractByToken({
         token: "bct",
         provider: params.provider,
@@ -62,6 +56,10 @@ export const loadAccountDetails = (params: {
       });
       const sklimaContract = getContractByToken({
         token: "sklima",
+        provider: params.provider,
+      });
+      const wsklimaContract = getContractByToken({
+        token: "wsklima",
         provider: params.provider,
       });
       const pKlimaContract = getContractByToken({

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -25,47 +25,47 @@ export const loadAccountDetails = (params: {
   return async (dispatch) => {
     try {
       const bctContract = getContract({
-        token: "bct",
+        contractName: "bct",
         provider: params.provider,
       });
       const nctContract = getContract({
-        token: "nct",
+        contractName: "nct",
         provider: params.provider,
       });
       const mco2Contract = getContract({
-        token: "mco2",
+        contractName: "mco2",
         provider: params.provider,
       });
       const uboContract = getContract({
-        token: "ubo",
+        contractName: "ubo",
         provider: params.provider,
       });
       const nboContract = getContract({
-        token: "nbo",
+        contractName: "nbo",
         provider: params.provider,
       });
       const usdcContract = getContract({
-        token: "usdc",
+        contractName: "usdc",
         provider: params.provider,
       });
       const klimaContract = getContract({
-        token: "klima",
+        contractName: "klima",
         provider: params.provider,
       });
       const sklimaContract = getContract({
-        token: "sklima",
+        contractName: "sklima",
         provider: params.provider,
       });
       const wsklimaContract = getContract({
-        token: "wsklima",
+        contractName: "wsklima",
         provider: params.provider,
       });
       const pKlimaContract = getContract({
-        token: "pklima",
+        contractName: "pklima",
         provider: params.provider,
       });
       const klimaDomainContract = getContract({
-        token: "klimaNameService",
+        contractName: "klimaNameService",
         provider: params.provider,
       });
 

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -1,7 +1,5 @@
-import { ethers, providers } from "ethers";
+import { providers } from "ethers";
 import { Thunk } from "state";
-
-import PunkTLD from "@klimadao/lib/abi/PunkTLD.json";
 
 import { addresses } from "@klimadao/lib/constants";
 import {

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -1,12 +1,15 @@
 import { ethers, providers } from "ethers";
 import { Thunk } from "state";
 
-import IERC20 from "@klimadao/lib/abi/IERC20.json";
 import wsKlima from "@klimadao/lib/abi/wsKlima.json";
 import PunkTLD from "@klimadao/lib/abi/PunkTLD.json";
 
 import { addresses } from "@klimadao/lib/constants";
-import { formatUnits, trimStringDecimals } from "@klimadao/lib/utils";
+import {
+  formatUnits,
+  trimStringDecimals,
+  getContractByToken,
+} from "@klimadao/lib/utils";
 import {
   setBalance,
   setExerciseAllowance,
@@ -24,56 +27,47 @@ export const loadAccountDetails = (params: {
 }): Thunk => {
   return async (dispatch) => {
     try {
-      const bctContract = new ethers.Contract(
-        addresses["mainnet"].bct,
-        IERC20.abi,
-        params.provider
-      );
-      const nctContract = new ethers.Contract(
-        addresses["mainnet"].nct,
-        IERC20.abi,
-        params.provider
-      );
-      const mco2Contract = new ethers.Contract(
-        addresses["mainnet"].mco2,
-        IERC20.abi,
-        params.provider
-      );
-      const uboContract = new ethers.Contract(
-        addresses["mainnet"].ubo,
-        IERC20.abi,
-        params.provider
-      );
-      const nboContract = new ethers.Contract(
-        addresses["mainnet"].nbo,
-        IERC20.abi,
-        params.provider
-      );
-      const usdcContract = new ethers.Contract(
-        addresses["mainnet"].usdc,
-        IERC20.abi,
-        params.provider
-      );
-      const klimaContract = new ethers.Contract(
-        addresses["mainnet"].klima,
-        IERC20.abi,
-        params.provider
-      );
-      const sklimaContract = new ethers.Contract(
-        addresses["mainnet"].sklima,
-        IERC20.abi,
-        params.provider
-      );
       const wsklimaContract = new ethers.Contract(
         addresses["mainnet"].wsklima,
         wsKlima.abi,
         params.provider
       );
-      const pKlimaContract = new ethers.Contract(
-        addresses["mainnet"].pklima,
-        IERC20.abi,
-        params.provider
-      );
+      const bctContract = getContractByToken({
+        token: "bct",
+        provider: params.provider,
+      });
+      const nctContract = getContractByToken({
+        token: "nct",
+        provider: params.provider,
+      });
+      const mco2Contract = getContractByToken({
+        token: "mco2",
+        provider: params.provider,
+      });
+      const uboContract = getContractByToken({
+        token: "ubo",
+        provider: params.provider,
+      });
+      const nboContract = getContractByToken({
+        token: "nbo",
+        provider: params.provider,
+      });
+      const usdcContract = getContractByToken({
+        token: "usdc",
+        provider: params.provider,
+      });
+      const klimaContract = getContractByToken({
+        token: "klima",
+        provider: params.provider,
+      });
+      const sklimaContract = getContractByToken({
+        token: "sklima",
+        provider: params.provider,
+      });
+      const pKlimaContract = getContractByToken({
+        token: "pklima",
+        provider: params.provider,
+      });
       // remember to add this to addresses object
       const klimaDomainContract = new ethers.Contract(
         addresses["mainnet"].klimaNameService,

--- a/app/actions/wrap.ts
+++ b/app/actions/wrap.ts
@@ -1,20 +1,18 @@
 import { addresses } from "@klimadao/lib/constants";
 import { ethers, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
-import IERC20 from "@klimadao/lib/abi/IERC20.json";
 import wsKlima from "@klimadao/lib/abi/wsKlima.json";
-import { formatUnits } from "@klimadao/lib/utils";
+import { formatUnits, getContractByToken } from "@klimadao/lib/utils";
 
 export const changeApprovalTransaction = async (params: {
   provider: providers.JsonRpcProvider;
   onStatus: OnStatusHandler;
 }) => {
   try {
-    const contract = new ethers.Contract(
-      addresses["mainnet"].sklima,
-      IERC20.abi,
-      params.provider.getSigner()
-    );
+    const contract = getContractByToken({
+      token: "sklima",
+      provider: params.provider,
+    });
     const value = ethers.utils.parseUnits("1000000000", "gwei"); //bignumber
     params.onStatus("userConfirmation", "");
     const txn = await contract.approve(

--- a/app/actions/wrap.ts
+++ b/app/actions/wrap.ts
@@ -1,14 +1,14 @@
 import { addresses } from "@klimadao/lib/constants";
 import { ethers, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
-import { formatUnits, getContractByToken } from "@klimadao/lib/utils";
+import { formatUnits, getContract } from "@klimadao/lib/utils";
 
 export const changeApprovalTransaction = async (params: {
   provider: providers.JsonRpcProvider;
   onStatus: OnStatusHandler;
 }) => {
   try {
-    const contract = getContractByToken({
+    const contract = getContract({
       token: "sklima",
       provider: params.provider.getSigner(),
     });
@@ -39,7 +39,7 @@ export const wrapTransaction = async (params: {
   onStatus: OnStatusHandler;
 }) => {
   try {
-    const contract = getContractByToken({
+    const contract = getContract({
       token: "wsklima",
       provider: params.provider.getSigner(),
     });

--- a/app/actions/wrap.ts
+++ b/app/actions/wrap.ts
@@ -9,7 +9,7 @@ export const changeApprovalTransaction = async (params: {
 }) => {
   try {
     const contract = getContract({
-      token: "sklima",
+      contractName: "sklima",
       provider: params.provider.getSigner(),
     });
     const value = ethers.utils.parseUnits("1000000000", "gwei"); //bignumber
@@ -40,7 +40,7 @@ export const wrapTransaction = async (params: {
 }) => {
   try {
     const contract = getContract({
-      token: "wsklima",
+      contractName: "wsklima",
       provider: params.provider.getSigner(),
     });
     params.onStatus("userConfirmation", "");

--- a/app/actions/wrap.ts
+++ b/app/actions/wrap.ts
@@ -1,7 +1,6 @@
 import { addresses } from "@klimadao/lib/constants";
 import { ethers, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
-import wsKlima from "@klimadao/lib/abi/wsKlima.json";
 import { formatUnits, getContractByToken } from "@klimadao/lib/utils";
 
 export const changeApprovalTransaction = async (params: {
@@ -40,11 +39,10 @@ export const wrapTransaction = async (params: {
   onStatus: OnStatusHandler;
 }) => {
   try {
-    const contract = new ethers.Contract(
-      addresses["mainnet"].wsklima,
-      wsKlima.abi,
-      params.provider.getSigner()
-    );
+    const contract = getContractByToken({
+      token: "wsklima",
+      provider: params.provider,
+    });
     params.onStatus("userConfirmation", "");
     const decimal = params.action === "wrap" ? 9 : 18;
     const txn = await contract[params.action](

--- a/app/actions/wrap.ts
+++ b/app/actions/wrap.ts
@@ -10,7 +10,7 @@ export const changeApprovalTransaction = async (params: {
   try {
     const contract = getContractByToken({
       token: "sklima",
-      provider: params.provider,
+      provider: params.provider.getSigner(),
     });
     const value = ethers.utils.parseUnits("1000000000", "gwei"); //bignumber
     params.onStatus("userConfirmation", "");
@@ -41,7 +41,7 @@ export const wrapTransaction = async (params: {
   try {
     const contract = getContractByToken({
       token: "wsklima",
-      provider: params.provider,
+      provider: params.provider.getSigner(),
     });
     params.onStatus("userConfirmation", "");
     const decimal = params.action === "wrap" ? 9 : 18;

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -50,13 +50,14 @@ export const getContractAbiByToken = (token: Token) => {
 };
 
 export const getContract = (params: {
-  token: Token;
+  contractName: Token;
   provider: providers.JsonRpcProvider | Signer;
 }): ethers.Contract => {
-  const abi = getContractAbiByToken(params.token);
-  if (!abi) throw new Error(`Unknown abi for token: ${params.token}`);
+  const abi = getContractAbiByToken(params.contractName);
+  if (!abi)
+    throw new Error(`Unknown abi for contractName: ${params.contractName}`);
   return new ethers.Contract(
-    addresses["mainnet"][params.token],
+    addresses["mainnet"][params.contractName],
     abi,
     params.provider
   );

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -8,10 +8,12 @@ import PunkTLD from "../../abi/PunkTLD.json";
 import PairContract from "../../abi/PairContract.json";
 import KlimaRetirementAggregator from "../../abi/KlimaRetirementAggregator.json";
 import ExercisePKlima from "../../abi/ExercisepKLIMA.json";
+import KlimaStakingHelper from "../../abi/KlimaStakingHelper.json";
+import KlimaStakingv2 from "../../abi/KlimaStakingv2.json";
 
 type Token = keyof typeof addresses["mainnet"];
 type ContractMap = {
-  [K in Token]: typeof IERC20["abi"];
+  [K in Token]: typeof IERC20["abi"] | typeof KlimaStakingHelper["abi"];
 };
 const contractMap = {
   // CARBON
@@ -37,6 +39,8 @@ const contractMap = {
   klimaBctLp: PairContract.abi,
   retirementAggregator: KlimaRetirementAggregator.abi,
   pklima_exercise: ExercisePKlima.abi,
+  staking_helper: KlimaStakingHelper.abi,
+  staking: KlimaStakingv2.abi,
 } as ContractMap;
 
 export const getContractAbiByToken = (token: Token) => {

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -5,6 +5,7 @@ import IERC20 from "../../abi/IERC20.json";
 import WSKLIMA from "../../abi/wsKlima.json";
 import DistributorContractv4 from "../../abi/DistributorContractv4.json";
 import PunkTLD from "../../abi/PunkTLD.json";
+import PairContract from "../../abi/PairContract.json";
 
 type Token = keyof typeof addresses["mainnet"];
 type ContractMap = {
@@ -30,6 +31,8 @@ const contractMap = {
   // Others
   distributor: DistributorContractv4.abi,
   klimaNameService: PunkTLD.abi,
+  bctUsdcLp: PairContract.abi,
+  klimaBctLp: PairContract.abi,
 } as ContractMap;
 
 export const getContractAbiByToken = (token: Token) => {

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -6,10 +6,11 @@ import WSKLIMA from "../../abi/wsKlima.json";
 import DistributorContractv4 from "../../abi/DistributorContractv4.json";
 import PunkTLD from "../../abi/PunkTLD.json";
 import PairContract from "../../abi/PairContract.json";
+import KlimaRetirementAggregator from "../../abi/KlimaRetirementAggregator.json";
 
 type Token = keyof typeof addresses["mainnet"];
 type ContractMap = {
-  [K in Token]: typeof IERC20["abi"] | typeof WSKLIMA["abi"];
+  [K in Token]: typeof IERC20["abi"];
 };
 const contractMap = {
   // CARBON
@@ -33,6 +34,7 @@ const contractMap = {
   klimaNameService: PunkTLD.abi,
   bctUsdcLp: PairContract.abi,
   klimaBctLp: PairContract.abi,
+  retirementAggregator: KlimaRetirementAggregator.abi,
 } as ContractMap;
 
 export const getContractAbiByToken = (token: Token) => {

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -1,0 +1,42 @@
+import { ethers, providers } from "ethers";
+
+import { addresses } from "../../constants";
+import IERC20 from "../../abi/IERC20.json";
+
+type Token = keyof typeof addresses["mainnet"];
+type ContractMap = {
+  [K in Token]: typeof IERC20["abi"] | typeof WSKLIMA["abi"];
+};
+const contractMap = {
+  // CARBON
+  bct: IERC20.abi,
+  mco2: IERC20.abi,
+  nct: IERC20.abi,
+  ubo: IERC20.abi,
+  nbo: IERC20.abi,
+
+  // KLIMA
+  klima: IERC20.abi,
+  sklima: IERC20.abi,
+  pklima: IERC20.abi,
+
+  // USDC
+  usdc: IERC20.abi,
+} as ContractMap;
+
+export const getContractAbiByToken = (token: Token) => {
+  return contractMap[token as keyof ContractMap];
+};
+
+export const getContractByToken = (params: {
+  token: Token;
+  provider: providers.JsonRpcProvider;
+}): ethers.Contract => {
+  const abi = getContractAbiByToken(params.token);
+  if (!abi) throw new Error(`Unknown abi for token: ${params.token}`);
+  return new ethers.Contract(
+    addresses["mainnet"][params.token],
+    abi,
+    params.provider
+  );
+};

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -2,6 +2,7 @@ import { ethers, providers } from "ethers";
 
 import { addresses } from "../../constants";
 import IERC20 from "../../abi/IERC20.json";
+import WSKLIMA from "../../abi/wsKlima.json";
 
 type Token = keyof typeof addresses["mainnet"];
 type ContractMap = {
@@ -18,6 +19,7 @@ const contractMap = {
   // KLIMA
   klima: IERC20.abi,
   sklima: IERC20.abi,
+  wsklima: WSKLIMA.abi,
   pklima: IERC20.abi,
 
   // USDC

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -12,9 +12,9 @@ import KlimaStakingHelper from "../../abi/KlimaStakingHelper.json";
 import KlimaStakingv2 from "../../abi/KlimaStakingv2.json";
 import KlimaRetirementStorage from "../../abi/KlimaRetirementStorage.json";
 
-type Token = keyof typeof addresses["mainnet"];
+type ContractName = keyof typeof addresses["mainnet"];
 type ContractMap = {
-  [K in Token]: typeof IERC20["abi"] | typeof KlimaStakingHelper["abi"];
+  [K in ContractName]: typeof IERC20["abi"] | typeof KlimaStakingHelper["abi"];
 };
 const contractMap = {
   // CARBON
@@ -45,15 +45,15 @@ const contractMap = {
   retirementStorage: KlimaRetirementStorage.abi,
 } as ContractMap;
 
-export const getContractAbiByToken = (token: Token) => {
-  return contractMap[token as keyof ContractMap];
+export const getContractAbiByName = (name: ContractName) => {
+  return contractMap[name as keyof ContractMap];
 };
 
 export const getContract = (params: {
-  contractName: Token;
+  contractName: ContractName;
   provider: providers.JsonRpcProvider | Signer;
 }): ethers.Contract => {
-  const abi = getContractAbiByToken(params.contractName);
+  const abi = getContractAbiByName(params.contractName);
   if (!abi)
     throw new Error(`Unknown abi for contractName: ${params.contractName}`);
   return new ethers.Contract(

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -3,6 +3,8 @@ import { ethers, providers } from "ethers";
 import { addresses } from "../../constants";
 import IERC20 from "../../abi/IERC20.json";
 import WSKLIMA from "../../abi/wsKlima.json";
+import DistributorContractv4 from "../../abi/DistributorContractv4.json";
+import PunkTLD from "../../abi/PunkTLD.json";
 
 type Token = keyof typeof addresses["mainnet"];
 type ContractMap = {
@@ -24,6 +26,10 @@ const contractMap = {
 
   // USDC
   usdc: IERC20.abi,
+
+  // Others
+  distributor: DistributorContractv4.abi,
+  klimaNameService: PunkTLD.abi,
 } as ContractMap;
 
 export const getContractAbiByToken = (token: Token) => {

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -7,6 +7,7 @@ import DistributorContractv4 from "../../abi/DistributorContractv4.json";
 import PunkTLD from "../../abi/PunkTLD.json";
 import PairContract from "../../abi/PairContract.json";
 import KlimaRetirementAggregator from "../../abi/KlimaRetirementAggregator.json";
+import ExercisePKlima from "../../abi/ExercisepKLIMA.json";
 
 type Token = keyof typeof addresses["mainnet"];
 type ContractMap = {
@@ -35,6 +36,7 @@ const contractMap = {
   bctUsdcLp: PairContract.abi,
   klimaBctLp: PairContract.abi,
   retirementAggregator: KlimaRetirementAggregator.abi,
+  pklima_exercise: ExercisePKlima.abi,
 } as ContractMap;
 
 export const getContractAbiByToken = (token: Token) => {

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -10,6 +10,7 @@ import KlimaRetirementAggregator from "../../abi/KlimaRetirementAggregator.json"
 import ExercisePKlima from "../../abi/ExercisepKLIMA.json";
 import KlimaStakingHelper from "../../abi/KlimaStakingHelper.json";
 import KlimaStakingv2 from "../../abi/KlimaStakingv2.json";
+import KlimaRetirementStorage from "../../abi/KlimaRetirementStorage.json";
 
 type Token = keyof typeof addresses["mainnet"];
 type ContractMap = {
@@ -41,6 +42,7 @@ const contractMap = {
   pklima_exercise: ExercisePKlima.abi,
   staking_helper: KlimaStakingHelper.abi,
   staking: KlimaStakingv2.abi,
+  retirementStorage: KlimaRetirementStorage.abi,
 } as ContractMap;
 
 export const getContractAbiByToken = (token: Token) => {

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -49,7 +49,7 @@ export const getContractAbiByToken = (token: Token) => {
   return contractMap[token as keyof ContractMap];
 };
 
-export const getContractByToken = (params: {
+export const getContract = (params: {
   token: Token;
   provider: providers.JsonRpcProvider | Signer;
 }): ethers.Contract => {

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -1,4 +1,4 @@
-import { ethers, providers } from "ethers";
+import { ethers, providers, Signer } from "ethers";
 
 import { addresses } from "../../constants";
 import IERC20 from "../../abi/IERC20.json";
@@ -51,7 +51,7 @@ export const getContractAbiByToken = (token: Token) => {
 
 export const getContractByToken = (params: {
   token: Token;
-  provider: providers.JsonRpcProvider;
+  provider: providers.JsonRpcProvider | Signer;
 }): ethers.Contract => {
   const abi = getContractAbiByToken(params.token);
   if (!abi) throw new Error(`Unknown abi for token: ${params.token}`);

--- a/lib/utils/getKlimaSupply/index.ts
+++ b/lib/utils/getKlimaSupply/index.ts
@@ -1,9 +1,9 @@
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
-import { formatUnits, getContractByToken } from "..";
+import { formatUnits, getContract } from "..";
 
 export const getKlimaSupply = async (providerUrl?: string): Promise<string> => {
   const provider = getJsonRpcProvider(providerUrl);
-  const klimaContract = getContractByToken({ token: "klima", provider });
+  const klimaContract = getContract({ token: "klima", provider });
   const totalSupply = await klimaContract.totalSupply();
 
   return formatUnits(totalSupply, 9); // KLIMA has 9 decimals

--- a/lib/utils/getKlimaSupply/index.ts
+++ b/lib/utils/getKlimaSupply/index.ts
@@ -3,7 +3,7 @@ import { formatUnits, getContract } from "..";
 
 export const getKlimaSupply = async (providerUrl?: string): Promise<string> => {
   const provider = getJsonRpcProvider(providerUrl);
-  const klimaContract = getContract({ token: "klima", provider });
+  const klimaContract = getContract({ contractName: "klima", provider });
   const totalSupply = await klimaContract.totalSupply();
 
   return formatUnits(totalSupply, 9); // KLIMA has 9 decimals

--- a/lib/utils/getKlimaSupply/index.ts
+++ b/lib/utils/getKlimaSupply/index.ts
@@ -1,16 +1,9 @@
-import { ethers } from "ethers";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
-import { addresses } from "../../constants";
-import IERC20 from "../../abi/IERC20.json";
-import { formatUnits } from "..";
+import { formatUnits, getContractByToken } from "..";
 
 export const getKlimaSupply = async (providerUrl?: string): Promise<string> => {
   const provider = getJsonRpcProvider(providerUrl);
-  const klimaContract = new ethers.Contract(
-    addresses.mainnet.klima,
-    IERC20.abi,
-    provider
-  );
+  const klimaContract = getContractByToken({ token: "klima", provider });
   const totalSupply = await klimaContract.totalSupply();
 
   return formatUnits(totalSupply, 9); // KLIMA has 9 decimals

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -6,7 +6,7 @@ import {
   formatUnits,
   getTokenDecimals,
   getIsValidAddress,
-  getContractByToken,
+  getContract,
 } from "../../utils";
 
 import {
@@ -18,7 +18,7 @@ import {
 
 export const createRetirementStorageContract = (
   provider: providers.JsonRpcProvider
-) => getContractByToken({ token: "retirementStorage", provider });
+) => getContract({ token: "retirementStorage", provider });
 
 export const getRetirementIndexInfo = async (params: {
   beneficiaryAddress: string;

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -1,12 +1,12 @@
-import { ethers, providers, BigNumber } from "ethers";
+import { providers, BigNumber } from "ethers";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
-import KlimaRetirementStorage from "../../abi/KlimaRetirementStorage.json";
 import { addresses } from "../../constants";
 import {
   getRetirementTokenByAddress,
   formatUnits,
   getTokenDecimals,
   getIsValidAddress,
+  getContractByToken,
 } from "../../utils";
 
 import {
@@ -18,13 +18,7 @@ import {
 
 export const createRetirementStorageContract = (
   provider: providers.JsonRpcProvider
-) => {
-  return new ethers.Contract(
-    addresses["mainnet"].retirementStorage,
-    KlimaRetirementStorage.abi,
-    provider
-  );
-};
+) => getContractByToken({ token: "retirementStorage", provider });
 
 export const getRetirementIndexInfo = async (params: {
   beneficiaryAddress: string;

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -18,7 +18,7 @@ import {
 
 export const createRetirementStorageContract = (
   provider: providers.JsonRpcProvider
-) => getContract({ token: "retirementStorage", provider });
+) => getContract({ contractName: "retirementStorage", provider });
 
 export const getRetirementIndexInfo = async (params: {
   beneficiaryAddress: string;

--- a/lib/utils/getStakingRewards/index.ts
+++ b/lib/utils/getStakingRewards/index.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
 import { addresses } from "../../constants";
-import { getEstimatedDailyRebases, getContractByToken } from "..";
+import { getEstimatedDailyRebases, getContract } from "..";
 import SKlima from "../../abi/sKlima.json";
 
 export const getStakingRewards = async (params: {
@@ -10,7 +10,7 @@ export const getStakingRewards = async (params: {
   providerUrl?: string;
 }): Promise<number> => {
   const provider = getJsonRpcProvider(params.providerUrl);
-  const distributorContract = getContractByToken({
+  const distributorContract = getContract({
     token: "distributor",
     provider,
   });

--- a/lib/utils/getStakingRewards/index.ts
+++ b/lib/utils/getStakingRewards/index.ts
@@ -1,8 +1,7 @@
 import { ethers } from "ethers";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
 import { addresses } from "../../constants";
-import { getEstimatedDailyRebases } from "..";
-import DistributorContractv4 from "../../abi/DistributorContractv4.json";
+import { getEstimatedDailyRebases, getContractByToken } from "..";
 import SKlima from "../../abi/sKlima.json";
 
 export const getStakingRewards = async (params: {
@@ -11,11 +10,10 @@ export const getStakingRewards = async (params: {
   providerUrl?: string;
 }): Promise<number> => {
   const provider = getJsonRpcProvider(params.providerUrl);
-  const distributorContract = new ethers.Contract(
-    addresses.mainnet.distributor,
-    DistributorContractv4.abi,
-    provider
-  );
+  const distributorContract = getContractByToken({
+    token: "distributor",
+    provider,
+  });
   const sklimaContract = new ethers.Contract(
     addresses.mainnet.sklima,
     SKlima.abi,

--- a/lib/utils/getStakingRewards/index.ts
+++ b/lib/utils/getStakingRewards/index.ts
@@ -11,7 +11,7 @@ export const getStakingRewards = async (params: {
 }): Promise<number> => {
   const provider = getJsonRpcProvider(params.providerUrl);
   const distributorContract = getContract({
-    token: "distributor",
+    contractName: "distributor",
     provider,
   });
   const sklimaContract = new ethers.Contract(

--- a/lib/utils/getTreasuryBalance/index.ts
+++ b/lib/utils/getTreasuryBalance/index.ts
@@ -2,13 +2,13 @@ import { providers } from "ethers";
 import { getInteger } from "../getInteger";
 import { addresses } from "../../constants";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
-import { getContractByToken } from "../getContract";
+import { getContract } from "../getContract";
 
 const getOwnedBCTFromSLP = async (params: {
   adr: "bctUsdcLp" | "klimaBctLp";
   provider: providers.JsonRpcProvider;
 }) => {
-  const contract = getContractByToken({
+  const contract = getContract({
     token: params.adr,
     provider: params.provider,
   });
@@ -43,7 +43,7 @@ export const getTreasuryBalance = async (
 ): Promise<number> => {
   try {
     const provider = getJsonRpcProvider(providerUrl);
-    const bctContract = getContractByToken({ token: "bct", provider });
+    const bctContract = getContract({ token: "bct", provider });
 
     const nakedBCT = getInteger(
       await bctContract.balanceOf(addresses.mainnet.treasury)

--- a/lib/utils/getTreasuryBalance/index.ts
+++ b/lib/utils/getTreasuryBalance/index.ts
@@ -1,9 +1,9 @@
 import { ethers, providers } from "ethers";
 import { getInteger } from "../getInteger";
-import IERC20 from "../../abi/IERC20.json";
 import PairContract from "../../abi/PairContract.json";
 import { addresses } from "../../constants";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
+import { getContractByToken } from "../getContract";
 
 const getOwnedBCTFromSLP = async (params: {
   adr: "bctUsdcLp" | "klimaBctLp";
@@ -46,11 +46,7 @@ export const getTreasuryBalance = async (
 ): Promise<number> => {
   try {
     const provider = getJsonRpcProvider(providerUrl);
-    const bctContract = new ethers.Contract(
-      addresses.mainnet.bct,
-      IERC20.abi,
-      provider
-    );
+    const bctContract = getContractByToken({ token: "bct", provider });
 
     const nakedBCT = getInteger(
       await bctContract.balanceOf(addresses.mainnet.treasury)

--- a/lib/utils/getTreasuryBalance/index.ts
+++ b/lib/utils/getTreasuryBalance/index.ts
@@ -1,6 +1,5 @@
-import { ethers, providers } from "ethers";
+import { providers } from "ethers";
 import { getInteger } from "../getInteger";
-import PairContract from "../../abi/PairContract.json";
 import { addresses } from "../../constants";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
 import { getContractByToken } from "../getContract";
@@ -9,12 +8,10 @@ const getOwnedBCTFromSLP = async (params: {
   adr: "bctUsdcLp" | "klimaBctLp";
   provider: providers.JsonRpcProvider;
 }) => {
-  const slpAddress = addresses.mainnet[params.adr];
-  const contract = new ethers.Contract(
-    slpAddress,
-    PairContract.abi,
-    params.provider
-  );
+  const contract = getContractByToken({
+    token: params.adr,
+    provider: params.provider,
+  });
   const [token0, token1, [reserve0, reserve1], treasurySLP, totalSLP] =
     await Promise.all([
       contract.token0() as string,

--- a/lib/utils/getTreasuryBalance/index.ts
+++ b/lib/utils/getTreasuryBalance/index.ts
@@ -9,7 +9,7 @@ const getOwnedBCTFromSLP = async (params: {
   provider: providers.JsonRpcProvider;
 }) => {
   const contract = getContract({
-    token: params.adr,
+    contractName: params.adr,
     provider: params.provider,
   });
   const [token0, token1, [reserve0, reserve1], treasurySLP, totalSLP] =
@@ -43,7 +43,7 @@ export const getTreasuryBalance = async (
 ): Promise<number> => {
   try {
     const provider = getJsonRpcProvider(providerUrl);
-    const bctContract = getContract({ token: "bct", provider });
+    const bctContract = getContract({ contractName: "bct", provider });
 
     const nakedBCT = getInteger(
       await bctContract.balanceOf(addresses.mainnet.treasury)

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -20,6 +20,7 @@ export { safeAdd } from "./safeAdd";
 export { safeSub } from "./safeSub";
 export { getEstimatedDailyRebases } from "./getEstimatedDailyRebases";
 export { fetchBlockRate } from "./fetchBlockRate";
+export { getContractAbiByToken, getContractByToken } from "./getContract";
 export { getTokenDecimals } from "./getTokenDecimals";
 export { getIsValidAddress } from "./getIsValidAddress";
 export { getRetirementTokenByAddress } from "./getRetirementTokenByAddress";

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -20,7 +20,7 @@ export { safeAdd } from "./safeAdd";
 export { safeSub } from "./safeSub";
 export { getEstimatedDailyRebases } from "./getEstimatedDailyRebases";
 export { fetchBlockRate } from "./fetchBlockRate";
-export { getContractAbiByToken, getContractByToken } from "./getContract";
+export { getContractAbiByToken, getContract } from "./getContract";
 export { getTokenDecimals } from "./getTokenDecimals";
 export { getIsValidAddress } from "./getIsValidAddress";
 export { getRetirementTokenByAddress } from "./getRetirementTokenByAddress";

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -20,7 +20,7 @@ export { safeAdd } from "./safeAdd";
 export { safeSub } from "./safeSub";
 export { getEstimatedDailyRebases } from "./getEstimatedDailyRebases";
 export { fetchBlockRate } from "./fetchBlockRate";
-export { getContractAbiByToken, getContract } from "./getContract";
+export { getContractAbiByName, getContract } from "./getContract";
 export { getTokenDecimals } from "./getTokenDecimals";
 export { getIsValidAddress } from "./getIsValidAddress";
 export { getRetirementTokenByAddress } from "./getRetirementTokenByAddress";

--- a/lib/utils/kns/index.ts
+++ b/lib/utils/kns/index.ts
@@ -1,6 +1,6 @@
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
 import { getIsValidAddress } from "../getIsValidAddress";
-import { getContractByToken } from "../getContract";
+import { getContract } from "../getContract";
 
 // https://www.kns.earth/#/
 export const isKNSDomain = (domain: string): boolean =>
@@ -12,7 +12,7 @@ export const createKNSDomainFromName = (name: string): string =>
 // Use this import and overwrite your provider if needed with
 // import { KNSContract } from '...'
 // KNSContract.provider = myProvider;
-export const KNSContract = getContractByToken({
+export const KNSContract = getContract({
   token: "klimaNameService",
   provider: getJsonRpcProvider(),
 });

--- a/lib/utils/kns/index.ts
+++ b/lib/utils/kns/index.ts
@@ -13,7 +13,7 @@ export const createKNSDomainFromName = (name: string): string =>
 // import { KNSContract } from '...'
 // KNSContract.provider = myProvider;
 export const KNSContract = getContract({
-  token: "klimaNameService",
+  contractName: "klimaNameService",
   provider: getJsonRpcProvider(),
 });
 

--- a/lib/utils/kns/index.ts
+++ b/lib/utils/kns/index.ts
@@ -1,8 +1,6 @@
-import { ethers } from "ethers";
-import { addresses } from "../../constants";
-import PunkTLD from "../../abi/PunkTLD.json";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
 import { getIsValidAddress } from "../getIsValidAddress";
+import { getContractByToken } from "../getContract";
 
 // https://www.kns.earth/#/
 export const isKNSDomain = (domain: string): boolean =>
@@ -14,11 +12,10 @@ export const createKNSDomainFromName = (name: string): string =>
 // Use this import and overwrite your provider if needed with
 // import { KNSContract } from '...'
 // KNSContract.provider = myProvider;
-export const KNSContract = new ethers.Contract(
-  addresses["mainnet"].klimaNameService,
-  PunkTLD.abi,
-  getJsonRpcProvider()
-);
+export const KNSContract = getContractByToken({
+  token: "klimaNameService",
+  provider: getJsonRpcProvider(),
+});
 
 export const getAddressByKNS = async (domain: string): Promise<string> => {
   try {

--- a/site/lib/getBalances.ts
+++ b/site/lib/getBalances.ts
@@ -1,4 +1,4 @@
-import { getJsonRpcProvider, getContractByToken } from "@klimadao/lib/utils";
+import { getJsonRpcProvider, getContract } from "@klimadao/lib/utils";
 import { formatUnits } from "@klimadao/lib/utils";
 
 type Params = {
@@ -16,11 +16,11 @@ export type Balances = {
 export const getBalances = async (params: Params): Promise<Balances> => {
   const provider = getJsonRpcProvider();
 
-  const bctContract = getContractByToken({ token: "bct", provider });
-  const nctContract = getContractByToken({ token: "nct", provider });
-  const mco2Contract = getContractByToken({ token: "mco2", provider });
-  const klimaContract = getContractByToken({ token: "klima", provider });
-  const sklimaContract = getContractByToken({ token: "sklima", provider });
+  const bctContract = getContract({ token: "bct", provider });
+  const nctContract = getContract({ token: "nct", provider });
+  const mco2Contract = getContract({ token: "mco2", provider });
+  const klimaContract = getContract({ token: "klima", provider });
+  const sklimaContract = getContract({ token: "sklima", provider });
 
   const klimaBalance = await klimaContract.balanceOf(params.address);
   const sklimaBalance = await sklimaContract.balanceOf(params.address);

--- a/site/lib/getBalances.ts
+++ b/site/lib/getBalances.ts
@@ -1,7 +1,4 @@
-import { ethers } from "ethers";
-import IERC20 from "@klimadao/lib/abi/IERC20.json";
-import { addresses } from "@klimadao/lib/constants";
-import { getJsonRpcProvider } from "@klimadao/lib/utils";
+import { getJsonRpcProvider, getContractByToken } from "@klimadao/lib/utils";
 import { formatUnits } from "@klimadao/lib/utils";
 
 type Params = {
@@ -19,31 +16,11 @@ export type Balances = {
 export const getBalances = async (params: Params): Promise<Balances> => {
   const provider = getJsonRpcProvider();
 
-  const bctContract = new ethers.Contract(
-    addresses["mainnet"].bct,
-    IERC20.abi,
-    provider
-  );
-  const nctContract = new ethers.Contract(
-    addresses["mainnet"].nct,
-    IERC20.abi,
-    provider
-  );
-  const mco2Contract = new ethers.Contract(
-    addresses["mainnet"].mco2,
-    IERC20.abi,
-    provider
-  );
-  const klimaContract = new ethers.Contract(
-    addresses["mainnet"].klima,
-    IERC20.abi,
-    provider
-  );
-  const sklimaContract = new ethers.Contract(
-    addresses["mainnet"].sklima,
-    IERC20.abi,
-    provider
-  );
+  const bctContract = getContractByToken({ token: "bct", provider });
+  const nctContract = getContractByToken({ token: "nct", provider });
+  const mco2Contract = getContractByToken({ token: "mco2", provider });
+  const klimaContract = getContractByToken({ token: "klima", provider });
+  const sklimaContract = getContractByToken({ token: "sklima", provider });
 
   const klimaBalance = await klimaContract.balanceOf(params.address);
   const sklimaBalance = await sklimaContract.balanceOf(params.address);

--- a/site/lib/getBalances.ts
+++ b/site/lib/getBalances.ts
@@ -16,11 +16,11 @@ export type Balances = {
 export const getBalances = async (params: Params): Promise<Balances> => {
   const provider = getJsonRpcProvider();
 
-  const bctContract = getContract({ token: "bct", provider });
-  const nctContract = getContract({ token: "nct", provider });
-  const mco2Contract = getContract({ token: "mco2", provider });
-  const klimaContract = getContract({ token: "klima", provider });
-  const sklimaContract = getContract({ token: "sklima", provider });
+  const bctContract = getContract({ contractName: "bct", provider });
+  const nctContract = getContract({ contractName: "nct", provider });
+  const mco2Contract = getContract({ contractName: "mco2", provider });
+  const klimaContract = getContract({ contractName: "klima", provider });
+  const sklimaContract = getContract({ contractName: "sklima", provider });
 
   const klimaBalance = await klimaContract.balanceOf(params.address);
   const sklimaBalance = await sklimaContract.balanceOf(params.address);


### PR DESCRIPTION
## Description

This is another preparation PR for ticket #9 
- map all token contracts to their corresponding Abi JSON files
- replace all Contracts with the new `getContract` lib util


This will make it easier later to create contracts objects like

```TS
const allContracts = createContracts(["bct", "nbo", "klima"]);
const allBalances = getBalancesFromContracts(allContracts);
const allAllowances = getAllowancesFromContracts(allContracts);
...
```
**TODO**
- do the same for Bonds later in another PR


## Related Ticket

Part of #9 

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
