### PR TITLE
remove UBO and NBO from klima retirements

### DIFF
--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -88,9 +88,9 @@ const tokenInfo: TokenInfoMap = {
   nct: { key: "nct", icon: NCT, label: "NCT" },
   mco2: { key: "mco2", icon: MCO2, label: "MCO2" },
   usdc: { key: "usdc", icon: USDC, label: "USDC" },
-  // klima: { key: "klima", icon: KLIMA, label: "KLIMA" },
-  // sklima: { key: "sklima", icon: KLIMA, label: "sKLIMA" },
-  // wsklima: { key: "wsklima", icon: KLIMA, label: "wsKLIMA" },
+  klima: { key: "klima", icon: KLIMA, label: "KLIMA" },
+  sklima: { key: "sklima", icon: KLIMA, label: "sKLIMA" },
+  wsklima: { key: "wsklima", icon: KLIMA, label: "wsKLIMA" },
 };
 
 interface Props {

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -58,7 +58,6 @@ import { DropdownWithModal } from "components/DropdownWithModal";
 import BCT from "public/icons/BCT.png";
 import NCT from "public/icons/NCT.png";
 import MCO2 from "public/icons/MCO2.png";
-import KLIMA from "public/icons/KLIMA.png";
 import USDC from "public/icons/USDC.png";
 import UBO from "public/icons/UBO.png";
 import NBO from "public/icons/NBO.png";
@@ -89,9 +88,9 @@ const tokenInfo: TokenInfoMap = {
   nct: { key: "nct", icon: NCT, label: "NCT" },
   mco2: { key: "mco2", icon: MCO2, label: "MCO2" },
   usdc: { key: "usdc", icon: USDC, label: "USDC" },
-  klima: { key: "klima", icon: KLIMA, label: "KLIMA" },
-  sklima: { key: "sklima", icon: KLIMA, label: "sKLIMA" },
-  wsklima: { key: "wsklima", icon: KLIMA, label: "wsKLIMA" },
+  // klima: { key: "klima", icon: KLIMA, label: "KLIMA" },
+  // sklima: { key: "sklima", icon: KLIMA, label: "sKLIMA" },
+  // wsklima: { key: "wsklima", icon: KLIMA, label: "wsKLIMA" },
 };
 
 interface Props {

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -58,6 +58,7 @@ import { DropdownWithModal } from "components/DropdownWithModal";
 import BCT from "public/icons/BCT.png";
 import NCT from "public/icons/NCT.png";
 import MCO2 from "public/icons/MCO2.png";
+import KLIMA from "public/icons/KLIMA.png";
 import USDC from "public/icons/USDC.png";
 import UBO from "public/icons/UBO.png";
 import NBO from "public/icons/NBO.png";

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -172,7 +172,17 @@ export type Bond = typeof bonds[number];
 
 // Spender with their Allowances tokens
 export const allowancesContracts = {
-  retirementAggregator: ["ubo", "nbo", "bct", "nct", "mco2", "usdc"],
+  retirementAggregator: [
+    "ubo",
+    "nbo",
+    "bct",
+    "nct",
+    "mco2",
+    "usdc",
+    "klima",
+    "sklima",
+    "wsklima",
+  ],
   staking_helper: ["klima"],
   staking: ["sklima"],
   wsklima: ["sklima"],
@@ -207,6 +217,9 @@ export const offsetCompatibility: CompatMap = {
   nct: ["bct", "nct"],
   mco2: ["mco2"],
   usdc: ["bct", "nct", "mco2", "ubo", "nbo"],
+  klima: ["bct", "mco2"],
+  sklima: ["bct", "mco2"],
+  wsklima: ["bct", "mco2"],
 };
 
 const SUBGRAPH_URL = "https://api.thegraph.com/subgraphs/name/klimadao";

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -172,17 +172,7 @@ export type Bond = typeof bonds[number];
 
 // Spender with their Allowances tokens
 export const allowancesContracts = {
-  retirementAggregator: [
-    "ubo",
-    "nbo",
-    "bct",
-    "nct",
-    "mco2",
-    "usdc",
-    "klima",
-    "sklima",
-    "wsklima",
-  ],
+  retirementAggregator: ["ubo", "nbo", "bct", "nct", "mco2", "usdc"],
   staking_helper: ["klima"],
   staking: ["sklima"],
   wsklima: ["sklima"],
@@ -217,9 +207,6 @@ export const offsetCompatibility: CompatMap = {
   nct: ["bct", "nct"],
   mco2: ["mco2"],
   usdc: ["bct", "nct", "mco2", "ubo", "nbo"],
-  klima: ["bct", "mco2", "ubo", "nbo"],
-  sklima: ["bct", "mco2", "ubo", "nbo"],
-  wsklima: ["bct", "mco2", "ubo", "nbo"],
 };
 
 const SUBGRAPH_URL = "https://api.thegraph.com/subgraphs/name/klimadao";


### PR DESCRIPTION
## Description
I removed klima, sklima, and wsklima from the input tokens on the retirements page.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #569 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
