### PR TITLE
DRAFT: Implemented custom transaction options for all transactions

### DIFF
--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -11,6 +11,7 @@ import BondCalcContract from "@klimadao/lib/abi/BondCalcContract.json";
 import OhmDai from "@klimadao/lib/abi/OhmDai.json";
 import IERC20 from "@klimadao/lib/abi/IERC20.json";
 import KlimaProV2 from "@klimadao/lib/abi/KlimaProV2.json";
+import { getTransactionOptions } from "@klimadao/lib/utils";
 
 const getBondAddress = (params: { bond: Bond }): string => {
   return {
@@ -336,7 +337,11 @@ export const changeApprovalTransaction = async (params: {
     const approvalAddress = getBondAddress({ bond: params.bond });
     const value = ethers.utils.parseUnits("1000000000", "ether");
     params.onStatus("userConfirmation", "");
-    const txn = await contract.approve(approvalAddress, value.toString());
+    const txn = await contract.approve(
+      approvalAddress,
+      value.toString(),
+      await getTransactionOptions()
+    );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);
     params.onStatus("done", "Approval was successful");
@@ -451,7 +456,8 @@ export const bondTransaction = async (params: {
       const txn = await contract.deposit(
         ethers.BigNumber.from(INVERSE_USDC_MARKET_ID),
         [formattedValue, formattedMinAmountOut],
-        [address, addresses.mainnet.daoMultiSig]
+        [address, addresses.mainnet.daoMultiSig],
+        await getTransactionOptions()
       );
       params.onStatus("networkConfirmation", "");
       await txn.wait(1);
@@ -480,7 +486,12 @@ export const bondTransaction = async (params: {
       const valueInWei = ethers.utils.parseUnits(params.value, "ether");
       const address = await signer.getAddress();
       params.onStatus("userConfirmation", "");
-      const txn = await contract.deposit(valueInWei, maxPremium, address);
+      const txn = await contract.deposit(
+        valueInWei,
+        maxPremium,
+        address,
+        await getTransactionOptions()
+      );
       params.onStatus("networkConfirmation", "");
       await txn.wait(1);
       params.onStatus("done", "Bond acquired successfully");
@@ -511,7 +522,11 @@ export const redeemTransaction = async (params: {
       signer
     );
     params.onStatus("userConfirmation", "");
-    const txn = await contract.redeem(params.address, params.shouldAutostake);
+    const txn = await contract.redeem(
+      params.address,
+      params.shouldAutostake,
+      await getTransactionOptions()
+    );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);
     params.onStatus("done", "Bond redeemed successfully");

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -1,6 +1,7 @@
 import { ethers, providers } from "ethers";
 import { Thunk } from "state";
 import { setCarbonRetiredBalances, updateAllowances } from "state/user";
+import { getTransactionOptions } from "@klimadao/lib/utils";
 
 import {
   addresses,
@@ -107,7 +108,8 @@ export const changeApprovalTransaction = async (params: {
     params.onStatus("userConfirmation", "");
     const txn = await contract.approve(
       addresses["mainnet"].retirementAggregator,
-      parsedValue.toString()
+      parsedValue.toString(),
+      await getTransactionOptions()
     );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);
@@ -215,7 +217,8 @@ export const retireCarbonTransaction = async (params: {
         params.beneficiaryAddress || params.address,
         params.beneficiaryName,
         params.retirementMessage,
-        params.specificAddresses
+        params.specificAddresses,
+        await getTransactionOptions()
       );
     } else {
       txn = await retireContract.retireCarbon(
@@ -228,7 +231,8 @@ export const retireCarbonTransaction = async (params: {
         params.amountInCarbon,
         params.beneficiaryAddress || params.address,
         params.beneficiaryName,
-        params.retirementMessage
+        params.retirementMessage,
+        await getTransactionOptions()
       );
     }
 

--- a/app/actions/pklima.ts
+++ b/app/actions/pklima.ts
@@ -9,6 +9,7 @@ import {
   trimStringDecimals,
   getContract,
 } from "@klimadao/lib/utils";
+import { getTransactionOptions } from "@klimadao/lib/utils";
 
 export const loadTerms = (params: {
   address: string;
@@ -72,7 +73,8 @@ export const changeApprovalTransaction = async (params: {
     params.onStatus("userConfirmation", "");
     const txn = await contract.approve(
       addresses["mainnet"].pklima_exercise,
-      value.toString()
+      value.toString(),
+      await getTransactionOptions()
     );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);
@@ -100,7 +102,8 @@ export const exerciseTransaction = async (params: {
     });
     params.onStatus("userConfirmation", "");
     const txn = await contract.exercise(
-      ethers.utils.parseUnits(params.value, "ether")
+      ethers.utils.parseUnits(params.value, "ether"),
+      await getTransactionOptions()
     );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);

--- a/app/actions/stake.ts
+++ b/app/actions/stake.ts
@@ -28,7 +28,11 @@ export const changeApprovalTransaction = async (params: {
       unstake: addresses["mainnet"].staking,
     }[params.action];
     params.onStatus("userConfirmation", "");
-    const txn = await contract.approve(address, parsedValue.toString());
+    const txn = await contract.approve(
+      address,
+      parsedValue.toString(),
+      await getTransactionOptions()
+    );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);
     params.onStatus("done", "Transaction approved successfully");
@@ -67,7 +71,7 @@ export const changeStakeTransaction = async (params: {
     const txn =
       params.action === "stake"
         ? await contract.stake(parsedValue, transactionOptions)
-        : await contract.unstake(parsedValue, true); // always trigger rebase because gas is cheap
+        : await contract.unstake(parsedValue, true, transactionOptions); // always trigger rebase because gas is cheap
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);
     params.onStatus("done", "Transaction confirmed");

--- a/app/actions/wrap.ts
+++ b/app/actions/wrap.ts
@@ -2,6 +2,7 @@ import { addresses } from "@klimadao/lib/constants";
 import { ethers, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
 import { formatUnits, getContract } from "@klimadao/lib/utils";
+import { getTransactionOptions } from "@klimadao/lib/utils";
 
 export const changeApprovalTransaction = async (params: {
   value: string;
@@ -17,7 +18,8 @@ export const changeApprovalTransaction = async (params: {
     params.onStatus("userConfirmation", "");
     const txn = await contract.approve(
       addresses["mainnet"].wsklima,
-      value.toString()
+      value.toString(),
+      await getTransactionOptions()
     );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);
@@ -47,7 +49,8 @@ export const wrapTransaction = async (params: {
     params.onStatus("userConfirmation", "");
     const decimal = params.action === "wrap" ? 9 : 18;
     const txn = await contract[params.action](
-      ethers.utils.parseUnits(params.value, decimal)
+      ethers.utils.parseUnits(params.value, decimal),
+      await getTransactionOptions()
     );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);


### PR DESCRIPTION
## Description

Implemented custom transaction options for all transactions. In the last PR it was implemented only for the stake transaction.

This PR is marked as draft because the following tests should be done (maybe by different persons).

- [x] Bond: Approve
- [x] Bond: Deposit (inverse_usdc)
- [ ] Bond: Deposit (other asset)
- [ ] Bond: Redeem
- [x] Offset: Approve
- [x] Offset: Retire carbon
- [x] Offset: Retire carbon with specific address
- [ ] PKlima: Approve
- [ ] PKlima: Exercise
- [ ] Stake: Approve Stake
- [X] Stake: Approve Unstake
- [X] Stake: Stake
- [X] Stake: Unstake
- [x] Wrap: Approve
- [x] Wrap: Wrap
- [x] Wrap: Unwrap





## Related Ticket

Resolves #519

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
