### PR TITLE
fix bond max calc to check max klima to usdc in wallet instead of klima

### DIFF
--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -434,10 +434,7 @@ export const Bond: FC<Props> = (props) => {
       return {
         label: <Trans id="bond.bond">Bond</Trans>,
         onClick: handleBond,
-        disabled:
-          !value ||
-          !bondMax ||
-          Number(bondState?.bondQuote) > bondMax / Number(bondState?.bondPrice),
+        disabled: !value || !bondMax,
       };
     } else if (view === "redeem") {
       return {

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -187,13 +187,10 @@ export const Bond: FC<Props> = (props) => {
       return "0";
     }
     const maxPayable = Number(bondState.maxBondPrice);
-    console.log("bondQuote", bondState.bondQuote)
+    console.log("bondQuote", bondState.bondQuote);
     const bondMax =
-      Number(bondState.bondQuote) <
-      Number(maxPayable)
-        ? (
-            Number(userState.balance.klima)
-          ).toString()
+      Number(bondState.bondQuote) < Number(maxPayable)
+        ? Number(userState.balance.klima).toString()
         : (maxPayable / Number(bondState.bondPrice)).toString();
     return bondMax;
   };
@@ -437,7 +434,10 @@ export const Bond: FC<Props> = (props) => {
       return {
         label: <Trans id="bond.bond">Bond</Trans>,
         onClick: handleBond,
-        disabled: !value || !bondMax || Number(bondState?.bondQuote) > bondMax / Number(bondState?.bondPrice),
+        disabled:
+          !value ||
+          !bondMax ||
+          Number(bondState?.bondQuote) > bondMax / Number(bondState?.bondPrice),
       };
     } else if (view === "redeem") {
       return {

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -187,11 +187,12 @@ export const Bond: FC<Props> = (props) => {
       return "0";
     }
     const maxPayable = Number(bondState.maxBondPrice);
-    //Number(bondState.maxBondPrice) / Number(bondState.bondPrice);
-
     const bondMax =
-      Number(userState.balance.klima) < Number(maxPayable)
-        ? userState.balance.klima
+      Number(userState.balance.klima) * Number(bondState.bondQuote) <
+      Number(maxPayable)
+        ? (
+            Number(userState.balance.klima) * Number(bondState.bondQuote)
+          ).toString()
         : maxPayable.toString();
     return bondMax;
   };

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -187,13 +187,14 @@ export const Bond: FC<Props> = (props) => {
       return "0";
     }
     const maxPayable = Number(bondState.maxBondPrice);
+    console.log("bondQuote", bondState.bondQuote)
     const bondMax =
-      Number(userState.balance.klima) * Number(bondState.bondQuote) <
+      Number(bondState.bondQuote) <
       Number(maxPayable)
         ? (
-            Number(userState.balance.klima) * Number(bondState.bondQuote)
+            Number(userState.balance.klima)
           ).toString()
-        : maxPayable.toString();
+        : (maxPayable / Number(bondState.bondPrice)).toString();
     return bondMax;
   };
 

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -187,10 +187,9 @@ export const Bond: FC<Props> = (props) => {
       return "0";
     }
     const maxPayable = Number(bondState.maxBondPrice);
-    console.log("bondQuote", bondState.bondQuote);
     const bondMax =
-      Number(bondState.bondQuote) < Number(maxPayable)
-        ? Number(userState.balance.klima).toString()
+      Number(userState.balance.klima) * Number(bondState.bondPrice)  < Number(maxPayable)
+        ? userState.balance.klima
         : (maxPayable / Number(bondState.bondPrice)).toString();
     return bondMax;
   };

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -188,7 +188,8 @@ export const Bond: FC<Props> = (props) => {
     }
     const maxPayable = Number(bondState.maxBondPrice);
     const bondMax =
-      Number(userState.balance.klima) * Number(bondState.bondPrice)  < Number(maxPayable)
+      Number(userState.balance.klima) * Number(bondState.bondPrice) <
+      Number(maxPayable)
         ? userState.balance.klima
         : (maxPayable / Number(bondState.bondPrice)).toString();
     return bondMax;

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -367,8 +367,6 @@ export const Bond: FC<Props> = (props) => {
 
   const hasAllowance = () => !!allowance && !!Number(allowance[props.bond]);
 
-  console.log("has allowance", hasAllowance());
-
   const isDisabled = view === "bond" && bondInfo.disabled;
   const getButtonProps = (): ButtonProps => {
     const value = Number(quantity || "0");
@@ -439,7 +437,7 @@ export const Bond: FC<Props> = (props) => {
       return {
         label: <Trans id="bond.bond">Bond</Trans>,
         onClick: handleBond,
-        disabled: !value || !bondMax || Number(bondState?.bondQuote) / Number(bondState?.bondPrice) > bondMax,
+        disabled: !value || !bondMax || Number(bondState?.bondQuote) > bondMax / Number(bondState?.bondPrice),
       };
     } else if (view === "redeem") {
       return {

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -439,7 +439,7 @@ export const Bond: FC<Props> = (props) => {
       return {
         label: <Trans id="bond.bond">Bond</Trans>,
         onClick: handleBond,
-        disabled: !value || !bondMax || Number(bondState?.bondQuote) > bondMax,
+        disabled: !value || !bondMax || Number(bondState?.bondQuote) / Number(bondState?.bondPrice) > bondMax,
       };
     } else if (view === "redeem") {
       return {

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -438,8 +438,7 @@ export const Bond: FC<Props> = (props) => {
       return {
         label: <Trans id="bond.bond">Bond</Trans>,
         onClick: handleBond,
-        disabled: !value || !bondMax,
-        //disabled: !value || !bondMax || Number(bondState?.bondQuote) > bondMax,
+        disabled: !value || !bondMax || Number(bondState?.bondQuote) > bondMax,
       };
     } else if (view === "redeem") {
       return {


### PR DESCRIPTION
## Description
the bond max was checking users wallet to calculate the max a user can spend. we need to multiply user klima balance by bond quote to get the right number and we were not.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
