### PR TITLE
Emotion source maps in site

### DIFF
--- a/site/.babelrc
+++ b/site/.babelrc
@@ -10,5 +10,5 @@
       }
     ]
   ],
-  "plugins": ["macros"]
+  "plugins": ["@emotion", "macros"]
 }

--- a/site/package.json
+++ b/site/package.json
@@ -31,6 +31,7 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
+    "@emotion/babel-plugin": "^11.9.5",
     "@lingui/cli": "^3.13.0",
     "@lingui/loader": "^3.13.0",
     "@lingui/macro": "^3.13.0",


### PR DESCRIPTION
## Description

Currently the `app` project is supplying source maps for emotion styling. The `site` project was missing this configuration.

When debugging or developing styling it is helpful to easily see the styles applied by css-in-js code (emotion).

## Related Ticket

Resolves #582

## Changes

| Before  | After  |
|---------|--------|
|![Screenshot 2022-08-05 062808](https://user-images.githubusercontent.com/7104689/182972312-5989486f-5f61-48bc-a5df-24141ae2bea4.png) |![Screenshot 2022-08-05 063134](https://user-images.githubusercontent.com/7104689/182972296-e994a43f-7824-44c9-ae02-d2ae3dd9fdd5.png)|


## Checklist

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
