### PR TITLE
Retirements: Check for empty subgraph data

### DIFF
--- a/lib/utils/subgraph/queryPolygonBridgedCarbon.ts
+++ b/lib/utils/subgraph/queryPolygonBridgedCarbon.ts
@@ -55,7 +55,7 @@ export const queryKlimaRetireByIndex = async (
 
 export const queryKlimaRetiresByAddress = async (
   beneficiaryAddress: string
-): Promise<KlimaRetire[]> => {
+): Promise<KlimaRetire[] | false> => {
   try {
     const result = await fetch(subgraphs.polygonBridgedCarbon, {
       method: "POST",
@@ -94,7 +94,7 @@ export const queryKlimaRetiresByAddress = async (
       }),
     });
     const json: QueryKlimaRetires = await result.json();
-    return json.data.klimaRetires;
+    return !!json.data.klimaRetires.length && json.data.klimaRetires;
   } catch (e) {
     console.error("Failed to query KlimaRetiresByAddress", e);
     return Promise.reject(e);

--- a/site/components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx
@@ -4,20 +4,28 @@ import { useRouter } from "next/router";
 import { TextGroup } from "../TextGroup";
 
 type Props = {
-  timestamp: string; // 10 digits
+  timestamp: string | null; // 10 digits
 };
 
 export const RetirementDate: FC<Props> = ({ timestamp }) => {
   const { locale } = useRouter();
-  const retirementDate = new Date(parseInt(timestamp) * 1000); //expects milliseconds
-  const formattedDate = new Intl.DateTimeFormat(locale, {
-    dateStyle: "full",
-  }).format(retirementDate);
+  const retirementDate = timestamp && new Date(parseInt(timestamp) * 1000); //expects milliseconds
+  const formattedDate =
+    retirementDate &&
+    new Intl.DateTimeFormat(locale, {
+      dateStyle: "full",
+    }).format(retirementDate);
 
   return (
     <TextGroup
       title={<Trans id="retirement.single.retirementDate.title">Date</Trans>}
-      text={formattedDate}
+      text={
+        formattedDate || (
+          <Trans id="retirement.single.timestamp.placeholder">
+            No retirement timestamp provided
+          </Trans>
+        )
+      }
     />
   );
 };

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -30,7 +30,7 @@ import { retirementTokenInfoMap } from "lib/getTokenInfo";
 type Props = {
   beneficiaryAddress: string;
   retirementTotals: string;
-  retirement: KlimaRetire;
+  retirement: KlimaRetire | null;
   retirementIndexInfo: RetirementIndexInfoResult;
   projectDetails?: VerraProjectDetails;
   nameserviceDomain?: string;
@@ -58,8 +58,8 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
     tokenIcon: tokenData.icon,
     beneficiaryName: retirementIndexInfo.beneficiaryName,
     retirementMessage: retirementIndexInfo.retirementMessage,
-    timestamp: retirement.timestamp,
-    transactionID: retirement.transaction?.id,
+    timestamp: retirement?.timestamp || null,
+    transactionID: retirement?.transaction?.id || null,
   };
 
   const retiree =
@@ -151,15 +151,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
               />
             </div>
             <div className="column">
-              <RetirementDate
-                timestamp={
-                  retireData.timestamp ||
-                  t({
-                    id: "retirement.single.timestamp.placeholder",
-                    message: "No retirement timestamp provided",
-                  })
-                }
-              />
+              <RetirementDate timestamp={retireData.timestamp} />
               <TextGroup
                 title={
                   <Trans id="retirement.single.retirementCertificate.title">
@@ -211,10 +203,12 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
           )}
         </div>
       </Section>
-      <ProjectDetails
-        projectDetails={props.projectDetails}
-        offset={props.retirement.offset}
-      />
+      {props.retirement?.offset && (
+        <ProjectDetails
+          projectDetails={props.projectDetails}
+          offset={props.retirement.offset}
+        />
+      )}
       <RetirementFooter />
       <Footer />
     </>

--- a/site/components/pages/Retirements/index.tsx
+++ b/site/components/pages/Retirements/index.tsx
@@ -127,14 +127,12 @@ export const RetirementPage: NextPage<Props> = (props) => {
             </Text>
           </div>
         </div>
+        <Breakdown totalsAndBalances={props.totalsAndBalances} />
         {klimaRetires && (
-          <>
-            <Breakdown totalsAndBalances={props.totalsAndBalances} />
-            <AllRetirements
-              klimaRetires={klimaRetires}
-              nameserviceDomain={props.nameserviceDomain}
-            />
-          </>
+          <AllRetirements
+            klimaRetires={klimaRetires}
+            nameserviceDomain={props.nameserviceDomain}
+          />
         )}
       </Section>
       <Section variant="gray" className={styles.sectionButtons}>

--- a/site/components/pages/Retirements/index.tsx
+++ b/site/components/pages/Retirements/index.tsx
@@ -24,7 +24,7 @@ import * as styles from "./styles";
 
 type Props = {
   totalsAndBalances: RetirementsTotalsAndBalances;
-  klimaRetires: KlimaRetire[];
+  klimaRetires: KlimaRetire[] | null;
   beneficiaryAddress: string;
   nameserviceDomain?: string;
   canonicalUrl?: string;
@@ -127,11 +127,15 @@ export const RetirementPage: NextPage<Props> = (props) => {
             </Text>
           </div>
         </div>
-        <Breakdown totalsAndBalances={props.totalsAndBalances} />
-        <AllRetirements
-          klimaRetires={klimaRetires}
-          nameserviceDomain={props.nameserviceDomain}
-        />
+        {klimaRetires && (
+          <>
+            <Breakdown totalsAndBalances={props.totalsAndBalances} />
+            <AllRetirements
+              klimaRetires={klimaRetires}
+              nameserviceDomain={props.nameserviceDomain}
+            />
+          </>
+        )}
       </Section>
       <Section variant="gray" className={styles.sectionButtons}>
         <div className={styles.sectionButtonsWrap}>

--- a/site/pages/retirements/[beneficiary]/[retirement_index].tsx
+++ b/site/pages/retirements/[beneficiary]/[retirement_index].tsx
@@ -29,7 +29,7 @@ interface PageProps {
   /** The resolved 0x address */
   beneficiaryAddress: string;
   retirementTotals: Params["retirement_index"];
-  retirement: KlimaRetire;
+  retirement: KlimaRetire | null;
   retirementIndexInfo: RetirementIndexInfoResult;
   projectDetails: VerraProjectDetails | null;
   nameserviceDomain: string | null;
@@ -105,7 +105,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
       promises
     );
 
-    if (!retirement || !retirementIndexInfo) {
+    if (!retirementIndexInfo) {
       throw new Error("No retirement found");
     }
 
@@ -114,7 +114,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
     }
 
     let projectDetails: VerraProjectDetails | null = null;
-    if (!!retirement.offset.projectID) {
+    if (retirement && !!retirement.offset.projectID) {
       projectDetails = await getVerraProjectByID(
         retirement.offset.projectID.replace("VCS-", "")
       );
@@ -122,7 +122,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
 
     return {
       props: {
-        retirement,
+        retirement: retirement || null,
         retirementIndexInfo,
         beneficiaryAddress: beneficiaryAddress,
         retirementTotals: params.retirement_index,

--- a/site/pages/retirements/[beneficiary]/index.tsx
+++ b/site/pages/retirements/[beneficiary]/index.tsx
@@ -27,7 +27,7 @@ interface PageProps {
   /** The resolved 0x address */
   beneficiaryAddress: string;
   totalsAndBalances: RetirementsTotalsAndBalances;
-  klimaRetires: KlimaRetire[];
+  klimaRetires: KlimaRetire[] | null;
   nameserviceDomain: string | null;
   canonicalUrl: string;
 }
@@ -90,7 +90,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
     return {
       props: {
         totalsAndBalances,
-        klimaRetires,
+        klimaRetires: klimaRetires || null,
         beneficiaryAddress: beneficiaryAddress,
         nameserviceDomain: isDomainInURL ? beneficiaryInUrl : null,
         canonicalUrl: `${urls.retirements}/${beneficiaryInUrl}`,


### PR DESCRIPTION
## Description

Users reported that the Retirement Receipt page returns a 404 after a successful Offset.

Under the assumption that this error occurs **when the subgraph is querying the data not fast enough**
this PR does the following:

- ensure that all queries return `false` on empty query results (Subgraph returns empty array on not found!)
- If the data is `false` => pass `null` to the Page props
- During rendering add fallback for empty data or render nothing




## Related Ticket

Closes https://github.com/KlimaDAO/klimadao/issues/568

## SCREENSHOTs

Spot the difference 😄 

| With Subgraph Data  | Without Subgraph Data  |
|---------|--------|
|<img width="426" alt="" src="https://user-images.githubusercontent.com/95881624/182347260-5bad3177-ad6e-420f-8781-200a00994944.png"> | <img width="633" alt="" src="https://user-images.githubusercontent.com/95881624/182346696-a0251aff-7180-497b-b598-fb4779f41e15.png">  |
|<img width="399" alt="" src="https://user-images.githubusercontent.com/95881624/182346146-97eb55e4-0694-4e88-abac-47b6e595b69e.png">  |<img width="635" alt="" src="https://user-images.githubusercontent.com/95881624/182345152-55bea111-dd89-497b-a47e-6fd0e0b7161b.png">  |


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
