### PR TITLE
Refactor: Move main sklima contract to getContract 

### DIFF
--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -10,8 +10,6 @@ import {
   getJsonRpcProvider,
   getContract,
 } from "@klimadao/lib/utils";
-import { addresses } from "@klimadao/lib/constants";
-import SKlima from "@klimadao/lib/abi/sKlima.json";
 
 export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
   return async (dispatch) => {
@@ -27,11 +25,10 @@ export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
         contractName: "sklima",
         provider: provider,
       });
-      const sKlimaMainContract = new ethers.Contract(
-        addresses["mainnet"].sklima,
-        SKlima.abi,
-        provider
-      );
+      const sKlimaMainContract = getContract({
+        contractName: "sklimaMain",
+        provider: provider,
+      });
 
       const promises = [
         distributorContract.info(0),

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -13,10 +13,7 @@ import KlimaStakingv2 from "../../abi/KlimaStakingv2.json";
 import KlimaRetirementStorage from "../../abi/KlimaRetirementStorage.json";
 import SKlima from "../../abi/sKlima.json";
 
-const mainTokenContracts = ["sklimaMain"] as const;
 type Address = keyof typeof addresses["mainnet"];
-type MainTokenContracts = typeof mainTokenContracts[number];
-type ContractName = Address | MainTokenContracts;
 type ContractMap = {
   [K in ContractName]: typeof IERC20["abi"] | typeof KlimaStakingHelper["abi"];
 };
@@ -31,8 +28,8 @@ const contractMap = {
   // KLIMA
   klima: IERC20.abi,
   sklima: IERC20.abi,
-  wsklima: WSKLIMA.abi,
   pklima: IERC20.abi,
+  wsklima: WSKLIMA.abi,
 
   // USDC
   usdc: IERC20.abi,
@@ -50,7 +47,8 @@ const contractMap = {
   staking_helper: KlimaStakingHelper.abi,
   staking: KlimaStakingv2.abi,
   retirementStorage: KlimaRetirementStorage.abi,
-} as ContractMap;
+} as const;
+type ContractName = keyof typeof contractMap;
 
 export const isKeyInAddresses = (name: string): boolean => {
   const keys = Object.keys(

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -50,14 +50,11 @@ const contractMap = {
 } as const;
 type ContractName = keyof typeof contractMap;
 
-export const isKeyInAddresses = (name: string): boolean => {
+export const isNameInAddresses = (name: string): boolean => {
   const keys = Object.keys(
     addresses.mainnet
   ) as (keyof typeof addresses["mainnet"])[];
-  const token = keys.find(
-    (key) => addresses["mainnet"][key].toLowerCase() === name.toLowerCase()
-  );
-  return !!token;
+  return keys.includes(name as keyof typeof addresses["mainnet"]);
 };
 
 export const getContractAbiByName = (name: ContractName) => {
@@ -71,11 +68,14 @@ export const getContract = (params: {
   const abi = getContractAbiByName(params.contractName);
   if (!abi)
     throw new Error(`Unknown abi for contractName: ${params.contractName}`);
-  const keyInAddresses = params.contractName.replace("Main", "") as Address;
-  if (!isKeyInAddresses)
-    throw new Error(`Unknown contract name in mainnet: ${keyInAddresses}`);
+
+  const nameInAddresses = params.contractName.replace("Main", "") as Address;
+  if (!isNameInAddresses(nameInAddresses)) {
+    throw new Error(`Unknown contract name in mainnet: ${nameInAddresses}`);
+  }
+
   return new ethers.Contract(
-    addresses["mainnet"][keyInAddresses],
+    addresses["mainnet"][nameInAddresses],
     abi,
     params.provider
   );

--- a/lib/utils/getStakingRewards/index.ts
+++ b/lib/utils/getStakingRewards/index.ts
@@ -1,8 +1,5 @@
-import { ethers } from "ethers";
 import { getJsonRpcProvider } from "../getJsonRpcProvider";
-import { addresses } from "../../constants";
 import { getEstimatedDailyRebases, getContract } from "..";
-import SKlima from "../../abi/sKlima.json";
 
 export const getStakingRewards = async (params: {
   days: number;
@@ -14,11 +11,11 @@ export const getStakingRewards = async (params: {
     contractName: "distributor",
     provider,
   });
-  const sklimaContract = new ethers.Contract(
-    addresses.mainnet.sklima,
-    SKlima.abi,
-    provider
-  );
+  const sklimaContract = getContract({
+    contractName: "sklimaMain",
+    provider,
+  });
+
   const circSupply = await sklimaContract.circulatingSupply();
   const info = await distributorContract.info(0);
   const stakingReward = await distributorContract.nextRewardAt(info.rate);


### PR DESCRIPTION
## Description

A tiny follow-up PR on https://github.com/KlimaDAO/klimadao/pull/503

- move the creation of the main sKlima contract to lib too
- improve types with letting TypeScript complain when a `contractName` does not exist in the `contractMap`

Now only the bonds contracts are the only ones left!
Will do this as soon as the Bonds views are done.

## Related Ticket

Preparation for #9 

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
