### PR TITLE
fix: do not translate hard coded values

### DIFF
--- a/site/components/pages/Infinity/Cards/Card.tsx
+++ b/site/components/pages/Infinity/Cards/Card.tsx
@@ -37,21 +37,17 @@ export const Card: FC<Props> = ({ card }) => {
       </div>
       <div className={styles.cardContent}>
         <Text t="body4" className={styles.cardMessage}>
-          <Trans id="infinity.quote">“{card.description}”</Trans>
+          “{card.description}”
         </Text>
         <div className={styles.cardFooter}>
           <div>
-            <Text t="h3">
-              <Trans id="infinity.retired_tons_number">
-                {trimWithLocale(card.tonsRetired, 2, locale)}
-              </Trans>
-            </Text>
+            <Text t="h3">{trimWithLocale(card.tonsRetired, 2, locale)}</Text>
             <Text>
               <Trans id="infinity.tonnes">Tonnes</Trans>
             </Text>
           </div>
           <Text t="badge" className={styles.cardDate}>
-            <Trans id="infinity.retired_date">{card.date}</Trans>
+            {card.date}
           </Text>
         </div>
       </div>

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"
@@ -850,19 +856,7 @@ msgstr ""
 msgid "infinity.polygon_story_title"
 msgstr ""
 
-#: components/pages/Infinity/Cards/Card.tsx:40
-msgid "infinity.quote"
-msgstr ""
-
-#: components/pages/Infinity/Cards/Card.tsx:54
-msgid "infinity.retired_date"
-msgstr ""
-
-#: components/pages/Infinity/Cards/Card.tsx:45
-msgid "infinity.retired_tons_number"
-msgstr ""
-
-#: components/pages/Infinity/Cards/Card.tsx:50
+#: components/pages/Infinity/Cards/Card.tsx:46
 #: components/pages/Infinity/index.tsx:389
 #: components/pages/Infinity/index.tsx:403
 msgid "infinity.tonnes"

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -856,19 +856,7 @@ msgstr "Polygon offset the network's carbon emissions since inception - roughly 
 msgid "infinity.polygon_story_title"
 msgstr "Polygon chose Klima Infinity to offset their blockchain network"
 
-#: components/pages/Infinity/Cards/Card.tsx:40
-msgid "infinity.quote"
-msgstr "“{0}”"
-
-#: components/pages/Infinity/Cards/Card.tsx:54
-msgid "infinity.retired_date"
-msgstr "{0}"
-
-#: components/pages/Infinity/Cards/Card.tsx:45
-msgid "infinity.retired_tons_number"
-msgstr "{0}"
-
-#: components/pages/Infinity/Cards/Card.tsx:50
+#: components/pages/Infinity/Cards/Card.tsx:46
 #: components/pages/Infinity/index.tsx:389
 #: components/pages/Infinity/index.tsx:403
 msgid "infinity.tonnes"


### PR DESCRIPTION
## Description

The infinity card values are all hard coded.
No need to wrap them in translation tags.

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
