### PR TITLE
Use .index() instead of sKlimaContract.balanceOf()

### DIFF
--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -21,19 +21,19 @@ export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
         contractName: "distributor",
         provider: provider,
       });
-      const sKlimaContract = getContract({
-        contractName: "sklima",
-        provider: provider,
-      });
       const sKlimaMainContract = getContract({
         contractName: "sklimaMain",
+        provider: provider,
+      });
+      const stakingContract = getContract({
+        contractName: "staking",
         provider: provider,
       });
 
       const promises = [
         distributorContract.info(0),
         sKlimaMainContract.circulatingSupply(),
-        sKlimaContract.balanceOf("0x693aD12DbA5F6E07dE86FaA21098B691F60A1BEa"),
+        stakingContract.index(),
         getTreasuryBalance(),
         distributorContract.nextEpochBlock(),
         fetchBlockRate(),


### PR DESCRIPTION
## Description

Use .index() of KlimaStakingv2 instead of sKlimaContract.balanceOf() of IERC20 contract

## Related Ticket

Resolves #511

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

I captured the values of the two methods while developming. I do not know if that matters but the numbers were not stricty equal

![image](https://user-images.githubusercontent.com/11857992/182385178-91bf189a-607b-4db6-b293-491d22621730.png)

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
