### PR TITLE
Add social share buttons on Single Retirement

### DIFF
--- a/lib/components/Icons/FacebookIcon.tsx
+++ b/lib/components/Icons/FacebookIcon.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+interface Props {
+  className?: string;
+}
+
+export const FacebookIcon = (props: Props) => (
+  <svg
+    className={props.className}
+    width="20"
+    height="20"
+    viewBox="0 0 17 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>Facebook</title>
+    <g clipPath="url(#clip0_1239_302)">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M0.5 8C0.5 11.96 3.38 15.24 7.18 15.92L7.22732 15.8813C7.22495 15.8809 7.22258 15.8804 7.22021 15.88V10.24H5.22021V8H7.22021V6.24C7.22021 4.24 8.50021 3.12 10.3402 3.12C10.9002 3.12 11.5402 3.2 12.1002 3.27999V5.31999H11.0602C10.1002 5.31999 9.86021 5.8 9.86021 6.44V8H11.9802L11.6202 10.24H9.86021V15.88C9.83579 15.8844 9.81136 15.8888 9.78694 15.8929L9.82 15.92C13.62 15.24 16.5 11.96 16.5 8C16.5 3.6 12.9 0 8.5 0C4.1 0 0.5 3.6 0.5 8Z"
+        fill="white"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_1239_302">
+        <rect width="16" height="16" fill="white" transform="translate(0.5)" />
+      </clipPath>
+    </defs>
+  </svg>
+);

--- a/lib/components/ThemeToggle/styles.ts
+++ b/lib/components/ThemeToggle/styles.ts
@@ -11,19 +11,22 @@ export const buttonToggle = css`
   /* min-height to conform with Lighthouse min tap-target */
   min-height: 4.8rem;
   min-width: 4.8rem;
-  padding: 0rem
+  padding: 0rem;
   cursor: pointer;
   border-radius: var(--border-radius);
   transition: opacity 0.3s ease 0s;
   background-color: var(--surface-01);
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     opacity: 0.7;
   }
   &:active {
     transform: scale(0.9);
   }
-  &, &:hover, &:visited {
+  &,
+  &:hover,
+  &:visited {
     color: white; /* same in darkmode */
   }
 `;

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -5,6 +5,7 @@ export { TextInfoTooltip, useTooltipSingleton } from "./TextInfoTooltip";
 export { DiscordIcon } from "./Icons/DiscordIcon";
 export { GithubIcon } from "./Icons/GithubIcon";
 export { LinkedInIcon } from "./Icons/LinkedInIcon";
+export { FacebookIcon } from "./Icons/FacebookIcon";
 export { MetaMaskFoxIcon } from "./Icons/MetaMaskFoxIcon";
 export { KlimaInfinityLogo } from "./Logos/KlimaInfinityLogo";
 export { KlimaInfinityLogoOnly } from "./Logos/KlimaInfinityLogoOnly";

--- a/site/components/FacebookButton/index.tsx
+++ b/site/components/FacebookButton/index.tsx
@@ -6,15 +6,13 @@ export const FACEBOOK_SHARE_URL = "https://www.facebook.com/sharer/sharer.php";
 
 type FacebookHref = {
   url: string;
-  title?: string;
 };
 
-// https://www.facebook.com/sharer/sharer.php?u=https://www.klimadao.finance/&quote=Awesome%20Text!
-export const getFacebookHref = ({ url, title }: FacebookHref) => {
+// https://www.facebook.com/sharer/sharer.php?u=https://www.klimadao.finance
+export const getFacebookHref = ({ url }: FacebookHref) => {
   const shareUrl = new URL(FACEBOOK_SHARE_URL);
   const search = new URLSearchParams({
     u: url,
-    ...(title ? { quote: title } : {}),
   }).toString();
 
   // combine URL with search params
@@ -23,11 +21,10 @@ export const getFacebookHref = ({ url, title }: FacebookHref) => {
 };
 
 type Props = {
-  title?: string;
   url?: string;
 };
 
-export const FacebookButton: FC<Props> = ({ title, url }) => {
+export const FacebookButton: FC<Props> = ({ url }) => {
   const [shareURL, setShareUrl] = useState<string>();
 
   // get parameters on the client because
@@ -35,7 +32,6 @@ export const FacebookButton: FC<Props> = ({ title, url }) => {
   useEffect(() => {
     setShareUrl(
       getFacebookHref({
-        title,
         url: url || window.location.href,
       })
     );

--- a/site/components/FacebookButton/index.tsx
+++ b/site/components/FacebookButton/index.tsx
@@ -1,0 +1,59 @@
+import { FC, useState, useEffect } from "react";
+import { ButtonPrimary, FacebookIcon } from "@klimadao/lib/components";
+import * as styles from "./styles";
+
+export const FACEBOOK_SHARE_URL = "https://www.facebook.com/sharer/sharer.php";
+
+type FacebookHref = {
+  url: string;
+  title?: string;
+};
+
+// https://www.facebook.com/sharer/sharer.php?u=https://www.klimadao.finance/&quote=Awesome%20Text!
+export const getFacebookHref = ({ url, title }: FacebookHref) => {
+  const shareUrl = new URL(FACEBOOK_SHARE_URL);
+  const search = new URLSearchParams({
+    u: url,
+    ...(title ? { quote: title } : {}),
+  }).toString();
+
+  // combine URL with search params
+  shareUrl.search = search;
+  return shareUrl.href;
+};
+
+type Props = {
+  title?: string;
+  url?: string;
+};
+
+export const FacebookButton: FC<Props> = ({ title, url }) => {
+  const [shareURL, setShareUrl] = useState<string>();
+
+  // get parameters on the client because
+  // url can be undefined and window is undefined on server
+  useEffect(() => {
+    setShareUrl(
+      getFacebookHref({
+        title,
+        url: url || window.location.href,
+      })
+    );
+  }, []);
+
+  return (
+    <ButtonPrimary
+      className={styles.facebookButton}
+      href={shareURL}
+      target="_blank"
+      disabled={!shareURL}
+      label={
+        <>
+          <FacebookIcon />
+          Facebook
+        </>
+      }
+      variant="gray"
+    />
+  );
+};

--- a/site/components/FacebookButton/styles.ts
+++ b/site/components/FacebookButton/styles.ts
@@ -1,0 +1,14 @@
+import { css } from "@emotion/css";
+
+export const facebookButton = css`
+  gap: 0.8rem;
+  text-transform: none;
+
+  & svg path {
+    fill: var(--font-02);
+  }
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;

--- a/site/components/LinkedInButton/index.tsx
+++ b/site/components/LinkedInButton/index.tsx
@@ -1,0 +1,56 @@
+import { FC, useState, useEffect } from "react";
+import { ButtonPrimary, LinkedInIcon } from "@klimadao/lib/components";
+import * as styles from "./styles";
+
+export const FACEBOOK_SHARE_URL =
+  "https://www.linkedin.com/sharing/share-offsite/?url={url}";
+
+type LinkedInHref = {
+  url: string;
+};
+
+// https://www.linkedin.com/sharing/share-offsite/?url=https://www.klimadao.finance/
+export const getLinkedInHref = ({ url }: LinkedInHref) => {
+  const shareUrl = new URL(FACEBOOK_SHARE_URL);
+  const search = new URLSearchParams({
+    url: url,
+  }).toString();
+
+  // combine URL with search params
+  shareUrl.search = search;
+  return shareUrl.href;
+};
+
+type Props = {
+  url?: string;
+};
+
+export const LinkedInButton: FC<Props> = ({ url }) => {
+  const [shareURL, setShareUrl] = useState<string>();
+
+  // get parameters on the client because
+  // url can be undefined and window is undefined on server
+  useEffect(() => {
+    setShareUrl(
+      getLinkedInHref({
+        url: url || window.location.href,
+      })
+    );
+  }, []);
+
+  return (
+    <ButtonPrimary
+      className={styles.linkedInButton}
+      href={shareURL}
+      target="_blank"
+      disabled={!shareURL}
+      label={
+        <>
+          <LinkedInIcon />
+          LinkedIn
+        </>
+      }
+      variant="gray"
+    />
+  );
+};

--- a/site/components/LinkedInButton/styles.ts
+++ b/site/components/LinkedInButton/styles.ts
@@ -1,0 +1,14 @@
+import { css } from "@emotion/css";
+
+export const linkedInButton = css`
+  gap: 0.8rem;
+  text-transform: none;
+
+  & svg path {
+    fill: var(--font-02);
+  }
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;

--- a/site/components/TweetButton/index.tsx
+++ b/site/components/TweetButton/index.tsx
@@ -1,0 +1,62 @@
+import { FC, useState, useEffect } from "react";
+import { ButtonPrimary, TwitterIcon } from "@klimadao/lib/components";
+import * as styles from "./styles";
+
+export const TWITTER_INTENT_URL = "https://twitter.com/intent/tweet";
+const TWITTER_HANDLE = "klimadao";
+
+type TwitterHref = {
+  title: string;
+  url: string;
+  tags: string[];
+};
+
+export const getTwitterHref = ({ url, title, tags }: TwitterHref) => {
+  const shareUrl = new URL(TWITTER_INTENT_URL);
+  const search = new URLSearchParams({
+    url,
+    text: title,
+    hashtags: tags.join(","),
+    via: TWITTER_HANDLE,
+  }).toString();
+  // combine URL with search params
+  shareUrl.search = search;
+  return shareUrl.href;
+};
+
+type Props = {
+  title: string;
+  url?: string;
+  tags: string[];
+};
+
+export const TweetButton: FC<Props> = ({ title, url, tags }) => {
+  const [shareURL, setShareUrl] = useState<string>();
+
+  // get parameters on the client because
+  // url can be undefined and window is undefined on server
+  useEffect(() => {
+    const getShareUrl = getTwitterHref({
+      title,
+      url: url || window.location.href,
+      tags,
+    });
+    setShareUrl(getShareUrl);
+  }, []);
+
+  return (
+    <ButtonPrimary
+      className={styles.tweetButton}
+      href={shareURL}
+      target="_blank"
+      disabled={!shareURL}
+      label={
+        <>
+          <TwitterIcon />
+          Twitter
+        </>
+      }
+      variant="gray"
+    />
+  );
+};

--- a/site/components/TweetButton/styles.ts
+++ b/site/components/TweetButton/styles.ts
@@ -1,0 +1,14 @@
+import { css } from "@emotion/css";
+
+export const tweetButton = css`
+  gap: 0.8rem;
+  text-transform: none;
+
+  & svg path {
+    fill: var(--font-02);
+  }
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;

--- a/site/components/pages/Retirements/CopyURLButton/index.tsx
+++ b/site/components/pages/Retirements/CopyURLButton/index.tsx
@@ -2,6 +2,9 @@ import { FC } from "react";
 import { ButtonPrimary } from "@klimadao/lib/components";
 import { Trans } from "@lingui/macro";
 import { useCopyToClipboard } from "hooks/useCopyToClipboard";
+import ContentCopy from "@mui/icons-material/ContentCopy";
+import Check from "@mui/icons-material/Check";
+import * as styles from "./styles";
 
 export const CopyURLButton: FC = () => {
   const [copied, doCopy] = useCopyToClipboard();
@@ -12,11 +15,18 @@ export const CopyURLButton: FC = () => {
 
   return (
     <ButtonPrimary
+      className={styles.copyButton}
       label={
         copied ? (
-          <Trans id="button.copyURL.copied">Copied</Trans>
+          <>
+            <Trans id="button.copyURL.copied">Copied</Trans>
+            <Check fontSize="inherit" />
+          </>
         ) : (
-          <Trans id="button.copyURL.copy">Copy URL</Trans>
+          <>
+            <Trans id="button.copyURL.copy">Copy URL</Trans>
+            <ContentCopy fontSize="inherit" />
+          </>
         )
       }
       onClick={handleCopy}

--- a/site/components/pages/Retirements/CopyURLButton/styles.ts
+++ b/site/components/pages/Retirements/CopyURLButton/styles.ts
@@ -1,0 +1,9 @@
+import { css } from "@emotion/css";
+
+export const copyButton = css`
+  gap: 0.8rem;
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;

--- a/site/components/pages/Retirements/Footer/styles.ts
+++ b/site/components/pages/Retirements/Footer/styles.ts
@@ -2,7 +2,7 @@ import { css } from "@emotion/css";
 import breakpoints from "@klimadao/lib/theme/breakpoints";
 
 export const section = css`
-  padding-top: 1rem;
+  padding-top: 4rem;
   padding-bottom: 4rem;
 
   ${breakpoints.medium} {

--- a/site/components/pages/Retirements/SingleRetirement/ProjectDetails/styles.ts
+++ b/site/components/pages/Retirements/SingleRetirement/ProjectDetails/styles.ts
@@ -2,6 +2,7 @@ import { css } from "@emotion/css";
 import breakpoints from "@klimadao/lib/theme/breakpoints";
 
 export const section = css`
+  padding-top: 5rem;
   padding-bottom: 4rem;
   ${breakpoints.medium} {
     padding-top: 9rem;

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -185,6 +185,16 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
       </Section>
       <Section variant="gray" className={styles.sectionButtons}>
         <div className={styles.sectionButtonsWrap}>
+          <TweetButton
+            title={`${retiree} retired ${retireData.amount} Tonnes of carbon`}
+            tags={["klimadao", "Offset"]}
+          />
+          <FacebookButton />
+          <LinkedInButton />
+        </div>
+      </Section>
+      <Section variant="gray" className={styles.sectionButtons}>
+        <div className={styles.sectionButtonsWrap}>
           <CopyURLButton />
           {retireData.transactionID && (
             <ButtonPrimary
@@ -205,16 +215,6 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
         projectDetails={props.projectDetails}
         offset={props.retirement.offset}
       />
-      <Section variant="gray" className={styles.sectionButtons}>
-        <div className={styles.sectionButtonsWrap}>
-          <TweetButton
-            title={`${retiree} retired ${retireData.amount} Tonnes of carbon`}
-            tags={["klimadao", "Offset"]}
-          />
-          <FacebookButton />
-          <LinkedInButton />
-        </div>
-      </Section>
       <RetirementFooter />
       <Footer />
     </>

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -192,6 +192,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
                 id: "retirement.single.view_on_polygon_scan",
                 message: "View on Polygonscan",
               })}
+              className={styles.buttonViewOnPolygon}
             />
           )}
         </div>

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -11,6 +11,9 @@ import { concatAddress, trimWithLocale } from "@klimadao/lib/utils";
 import { Navigation } from "components/Navigation";
 import { PageHead } from "components/PageHead";
 import { Footer } from "components/Footer";
+import { TweetButton } from "components/TweetButton";
+import { FacebookButton } from "components/FacebookButton";
+import { LinkedInButton } from "components/LinkedInButton";
 import { RetirementHeader } from "./RetirementHeader";
 import { RetirementMessage } from "./RetirementMessage";
 import { RetirementValue } from "./RetirementValue";
@@ -59,6 +62,11 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
     transactionID: retirement.transaction?.id,
   };
 
+  const retiree =
+    retireData.beneficiaryName ||
+    nameserviceDomain ||
+    concatAddress(beneficiaryAddress);
+
   return (
     <>
       <PageHead
@@ -68,11 +76,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
         })}
         mediaTitle={t({
           id: "retirement.head.metaTitle",
-          message: `${
-            retireData.beneficiaryName ||
-            nameserviceDomain ||
-            concatAddress(beneficiaryAddress)
-          } retired ${retireData.amount} Tonnes of carbon`,
+          message: `${retiree} retired ${retireData.amount} Tonnes of carbon`,
         })}
         metaDescription={t({
           id: "retirement.head.metaDescription",
@@ -201,6 +205,16 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
         projectDetails={props.projectDetails}
         offset={props.retirement.offset}
       />
+      <Section variant="gray" className={styles.sectionButtons}>
+        <div className={styles.sectionButtonsWrap}>
+          <TweetButton
+            title={`${retiree} retired ${retireData.amount} Tonnes of carbon`}
+            tags={["klimadao", "Offset"]}
+          />
+          <FacebookButton />
+          <LinkedInButton />
+        </div>
+      </Section>
       <RetirementFooter />
       <Footer />
     </>

--- a/site/components/pages/Retirements/SingleRetirement/styles.ts
+++ b/site/components/pages/Retirements/SingleRetirement/styles.ts
@@ -50,7 +50,7 @@ export const data_description = css`
 `;
 
 export const sectionButtons = css`
-  padding: unset !important;
+  padding: 2.8rem 0 !important;
   grid-column: full;
 `;
 

--- a/site/components/pages/Retirements/SingleRetirement/styles.ts
+++ b/site/components/pages/Retirements/SingleRetirement/styles.ts
@@ -67,3 +67,9 @@ export const sectionButtonsWrap = css`
     flex-direction: row;
   }
 `;
+
+export const buttonViewOnPolygon = css`
+  &:hover {
+    opacity: 0.7; // same styles as of for CopyButton
+  }
+`;

--- a/site/components/pages/Retirements/SingleRetirement/styles.ts
+++ b/site/components/pages/Retirements/SingleRetirement/styles.ts
@@ -61,10 +61,11 @@ export const sectionButtonsWrap = css`
   align-items: center;
   flex-direction: column;
   gap: 2.8rem;
-  padding: 2.8rem 1.5rem;
+  padding: 0rem 1.5rem;
 
   ${breakpoints.medium} {
     flex-direction: row;
+    padding: 0rem 1.5rem;
   }
 `;
 


### PR DESCRIPTION
## Description

This PR adds the Social Share Buttons on the Retirement Single Page:
- Twitter
- Facebook
- Linkedin

**Note:**
Only for Twitter it works **to add a custom text to the shared URL**
For Facebook and Linkedin it does not.

**Another Note:**
In order to make the sharing work properly
=> all meta data has to be correct !
Twitter, Facebook and Linkedin retrieve the data from the meta tags.
=> Twitter takes other meta tags than Facebook or LinkedIn, Try it out yourself.
**Please ensure that all translations are correct for the meta data too** ❗ ❗ 

## Testing

Open the Preview URL and add the retirement page Data.
Like: `https://klimadao-site-git-add-social-share-on-retirement-klimadao.vercel.app/retirements/<YOUR-ADDRESS>/<YOU-NUMBER-OF-RETIREMENT>`

Examples:
- [With KNS](https://klimadao-site-git-add-social-share-on-retirement-klimadao.vercel.app/retirements/markcuban.klima/2)
- [With ENS (-> data always resolves to KNS)](https://klimadao-site-git-add-social-share-on-retirement-klimadao.vercel.app/retirements/klimadao.eth/2) 
- [With custom Beneficiary](https://klimadao-site-git-add-social-share-on-retirement-klimadao.vercel.app/retirements/0x20a580444dd4a90cc8990da7b480c5e3d605a26f/2)

... and use the Social Share buttons
Do not forget: If you really share this link => this will share the Preview URL 🙃 


## Related Ticket

Closes https://github.com/KlimaDAO/klimadao/issues/418

## Screenshots
<p align="center">
<img width="200" alt="Bildschirmfoto 2022-07-04 um 16 20 26" src="https://user-images.githubusercontent.com/95881624/177173778-52f05296-28c1-4b3a-9b58-939a8c55326a.png">
<img width="200" alt="Bildschirmfoto 2022-07-04 um 16 20 47" src="https://user-images.githubusercontent.com/95881624/177173794-773550ec-1ca3-4b2b-bdd8-4b9068690fb4.png">
<img width="200" alt="Bildschirmfoto 2022-07-04 um 16 21 05" src="https://user-images.githubusercontent.com/95881624/177173799-c58044a6-5e73-42c1-b6f3-28c59ac7ca2e.png">
</p>

-----

<p align="center">
<img width="1162" alt="Bildschirmfoto 2022-07-05 um 12 37 57" src="https://user-images.githubusercontent.com/95881624/177310237-fecbe1d2-f03c-46de-860d-942d76e12f3d.png">

</p>


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
