### PR TITLE
pledge dashboard tweaks

### DIFF
--- a/site/components/pages/Pledge/PledgeDashboard/Cards/BaseCard/styles.ts
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/BaseCard/styles.ts
@@ -1,5 +1,6 @@
 import { css } from "@emotion/css";
 import * as common from "@klimadao/lib/theme/common";
+import breakpoints from "@klimadao/lib/theme/breakpoints";
 
 export const cardHeader = css`
   display: flex;
@@ -28,4 +29,8 @@ export const card = css`
   flex-direction: column;
   align-content: start;
   padding: 1.8rem;
+
+  ${breakpoints.desktop} {
+    padding: 2rem;
+  }
 `;

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/BaseCard/styles.ts
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/BaseCard/styles.ts
@@ -18,7 +18,7 @@ export const title = css`
 
   svg {
     fill: var(--font-01);
-    font-size: 3rem;
+    font-size: 3.2rem;
   }
 `;
 
@@ -31,6 +31,6 @@ export const card = css`
   padding: 1.8rem;
 
   ${breakpoints.desktop} {
-    padding: 2rem;
+    padding: 2.2rem;
   }
 `;

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx
@@ -33,11 +33,11 @@ const renderActiveIndex = (props: SectorProps) => (
 );
 
 export const FootprintChart: FC<FootprintChartProps> = (props) => {
-  const [activeIndex, setactiveIndex] = useState<number>(33);
+  const [activeIndex, setActiveIndex] = useState<number>(33);
 
-  const onSectorLeave = (): void => setactiveIndex(33);
+  const onSectorLeave = (): void => setActiveIndex(33);
   const onSectorEnter = (_data: CategoryWithPercent, index: number): void =>
-    setactiveIndex(index);
+    setActiveIndex(index);
 
   return (
     <PieChart width={200} height={200}>
@@ -97,7 +97,7 @@ const CustomTooltip: FC<TooltipProps<number, string>> = ({
           {payload[0].name}
         </Text>
         <Text t="caption" color="lightest">
-          {payload[0].value}% of footprint
+          {+payload[0].payload.percent.toFixed(2)}% of footprint
         </Text>
         <Text t="caption" color="lightest">
           {payload[0].payload.quantity} Carbon Tonne(s)

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
@@ -47,7 +47,7 @@ const calcFootprintPercent = (
 ): CategoryWithPercent[] => {
   return categories.map((category, index) => ({
     ...category,
-    percent: Math.round((category.quantity / total) * 100),
+    percent: (category.quantity / total) * 100,
     fill: COLOR_PALETTE[index],
   }));
 };
@@ -100,7 +100,7 @@ export const FootprintCard: FC<Props> = (props) => {
                       className={styles.categoryRow_percentage}
                       style={{ color: `${category.fill}` }}
                     >
-                      {category.percent}%
+                      {+category.percent.toFixed(2)}%
                     </span>
                   </Text>
                 </div>

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
@@ -41,7 +41,7 @@ export interface CategoryWithPercent extends Category {
   fill: string;
 }
 
-const calcFootprintPercent = (
+const calculateFootprintPercent = (
   total: number,
   categories: Category[]
 ): CategoryWithPercent[] => {
@@ -58,7 +58,7 @@ export const FootprintCard: FC<Props> = (props) => {
   const sortedCategories = footprint.categories.sort(
     (a, b) => a.quantity - b.quantity
   );
-  const categoriesWithPercent = calcFootprintPercent(
+  const categoriesWithPercent = calculateFootprintPercent(
     footprint.total,
     sortedCategories
   );

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/styles.ts
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/styles.ts
@@ -50,15 +50,22 @@ export const categoryRow = css`
 `;
 
 export const categoryRow_name = css`
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-word;
 `;
 
 export const catergoryRow_values = css`
   display: flex;
   flex-direction: row;
   white-space: nowrap;
+
+  ${breakpoints.medium} {
+    min-width: 18rem;
+    justify-content: end;
+  }
+
+  ${breakpoints.desktop} {
+    min-width: 16rem;
+  }
 `;
 
 export const categoryRow_divider = css`

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import HowToRegOutlinedIcon from "@mui/icons-material/HowToRegOutlined";
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import { Text } from "@klimadao/lib/components";
 
 import { BaseCard } from "../BaseCard";
@@ -13,7 +13,7 @@ export const MethodologyCard: FC<Props> = (props) => {
   return (
     <BaseCard
       title="Methodology"
-      icon={<HowToRegOutlinedIcon fontSize="large" />}
+      icon={<DescriptionOutlinedIcon fontSize="large" />}
     >
       <Text t="body2">{props.methodology || defaultText}</Text>
     </BaseCard>

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx
@@ -15,9 +15,7 @@ export const MethodologyCard: FC<Props> = (props) => {
       title="Methodology"
       icon={<HowToRegOutlinedIcon fontSize="large" />}
     >
-      <Text t="body2">
-        <em>"{props.methodology || defaultText}"</em>
-      </Text>
+      <Text t="body2">{props.methodology || defaultText}</Text>
     </BaseCard>
   );
 };

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -27,7 +27,11 @@ export const formSchema = yup
       .array()
       .of(
         yup.object({
-          name: yup.string().required("Enter a category").trim(),
+          name: yup
+            .string()
+            .required("Enter a category")
+            .max(32, "Enter less than 32 characters")
+            .trim(),
           quantity: yup
             .number()
             .required("Enter a carbon tonne estimate")

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -10,12 +10,12 @@ export const formSchema = yup
     description: yup
       .string()
       .required("Enter a pledge")
-      .max(280, "Enter less than 280 characters")
+      .max(500, "Enter less than 500 characters")
       .trim(),
     methodology: yup
       .string()
       .required("Enter a methodology")
-      .max(280, "Enter less than 280 characters")
+      .max(1000, "Enter less than 1000 characters")
       .trim(),
     footprint: yup
       .number()


### PR DESCRIPTION
## Description

Addresses the majority of display related feedback raised through QA:
- Changes `methodology` character limit to 1000 (arbitrary number)
- Changes `description` character limit to 500.
- Update methodology card icon,
- Display footprint percent values to 2 decimal points (on chart tooltip and table)
- Footprint category:
  - Made the call to remove text overflow and just wrap the text instead of showing tooltip on hover.
  - Limit category naming to 32 characters, the equivalent of two rows on desktop view. We can revisit these character limit if the need arises.

## Related Ticket

https://github.com/KlimaDAO/klimadao/issues/489

## Changes

| Before  | After  |
|---------|--------|
|<img width="531" alt="image" src="https://user-images.githubusercontent.com/97446324/180168420-247ddd26-3d0c-4cd2-8b34-8f57e8878614.png">|<img width="539" alt="image" src="https://user-images.githubusercontent.com/97446324/180168238-03a96d0f-1ffa-4395-a372-4ae48dcfc0fe.png">|


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
