### PR TITLE
run lingui:compile in build script

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",
-    "build": "prettier --check . && next build",
+    "build": "prettier --check . && npm run lingui:compile && next build",
     "start": "next start",
     "export": "next export",
     "lint": "next lint",

--- a/site/package.json
+++ b/site/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prettier --check . && next build",
+    "build": "prettier --check . && npm run lingui:compile && next build",
     "start": "next start",
     "lint": "next lint",
     "lingui:extract": "node ../scripts/lingui.js extract --clean --overwrite",


### PR DESCRIPTION
`npm run postinstall` stopped working. I don't understand why or how this is possible. This is a **temporary workaround** that adds string compilation as a step to the main build script.

Track the underlying issue here #518 