### PR TITLE
Bonds: Use new TXN Modal for Approval & Bond & Redeem

### DIFF
--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -12,32 +12,42 @@ import OhmDai from "@klimadao/lib/abi/OhmDai.json";
 import IERC20 from "@klimadao/lib/abi/IERC20.json";
 import KlimaProV2 from "@klimadao/lib/abi/KlimaProV2.json";
 
+const bondMapToTokenName = {
+  klima_bct_lp: "klimaBctLp",
+  klima_usdc_lp: "klimaUsdcLp",
+  bct_usdc_lp: "bctUsdcLp",
+  klima_mco2_lp: "klimaMco2Lp",
+  inverse_usdc: "klimaProV2",
+  mco2: "mco2",
+  bct: "bct",
+  nbo: "nbo",
+  ubo: "ubo",
+} as const;
+type BondName = keyof typeof bondMapToTokenName;
+type BondToken = typeof bondMapToTokenName[BondName];
+
+const bondMapToBondName = {
+  klima_bct_lp: "bond_klimaBctLp",
+  klima_usdc_lp: "bond_klimaUsdcLp",
+  bct_usdc_lp: "bond_bctUsdcLp",
+  klima_mco2_lp: "bond_klimaMco2Lp",
+  inverse_usdc: "klimaProV2",
+  mco2: "bond_mco2",
+  bct: "bond_bct",
+  nbo: "bond_nbo",
+  ubo: "bond_ubo",
+} as const;
+type BondCName = keyof typeof bondMapToBondName;
+type BondContractName = typeof bondMapToBondName[BondCName];
+
 const getBondAddress = (params: { bond: Bond }): string => {
-  return {
-    klima_mco2_lp: addresses["mainnet"].bond_klimaMco2Lp,
-    klima_bct_lp: addresses["mainnet"].bond_klimaBctLp,
-    klima_usdc_lp: addresses["mainnet"].bond_klimaUsdcLp,
-    bct: addresses["mainnet"].bond_bct,
-    bct_usdc_lp: addresses["mainnet"].bond_bctUsdcLp,
-    mco2: addresses["mainnet"].bond_mco2,
-    nbo: addresses["mainnet"].bond_nbo,
-    ubo: addresses["mainnet"].bond_ubo,
-    inverse_usdc: addresses["mainnet"].klimaProV2,
-  }[params.bond];
+  const bondName = bondMapToBondName[params.bond];
+  return addresses["mainnet"][bondName as BondContractName];
 };
 
 const getReserveAddress = (params: { bond: Bond }): string => {
-  return {
-    klima_bct_lp: addresses["mainnet"].klimaBctLp,
-    klima_usdc_lp: addresses["mainnet"].klimaUsdcLp,
-    bct: addresses["mainnet"].bct,
-    mco2: addresses["mainnet"].mco2,
-    bct_usdc_lp: addresses["mainnet"].bctUsdcLp,
-    klima_mco2_lp: addresses["mainnet"].klimaMco2Lp,
-    nbo: addresses["mainnet"].nbo,
-    ubo: addresses["mainnet"].ubo,
-    inverse_usdc: addresses["mainnet"].klimaProV2,
-  }[params.bond];
+  const tokenName = bondMapToTokenName[params.bond];
+  return addresses["mainnet"][tokenName as BondToken];
 };
 
 const getReserveABI = (params: { bond: Bond }): ContractInterface => {

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -1,14 +1,17 @@
-import { ContractInterface, ethers, providers } from "ethers";
+import { ethers, providers } from "ethers";
 import { Thunk } from "state";
 import { setBond } from "state/bonds";
 import { OnStatusHandler } from "./utils";
 import { setBondAllowance } from "state/user";
-import { formatUnits, getJsonRpcProvider } from "@klimadao/lib/utils";
+import {
+  formatUnits,
+  getJsonRpcProvider,
+  getContract,
+} from "@klimadao/lib/utils";
 import { addresses, Bond } from "@klimadao/lib/constants";
 import Depository from "@klimadao/lib/abi/KlimaBondDepository_Regular.json";
 import PairContract from "@klimadao/lib/abi/PairContract.json";
 import BondCalcContract from "@klimadao/lib/abi/BondCalcContract.json";
-import OhmDai from "@klimadao/lib/abi/OhmDai.json";
 import IERC20 from "@klimadao/lib/abi/IERC20.json";
 import KlimaProV2 from "@klimadao/lib/abi/KlimaProV2.json";
 
@@ -50,20 +53,6 @@ const getReserveAddress = (params: { bond: Bond }): string => {
   return addresses["mainnet"][tokenName as BondToken];
 };
 
-const getReserveABI = (params: { bond: Bond }): ContractInterface => {
-  return {
-    klima_bct_lp: OhmDai.abi,
-    klima_usdc_lp: OhmDai.abi,
-    bct: IERC20.abi,
-    mco2: IERC20.abi,
-    bct_usdc_lp: OhmDai.abi,
-    klima_mco2_lp: OhmDai.abi,
-    nbo: IERC20.abi,
-    ubo: IERC20.abi,
-    inverse_usdc: KlimaProV2.abi,
-  }[params.bond];
-};
-
 const getIsInverse = (params: { bond: Bond }): boolean => {
   return {
     ubo: false,
@@ -94,11 +83,11 @@ export function contractForReserve(params: {
   bond: Bond;
   providerOrSigner: providers.JsonRpcProvider | providers.JsonRpcSigner;
 }) {
-  return new ethers.Contract(
-    getReserveAddress({ bond: params.bond }),
-    getReserveABI({ bond: params.bond }),
-    params.providerOrSigner
-  );
+  const token = bondMapToTokenName[params.bond];
+  return getContract({
+    contractName: token,
+    provider: params.providerOrSigner,
+  });
 }
 
 const getBCTMarketPrice = async (params: {

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -26,6 +26,8 @@ export const bondMapToTokenName = {
 } as const;
 export type BondTokens = keyof typeof bondMapToTokenName;
 type BondToken = typeof bondMapToTokenName[BondTokens];
+type NormalBond = Exclude<BondTokens, "inverse_usdc">;
+type InverseBond = Extract<BondTokens, "inverse_usdc">;
 
 export const bondMapToBondName = {
   klima_bct_lp: "bond_klimaBctLp",
@@ -64,13 +66,16 @@ const getBondAddress = (params: { bond: Bond }): string => {
   return addresses["mainnet"][bondName as BondContractName];
 };
 
-const getReserveAddress = (params: { bond: BondTokens }): string => {
+const getReserveAddress = (params: { bond: NormalBond }): string => {
   const tokenName = bondMapToTokenName[params.bond];
   return addresses["mainnet"][tokenName as BondToken];
 };
 
-export const getIsInverse = (bond: Bond): boolean =>
-  bond === "inverse_usdc" && bondMapToBondName[bond] === "klimaProV2";
+export const getIsInverse = (
+  bond: NormalBond | InverseBond
+): bond is InverseBond => {
+  return bond === "inverse_usdc";
+};
 
 export const contractForBond = (params: {
   bond: Bond;

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -40,6 +40,24 @@ const bondMapToBondName = {
 type BondCName = keyof typeof bondMapToBondName;
 type BondContractName = typeof bondMapToBondName[BondCName];
 
+type TokensForPairContract =
+  | "klimaBctLp"
+  | "klimaUboLp"
+  | "klimaMco2Lp"
+  | "klimaNboLp" // not a Bond token
+  | "klimaUsdcLp"; // not a Bond token;
+
+const getPairContract = (params: {
+  token: TokensForPairContract;
+  provider: providers.JsonRpcProvider;
+}) => {
+  return new ethers.Contract(
+    addresses["mainnet"][params.token],
+    PairContract.abi,
+    params.provider
+  );
+};
+
 const getBondAddress = (params: { bond: Bond }): string => {
   const bondName = bondMapToBondName[params.bond];
   return addresses["mainnet"][bondName as BondContractName];
@@ -75,11 +93,10 @@ export function contractForReserve(params: {
 const getBCTMarketPrice = async (params: {
   provider: providers.JsonRpcProvider;
 }) => {
-  const pairContract = new ethers.Contract(
-    addresses["mainnet"].klimaBctLp,
-    PairContract.abi,
-    params.provider
-  );
+  const pairContract = getPairContract({
+    token: "klimaBctLp",
+    provider: params.provider,
+  });
   const reserves = await pairContract.getReserves();
   // [BCT, KLIMA] - KLIMA has 9 decimals, BCT has 18 decimals
   return reserves[0] / (reserves[1] * Math.pow(10, 9));
@@ -88,11 +105,10 @@ const getBCTMarketPrice = async (params: {
 const getUBOMarketPrice = async (params: {
   provider: providers.JsonRpcProvider;
 }) => {
-  const pairContract = new ethers.Contract(
-    addresses["mainnet"].klimaUboLp,
-    PairContract.abi,
-    params.provider
-  );
+  const pairContract = getPairContract({
+    token: "klimaUboLp",
+    provider: params.provider,
+  });
   const reserves = await pairContract.getReserves();
   // [UBO, KLIMA] - UBO has 18 decimals, KLIMA has 9 decimals
   return reserves[0] / (reserves[1] * Math.pow(10, 9));
@@ -101,11 +117,10 @@ const getUBOMarketPrice = async (params: {
 const getNBOMarketPrice = async (params: {
   provider: providers.JsonRpcProvider;
 }) => {
-  const pairContract = new ethers.Contract(
-    addresses["mainnet"].klimaNboLp,
-    PairContract.abi,
-    params.provider
-  );
+  const pairContract = getPairContract({
+    token: "klimaNboLp",
+    provider: params.provider,
+  });
   const reserves = await pairContract.getReserves();
   // [KLIMA, NBO] - KLIMA has 9 decimals, NBO has 18 decimals,
   return reserves[1] / (reserves[0] * Math.pow(10, 9));
@@ -115,11 +130,10 @@ const getNBOMarketPrice = async (params: {
 const getKlimaUSDCMarketPrice = async (params: {
   provider: providers.JsonRpcProvider;
 }) => {
-  const pairContract = new ethers.Contract(
-    addresses["mainnet"].klimaUsdcLp,
-    PairContract.abi,
-    params.provider
-  );
+  const pairContract = getPairContract({
+    token: "klimaUsdcLp",
+    provider: params.provider,
+  });
   const reserves = await pairContract.getReserves();
   // [USDC, KLIMA] - USDC has 6 decimals KLIMA has 9 decimals
   // divide usdc/klima to get klima usdc price
@@ -129,11 +143,10 @@ const getKlimaUSDCMarketPrice = async (params: {
 const getInverseKlimaUSDCPrice = async (params: {
   provider: providers.JsonRpcProvider;
 }) => {
-  const pairContract = new ethers.Contract(
-    addresses["mainnet"].klimaUsdcLp,
-    PairContract.abi,
-    params.provider
-  );
+  const pairContract = getPairContract({
+    token: "klimaUsdcLp",
+    provider: params.provider,
+  });
   const reserves = await pairContract.getReserves();
   // [USDC, KLIMA] - USDC has 6 decimals KLIMA has 9 decimals
   // returns klimas per dollar
@@ -144,11 +157,10 @@ const getInverseKlimaUSDCPrice = async (params: {
 const getMCO2MarketPrice = async (params: {
   provider: providers.JsonRpcProvider;
 }) => {
-  const pairContract = new ethers.Contract(
-    addresses["mainnet"].klimaMco2Lp,
-    PairContract.abi,
-    params.provider
-  );
+  const pairContract = getPairContract({
+    token: "klimaMco2Lp",
+    provider: params.provider,
+  });
   const reserves = await pairContract.getReserves();
   // [MCO2, KLIMA] - KLIMA has 9 decimals, MCO2 has 18 decimals
   const MCO2KLIMAPrice = reserves[1] / (reserves[0] * Math.pow(10, 9));

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -7,7 +7,6 @@ import {
   formatUnits,
   getJsonRpcProvider,
   getContract,
-  getTokenDecimals,
 } from "@klimadao/lib/utils";
 import { addresses, Bond } from "@klimadao/lib/constants";
 import PairContract from "@klimadao/lib/abi/PairContract.json";
@@ -308,39 +307,6 @@ export const calcBondDetails = (params: {
       );
     }
   };
-};
-
-export const changeApprovalTransaction = async (params: {
-  value: string;
-  provider: providers.JsonRpcProvider;
-  token: BondToken | "klima";
-  spender: BondContractName;
-  onStatus: OnStatusHandler;
-}) => {
-  try {
-    const contract = getContract({
-      contractName: params.token,
-      provider: params.provider.getSigner(),
-    });
-    const decimals = getTokenDecimals(params.token);
-    const parsedValue = ethers.utils.parseUnits(params.value, decimals);
-    params.onStatus("userConfirmation", "");
-    const txn = await contract.approve(
-      addresses["mainnet"][params.spender],
-      parsedValue.toString()
-    );
-    params.onStatus("networkConfirmation", "");
-    await txn.wait(1);
-    params.onStatus("done", "Approval was successful");
-    return formatUnits(parsedValue, decimals);
-  } catch (error: any) {
-    if (error.code === 4001) {
-      params.onStatus("error", "userRejected");
-      throw error;
-    }
-    params.onStatus("error");
-    throw error;
-  }
 };
 
 export const calculateUserBondDetails = (params: {

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -42,10 +42,10 @@ type BondContractName = typeof bondMapToBondName[BondCName];
 
 type TokensForPairContract =
   | "klimaBctLp"
-  | "klimaUboLp"
+  | "klimaUsdcLp"
   | "klimaMco2Lp"
-  | "klimaNboLp" // not a Bond token
-  | "klimaUsdcLp"; // not a Bond token;
+  | "klimaUboLp" // not a Bond token
+  | "klimaNboLp"; // not a Bond token // not a Bond token
 
 const getPairContract = (params: {
   token: TokensForPairContract;

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -11,7 +11,6 @@ import {
 import { addresses, Bond } from "@klimadao/lib/constants";
 import PairContract from "@klimadao/lib/abi/PairContract.json";
 import BondCalcContract from "@klimadao/lib/abi/BondCalcContract.json";
-import IERC20 from "@klimadao/lib/abi/IERC20.json";
 
 const bondMapToTokenName = {
   klima_bct_lp: "klimaBctLp",
@@ -306,11 +305,10 @@ export const changeApprovalTransaction = async (params: {
 }) => {
   try {
     const contract = params.isInverse
-      ? new ethers.Contract(
-          addresses["mainnet"].klima,
-          IERC20.abi,
-          params.provider.getSigner()
-        )
+      ? getContract({
+          contractName: "klima",
+          provider: params.provider.getSigner(),
+        })
       : contractForReserve({
           bond: params.bond,
           providerOrSigner: params.provider.getSigner(),
@@ -348,11 +346,10 @@ export const calculateUserBondDetails = (params: {
       bond: params.bond,
       providerOrSigner: params.provider,
     });
-    const klimaContract = new ethers.Contract(
-      addresses["mainnet"].klima,
-      IERC20.abi,
-      params.provider
-    );
+    const klimaContract = getContract({
+      contractName: "klima",
+      provider: params.provider,
+    });
     // inverse bonds dont have user details
     if (getIsInverse(params.bond)) {
       const inverseAllowance = await klimaContract.allowance(

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -9,11 +9,9 @@ import {
   getContract,
 } from "@klimadao/lib/utils";
 import { addresses, Bond } from "@klimadao/lib/constants";
-import Depository from "@klimadao/lib/abi/KlimaBondDepository_Regular.json";
 import PairContract from "@klimadao/lib/abi/PairContract.json";
 import BondCalcContract from "@klimadao/lib/abi/BondCalcContract.json";
 import IERC20 from "@klimadao/lib/abi/IERC20.json";
-import KlimaProV2 from "@klimadao/lib/abi/KlimaProV2.json";
 
 const bondMapToTokenName = {
   klima_bct_lp: "klimaBctLp",
@@ -69,14 +67,10 @@ const getIsInverse = (params: { bond: Bond }): boolean => {
 
 export const contractForBond = (params: {
   bond: Bond;
-  provider: providers.JsonRpcProvider;
+  provider: providers.JsonRpcProvider | providers.JsonRpcSigner;
 }) => {
-  const address = getBondAddress({ bond: params.bond });
-  if (getIsInverse({ bond: params.bond })) {
-    return new ethers.Contract(address, KlimaProV2.abi, params.provider);
-  } else {
-    return new ethers.Contract(address, Depository.abi, params.provider);
-  }
+  const token = bondMapToBondName[params.bond];
+  return getContract({ contractName: token, provider: params.provider });
 };
 
 export function contractForReserve(params: {
@@ -427,12 +421,10 @@ export const bondTransaction = async (params: {
     try {
       const acceptedSlippage = 0.0; // 20% instead of 2% bc 2% not working. 20% also not working lol
       const signer = params.provider.getSigner();
-      const contractAddress = getBondAddress({ bond: params.bond });
-      const contract = new ethers.Contract(
-        contractAddress,
-        KlimaProV2.abi,
-        signer
-      );
+      const contract = contractForBond({
+        bond: params.bond,
+        provider: signer,
+      });
       const bondPrice = await contract.marketPrice(INVERSE_USDC_MARKET_ID);
       // minimum amount to be paid out in usdc. need bondPrice in usdc
       const minAmountOut =
@@ -467,12 +459,10 @@ export const bondTransaction = async (params: {
   } else {
     try {
       const signer = params.provider.getSigner();
-      const contractAddress = getBondAddress({ bond: params.bond });
-      const contract = new ethers.Contract(
-        contractAddress,
-        Depository.abi,
-        signer
-      );
+      const contract = contractForBond({
+        bond: params.bond,
+        provider: signer,
+      });
       const calculatePremium = await contract.bondPrice();
       const acceptedSlippage = params.slippage / 100 || 0.02; // 2%
       const maxPremium = Math.round(calculatePremium * (1 + acceptedSlippage));
@@ -503,12 +493,10 @@ export const redeemTransaction = async (params: {
 }) => {
   try {
     const signer = params.provider.getSigner();
-    const contractAddress = getBondAddress({ bond: params.bond });
-    const contract = new ethers.Contract(
-      contractAddress,
-      Depository.abi,
-      signer
-    );
+    const contract = contractForBond({
+      bond: params.bond,
+      provider: signer,
+    });
     params.onStatus("userConfirmation", "");
     const txn = await contract.redeem(params.address, params.shouldAutostake);
     params.onStatus("networkConfirmation", "");

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -390,7 +390,7 @@ export const bondTransaction = async (params: {
   slippage: number;
   onStatus: OnStatusHandler;
 }) => {
-  if (params.bond === "inverse_usdc") {
+  if (getIsInverse(params.bond)) {
     try {
       const acceptedSlippage = 0.0; // 20% instead of 2% bc 2% not working. 20% also not working lol
       const signer = params.provider.getSigner();

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -310,6 +310,7 @@ export const calcBondDetails = (params: {
 };
 
 export const changeApprovalTransaction = async (params: {
+  value: string;
   provider: providers.JsonRpcProvider;
   bond: Bond;
   onStatus: OnStatusHandler;
@@ -326,13 +327,13 @@ export const changeApprovalTransaction = async (params: {
           providerOrSigner: params.provider.getSigner(),
         });
     const approvalAddress = getBondAddress({ bond: params.bond });
-    const value = ethers.utils.parseUnits("1000000000", "ether");
+    const parsedValue = ethers.utils.parseUnits(params.value, "ether");
     params.onStatus("userConfirmation", "");
-    const txn = await contract.approve(approvalAddress, value.toString());
+    const txn = await contract.approve(approvalAddress, parsedValue.toString());
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);
     params.onStatus("done", "Approval was successful");
-    return value;
+    return params.value;
   } catch (error: any) {
     if (error.code === 4001) {
       params.onStatus("error", "userRejected");

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -105,7 +105,7 @@ export const loadAccountDetails = (params: {
       const promisesAllowance = spenders.reduce((arr, spender) => {
         const tokens = getTokensFromSpender(spender);
         tokens.forEach((tkn) => {
-          const contract = assetsContracts[tkn];
+          const contract = assetsContracts[tkn as Asset];
           if (contract) {
             arr.push(
               getAllowance({

--- a/app/components/NotificationModal/index.tsx
+++ b/app/components/NotificationModal/index.tsx
@@ -61,14 +61,9 @@ export const NotificationModal: FC = () => {
     dispatch(setAppState({ notificationStatus: null }));
   });
 
-  // temp fix to not show this modal on specific routes until this component can be removed completely
-  if (
-    pathname === "/stake" ||
-    pathname === "/offset" ||
-    pathname === "/wrap" ||
-    pathname.startsWith("/bonds/")
-  )
-    return null;
+  // all views do have the Transaction Modal, except of pklima which is not maintained no more
+  // if pklima view is removed, you can also remove this Component here
+  if (pathname !== "/pklima") return null;
 
   if (!status) return null;
 

--- a/app/components/NotificationModal/index.tsx
+++ b/app/components/NotificationModal/index.tsx
@@ -62,7 +62,12 @@ export const NotificationModal: FC = () => {
   });
 
   // temp fix to not show this modal on specific routes until this component can be removed completely
-  if (pathname === "/stake" || pathname === "/offset" || pathname === "/wrap")
+  if (
+    pathname === "/stake" ||
+    pathname === "/offset" ||
+    pathname === "/wrap" ||
+    pathname.startsWith("/bonds/")
+  )
     return null;
 
   if (!status) return null;

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -13,6 +13,7 @@ import {
   calculateUserBondDetails,
   bondMapToBondName,
   bondMapToTokenName,
+  getIsInverse,
 } from "actions/bonds";
 
 import { changeApprovalTransaction } from "actions/utils";
@@ -208,7 +209,7 @@ export const Bond: FC<Props> = (props) => {
   };
 
   const getBondMax = (): string => {
-    if (bondState?.bond === "inverse_usdc") {
+    if (!!bondState && getIsInverse(bondState.bond)) {
       return getInverseBondMax();
     }
     return getBondV1Max();
@@ -348,7 +349,7 @@ export const Bond: FC<Props> = (props) => {
   };
 
   const handleBond = () => {
-    if (props.bond === "inverse_usdc") {
+    if (getIsInverse(props.bond)) {
       return handleInverseBond();
     }
     return handleV1Bond();
@@ -496,7 +497,7 @@ export const Bond: FC<Props> = (props) => {
     if (!props.isConnected) {
       return 0;
     }
-    if (props.bond === "inverse_usdc") {
+    if (getIsInverse(props.bond)) {
       return trimWithPlaceholder(
         userState?.balance?.klima,
         Number(userState?.balance?.klima) < 1 ? 18 : 2,
@@ -514,7 +515,7 @@ export const Bond: FC<Props> = (props) => {
     if (!props.isConnected) {
       return false;
     }
-    if (props.bond === "inverse_usdc") {
+    if (getIsInverse(props.bond)) {
       return Number(quantity) > Number(userState?.balance?.klima);
     }
     return Number(quantity) > Number(bondState?.balance);
@@ -525,7 +526,7 @@ export const Bond: FC<Props> = (props) => {
 
   return (
     <>
-      {props.bond !== "inverse_usdc" && <BondBalancesCard bond={props.bond} />}
+      {getIsInverse(props.bond) && <BondBalancesCard bond={props.bond} />}
       <div className={styles.bondCard}>
         <div className={styles.bondCard_header}>
           <Link to="/bonds" className={styles.backButton}>
@@ -557,7 +558,7 @@ export const Bond: FC<Props> = (props) => {
         </div>
         <div className={styles.bondCard_ui}>
           <div className={styles.inputsContainer}>
-            {props.bond !== "inverse_usdc" && (
+            {!getIsInverse(props.bond) && (
               <div className={styles.stakeSwitch}>
                 <button
                   className={styles.switchButton}
@@ -634,7 +635,7 @@ export const Bond: FC<Props> = (props) => {
                 value={getBalance()}
                 warning={getBalanceExceeded()}
               />
-              {props.bond === "inverse_usdc" ? (
+              {getIsInverse(props.bond) ? (
                 /**
                  *
                  * INVERSE BONDS

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -467,7 +467,7 @@ export const Bond: FC<Props> = (props) => {
     } else if (viewIsReedem) {
       return {
         label: <Trans id="bond.redeem">Redeem</Trans>,
-        onClick: handleRedeem,
+        onClick: () => setShowTransactionModal(true),
         disabled: !Number(bondState?.pendingPayout),
       };
     } else {
@@ -1074,20 +1074,26 @@ export const Bond: FC<Props> = (props) => {
           title={
             <Text t="h4" className={styles.transaction_modal_header_title}>
               <SpaOutlined />
-              <Trans id="bond.transaction_modal.title" comment="Bond {0}">
-                Bond {bondInfo.name}
-              </Trans>
+              {viewIsBond ? (
+                <Trans id="bond.transaction_modal.title" comment="Bond {0}">
+                  Bond {bondInfo.name}
+                </Trans>
+              ) : (
+                "Redeem Klima"
+              )}
             </Text>
           }
           onCloseModal={closeModal}
-          token={bondMapToTokenName[props.bond]}
+          token={viewIsBond ? bondMapToTokenName[props.bond] : "klima"}
           spender={bondMapToBondName[props.bond]}
-          value={quantity.toString()}
+          value={
+            viewIsBond ? quantity.toString() : bondState?.pendingPayout || "0"
+          }
           status={fullStatus}
           onResetStatus={() => setStatus(null)}
-          onApproval={handleAllowance}
-          hasApproval={hasApproval()}
-          onSubmit={handleBond}
+          onApproval={handleAllowance} // skipped if is Reedem
+          hasApproval={viewIsBond ? hasApproval() : true} // Redeem needs no approval
+          onSubmit={viewIsBond ? handleBond : handleRedeem}
         />
       )}
 

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -14,6 +14,7 @@ import {
   bondMapToBondName,
   bondMapToTokenName,
   getIsInverse,
+  BondWithoutInverse,
 } from "actions/bonds";
 
 import { Trans, t } from "@lingui/macro";
@@ -245,7 +246,7 @@ export const Bond: FC<Props> = (props) => {
       const token =
         !!bondState && getIsInverse(bondState.bond)
           ? "klima"
-          : bondMapToTokenName[props.bond];
+          : bondMapToTokenName[props.bond as BondWithoutInverse]; // we know here it can't be inverse
       const spender = bondMapToBondName[props.bond];
 
       setStatus(null);

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -13,8 +13,6 @@ import {
   calculateUserBondDetails,
   bondMapToBondName,
   bondMapToTokenName,
-  getIsInverse,
-  BondWithoutInverse,
 } from "actions/bonds";
 
 import { changeApprovalTransaction } from "actions/utils";
@@ -253,10 +251,7 @@ export const Bond: FC<Props> = (props) => {
     try {
       if (!props.provider) return;
 
-      const token =
-        !!bondState && getIsInverse(bondState.bond)
-          ? "klima"
-          : bondMapToTokenName[props.bond as BondWithoutInverse]; // we know here it can't be inverse
+      const token = bondMapToTokenName[props.bond];
       const spender = bondMapToBondName[props.bond];
 
       setStatus(null);
@@ -1085,11 +1080,7 @@ export const Bond: FC<Props> = (props) => {
             </Text>
           }
           onCloseModal={closeModal}
-          token={
-            !!bondState && getIsInverse(bondState.bond)
-              ? "klima"
-              : bondMapToTokenName[props.bond as BondWithoutInverse]
-          }
+          token={bondMapToTokenName[props.bond]}
           spender={bondMapToBondName[props.bond]}
           value={quantity.toString()}
           status={fullStatus}

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -11,6 +11,9 @@ import {
   redeemTransaction,
   calcBondDetails,
   calculateUserBondDetails,
+  bondMapToBondName,
+  bondMapToTokenName,
+  getIsInverse,
 } from "actions/bonds";
 
 import { Trans, t } from "@lingui/macro";
@@ -238,13 +241,21 @@ export const Bond: FC<Props> = (props) => {
   const handleAllowance = async () => {
     try {
       if (!props.provider) return;
+
+      const token =
+        !!bondState && getIsInverse(bondState.bond)
+          ? "klima"
+          : bondMapToTokenName[props.bond];
+      const spender = bondMapToBondName[props.bond];
+
       setStatus(null);
+
       const approvedValue = await changeApprovalTransaction({
         value: quantity.toString(),
         provider: props.provider,
-        bond: props.bond,
+        token,
+        spender,
         onStatus: setStatus,
-        isInverse: bondState && bondState.bond === "inverse_usdc",
       });
       dispatch(setBondAllowance({ [props.bond]: approvedValue }));
     } catch (e) {

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -6,7 +6,6 @@ import { setAppState, AppNotificationStatus, TxnStatus } from "state/app";
 import { selectNotificationStatus, selectLocale } from "state/selectors";
 import { TippyProps } from "@tippyjs/react";
 import {
-  changeApprovalTransaction,
   bondTransaction,
   redeemTransaction,
   calcBondDetails,
@@ -16,6 +15,8 @@ import {
   getIsInverse,
   BondWithoutInverse,
 } from "actions/bonds";
+
+import { changeApprovalTransaction } from "actions/utils";
 
 import { Trans, t } from "@lingui/macro";
 import { prettifySeconds } from "@klimadao/lib/utils";

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -1075,11 +1075,16 @@ export const Bond: FC<Props> = (props) => {
             <Text t="h4" className={styles.transaction_modal_header_title}>
               <SpaOutlined />
               {viewIsBond ? (
-                <Trans id="bond.transaction_modal.title" comment="Bond {0}">
+                <Trans
+                  id="bond.transaction_modal.bond.title"
+                  comment="Bond {0}"
+                >
                   Bond {bondInfo.name}
                 </Trans>
               ) : (
-                "Redeem Klima"
+                <Trans id="bond.transaction_modal.redeem.title">
+                  Redeem Klima
+                </Trans>
               )}
             </Text>
           }

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -217,7 +217,7 @@ export const Bond: FC<Props> = (props) => {
 
   const setMax = () => {
     setStatus(null);
-    if (view === "bond") {
+    if (viewIsBond) {
       setQuantity(getBondMax());
     } else {
       setQuantity(bondState?.pendingPayout ?? "0");
@@ -387,7 +387,10 @@ export const Bond: FC<Props> = (props) => {
     );
   };
 
-  const isDisabled = view === "bond" && bondInfo.disabled;
+  const viewIsBond = view === "bond";
+  const viewIsReedem = view === "redeem";
+
+  const isDisabled = viewIsBond && bondInfo.disabled;
 
   const getButtonProps = (): ButtonProps => {
     const value = Number(quantity || "0");
@@ -411,13 +414,13 @@ export const Bond: FC<Props> = (props) => {
         onClick: undefined,
         disabled: true,
       };
-    } else if (view === "bond" && !value) {
+    } else if (viewIsBond && !value) {
       return {
         label: <Trans id="shared.enter_quantity">Enter Quantity</Trans>,
         onClick: undefined,
         disabled: true,
       };
-    } else if (view === "redeem" && !Number(bondState?.pendingPayout)) {
+    } else if (viewIsReedem && !Number(bondState?.pendingPayout)) {
       return {
         label: <Trans id="bond.not_redeemable">Not Redeemable</Trans>,
         onClick: undefined,
@@ -455,13 +458,13 @@ export const Bond: FC<Props> = (props) => {
         onClick: () => setShowTransactionModal(true),
         variant: "blueRounded",
       };
-    } else if (view === "bond") {
+    } else if (viewIsBond) {
       return {
         label: <Trans id="bond.bond">Bond</Trans>,
         onClick: () => setShowTransactionModal(true),
         disabled: !value || !bondMax,
       };
-    } else if (view === "redeem") {
+    } else if (viewIsReedem) {
       return {
         label: <Trans id="bond.redeem">Redeem</Trans>,
         onClick: handleRedeem,
@@ -478,12 +481,12 @@ export const Bond: FC<Props> = (props) => {
   };
 
   const getInputPlaceholder = (): string => {
-    if (view === "bond") {
+    if (viewIsBond) {
       return t({
         id: "bond.inputplaceholder.amount_to_bond",
         message: "Amount to bond",
       });
-    } else if (view === "redeem") {
+    } else if (viewIsReedem) {
       return t({
         id: "bond.inputplaceholder.amount_to_redeem",
         message: "Amount to redeem",
@@ -566,7 +569,7 @@ export const Bond: FC<Props> = (props) => {
                   onClick={() => {
                     setView("bond");
                   }}
-                  data-active={view === "bond"}
+                  data-active={viewIsBond}
                 >
                   <Trans id="bond.bond">Bond</Trans>
                 </button>
@@ -576,7 +579,7 @@ export const Bond: FC<Props> = (props) => {
                   onClick={() => {
                     setView("redeem");
                   }}
-                  data-active={view === "redeem"}
+                  data-active={viewIsReedem}
                 >
                   <Trans id="bond.redeem">Redeem</Trans>
                 </button>
@@ -586,26 +589,22 @@ export const Bond: FC<Props> = (props) => {
               <input
                 className={styles.stakeInput_input}
                 value={
-                  view === "bond"
-                    ? quantity || ""
-                    : bondState?.pendingPayout || ""
+                  viewIsBond ? quantity || "" : bondState?.pendingPayout || ""
                 }
                 onChange={(e) => setQuantity(e.target.value)}
                 type="number"
                 placeholder={getInputPlaceholder()}
                 min="0"
                 step={
-                  view === "bond" && bondInfo.balanceUnit === "SLP"
-                    ? "0.0001"
-                    : "1"
+                  viewIsBond && bondInfo.balanceUnit === "SLP" ? "0.0001" : "1"
                 }
-                disabled={view === "redeem"}
+                disabled={viewIsReedem}
               />
               <button
                 className={styles.stakeInput_max}
                 type="button"
                 onClick={setMax}
-                disabled={view === "redeem"}
+                disabled={viewIsReedem}
               >
                 <Trans id="shared.max">Max</Trans>
               </button>
@@ -617,7 +616,7 @@ export const Bond: FC<Props> = (props) => {
             )}
             <div className="hr" />
           </div>
-          {view === "bond" && (
+          {viewIsBond && (
             <ul className={styles.dataContainer}>
               {sourceSingleton}
               <DataRow
@@ -918,7 +917,7 @@ export const Bond: FC<Props> = (props) => {
               )}
             </ul>
           )}
-          {view === "redeem" && (
+          {viewIsReedem && (
             <ul className={styles.dataContainer}>
               {sourceSingleton}
               <li className={styles.dataContainer_row}>
@@ -1012,7 +1011,7 @@ export const Bond: FC<Props> = (props) => {
               </li>
             </ul>
           )}
-          {isBondDiscountNegative && view === "bond" && (
+          {isBondDiscountNegative && viewIsBond && (
             <Text t="caption" align="center">
               <Trans
                 id="bond.this_bond_price_is_inflated"
@@ -1047,7 +1046,7 @@ export const Bond: FC<Props> = (props) => {
                   {...getButtonProps()}
                   className={styles.submitButton}
                 />
-                {view === "redeem" && !showSpinner && (
+                {viewIsReedem && !showSpinner && (
                   <div className={styles.checkboxContainer}>
                     <Checkbox
                       checked={shouldAutostake}

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -151,6 +151,14 @@ export const Bond: FC<Props> = (props) => {
       status === "networkConfirmation" ||
       isLoading);
 
+  const viewIsBond = view === "bond";
+  const viewIsReedem = view === "redeem";
+
+  const isDisabled = viewIsBond && bondInfo.disabled;
+
+  const isBondDiscountNegative =
+    !!bondState?.bondDiscount && bondState?.bondDiscount < 0;
+
   const closeModal = () => {
     setStatus(null);
     setShowTransactionModal(false);
@@ -387,11 +395,6 @@ export const Bond: FC<Props> = (props) => {
     );
   };
 
-  const viewIsBond = view === "bond";
-  const viewIsReedem = view === "redeem";
-
-  const isDisabled = viewIsBond && bondInfo.disabled;
-
   const getButtonProps = (): ButtonProps => {
     const value = Number(quantity || "0");
     const bondMax = Number(getBondMax());
@@ -523,9 +526,6 @@ export const Bond: FC<Props> = (props) => {
     }
     return Number(quantity) > Number(bondState?.balance);
   };
-
-  const isBondDiscountNegative =
-    !!bondState?.bondDiscount && bondState?.bondDiscount < 0;
 
   return (
     <>

--- a/app/components/views/Bond/styles.ts
+++ b/app/components/views/Bond/styles.ts
@@ -13,6 +13,12 @@ export {
   submitButton,
 } from "../Stake/styles";
 
+export const transaction_modal_header_title = css`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+`;
+
 export const bondCard = css`
   position: relative;
   display: grid;

--- a/app/components/views/ChooseBond/index.tsx
+++ b/app/components/views/ChooseBond/index.tsx
@@ -12,6 +12,7 @@ import { Text } from "@klimadao/lib/components";
 import * as styles from "./styles";
 import SpaOutlined from "@mui/icons-material/SpaOutlined";
 import { Image } from "components/Image";
+import { getIsInverse } from "actions/bonds";
 
 // put inverse into bonds array and add to useBond
 
@@ -35,11 +36,11 @@ export const useBond = (bond: Bond) => {
     inverse_usdc: false,
   };
 
-  if (bond === "inverse_usdc" && Number(bondState?.capacity) < 1) {
+  if (getIsInverse(bond) && Number(bondState?.capacity) < 1) {
     // set to sold out if capacity reaches zero
     disabledBonds[bond] = true;
   } else if (
-    bond !== "inverse_usdc" &&
+    !getIsInverse(bond) &&
     bondPrice &&
     bondFee &&
     parseFloat(bondPrice) < 1 + bondFee

--- a/app/lib/getTokenInfo.ts
+++ b/app/lib/getTokenInfo.ts
@@ -12,7 +12,6 @@ import KlimaBCTLP from "public/icons/BCT-KLIMA-LP.png";
 import KlimaUsdcLP from "public/icons/KLIMA-USDC-LP.png";
 import BCTUSDCLP from "public/icons/BCT-USDC-LP.png";
 import KlimaMCO2LP from "public/icons/KLIMA-MCO2-LP.png";
-// import INVERSE_USDC from "public/icons/KLIMA-USDC-LP.png";
 
 type TokenInfoMap = {
   [key in AllowancesToken]: {

--- a/app/lib/getTokenInfo.ts
+++ b/app/lib/getTokenInfo.ts
@@ -8,6 +8,11 @@ import KLIMA from "public/icons/KLIMA.png";
 import USDC from "public/icons/USDC.png";
 import UBO from "public/icons/UBO.png";
 import NBO from "public/icons/NBO.png";
+import KlimaBCTLP from "public/icons/BCT-KLIMA-LP.png";
+import KlimaUsdcLP from "public/icons/KLIMA-USDC-LP.png";
+import BCTUSDCLP from "public/icons/BCT-USDC-LP.png";
+import KlimaMCO2LP from "public/icons/KLIMA-MCO2-LP.png";
+// import INVERSE_USDC from "public/icons/KLIMA-USDC-LP.png";
 
 type TokenInfoMap = {
   [key in AllowancesToken]: {
@@ -28,4 +33,16 @@ export const tokenInfo: TokenInfoMap = {
   sklima: { key: "sklima", icon: KLIMA, label: "sKLIMA" },
   wsklima: { key: "wsklima", icon: KLIMA, label: "wsKLIMA" },
   pklima: { key: "pklima", icon: KLIMA, label: "pklima" },
+  bctUsdcLp: { key: "bctUsdcLp", icon: BCTUSDCLP, label: "KLIMA/BCT LP" },
+  klimaUsdcLp: {
+    key: "klimaUsdcLp",
+    icon: KlimaUsdcLP,
+    label: "KLIMA/USDC LP",
+  },
+  klimaBctLp: { key: "klimaBctLp", icon: KlimaBCTLP, label: "KLIMA/BCT LP" },
+  klimaMco2Lp: {
+    key: "klimaMco2Lp",
+    icon: KlimaMCO2LP,
+    label: "KLIMA/MCO2 LP",
+  },
 };

--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -181,7 +181,11 @@ msgstr ""
 
 #. Bond {0}
 #: components/views/Bond/index.tsx:1078
-msgid "bond.transaction_modal.title"
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#: components/views/Bond/index.tsx:1085
+msgid "bond.transaction_modal.redeem.title"
 msgstr ""
 
 #: components/views/Bond/index.tsx:925

--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -6,8 +6,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
-#: components/views/Bond/index.tsx:677
+#: components/views/Bond/index.tsx:701
 msgid "Capacity"
 msgstr ""
 
@@ -32,175 +38,180 @@ msgid "advanced"
 msgstr ""
 
 #. Long sentence
-#: components/views/Bond/index.tsx:1003
+#: components/views/Bond/index.tsx:1027
 msgid "bond.all_demand_has_been_filled"
 msgstr ""
 
-#: components/views/Bond/index.tsx:600
+#: components/views/Bond/index.tsx:624
 msgid "bond.balance"
 msgstr ""
 
 #. Long sentence
-#: components/views/Bond/index.tsx:604
+#: components/views/Bond/index.tsx:628
 msgid "bond.balance.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:435
-#: components/views/Bond/index.tsx:546
+#: components/views/Bond/index.tsx:466
+#: components/views/Bond/index.tsx:574
 msgid "bond.bond"
 msgstr ""
 
-#: components/views/Bond/index.tsx:757
+#: components/views/Bond/index.tsx:781
 msgid "bond.bond_price"
 msgstr ""
 
 #. Long sentence
-#: components/views/Bond/index.tsx:761
+#: components/views/Bond/index.tsx:785
 msgid "bond.bond_price.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:626
+#: components/views/Bond/index.tsx:650
 msgid "bond.bond_price.tooltip.inverse"
 msgstr ""
 
 #. Bond {0}
-#: components/views/Bond/index.tsx:525
+#: components/views/Bond/index.tsx:553
 msgid "bond.bond_token"
 msgstr ""
 
-#: components/views/Bond/index.tsx:422
+#: components/views/Bond/index.tsx:453
 msgid "bond.capacity_exceeded"
 msgstr ""
 
-#: components/views/Bond/index.tsx:963
+#: components/views/Bond/index.tsx:987
 msgid "bond.date_of_full_vesting"
 msgstr ""
 
-#: components/views/Bond/index.tsx:968
+#: components/views/Bond/index.tsx:992
 msgid "bond.date_of_full_vesting.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:793
+#: components/views/Bond/index.tsx:817
 msgid "bond.debt_ratio"
 msgstr ""
 
 #. Long sentence
-#: components/views/Bond/index.tsx:797
+#: components/views/Bond/index.tsx:821
 msgid "bond.debt_ratio.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:828
+#: components/views/Bond/index.tsx:852
 msgid "bond.discount"
 msgstr ""
 
-#: components/views/Bond/index.tsx:832
+#: components/views/Bond/index.tsx:856
 msgid "bond.discount.description_tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:457
+#: components/views/Bond/index.tsx:488
 msgid "bond.inputplaceholder.amount_to_bond"
 msgstr ""
 
-#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:493
 msgid "bond.inputplaceholder.amount_to_redeem"
 msgstr ""
 
-#: components/views/Bond/index.tsx:659
+#: components/views/Bond/index.tsx:683
 msgid "bond.inverse.premium"
 msgstr ""
 
-#: components/views/Bond/index.tsx:663
+#: components/views/Bond/index.tsx:687
 msgid "bond.inverse.premium.description"
 msgstr ""
 
-#: components/views/Bond/index.tsx:622
-#: components/views/Bond/index.tsx:773
+#: components/views/Bond/index.tsx:646
+#: components/views/Bond/index.tsx:797
 msgid "bond.market_price"
 msgstr ""
 
 #. Long sentence
-#: components/views/Bond/index.tsx:777
+#: components/views/Bond/index.tsx:801
 msgid "bond.market_price.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:412
+#: components/views/Bond/index.tsx:443
 msgid "bond.max_exceeded"
 msgstr ""
 
-#: components/views/Bond/index.tsx:695
-#: components/views/Bond/index.tsx:847
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
 msgid "bond.maximum"
 msgstr ""
 
-#: components/views/Bond/index.tsx:699
-#: components/views/Bond/index.tsx:851
+#: components/views/Bond/index.tsx:723
+#: components/views/Bond/index.tsx:875
 msgid "bond.maximum.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:397
+#: components/views/Bond/index.tsx:428
 msgid "bond.not_redeemable"
 msgstr ""
 
-#: components/views/Bond/index.tsx:640
+#: components/views/Bond/index.tsx:664
 msgid "bond.payout_per_klima"
 msgstr ""
 
-#: components/views/Bond/index.tsx:644
+#: components/views/Bond/index.tsx:668
 msgid "bond.payout_per_klima.description_inverse"
 msgstr ""
 
-#: components/views/Bond/index.tsx:441
-#: components/views/Bond/index.tsx:556
+#: components/views/Bond/index.tsx:472
+#: components/views/Bond/index.tsx:584
 msgid "bond.redeem"
 msgstr ""
 
-#: components/views/Bond/index.tsx:930
+#: components/views/Bond/index.tsx:954
 msgid "bond.redeemable"
 msgstr ""
 
 #. Long sentence
-#: components/views/Bond/index.tsx:933
+#: components/views/Bond/index.tsx:957
 msgid "bond.redeemable.tooltip"
 msgstr ""
 
 #. should autostake?
-#: components/views/Bond/index.tsx:1033
+#: components/views/Bond/index.tsx:1057
 msgid "bond.should_autostake"
 msgstr ""
 
 #. Long sentence
-#: components/views/Bond/index.tsx:992
+#: components/views/Bond/index.tsx:1016
 msgid "bond.this_bond_price_is_inflated"
 msgstr ""
 
-#: components/views/Bond/index.tsx:901
+#. Bond {0}
+#: components/views/Bond/index.tsx:1078
+msgid "bond.transaction_modal.title"
+msgstr ""
+
+#: components/views/Bond/index.tsx:925
 msgid "bond.unredeemed"
 msgstr ""
 
 #. Long sentence
-#: components/views/Bond/index.tsx:904
+#: components/views/Bond/index.tsx:928
 msgid "bond.unredeemed.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:813
+#: components/views/Bond/index.tsx:837
 msgid "bond.vesting_term_end"
 msgstr ""
 
-#: components/views/Bond/index.tsx:817
+#: components/views/Bond/index.tsx:841
 msgid "bond.vesting_term_end.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:726
-#: components/views/Bond/index.tsx:870
+#: components/views/Bond/index.tsx:750
+#: components/views/Bond/index.tsx:894
 msgid "bond.you_will_get"
 msgstr ""
 
-#: components/views/Bond/index.tsx:730
+#: components/views/Bond/index.tsx:754
 msgid "bond.you_will_get.description_inverse"
 msgstr ""
 
 #. Long sentence
-#: components/views/Bond/index.tsx:874
+#: components/views/Bond/index.tsx:898
 msgid "bond.you_will_get.tooltip"
 msgstr ""
 
@@ -227,7 +238,7 @@ msgstr ""
 msgid "buy.not_connected"
 msgstr ""
 
-#: components/views/Bond/index.tsx:680
+#: components/views/Bond/index.tsx:704
 msgid "capacity.description_inverse"
 msgstr ""
 
@@ -248,64 +259,64 @@ msgstr ""
 msgid "checkurlbanner.verify_url_and_bookmark_this_page"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:91
+#: components/views/ChooseBond/index.tsx:92
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:196
+#: components/views/ChooseBond/index.tsx:197
 msgid "choose_bond.bond_carbon"
 msgstr ""
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:199
+#: components/views/ChooseBond/index.tsx:200
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:223
+#: components/views/ChooseBond/index.tsx:224
 msgid "choose_bond.choose_bond"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:111
+#: components/views/ChooseBond/index.tsx:112
 msgid "choose_bond.inverse_usdc"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:99
+#: components/views/ChooseBond/index.tsx:100
 msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:95
+#: components/views/ChooseBond/index.tsx:96
 msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:87
+#: components/views/ChooseBond/index.tsx:88
 msgid "choose_bond.mco2.moss_carbon_credit_token"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:107
+#: components/views/ChooseBond/index.tsx:108
 msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:83
+#: components/views/ChooseBond/index.tsx:84
 msgid "choose_bond.nbo.description"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:226
+#: components/views/ChooseBond/index.tsx:227
 msgid "choose_bond.percent_discount"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:252
+#: components/views/ChooseBond/index.tsx:253
 msgid "choose_bond.sold_out"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:213
+#: components/views/ChooseBond/index.tsx:214
 msgid "choose_bond.treasury_balance"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:79
+#: components/views/ChooseBond/index.tsx:80
 msgid "choose_bond.ubo.description"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:103
+#: components/views/ChooseBond/index.tsx:104
 msgid "choose_bond.usdc_lp.bct_usdc_sushiswap_liquidity"
 msgstr ""
 
@@ -420,7 +431,7 @@ msgstr ""
 msgid "modal.user_confirmation"
 msgstr ""
 
-#: components/views/Bond/index.tsx:510
+#: components/views/Bond/index.tsx:538
 msgid "nav.back"
 msgstr ""
 
@@ -615,7 +626,7 @@ msgid "pklima.update"
 msgstr ""
 
 #: components/TransactionModal/Approve.tsx:100
-#: components/views/Bond/index.tsx:428
+#: components/views/Bond/index.tsx:459
 #: components/views/Offset/index.tsx:355
 #: components/views/Stake/index.tsx:259
 #: components/views/Wrap/index.tsx:227
@@ -630,12 +641,12 @@ msgstr ""
 msgid "shared.change_language"
 msgstr ""
 
-#: components/views/Bond/index.tsx:406
+#: components/views/Bond/index.tsx:437
 #: components/views/PKlima/index.tsx:165
 msgid "shared.confirming"
 msgstr ""
 
-#: components/views/Bond/index.tsx:379
+#: components/views/Bond/index.tsx:410
 #: components/views/Buy/index.tsx:113
 #: components/views/Offset/index.tsx:320
 #: components/views/PKlima/index.tsx:150
@@ -653,15 +664,15 @@ msgstr ""
 msgid "shared.enter_amount"
 msgstr ""
 
-#: components/views/Bond/index.tsx:391
+#: components/views/Bond/index.tsx:422
 #: components/views/Offset/index.tsx:332
 #: components/views/Stake/index.tsx:245
 #: components/views/Wrap/index.tsx:208
 msgid "shared.enter_quantity"
 msgstr ""
 
-#: components/views/Bond/index.tsx:448
-#: components/views/Bond/index.tsx:467
+#: components/views/Bond/index.tsx:479
+#: components/views/Bond/index.tsx:498
 #: components/views/Stake/index.tsx:288
 msgid "shared.error"
 msgstr ""
@@ -679,7 +690,7 @@ msgstr ""
 #: components/CarbonTonnesBreakdownCard/index.tsx:48
 #: components/RebaseCard/index.tsx:58
 #: components/RebaseCard/index.tsx:69
-#: components/views/Bond/index.tsx:385
+#: components/views/Bond/index.tsx:416
 #: components/views/Loading/index.tsx:11
 #: components/views/Offset/index.tsx:326
 #: components/views/Offset/index.tsx:414
@@ -692,7 +703,7 @@ msgstr ""
 msgid "shared.loading"
 msgstr ""
 
-#: components/views/Bond/index.tsx:585
+#: components/views/Bond/index.tsx:609
 #: components/views/PKlima/index.tsx:237
 #: components/views/Stake/index.tsx:384
 #: components/views/Wrap/index.tsx:342
@@ -703,7 +714,7 @@ msgstr ""
 msgid "shared.retire"
 msgstr ""
 
-#: components/views/Bond/index.tsx:373
+#: components/views/Bond/index.tsx:404
 msgid "shared.sold_out"
 msgstr ""
 

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/views/Bond/index.tsx:677
+#: components/views/Bond/index.tsx:701
 msgid "Capacity"
 msgstr "Capacity"
 
@@ -38,175 +38,180 @@ msgid "advanced"
 msgstr "ADVANCED"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:1003
+#: components/views/Bond/index.tsx:1027
 msgid "bond.all_demand_has_been_filled"
 msgstr "SOLD OUT. All demand has been filled for this bond. Thank you, Klimates!"
 
-#: components/views/Bond/index.tsx:600
+#: components/views/Bond/index.tsx:624
 msgid "bond.balance"
 msgstr "Balance"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:604
+#: components/views/Bond/index.tsx:628
 msgid "bond.balance.tooltip"
 msgstr "Balance available for bonding"
 
-#: components/views/Bond/index.tsx:435
-#: components/views/Bond/index.tsx:546
+#: components/views/Bond/index.tsx:466
+#: components/views/Bond/index.tsx:574
 msgid "bond.bond"
 msgstr "Bond"
 
-#: components/views/Bond/index.tsx:757
+#: components/views/Bond/index.tsx:781
 msgid "bond.bond_price"
 msgstr "Bond price"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:761
+#: components/views/Bond/index.tsx:785
 msgid "bond.bond_price.tooltip"
 msgstr "Discounted price. Total amount to bond 1 full KLIMA (fractional bonds are also allowed)"
 
-#: components/views/Bond/index.tsx:626
+#: components/views/Bond/index.tsx:650
 msgid "bond.bond_price.tooltip.inverse"
 msgstr "Current trading price of KLIMA on the market"
 
 #. Bond {0}
-#: components/views/Bond/index.tsx:525
+#: components/views/Bond/index.tsx:553
 msgid "bond.bond_token"
 msgstr "Bond {0}"
 
-#: components/views/Bond/index.tsx:422
+#: components/views/Bond/index.tsx:453
 msgid "bond.capacity_exceeded"
 msgstr "CAPACITY EXCEEDED"
 
-#: components/views/Bond/index.tsx:963
+#: components/views/Bond/index.tsx:987
 msgid "bond.date_of_full_vesting"
 msgstr "Date of full vesting"
 
-#: components/views/Bond/index.tsx:968
+#: components/views/Bond/index.tsx:992
 msgid "bond.date_of_full_vesting.tooltip"
 msgstr "Date when the entire bond value can be redeemed"
 
-#: components/views/Bond/index.tsx:793
+#: components/views/Bond/index.tsx:817
 msgid "bond.debt_ratio"
 msgstr "Debt ratio"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:797
+#: components/views/Bond/index.tsx:821
 msgid "bond.debt_ratio.tooltip"
 msgstr "Protocol's current ratio of supply to outstanding bonds"
 
-#: components/views/Bond/index.tsx:828
+#: components/views/Bond/index.tsx:852
 msgid "bond.discount"
 msgstr "Bond discount"
 
-#: components/views/Bond/index.tsx:832
+#: components/views/Bond/index.tsx:856
 msgid "bond.discount.description_tooltip"
 msgstr "Percentage discount (or premium if negative) relative to the market value of KLIMA."
 
-#: components/views/Bond/index.tsx:457
+#: components/views/Bond/index.tsx:488
 msgid "bond.inputplaceholder.amount_to_bond"
 msgstr "Amount to bond"
 
-#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:493
 msgid "bond.inputplaceholder.amount_to_redeem"
 msgstr "Amount to redeem"
 
-#: components/views/Bond/index.tsx:659
+#: components/views/Bond/index.tsx:683
 msgid "bond.inverse.premium"
 msgstr "Premium"
 
-#: components/views/Bond/index.tsx:663
+#: components/views/Bond/index.tsx:687
 msgid "bond.inverse.premium.description"
 msgstr "Premium relative to the market value of KLIMA."
 
-#: components/views/Bond/index.tsx:622
-#: components/views/Bond/index.tsx:773
+#: components/views/Bond/index.tsx:646
+#: components/views/Bond/index.tsx:797
 msgid "bond.market_price"
 msgstr "Market price"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:777
+#: components/views/Bond/index.tsx:801
 msgid "bond.market_price.tooltip"
 msgstr "Current trading price of KLIMA, without bond discount"
 
-#: components/views/Bond/index.tsx:412
+#: components/views/Bond/index.tsx:443
 msgid "bond.max_exceeded"
 msgstr "MAX EXCEEDED"
 
-#: components/views/Bond/index.tsx:695
-#: components/views/Bond/index.tsx:847
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
 msgid "bond.maximum"
 msgstr "Maximum"
 
-#: components/views/Bond/index.tsx:699
-#: components/views/Bond/index.tsx:851
+#: components/views/Bond/index.tsx:723
+#: components/views/Bond/index.tsx:875
 msgid "bond.maximum.tooltip"
 msgstr "Maximum amount you can acquire by bonding"
 
-#: components/views/Bond/index.tsx:397
+#: components/views/Bond/index.tsx:428
 msgid "bond.not_redeemable"
 msgstr "Not Redeemable"
 
-#: components/views/Bond/index.tsx:640
+#: components/views/Bond/index.tsx:664
 msgid "bond.payout_per_klima"
 msgstr "Payout per KLIMA"
 
-#: components/views/Bond/index.tsx:644
+#: components/views/Bond/index.tsx:668
 msgid "bond.payout_per_klima.description_inverse"
 msgstr "If you bond 1 KLIMA, you will receive this amount in USDC."
 
-#: components/views/Bond/index.tsx:441
-#: components/views/Bond/index.tsx:556
+#: components/views/Bond/index.tsx:472
+#: components/views/Bond/index.tsx:584
 msgid "bond.redeem"
 msgstr "Redeem"
 
-#: components/views/Bond/index.tsx:930
+#: components/views/Bond/index.tsx:954
 msgid "bond.redeemable"
 msgstr "Redeemable"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:933
+#: components/views/Bond/index.tsx:957
 msgid "bond.redeemable.tooltip"
 msgstr "Amount of KLIMA that has already vested and can be redeemed"
 
 #. should autostake?
-#: components/views/Bond/index.tsx:1033
+#: components/views/Bond/index.tsx:1057
 msgid "bond.should_autostake"
 msgstr "Automatically stake for sKLIMA"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:992
+#: components/views/Bond/index.tsx:1016
 msgid "bond.this_bond_price_is_inflated"
 msgstr "⚠️ Warning: this bond price is inflated because the current discount rate is negative."
 
-#: components/views/Bond/index.tsx:901
+#. Bond {0}
+#: components/views/Bond/index.tsx:1078
+msgid "bond.transaction_modal.title"
+msgstr "Bond {0}"
+
+#: components/views/Bond/index.tsx:925
 msgid "bond.unredeemed"
 msgstr "Unredeemed"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:904
+#: components/views/Bond/index.tsx:928
 msgid "bond.unredeemed.tooltip"
 msgstr "Remaining unredeemed value (vested and un-vested)"
 
-#: components/views/Bond/index.tsx:813
+#: components/views/Bond/index.tsx:837
 msgid "bond.vesting_term_end"
 msgstr "Vesting term end"
 
-#: components/views/Bond/index.tsx:817
+#: components/views/Bond/index.tsx:841
 msgid "bond.vesting_term_end.tooltip"
 msgstr "If you bond now, your vesting term ends at this date. Klima is slowly unlocked for redemption over the duration of this term."
 
-#: components/views/Bond/index.tsx:726
-#: components/views/Bond/index.tsx:870
+#: components/views/Bond/index.tsx:750
+#: components/views/Bond/index.tsx:894
 msgid "bond.you_will_get"
 msgstr "You will get"
 
-#: components/views/Bond/index.tsx:730
+#: components/views/Bond/index.tsx:754
 msgid "bond.you_will_get.description_inverse"
 msgstr "Amount you will get, at the provided input quantity"
 
 #. Long sentence
-#: components/views/Bond/index.tsx:874
+#: components/views/Bond/index.tsx:898
 msgid "bond.you_will_get.tooltip"
 msgstr "Amount of bonded KLIMA you will get, at the provided input quantity"
 
@@ -233,7 +238,7 @@ msgstr "Buy KLIMA directly using our partner, <0>Mobilum</0>. Double check that 
 msgid "buy.not_connected"
 msgstr "Not Connected"
 
-#: components/views/Bond/index.tsx:680
+#: components/views/Bond/index.tsx:704
 msgid "capacity.description_inverse"
 msgstr "This is the amount of USDC in the contract available for bonds."
 
@@ -254,64 +259,64 @@ msgstr "<0>app.klimadao.finance</0> is the only official domain."
 msgid "checkurlbanner.verify_url_and_bookmark_this_page"
 msgstr "⚠️ Verify the URL and bookmark this page!"
 
-#: components/views/ChooseBond/index.tsx:91
+#: components/views/ChooseBond/index.tsx:92
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr "Toucan Base Carbon Tonne"
 
-#: components/views/ChooseBond/index.tsx:196
+#: components/views/ChooseBond/index.tsx:197
 msgid "choose_bond.bond_carbon"
 msgstr "Bond Carbon"
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:199
+#: components/views/ChooseBond/index.tsx:200
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr "The best way to buy KLIMA. Commit carbon to our treasury, and receive KLIMA at a discount. All bonds (except inverse bonds) have a mandatory 5 day vesting period."
 
-#: components/views/ChooseBond/index.tsx:223
+#: components/views/ChooseBond/index.tsx:224
 msgid "choose_bond.choose_bond"
 msgstr "Choose a bond"
 
-#: components/views/ChooseBond/index.tsx:111
+#: components/views/ChooseBond/index.tsx:112
 msgid "choose_bond.inverse_usdc"
 msgstr "Provide KLIMA, receive USDC"
 
-#: components/views/ChooseBond/index.tsx:99
+#: components/views/ChooseBond/index.tsx:100
 msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
 msgstr "KLIMA/BCT Sushiswap Liquidity"
 
-#: components/views/ChooseBond/index.tsx:95
+#: components/views/ChooseBond/index.tsx:96
 msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
 msgstr "KLIMA/USDC Sushiswap Liquidity"
 
-#: components/views/ChooseBond/index.tsx:87
+#: components/views/ChooseBond/index.tsx:88
 msgid "choose_bond.mco2.moss_carbon_credit_token"
 msgstr "MOSS Carbon Credit Token"
 
-#: components/views/ChooseBond/index.tsx:107
+#: components/views/ChooseBond/index.tsx:108
 msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
 msgstr "KLIMA/MCO2 Quickswap Liquidity"
 
-#: components/views/ChooseBond/index.tsx:83
+#: components/views/ChooseBond/index.tsx:84
 msgid "choose_bond.nbo.description"
 msgstr "C3 Nature Based Offset"
 
-#: components/views/ChooseBond/index.tsx:226
+#: components/views/ChooseBond/index.tsx:227
 msgid "choose_bond.percent_discount"
 msgstr "% Discount"
 
-#: components/views/ChooseBond/index.tsx:252
+#: components/views/ChooseBond/index.tsx:253
 msgid "choose_bond.sold_out"
 msgstr "SOLD OUT"
 
-#: components/views/ChooseBond/index.tsx:213
+#: components/views/ChooseBond/index.tsx:214
 msgid "choose_bond.treasury_balance"
 msgstr "Treasury Balance"
 
-#: components/views/ChooseBond/index.tsx:79
+#: components/views/ChooseBond/index.tsx:80
 msgid "choose_bond.ubo.description"
 msgstr "C3 Universal Basic Offset"
 
-#: components/views/ChooseBond/index.tsx:103
+#: components/views/ChooseBond/index.tsx:104
 msgid "choose_bond.usdc_lp.bct_usdc_sushiswap_liquidity"
 msgstr "BCT/USDC Sushiswap Liquidity"
 
@@ -426,7 +431,7 @@ msgstr "PENDING"
 msgid "modal.user_confirmation"
 msgstr "CONFIRMATION"
 
-#: components/views/Bond/index.tsx:510
+#: components/views/Bond/index.tsx:538
 msgid "nav.back"
 msgstr "BACK"
 
@@ -621,7 +626,7 @@ msgid "pklima.update"
 msgstr "The updated contract now assumes pKLIMA holders have staked and earned rewards on previously claimed tokens. Prior to the November fix, these staking rewards were not counted against your supply share limit, which meant your share of the total KLIMA supply could surpass the limit defined in your terms."
 
 #: components/TransactionModal/Approve.tsx:100
-#: components/views/Bond/index.tsx:428
+#: components/views/Bond/index.tsx:459
 #: components/views/Offset/index.tsx:355
 #: components/views/Stake/index.tsx:259
 #: components/views/Wrap/index.tsx:227
@@ -636,12 +641,12 @@ msgstr "Balances"
 msgid "shared.change_language"
 msgstr "Change language"
 
-#: components/views/Bond/index.tsx:406
+#: components/views/Bond/index.tsx:437
 #: components/views/PKlima/index.tsx:165
 msgid "shared.confirming"
 msgstr "Confirming"
 
-#: components/views/Bond/index.tsx:379
+#: components/views/Bond/index.tsx:410
 #: components/views/Buy/index.tsx:113
 #: components/views/Offset/index.tsx:320
 #: components/views/PKlima/index.tsx:150
@@ -659,15 +664,15 @@ msgstr "Copy Address {0}"
 msgid "shared.enter_amount"
 msgstr "Enter Amount"
 
-#: components/views/Bond/index.tsx:391
+#: components/views/Bond/index.tsx:422
 #: components/views/Offset/index.tsx:332
 #: components/views/Stake/index.tsx:245
 #: components/views/Wrap/index.tsx:208
 msgid "shared.enter_quantity"
 msgstr "ENTER QUANTITY"
 
-#: components/views/Bond/index.tsx:448
-#: components/views/Bond/index.tsx:467
+#: components/views/Bond/index.tsx:479
+#: components/views/Bond/index.tsx:498
 #: components/views/Stake/index.tsx:288
 msgid "shared.error"
 msgstr "ERROR"
@@ -685,7 +690,7 @@ msgstr "INVALID INPUTS"
 #: components/CarbonTonnesBreakdownCard/index.tsx:48
 #: components/RebaseCard/index.tsx:58
 #: components/RebaseCard/index.tsx:69
-#: components/views/Bond/index.tsx:385
+#: components/views/Bond/index.tsx:416
 #: components/views/Loading/index.tsx:11
 #: components/views/Offset/index.tsx:326
 #: components/views/Offset/index.tsx:414
@@ -698,7 +703,7 @@ msgstr "INVALID INPUTS"
 msgid "shared.loading"
 msgstr "Loading..."
 
-#: components/views/Bond/index.tsx:585
+#: components/views/Bond/index.tsx:609
 #: components/views/PKlima/index.tsx:237
 #: components/views/Stake/index.tsx:384
 #: components/views/Wrap/index.tsx:342
@@ -709,7 +714,7 @@ msgstr "Max"
 msgid "shared.retire"
 msgstr "RETIRE CARBON"
 
-#: components/views/Bond/index.tsx:373
+#: components/views/Bond/index.tsx:404
 msgid "shared.sold_out"
 msgstr "Sold Out"
 

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -181,8 +181,12 @@ msgstr "⚠️ Warning: this bond price is inflated because the current discount
 
 #. Bond {0}
 #: components/views/Bond/index.tsx:1078
-msgid "bond.transaction_modal.title"
+msgid "bond.transaction_modal.bond.title"
 msgstr "Bond {0}"
+
+#: components/views/Bond/index.tsx:1085
+msgid "bond.transaction_modal.redeem.title"
+msgstr "Redeem Klima"
 
 #: components/views/Bond/index.tsx:925
 msgid "bond.unredeemed"

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -187,6 +187,15 @@ export const allowancesContracts = {
   staking: ["sklima"],
   wsklima: ["sklima"],
   pklima_exercise: ["bct", "pklima"],
+  bond_klimaMco2Lp: ["klimaMco2Lp"],
+  bond_klimaBctLp: ["klimaBctLp"],
+  bond_klimaUsdcLp: ["klimaUsdcLp"],
+  bond_bct: ["bct"],
+  bond_bctUsdcLp: ["bctUsdcLp"],
+  bond_mco2: ["mco2"],
+  bond_nbo: ["nbo"],
+  bond_ubo: ["ubo"],
+  klimaProV2: ["klima"],
 } as const;
 
 export const EPOCH_INTERVAL = 11520;

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -44,6 +44,8 @@ const contractMap = {
   klimaUsdcLp: OhmDai.abi,
   bctUsdcLp: OhmDai.abi,
   klimaMco2Lp: OhmDai.abi,
+
+  // Bonds Inverse
   klimaProV2: KlimaProV2.abi,
 
   // Bonds Contracts

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -5,13 +5,15 @@ import IERC20 from "../../abi/IERC20.json";
 import WSKLIMA from "../../abi/wsKlima.json";
 import DistributorContractv4 from "../../abi/DistributorContractv4.json";
 import PunkTLD from "../../abi/PunkTLD.json";
-import PairContract from "../../abi/PairContract.json";
 import KlimaRetirementAggregator from "../../abi/KlimaRetirementAggregator.json";
 import ExercisePKlima from "../../abi/ExercisepKLIMA.json";
 import KlimaStakingHelper from "../../abi/KlimaStakingHelper.json";
 import KlimaStakingv2 from "../../abi/KlimaStakingv2.json";
 import KlimaRetirementStorage from "../../abi/KlimaRetirementStorage.json";
 import SKlima from "../../abi/sKlima.json";
+import OhmDai from "../../abi/OhmDai.json";
+import Depository from "../../abi/KlimaBondDepository_Regular.json";
+import KlimaProV2 from "../../abi/KlimaProV2.json";
 
 type Address = keyof typeof addresses["mainnet"];
 type ContractMap = {
@@ -37,11 +39,26 @@ const contractMap = {
   // Main Contracts
   sklimaMain: SKlima.abi,
 
+  // Bonds Tokens
+  klimaBctLp: OhmDai.abi,
+  klimaUsdcLp: OhmDai.abi,
+  bctUsdcLp: OhmDai.abi,
+  klimaMco2Lp: OhmDai.abi,
+  klimaProV2: KlimaProV2.abi,
+
+  // Bonds Contracts
+  bond_klimaBctLp: Depository.abi,
+  bond_klimaUsdcLp: Depository.abi,
+  bond_bctUsdcLp: Depository.abi,
+  bond_klimaMco2Lp: Depository.abi,
+  bond_mco2: Depository.abi,
+  bond_bct: Depository.abi,
+  bond_nbo: Depository.abi,
+  bond_ubo: Depository.abi,
+
   // Others
   distributor: DistributorContractv4.abi,
   klimaNameService: PunkTLD.abi,
-  bctUsdcLp: PairContract.abi,
-  klimaBctLp: PairContract.abi,
   retirementAggregator: KlimaRetirementAggregator.abi, // offset
   pklima_exercise: ExercisePKlima.abi,
   staking_helper: KlimaStakingHelper.abi, // stake

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"


### PR DESCRIPTION
## Description

This PR replaces the former NotificationModal with the new TransactionModal for the following actions:

- approve bond amount for spender contract
- submit final bond action
- redeem pending amounts

This PR also includes these refactorings:
- use the same generic `changeApprovalAction` from utils (same as for Stake, Wrap, Offset)
- add bonds addresses and their matching ABIs to lib/getContract
- adjust all types accordingly
- use `getContract` lib wherever possible

**Please follow the [commit history](https://github.com/KlimaDAO/klimadao/pull/600/commits) to get along with all the changes 🔥** 
=> useful keyboard commands "n" and "p" to browse through the commits

## Open Questions

- [x] What should happen with `redeem` ?  Use the same transactionModal again? Does that fit? => DONE IN THIS PR ✅ 
- [x] How to test the disabled bonds? => answered below: not testable
- [x] A big chunk is still missing:  Add allowances for bonds to the same redux allowances state as for Stake, Wrap, Offset => follow-up PR? This one is already pretty big => new ticket #627




## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/579


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
