### PR TITLE
update grid layout on app pages

### DIFF
--- a/app/components/views/Bond/styles.ts
+++ b/app/components/views/Bond/styles.ts
@@ -33,7 +33,7 @@ export const bondCard = css`
 
   ${breakpoints.desktop} {
     grid-column: cardsleft;
-    grid-row: 2 / span 3;
+    grid-row: 1 / span 3;
     gap: 4.8rem;
     grid-template-rows: 1fr 1fr 1fr;
     align-items: start;

--- a/app/components/views/Buy/styles.ts
+++ b/app/components/views/Buy/styles.ts
@@ -11,7 +11,13 @@ export const buyCard = css`
   border-radius: 1.2rem;
   padding-top: 2.4rem;
   gap: 2.4rem;
-
+  overflow: scroll;
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
   .hr {
     height: 2px;
     background-color: var(--surface-01);
@@ -23,9 +29,9 @@ export const buyCard = css`
 
   ${breakpoints.desktop} {
     grid-column: cardsleft;
-    grid-row: 2 / span 3;
-    grid-template-rows: 1fr 1fr 1fr;
+    grid-row: 1 / 5;
     align-items: start;
+    padding-bottom: 1.6rem;
   }
 
   ${breakpoints.desktopLarge} {

--- a/app/components/views/ChooseBond/styles.ts
+++ b/app/components/views/ChooseBond/styles.ts
@@ -9,7 +9,15 @@ export const chooseBondCard = css`
   gap: 2.4rem;
   align-content: start;
   grid-column: 1 / 3;
-
+  grid-row: 1 / 5;
+  overflow: scroll;
+  grid-template-rows: 1fr !important;
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
   ${breakpoints.small} {
     padding: 2.4rem;
   }
@@ -33,7 +41,6 @@ export const chooseBondCard_header = css`
 export const chooseBondCard_ui = css`
   display: grid;
   gap: 2.4rem;
-
   ${breakpoints.medium} {
     border: 2px solid var(--surface-01);
     padding: 2.4rem;
@@ -54,7 +61,7 @@ export const columnRight = css`
 
   ${breakpoints.desktop} {
     grid-column: 2 / 3;
-    grid-row: span 2;
+    grid-row-start: 2;
   }
 `;
 

--- a/app/components/views/Info/styles.ts
+++ b/app/components/views/Info/styles.ts
@@ -1,18 +1,22 @@
 import { css } from "@emotion/css";
 
-import { stakeCard } from "../Stake/styles";
+import { chooseBondCard } from "../ChooseBond/styles";
 
 export const container = css`
-  ${stakeCard};
-  display: flex;
+  ${chooseBondCard};
   flex-direction: column;
   color: var(--font-01);
-  min-height: 88rem;
+  overflow: scroll;
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
   .infoSection {
     display: grid;
     gap: 0.8rem;
   }
-
   .addressRow {
     display: grid;
     grid-template-columns: repeat(3, max-content);

--- a/app/components/views/Offset/styles.ts
+++ b/app/components/views/Offset/styles.ts
@@ -8,7 +8,7 @@ export const columnRight = css`
   gap: 2.4rem;
   grid-column: 1 / 3;
   align-content: start;
-
+  grid-row: 2 / auto;
   ${breakpoints.desktop} {
     grid-column: 2 / 3;
   }
@@ -33,10 +33,16 @@ export const offsetCard = css`
   padding: 2.4rem;
   gap: 2.4rem;
   grid-column: 1 / 3;
-
+  overflow: scroll;
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
   ${breakpoints.desktop} {
     grid-column: cardsleft;
-    grid-row: 2 / auto;
+    grid-row: 1 / 5;
     gap: 4.8rem;
     align-items: start;
   }

--- a/app/components/views/Stake/styles.ts
+++ b/app/components/views/Stake/styles.ts
@@ -12,6 +12,13 @@ export const stakeCard = css`
   gap: 2.4rem;
   align-content: start;
   grid-column: 1 / 3;
+  overflow: scroll;
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 
   .hr {
     height: 2px;
@@ -24,7 +31,7 @@ export const stakeCard = css`
 
   ${breakpoints.desktop} {
     grid-column: cardsleft;
-    grid-row: 2 / span 3;
+    grid-row: 1 / span 3;
     gap: 4.8rem;
     grid-template-rows: 1fr 1fr 1fr;
     align-items: start;

--- a/app/components/views/Wrap/index.tsx
+++ b/app/components/views/Wrap/index.tsx
@@ -35,7 +35,10 @@ import { useAppDispatch } from "state";
 import { useTypedSelector } from "lib/hooks/useTypedSelector";
 
 import * as styles from "components/views/Stake/styles";
+import * as bondStyles from "components/views/ChooseBond/styles";
+import * as overRideStyles from "./styles";
 import { Trans, defineMessage } from "@lingui/macro";
+import { cx } from "@emotion/css";
 
 interface Props {
   provider?: ethers.providers.Web3Provider;
@@ -260,7 +263,10 @@ export const Wrap: FC<Props> = (props) => {
         }
       />
 
-      <div className={styles.stakeCard} style={{ minHeight: "74rem" }}>
+      <div
+        className={cx(bondStyles.chooseBondCard, overRideStyles.wrapCard)}
+        style={{ minHeight: "74rem" }}
+      >
         <div className={styles.stakeCard_header}>
           <Text t="h4" className={styles.stakeCard_header_title}>
             <FlipOutlined />

--- a/app/components/views/Wrap/styles.ts
+++ b/app/components/views/Wrap/styles.ts
@@ -1,0 +1,5 @@
+import { css } from "@emotion/css";
+
+export const wrapCard = css`
+  grid-row: 1 / span 3 !important;
+`;


### PR DESCRIPTION
## Description
I updated the grid layout to use the dead space at the top. Some components scroll now. Similar feel but the other cards are now in view the whole time.
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #563 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
