### PR TITLE
Infinity footer navigation tweaks (#532)

### DIFF
--- a/site/components/Footer/index.tsx
+++ b/site/components/Footer/index.tsx
@@ -28,8 +28,8 @@ export const Footer: FC<Props> = (props) => {
 
   return (
     <footer className={cx(styles.footer, props.className)}>
-      <div className={styles.footer_content}>
-        <nav className={styles.footer_nav}>
+      <div className={cx(styles.footer_content, "footer_content")}>
+        <nav className={cx(styles.footer_nav, "footer_nav")}>
           <Link href="/">
             <a>
               <Trans id="shared.home">Home</Trans>

--- a/site/components/pages/Infinity/index.tsx
+++ b/site/components/pages/Infinity/index.tsx
@@ -42,6 +42,7 @@ import logoPolygonInfinity from "public/logo-polygon-infinity.png";
 import * as styles from "./styles";
 
 import { urls } from "@klimadao/lib/constants";
+import { cx } from "@emotion/css";
 
 const linkToBlogUserGuide = `${urls.siteBlog}/klima-infinity-user-guide`;
 const linkToBlogFAQ = `${urls.siteBlog}/klima-infinity-faqs`;
@@ -684,7 +685,10 @@ export const Infinity: NextPage<Props> = ({ fixedThemeName }) => {
           </div>
         </div>
       </Section>
-      <Section variant="black" className={styles.ctaSection}>
+      <Section
+        variant="black"
+        className={cx(styles.ctaSection, styles.footerContainer)}
+      >
         <div className="cta_container">
           <div className="cta_left_container">
             <div className="cta_logo">
@@ -716,10 +720,9 @@ export const Infinity: NextPage<Props> = ({ fixedThemeName }) => {
             />
           </div>
         </div>
+        <div className={styles.divider} />
+        <Footer className={styles.footer} />
       </Section>
-      <div className={styles.footerWrapper}>
-        <Footer />
-      </div>
     </>
   );
 };

--- a/site/components/pages/Infinity/styles.ts
+++ b/site/components/pages/Infinity/styles.ts
@@ -758,25 +758,13 @@ export const faqSection = css`
 export const ctaSection = css`
   position: relative;
   overflow: hidden;
-  background-color: #000;
-  background: radial-gradient(
-      circle at top right,
-      rgba(11, 161, 255, 0.6),
-      transparent 200px
-    ),
-    radial-gradient(at bottom left, rgba(11, 161, 255, 0.5), transparent 200px);
 
   ${breakpoints.large} {
     background: radial-gradient(
-        circle at top right,
-        rgba(11, 161, 255, 0.5),
-        transparent 800px
-      ),
-      radial-gradient(
-        at bottom left,
-        rgba(11, 161, 255, 0.5),
-        transparent 900px
-      );
+      circle at right,
+      rgb(4 65 104 / 60%),
+      transparent 90%
+    );
   }
 
   .cta_container {
@@ -789,6 +777,7 @@ export const ctaSection = css`
     display: flex;
     gap: 1.6rem;
     align-items: center;
+    justify-content: center;
     flex-direction: column;
     padding-right: 0;
     position: relative;
@@ -805,7 +794,10 @@ export const ctaSection = css`
       font-weight: 300;
       line-height: 32px;
       letter-spacing: 0em;
-      text-align: left;
+      text-align: center;
+      ${breakpoints.large} {
+        text-align: left;
+      }
     }
   }
   .cta_right_container {
@@ -824,7 +816,6 @@ export const ctaSection = css`
     }
   }
   .cta_logo {
-    height: 100%;
     width: 100%;
     max-width: 30rem;
     ${breakpoints.large} {
@@ -833,10 +824,60 @@ export const ctaSection = css`
   }
 `;
 
-export const footerWrapper = css`
-  grid-column: full;
-  grid-template-columns: inherit;
-  footer {
-    background-color: black;
+export const footerContainer = css`
+  padding-bottom: 3rem;
+  padding-top: 5rem;
+  grid-template-rows: 1fr 50px 1fr;
+  row-gap: 1rem;
+  background-image: radial-gradient(
+    circle at top right,
+    rgb(11 103 160 / 60%),
+    transparent 135%
+  );
+
+  ${breakpoints.large} {
+    padding-bottom: 3rem;
   }
+`;
+
+export const footer = css`
+  background: none;
+  padding: 2rem 0;
+  grid-column: main;
+
+  .footer_content {
+    gap: 5rem;
+    grid-column: full;
+    justify-content: space-between;
+  }
+
+  .footer_nav {
+    column-gap: 3rem;
+    a {
+      // Full width link on mobile
+      width: 100%;
+      ${breakpoints.medium} {
+        width: auto;
+      }
+    }
+  }
+
+  nav {
+    max-height: unset;
+    width: 100%;
+    justify-content: space-between;
+    flex-direction: row;
+    ${breakpoints.medium} {
+      width: unset;
+    }
+  }
+`;
+
+export const divider = css`
+  grid-column: main;
+  margin-top: auto;
+  height: 0.15rem;
+  width: 100%;
+  opacity: 0.3;
+  background-color: var(--font-03);
 `;


### PR DESCRIPTION
## Description
This change includes an alignment of the footer within the Infinity page to that of the designs specified [here](https://www.figma.com/file/YM245UOgve7XknodVL9IX1/Navigation-discovery?node-id=0%3A1)

[Desktop Design Screenshot](https://user-images.githubusercontent.com/7104689/182363459-f901736b-9ad3-4a34-84e5-b33abb8ad62d.png)
[Mobile Design Screenshot](https://user-images.githubusercontent.com/95881624/181769814-c0d4b646-4b44-4004-8616-9b4d0bf200a6.png)

Markup & source changes:
* Update the  existing `site/components/Footer` to allow selective styling of content and nav sections
* Lifted `site` instance of `Footer` in to the CTA section above to share and overlay the gradient background (this could have been done with absolute positioning and margin if preferred).
* Added missing horizontal divider

Styling changes:
* Updated the gradient background to a single gradient to match the designs
* Full width list in mobile breakpoints within the footer (except for icons)
* Various alignment and responsiveness tweaks

## Related Ticket

[Site Infinity: Footer Navigation tweaks](https://github.com/KlimaDAO/klimadao/issues/558)

Resolves #532


## Changes

|     | Before  | After  |
|----|---------|--------|
|  **Mobile**  |![image](https://user-images.githubusercontent.com/7104689/182363648-43ab397f-b7ab-4be7-a988-44c2c6be37f8.png) |![image](https://user-images.githubusercontent.com/7104689/182363702-266f0078-33ee-4665-9e0e-bfb55effd726.png)|
|  **Desktop**  |![image](https://user-images.githubusercontent.com/7104689/182363375-21953e70-6de8-46a1-9cfe-7e67d2ebd940.png) |![image](https://user-images.githubusercontent.com/7104689/182363459-f901736b-9ad3-4a34-84e5-b33abb8ad62d.png)|


## Checklist

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
