### PR TITLE
site/pledges: extract strings for i18n

### DIFF
--- a/site/components/pages/Pledge/HeaderDesktop/index.tsx
+++ b/site/components/pages/Pledge/HeaderDesktop/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import dynamic from "next/dynamic";
+import { t } from "@lingui/macro";
 import { KlimaInfinityLogo, ButtonPrimary } from "@klimadao/lib/components";
 import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
 import Link from "next/link";
@@ -37,7 +38,7 @@ export const HeaderDesktop: FC<Props> = (props) => {
         {props.canEditPledge && (
           <ButtonPrimary
             key="toggleModal"
-            label="Edit Pledge"
+            label={t({ id: "pledges.edit_pledge", message: "Edit Pledge" })}
             onClick={() => props.toggleEditModal?.(true)}
           />
         )}
@@ -45,7 +46,10 @@ export const HeaderDesktop: FC<Props> = (props) => {
         {isConnected && address ? (
           <ButtonPrimary label={concatAddress(address)} onClick={disconnect} />
         ) : (
-          <ButtonPrimary label="Connect" onClick={connect} />
+          <ButtonPrimary
+            label={t({ id: "shared.connect", message: "Connect" })}
+            onClick={connect}
+          />
         )}
       </div>
     </div>

--- a/site/components/pages/Pledge/HeaderMobile/index.tsx
+++ b/site/components/pages/Pledge/HeaderMobile/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import dynamic from "next/dynamic";
+import { t } from "@lingui/macro";
 import { ButtonPrimary, KlimaInfinityLogoOnly } from "@klimadao/lib/components";
 import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
 
@@ -53,7 +54,7 @@ export const HeaderMobile: FC<Props> = (props) => {
           ) : (
             <ButtonPrimary
               className={styles.authButton}
-              label="Connect"
+              label={t({ id: "shared.connect", message: "Connect" })}
               onClick={connect}
             />
           )}

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/TokenRow/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/TokenRow/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { useRouter } from "next/router";
+import { Trans } from "@lingui/macro";
 import { Text } from "@klimadao/lib/components";
 import { trimStringDecimals } from "@klimadao/lib/utils";
 
@@ -36,7 +37,7 @@ export const TokenRow: FC<TokenRowProps> = (props) => {
           </div>
         ) : (
           <Text t="h4" color="lightest">
-            Loading...
+            <Trans id="shared.loading">Loading...</Trans>
           </Text>
         )}
       </div>

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
+import { t } from "@lingui/macro";
 import CloudQueueIcon from "@mui/icons-material/CloudQueue";
 import map from "lodash/map";
 import groupBy from "lodash/groupBy";
@@ -77,7 +78,13 @@ export const AssetBalanceCard: FC<Props> = (props) => {
   }, []);
 
   return (
-    <BaseCard title="Carbon Assets" icon={<CloudQueueIcon fontSize="large" />}>
+    <BaseCard
+      title={t({
+        id: "pledges.dashboard.assets.title",
+        message: "Carbon Assets",
+      })}
+      icon={<CloudQueueIcon fontSize="large" />}
+    >
       <div className={styles.tokenCardContainer}>
         {map(tokenHoldingAndBalances, (token, index) => (
           <div className={styles.tokenRowContainer} key={index}>

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx
@@ -1,4 +1,6 @@
 import React, { FC, useState } from "react";
+import { useRouter } from "next/router";
+import { Trans } from "@lingui/macro";
 import {
   Cell,
   Pie,
@@ -9,6 +11,7 @@ import {
   TooltipProps,
 } from "recharts";
 import { Text } from "@klimadao/lib/components";
+import { trimWithLocale } from "@klimadao/lib/utils";
 
 import { CategoryWithPercent } from ".";
 import * as styles from "./styles";
@@ -89,6 +92,8 @@ const CustomTooltip: FC<TooltipProps<number, string>> = ({
   active,
   payload,
 }) => {
+  const { locale } = useRouter();
+
   if (active && payload && payload.length) {
     return (
       <div className={styles.footprintChart_tooltip}>
@@ -96,10 +101,15 @@ const CustomTooltip: FC<TooltipProps<number, string>> = ({
           {payload[0].name}
         </Text>
         <Text t="caption" color="lightest">
-          {+payload[0].payload.percent.toFixed(2)}% of footprint
+          <Trans id="pledges.dashboard.footprint.tooltip.category_percent">
+            {trimWithLocale(payload[0].payload.percent, 2, locale)}% of
+            footprint
+          </Trans>
         </Text>
         <Text t="caption" color="lightest">
-          {payload[0].payload.quantity} Carbon Tonne(s)
+          <Trans id="pledges.dashboard.footprint.tooltip.quantity">
+            {payload[0].payload.quantity} Carbon Tonne(s)
+          </Trans>
         </Text>
       </div>
     );

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
@@ -1,7 +1,10 @@
 import React, { FC } from "react";
+import { useRouter } from "next/router";
 import dynamic from "next/dynamic";
+import { Trans, t } from "@lingui/macro";
 import LocalGasStationOutlinedIcon from "@mui/icons-material/LocalGasStationOutlined";
 import { Text } from "@klimadao/lib/components";
+import { trimWithLocale } from "@klimadao/lib/utils";
 
 import { Footprint, Category } from "../../../types";
 import { BaseCard } from "../BaseCard";
@@ -53,8 +56,10 @@ const calculateFootprintPercent = (
 };
 
 export const FootprintCard: FC<Props> = (props) => {
+  const { locale } = useRouter();
   const footprint = props.footprint[props.footprint.length - 1];
   const hasFootprint = footprint.total !== 0;
+  // footprint categories sorted from low to high
   const sortedCategories = footprint.categories.sort(
     (a, b) => a.quantity - b.quantity
   );
@@ -65,7 +70,10 @@ export const FootprintCard: FC<Props> = (props) => {
 
   return (
     <BaseCard
-      title="Footprint"
+      title={t({
+        id: "pledges.dashboard.footprint.title",
+        message: "Footprint",
+      })}
       icon={<LocalGasStationOutlinedIcon fontSize="large" />}
     >
       <div className={styles.summary}>
@@ -76,10 +84,10 @@ export const FootprintCard: FC<Props> = (props) => {
         )}
         <div className={styles.footprintTotal}>
           <Text t="h1" uppercase>
-            {+footprint.total.toFixed(2)}
+            {trimWithLocale(footprint.total, 2, locale)}
           </Text>
           <Text t="h3" color="lightest" uppercase>
-            Tonnes
+            <Trans id="pledges.dashboard.footprint.tonnes">Tonnes</Trans>
           </Text>
         </div>
       </div>
@@ -94,13 +102,13 @@ export const FootprintCard: FC<Props> = (props) => {
                 </Text>
                 <div className={styles.catergoryRow_values}>
                   <Text t="h4" uppercase>
-                    {+category.quantity.toFixed(2)}{" "}
+                    {trimWithLocale(category.quantity, 2, locale)}{" "}
                     <span className={styles.categoryRow_divider}>|</span>{" "}
                     <span
                       className={styles.categoryRow_percentage}
                       style={{ color: `${category.fill}` }}
                     >
-                      {+category.percent.toFixed(2)}%
+                      {trimWithLocale(category.percent, 2, locale)}%
                     </span>
                   </Text>
                 </div>

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from "react";
+import { t } from "@lingui/macro";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import { Text } from "@klimadao/lib/components";
 
@@ -9,10 +10,17 @@ type Props = {
 };
 
 export const MethodologyCard: FC<Props> = (props) => {
-  const defaultText = "How will you meet your pledge?";
+  const defaultText = t({
+    id: "pledges.dashboard.metholodogy.default_text",
+    message: "How will you meet your pledge?",
+  });
+
   return (
     <BaseCard
-      title="Methodology"
+      title={t({
+        id: "pledges.dashboard.metholodogy.title",
+        message: "Methodology",
+      })}
       icon={<DescriptionOutlinedIcon fontSize="large" />}
     >
       <Text t="body2">{props.methodology || defaultText}</Text>

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from "react";
+import { t } from "@lingui/macro";
 import MailOutlineIcon from "@mui/icons-material/MailOutline";
 import { Text } from "@klimadao/lib/components";
 
@@ -9,10 +10,19 @@ type Props = {
 };
 
 export const PledgeCard: FC<Props> = (props) => {
-  const defaultText = "Write your pledge today!";
+  const defaultText = t({
+    id: "pledges.dashboard.pledge.default_text",
+    message: "Write your pledge today!",
+  });
 
   return (
-    <BaseCard title="Pledge" icon={<MailOutlineIcon fontSize="large" />}>
+    <BaseCard
+      title={t({
+        id: "pledges.dashboard.pledge.title",
+        message: "Pledge",
+      })}
+      icon={<MailOutlineIcon fontSize="large" />}
+    >
       <Text t="body2">
         <em>"{props.pledge || defaultText}"</em>
       </Text>

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from "react";
+import { Trans } from "@lingui/macro";
 import {
   Bar,
   BarChart,
@@ -137,7 +138,9 @@ const CustomTooltip: FC<TooltipProps<number, string>> = ({
           {payload[0].payload.name}
         </Text>
         <Text t="caption" color="lightest">
-          {+Number(payload[0].value).toFixed(2)} Carbon Tonne(s) retired
+          <Trans id="pledges.dashboard.retirements.tooltip.tonnes_retired">
+            {+Number(payload[0].value).toFixed(2)} Carbon Tonne(s) Retired
+          </Trans>
         </Text>
       </div>
     );

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from "react";
+import { Trans, t } from "@lingui/macro";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import LocalFireDepartmentIcon from "@mui/icons-material/LocalFireDepartment";
@@ -39,7 +40,10 @@ export const RetirementsCard: FC<Props> = (props) => {
 
   return (
     <BaseCard
-      title="Retirements"
+      title={t({
+        id: "pledges.dashboard.retirements.title",
+        message: "Retirements",
+      })}
       icon={<LocalFireDepartmentIcon fontSize="large" />}
       action={linkToRetirements}
     >
@@ -50,12 +54,14 @@ export const RetirementsCard: FC<Props> = (props) => {
           </Text>
         ) : (
           <Text t="h4" color="lightest">
-            Loading...
+            <Trans id="shared.loading">Loading...</Trans>
           </Text>
         )}
 
         <Text t="h4" color="lightest">
-          Total Carbon Tonnes Retired
+          <Trans id="pledges.dashboard.retirements.total_tonnes_retired">
+            Total Carbon Tonnes Retired
+          </Trans>
         </Text>
       </div>
 

--- a/site/components/pages/Pledge/PledgeDashboard/Profile/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Profile/index.tsx
@@ -1,4 +1,6 @@
 import React, { FC, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { Trans } from "@lingui/macro";
 import { Text } from "@klimadao/lib/components";
 import {
   concatAddress,
@@ -7,6 +9,7 @@ import {
 } from "@klimadao/lib/utils";
 import { Domain } from "@klimadao/lib/types/domains";
 import { RetirementsTotalsAndBalances } from "@klimadao/lib/types/offset";
+import { trimWithLocale } from "@klimadao/lib/utils";
 
 import { getInfuraUrlPolygon } from "lib/getInfuraUrl";
 import { Pledge } from "../../types";
@@ -19,6 +22,7 @@ type Props = {
 };
 
 export const Profile: FC<Props> = (props) => {
+  const { locale } = useRouter();
   const [profileData, setProfileData] = useState<Domain | null>(null);
 
   useEffect(() => {
@@ -46,9 +50,7 @@ export const Profile: FC<Props> = (props) => {
   const pledgeProgress =
     totalTonnesRetired && (totalTonnesRetired / currentFootprint.total) * 100;
   const displayPledgeProgress =
-    !isNaN(totalTonnesRetired) &&
-    !isNaN(totalTonnesRetired) &&
-    currentFootprint.total > 0;
+    !isNaN(totalTonnesRetired) && currentFootprint.total > 0;
 
   const renderPledgeProgress = () => {
     if (!displayPledgeProgress) return null;
@@ -56,14 +58,18 @@ export const Profile: FC<Props> = (props) => {
     if (pledgeProgress >= 100) {
       return (
         <Text t="h4" className={styles.pledgeProgress}>
-          &ge; 100% of Pledge Met
+          <Trans id="pledges.dashboard.profile.pledge_met">
+            &ge; 100% of Pledge Met
+          </Trans>
         </Text>
       );
     }
 
     return (
       <Text t="h4" className={styles.pledgeProgress}>
-        {Math.round(pledgeProgress)}% of Pledge Met
+        <Trans id="pledges.dashboard.profile.pledge_progress">
+          {Math.round(pledgeProgress)}% of Pledge Met
+        </Trans>
       </Text>
     );
   };
@@ -92,8 +98,11 @@ export const Profile: FC<Props> = (props) => {
 
       <div className={styles.progressContainer}>
         <Text t="h4" color="lightest" align="center">
-          Pledged to Offset{" "}
-          <strong>{+currentFootprint.total.toFixed(2)}</strong> Carbon Tonnes
+          <Trans id="pledges.dashboard.profile.pledged_to_offset">
+            Pledged to Offset{" "}
+            <strong>{trimWithLocale(currentFootprint.total, 2, locale)}</strong>{" "}
+            Carbon Tonnes
+          </Trans>
         </Text>
 
         {renderPledgeProgress()}

--- a/site/components/pages/Pledge/PledgeDashboard/Profile/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Profile/index.tsx
@@ -59,7 +59,7 @@ export const Profile: FC<Props> = (props) => {
       return (
         <Text t="h4" className={styles.pledgeProgress}>
           <Trans id="pledges.dashboard.profile.pledge_met">
-            &ge; 100% of Pledge Met
+            ≥ 100% of Pledge Met
           </Trans>
         </Text>
       );

--- a/site/components/pages/Pledge/PledgeDashboard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { NextPage } from "next";
+import { t } from "@lingui/macro";
 import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
 import { RetirementsTotalsAndBalances } from "@klimadao/lib/types/offset";
 
@@ -41,14 +42,25 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
     setShowModal(false);
   };
 
+  const pledgeOwnerTitle =
+    pledge.name || props.domain || concatAddress(pledge.ownerAddress);
+
   return (
     <PledgeLayout canEditPledge={canEditPledge} toggleEditModal={setShowModal}>
       <PageHead
-        title="Klima Infinity | Pledge"
-        mediaTitle={`${
-          pledge.name || props.domain || concatAddress(pledge.ownerAddress)
-        }'s pledge`}
-        metaDescription="Drive climate action and earn rewards with a carbon-backed digital currency." // Need better meta description
+        title={t({
+          id: "pledges.dashboard.head.title",
+          message: "KlimaDAO | Pledges",
+        })}
+        mediaTitle={t({
+          id: "pledges.dashboard.head.metaTitle",
+          message: `${pledgeOwnerTitle}'s pledge`,
+        })}
+        metaDescription={t({
+          id: "shared.head.description",
+          message:
+            "Drive climate action and earn rewards with a carbon-backed digital currency.", // Do we need a better metadescription??
+        })}
         canonicalUrl={props.canonicalUrl}
       />
       <Modal
@@ -66,7 +78,7 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
       <div className={styles.contentContainer}>
         <Profile
           domain={props.domain}
-          pledge={props.pledge}
+          pledge={pledge}
           retirements={props.retirements}
         />
 

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -1,7 +1,9 @@
 import React, { FC, useState } from "react";
+import { Trans, t } from "@lingui/macro";
+import { useRouter } from "next/router";
 import { ButtonPrimary, Text } from "@klimadao/lib/components";
 import ClearIcon from "@mui/icons-material/Clear";
-import { useWeb3 } from "@klimadao/lib/utils";
+import { trimWithLocale, useWeb3 } from "@klimadao/lib/utils";
 import { yupResolver } from "@hookform/resolvers/yup";
 import {
   useForm,
@@ -28,6 +30,7 @@ type TotalFootprintProps = {
 };
 
 const TotalFootprint = ({ control, setValue }: TotalFootprintProps) => {
+  const { locale } = useRouter();
   const categories = useWatch({ name: "categories", control });
 
   const totalFootprint: number = categories.reduce(
@@ -38,7 +41,10 @@ const TotalFootprint = ({ control, setValue }: TotalFootprintProps) => {
 
   return (
     <Text t="h4">
-      Total Footprint: {+totalFootprint.toFixed(2)} Carbon Tonnes
+      <Trans id="pledges.form.total_footprint_summary">
+        Total Footprint: {trimWithLocale(totalFootprint, 2, locale)} Carbon
+        Tonnes
+      </Trans>
     </Text>
   );
 };
@@ -98,20 +104,30 @@ export const PledgeForm: FC<Props> = (props) => {
     <form className={styles.container} onSubmit={handleSubmit(onSubmit)}>
       {serverError && (
         <Text className={styles.errorMessage} t="caption">
-          Something went wrong. Please try again.
+          <Trans id="pledges.form.generic_error">
+            Something went wrong. Please try again.
+          </Trans>
         </Text>
       )}
 
       <InputField
-        label="Name"
-        placeholder="Name or company name"
+        id="name"
+        label={t({ id: "pledges.form.input.name.label", message: "Name" })}
+        placeholder={t({
+          id: "pledges.form.input.name.placeholder",
+          message: "Name or company name",
+        })}
         type="text"
         errors={formState.errors.name}
         {...register("name")}
       />
 
       <InputField
-        label="Profile image url (optional)"
+        id="profileImageUrl"
+        label={t({
+          id: "pledges.form.input.profileImageUrl.label",
+          message: "Profile image url (optional)",
+        })}
         placeholder="https://"
         type="text"
         errors={formState.errors.profileImageUrl}
@@ -120,28 +136,45 @@ export const PledgeForm: FC<Props> = (props) => {
 
       <TextareaField
         id="pledge"
-        label="Pledge"
         rows={2}
-        placeholder="What is your pledge?"
+        label={t({
+          id: "pledges.form.input.description.label",
+          message: "Pledge",
+        })}
+        placeholder={t({
+          id: "pledges.form.input.description.placeholder",
+          message: "What is your pledge?",
+        })}
         errors={formState.errors.description}
         {...register("description")}
       />
 
       <TextareaField
         id="methodology"
-        label="Methodology"
         rows={6}
-        placeholder="What tools or methodologies did you use to determine your carbon footprint?"
+        label={t({
+          id: "pledges.form.input.methodology.label",
+          message: "Methodology",
+        })}
+        placeholder={t({
+          id: "pledges.form.input.methodology.placeholder",
+          message:
+            "What tools or methodologies did you use to calculate your carbon footprint?",
+        })}
         errors={formState.errors.methodology}
         {...register("methodology")}
       />
 
       <div className={styles.categories_section}>
-        <Text t="caption">Footprint</Text>
+        <Text t="caption">
+          <Trans id="pledges.form.footprint.label">Footprint</Trans>
+        </Text>
 
         {fields.length === 0 && (
           <Text t="caption" style={{ textAlign: "center", marginTop: "1rem" }}>
-            Add a category and start calculating your carbon footprint
+            <Trans id="pledges.form.footprint.prompt">
+              Add a category and start calculating your carbon footprint
+            </Trans>
           </Text>
         )}
 
@@ -150,18 +183,30 @@ export const PledgeForm: FC<Props> = (props) => {
             <div className={styles.categoryRow} key={field.id}>
               <div className={styles.categoryRow_inputs}>
                 <InputField
-                  label="Name"
                   hideLabel
-                  placeholder="Category name"
+                  label={t({
+                    id: "pledges.form.input.categoryName.label",
+                    message: "Category",
+                  })}
+                  placeholder={t({
+                    id: "pledges.form.input.categoryName.placeholder",
+                    message: "Category name",
+                  })}
                   type="text"
                   errors={formState.errors.categories?.[index]?.name}
                   {...register(`categories.${index}.name` as const)}
                 />
 
                 <InputField
-                  label="Quantity"
                   hideLabel
-                  placeholder="Carbon tonnes"
+                  label={t({
+                    id: "pledges.form.input.categoryQuantity.label",
+                    message: "Quantity",
+                  })}
+                  placeholder={t({
+                    id: "pledges.form.input.categoryQuantity.placeholder",
+                    message: "Carbon tonnes",
+                  })}
                   type="number"
                   errors={formState.errors.categories?.[index]?.quantity}
                   {...register(`categories.${index}.quantity` as const)}
@@ -183,7 +228,10 @@ export const PledgeForm: FC<Props> = (props) => {
             <ButtonPrimary
               className={styles.categories_appendButton}
               variant="gray"
-              label="Add category"
+              label={t({
+                id: "pledges.form.add_footprint_category_button",
+                message: "Add category",
+              })}
               onClick={() => append({ name: "", quantity: 0 })}
             />
           </div>
@@ -191,8 +239,11 @@ export const PledgeForm: FC<Props> = (props) => {
       </div>
 
       <InputField
-        label="Total footprint"
         hideLabel
+        label={t({
+          id: "pledges.form.input.totalFootprint.label",
+          message: "Total footprint",
+        })}
         type="hidden"
         errors={formState.errors.footprint}
         {...register("footprint")}
@@ -203,7 +254,10 @@ export const PledgeForm: FC<Props> = (props) => {
       {/* better to use an input type=submit */}
       <ButtonPrimary
         disabled={!isDirty || !isValid}
-        label="Save pledge"
+        label={t({
+          id: "pledges.form.submit_button",
+          message: "Save pledge",
+        })}
         onClick={handleSubmit(onSubmit)}
       />
     </form>

--- a/site/components/pages/Pledge/index.tsx
+++ b/site/components/pages/Pledge/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { ethers } from "ethers";
 import { useRouter } from "next/router";
 import { NextPage } from "next";
-import { t } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
 import { ButtonPrimary, Text } from "@klimadao/lib/components";
 import { getIsDomainInURL } from "lib/getIsDomainInURL";
 
@@ -64,7 +64,9 @@ export const Pledge: NextPage = () => {
 
           {error && (
             <Text className={styles.errorMessage} t="caption">
-              Enter a valid ethereum wallet address or ENS/KNS domain
+              <Trans id="pledges.home.search.error_message">
+                Enter a wallet address, .klima or .eth domain
+              </Trans>
             </Text>
           )}
 

--- a/site/components/pages/Pledge/index.tsx
+++ b/site/components/pages/Pledge/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { ethers } from "ethers";
 import { useRouter } from "next/router";
 import { NextPage } from "next";
+import { t } from "@lingui/macro";
 import { ButtonPrimary, Text } from "@klimadao/lib/components";
 import { getIsDomainInURL } from "lib/getIsDomainInURL";
 
@@ -36,9 +37,20 @@ export const Pledge: NextPage = () => {
   return (
     <PledgeLayout>
       <PageHead
-        title="Klima Infinity | Pledge"
-        mediaTitle="Klima Infinity - Search for or start a pledge to the world today" // TODO - copy check
-        metaDescription="Drive climate action and earn rewards with a carbon-backed digital currency." // Need better meta description
+        title={t({
+          id: "pledges.head.title",
+          message: "KlimaDAO | Pledges",
+        })}
+        mediaTitle={t({
+          id: "pledges.head.metaTitle",
+          message:
+            "Klima Infinity - Search for or start a pledge to the world today", // TODO - copy check
+        })}
+        metaDescription={t({
+          id: "pledges.head.metaDescription",
+          message:
+            "Drive climate action and earn rewards with a carbon-backed digital currency.", // Need better meta description
+        })}
       />
       <div className={styles.container}>
         <form className={styles.inputContainer} onSubmit={handleFormSubmit}>

--- a/site/components/pages/Pledge/index.tsx
+++ b/site/components/pages/Pledge/index.tsx
@@ -56,7 +56,10 @@ export const Pledge: NextPage = () => {
         <form className={styles.inputContainer} onSubmit={handleFormSubmit}>
           <input
             className={styles.input}
-            placeholder="Enter an address or an ENS/KNS domain"
+            placeholder={t({
+              id: "pledges.home.search.placeholder",
+              message: "Enter a wallet address, .klima or .eth domain",
+            })}
             value={address}
             data-error={error}
             onChange={handleAddressInputChange}

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -914,6 +914,162 @@ msgstr "Invest in the future."
 msgid "mission.header"
 msgstr "KlimaDAO's mission is to democratize climate action"
 
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:82
+msgid "pledges.dashboard.assets.title"
+msgstr "Carbon Assets"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:73
+msgid "pledges.dashboard.footprint.title"
+msgstr "Footprint"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:90
+msgid "pledges.dashboard.footprint.tonnes"
+msgstr "Tonnes"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:104
+msgid "pledges.dashboard.footprint.tooltip.category_percent"
+msgstr "{0}% of footprint"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:110
+msgid "pledges.dashboard.footprint.tooltip.quantity"
+msgstr "{0} Carbon Tonne(s)"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:55
+msgid "pledges.dashboard.head.metaTitle"
+msgstr "{pledgeOwnerTitle}'s pledge"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:51
+msgid "pledges.dashboard.head.title"
+msgstr "KlimaDAO | Pledges"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:13
+msgid "pledges.dashboard.metholodogy.default_text"
+msgstr "How will you meet your pledge?"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:20
+msgid "pledges.dashboard.metholodogy.title"
+msgstr "Methodology"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:13
+msgid "pledges.dashboard.pledge.default_text"
+msgstr "Write your pledge today!"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:20
+msgid "pledges.dashboard.pledge.title"
+msgstr "Pledge"
+
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:61
+msgid "pledges.dashboard.profile.pledge_met"
+msgstr "≥ 100% of Pledge Met"
+
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:70
+msgid "pledges.dashboard.profile.pledge_progress"
+msgstr "{0}% of Pledge Met"
+
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:101
+msgid "pledges.dashboard.profile.pledged_to_offset"
+msgstr "Pledged to Offset <0>{0}</0> Carbon Tonnes"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:43
+msgid "pledges.dashboard.retirements.title"
+msgstr "Retirements"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
+msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
+msgstr "{0} Carbon Tonne(s) Retired"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:62
+msgid "pledges.dashboard.retirements.total_tonnes_retired"
+msgstr "Total Carbon Tonnes Retired"
+
+#: components/pages/Pledge/HeaderDesktop/index.tsx:41
+msgid "pledges.edit_pledge"
+msgstr "Edit Pledge"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:231
+msgid "pledges.form.add_footprint_category_button"
+msgstr "Add category"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:170
+msgid "pledges.form.footprint.label"
+msgstr "Footprint"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:175
+msgid "pledges.form.footprint.prompt"
+msgstr "Add a category and start calculating your carbon footprint"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:107
+msgid "pledges.form.generic_error"
+msgstr "Something went wrong. Please try again."
+
+#: components/pages/Pledge/PledgeForm/index.tsx:187
+msgid "pledges.form.input.categoryName.label"
+msgstr "Category"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:191
+msgid "pledges.form.input.categoryName.placeholder"
+msgstr "Category name"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:202
+msgid "pledges.form.input.categoryQuantity.label"
+msgstr "Quantity"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:206
+msgid "pledges.form.input.categoryQuantity.placeholder"
+msgstr "Carbon tonnes"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:140
+msgid "pledges.form.input.description.label"
+msgstr "Pledge"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:144
+msgid "pledges.form.input.description.placeholder"
+msgstr "What is your pledge?"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:155
+msgid "pledges.form.input.methodology.label"
+msgstr "Methodology"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:159
+msgid "pledges.form.input.methodology.placeholder"
+msgstr "What tools or methodologies did you use to calculate your carbon footprint?"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:115
+msgid "pledges.form.input.name.label"
+msgstr "Name"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:116
+msgid "pledges.form.input.name.placeholder"
+msgstr "Name or company name"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:127
+msgid "pledges.form.input.profileImageUrl.label"
+msgstr "Profile image url (optional)"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:243
+msgid "pledges.form.input.totalFootprint.label"
+msgstr "Total footprint"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:257
+msgid "pledges.form.submit_button"
+msgstr "Save pledge"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:44
+msgid "pledges.form.total_footprint_summary"
+msgstr "Total Footprint: {0} Carbon Tonnes"
+
+#: components/pages/Pledge/index.tsx:49
+msgid "pledges.head.metaDescription"
+msgstr "Drive climate action and earn rewards with a carbon-backed digital currency."
+
+#: components/pages/Pledge/index.tsx:44
+msgid "pledges.head.metaTitle"
+msgstr "Klima Infinity - Search for or start a pledge to the world today"
+
+#: components/pages/Pledge/index.tsx:40
+msgid "pledges.head.title"
+msgstr "KlimaDAO | Pledges"
+
 #: components/pages/Podcast/index.tsx:21
 msgid "podcast.head.description"
 msgstr "Planet of the Klimates is a community-driven podcast featuring conversations with Klima Partners and thought leaders on climate science, blockchain, and more. You can explore the latest episodes and full archive of shows directly below, and also find PotK on your favourite podcast platform, including <0>RSS</0> and <1>Apple Podcasts</1>"
@@ -1121,6 +1277,11 @@ msgstr "Buy"
 msgid "shared.community"
 msgstr "Community"
 
+#: components/pages/Pledge/HeaderDesktop/index.tsx:50
+#: components/pages/Pledge/HeaderMobile/index.tsx:57
+msgid "shared.connect"
+msgstr "Connect"
+
 #: components/Footer/index.tsx:59
 #: components/pages/Resources/ResourcesHeader/index.tsx:87
 msgid "shared.contact"
@@ -1153,6 +1314,7 @@ msgstr "Enter App"
 
 #: components/pages/Buy/index.tsx:46
 #: components/pages/Home/index.tsx:72
+#: components/pages/Pledge/PledgeDashboard/index.tsx:59
 #: components/pages/Podcast/index.tsx:34
 #: components/pages/Retirements/index.tsx:59
 #: components/pages/errors/Custom500.tsx:23
@@ -1176,6 +1338,11 @@ msgstr "Get Started"
 #: components/Navigation/index.tsx:66
 msgid "shared.infity"
 msgstr "Infinity"
+
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/TokenRow/index.tsx:40
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:57
+msgid "shared.loading"
+msgstr "Loading..."
 
 #: components/Navigation/index.tsx:71
 #: components/Navigation/index.tsx:96

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1070,6 +1070,10 @@ msgstr "Klima Infinity - Search for or start a pledge to the world today"
 msgid "pledges.head.title"
 msgstr "KlimaDAO | Pledges"
 
+#: components/pages/Pledge/index.tsx:67
+msgid "pledges.home.search.error_message"
+msgstr "Enter a wallet address, .klima or .eth domain"
+
 #: components/pages/Podcast/index.tsx:21
 msgid "podcast.head.description"
 msgstr "Planet of the Klimates is a community-driven podcast featuring conversations with Klima Partners and thought leaders on climate science, blockchain, and more. You can explore the latest episodes and full archive of shows directly below, and also find PotK on your favourite podcast platform, including <0>RSS</0> and <1>Apple Podcasts</1>"

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1070,8 +1070,12 @@ msgstr "Klima Infinity - Search for or start a pledge to the world today"
 msgid "pledges.head.title"
 msgstr "KlimaDAO | Pledges"
 
-#: components/pages/Pledge/index.tsx:67
+#: components/pages/Pledge/index.tsx:70
 msgid "pledges.home.search.error_message"
+msgstr "Enter a wallet address, .klima or .eth domain"
+
+#: components/pages/Pledge/index.tsx:59
+msgid "pledges.home.search.placeholder"
 msgstr "Enter a wallet address, .klima or .eth domain"
 
 #: components/pages/Podcast/index.tsx:21


### PR DESCRIPTION
## Description

Extract strings from `/pledges/*` for translations.

Translating form error message strings is not as straight forward as utilising lingui macros so I'm going to pull that out into a separate ticket to be worked on :)

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
