### PR TITLE
Retirement certificate enhancements

### DIFF
--- a/lib/types/subgraph.ts
+++ b/lib/types/subgraph.ts
@@ -22,6 +22,7 @@ export interface KlimaRetire {
     standard: string; // "VCS" or "" for Moss
     vintage: string;
     methodology: string;
+    methodologyCategory: string;
     category: string;
   };
 }

--- a/lib/utils/subgraph/queryPolygonBridgedCarbon.ts
+++ b/lib/utils/subgraph/queryPolygonBridgedCarbon.ts
@@ -41,6 +41,7 @@ export const queryKlimaRetireByIndex = async (
                 standard
                 vintage
                 methodology
+                methodologyCategory
                 category
               }
             }

--- a/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/generateCertificate.ts
+++ b/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/generateCertificate.ts
@@ -21,6 +21,7 @@ type Params = {
   beneficiaryAddress: string;
   projectDetails?: VerraProjectDetails;
   retirement: KlimaRetire;
+  retirementIndex: string;
   retirementMessage: string;
   retirementUrl: string;
   tokenData: {
@@ -54,6 +55,7 @@ const featureImageMap = {
 
 export const generateCertificate = (params: Params): void => {
   const isMossRetirement = params.retirement.offset.bridge === "Moss";
+  const fileName = `retirement_${params.retirementIndex}_${params.beneficiaryAddress}.pdf`;
 
   const doc = new jsPDF({
     orientation: "landscape",
@@ -277,5 +279,5 @@ export const generateCertificate = (params: Params): void => {
   if (isMossRetirement) printMossProjectDetails();
   printRetirementLink();
 
-  doc.save(`${params.retirement.id}.pdf`);
+  doc.save(fileName);
 };

--- a/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/generateCertificate.ts
+++ b/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/generateCertificate.ts
@@ -40,7 +40,7 @@ const spacing = {
   beneficiaryName: 81,
   transactionDetails: 130,
   projectDetails: 152,
-  tokenImage: { x: 143, y: 156 },
+  tokenImage: { x: 145, y: 158 },
   retirementLink: 200,
 };
 
@@ -186,6 +186,10 @@ export const generateCertificate = (params: Params): void => {
       {
         label: "Methodology",
         value: params.retirement.offset.methodology,
+      },
+      {
+        label: "Type",
+        value: params.retirement.offset.methodologyCategory,
       },
       {
         label: "Country/Region",

--- a/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { ButtonPrimary } from "@klimadao/lib/components";
+import { Trans, t } from "@lingui/macro";
 
 import { KlimaRetire } from "@klimadao/lib/types/subgraph";
 import { VerraProjectDetails } from "@klimadao/lib/types/verra";
@@ -26,5 +27,13 @@ export const DownloadCertificateButton: FC<DownloadCertificateButtonProps> = (
 ) => {
   const handleClick = () => generateCertificate(props);
 
-  return <ButtonPrimary onClick={handleClick} label="Download PDF" />;
+  return (
+    <ButtonPrimary
+      onClick={handleClick}
+      label={t({
+        id: "retirement.single.download_certificate_button",
+        message: "Download PDF",
+      })}
+    />
+  );
 };

--- a/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx
@@ -11,6 +11,7 @@ export interface DownloadCertificateButtonProps {
   beneficiaryAddress: string;
   projectDetails?: VerraProjectDetails;
   retirement: KlimaRetire;
+  retirementIndex: string;
   retirementMessage: string;
   retirementUrl: string;
   tokenData: {

--- a/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { ButtonPrimary } from "@klimadao/lib/components";
-import { Trans, t } from "@lingui/macro";
+import { t } from "@lingui/macro";
 
 import { KlimaRetire } from "@klimadao/lib/types/subgraph";
 import { VerraProjectDetails } from "@klimadao/lib/types/verra";

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -41,8 +41,8 @@ const DownloadCertificateButton: React.ComponentType<DownloadCertificateButtonPr
 
 type Props = {
   beneficiaryAddress: string;
-  retirementTotals: string;
   retirement: KlimaRetire | null;
+  retirementIndex: string;
   retirementIndexInfo: RetirementIndexInfoResult;
   projectDetails?: VerraProjectDetails;
   nameserviceDomain?: string;
@@ -177,6 +177,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
                       beneficiaryName={retireData.beneficiaryName}
                       beneficiaryAddress={beneficiaryAddress}
                       retirement={retirement}
+                      retirementIndex={props.retirementIndex}
                       retirementMessage={retireData.retirementMessage}
                       retirementUrl={`${urls.home}/${asPath}`}
                       projectDetails={props.projectDetails}

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -30,13 +30,26 @@ import { RetirementFooter } from "../Footer";
 import { CopyURLButton } from "../CopyURLButton";
 import * as styles from "./styles";
 
+const LoadingCertificateButton: React.FC = () => (
+  <ButtonPrimary
+    disabled={true}
+    label={t({
+      id: "shared.loading",
+      message: "Loading...",
+    })}
+  />
+);
+
 const DownloadCertificateButton: React.ComponentType<DownloadCertificateButtonProps> =
   dynamic(
     () =>
       import("./DownloadCertificateButton").then(
         (mod) => mod.DownloadCertificateButton
       ),
-    { ssr: false }
+    {
+      ssr: false,
+      loading: () => <LoadingCertificateButton />,
+    }
   );
 
 type Props = {
@@ -172,7 +185,7 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
                   </Trans>
                 }
                 text={
-                  retirement && (
+                  retirement ? (
                     <DownloadCertificateButton
                       beneficiaryName={retireData.beneficiaryName}
                       beneficiaryAddress={beneficiaryAddress}
@@ -183,6 +196,8 @@ export const SingleRetirementPage: NextPage<Props> = (props) => {
                       projectDetails={props.projectDetails}
                       tokenData={tokenData}
                     />
+                  ) : (
+                    <LoadingCertificateButton />
                   )
                 }
               />

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1115,39 +1115,43 @@ msgstr "Use carbon-backed KLIMA tokens to govern, swap, and earn staking rewards
 msgid "retirement.footer.buy_klima.title"
 msgstr "Acquire, stake, and get rewarded."
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:94
+#: components/pages/Retirements/SingleRetirement/index.tsx:107
 msgid "retirement.head.metaDescription"
 msgstr "Transparent, on-chain offsets powered by KlimaDAO."
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:90
+#: components/pages/Retirements/SingleRetirement/index.tsx:103
 msgid "retirement.head.metaTitle"
 msgstr "{retiree} retired {0} Tonnes of carbon"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:86
+#: components/pages/Retirements/SingleRetirement/index.tsx:99
 msgid "retirement.head.title"
 msgstr "KlimaDAO | Carbon Retirement Receipt"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:140
+#: components/pages/Retirements/SingleRetirement/index.tsx:153
 msgid "retirement.single.beneficiary.placeholder"
 msgstr "No beneficiary name provided"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:134
+#: components/pages/Retirements/SingleRetirement/index.tsx:147
 msgid "retirement.single.beneficiary.title"
 msgstr "Beneficiary"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:148
+#: components/pages/Retirements/SingleRetirement/index.tsx:161
 msgid "retirement.single.beneficiaryAddress.title"
 msgstr "Beneficiary Address"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:191
+#: components/pages/Retirements/SingleRetirement/index.tsx:207
 msgid "retirement.single.disclaimer"
 msgstr "This represents the permanent retirement of tokenized carbon assets on the Polygon blockchain. This retirement and the associated data are immutable public records."
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:105
+#: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:33
+msgid "retirement.single.download_certificate_button"
+msgstr "Download PDF"
+
+#: components/pages/Retirements/SingleRetirement/index.tsx:118
 msgid "retirement.single.header.quantity"
 msgstr "{0}t"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:110
+#: components/pages/Retirements/SingleRetirement/index.tsx:123
 msgid "retirement.single.header.subline"
 msgstr "CO2-Equivalent Emissions Offset (Metric Tonnes)"
 
@@ -1183,7 +1187,7 @@ msgstr "View on Polygonscan"
 msgid "retirement.single.quantity"
 msgstr "QUANTITY RETIRED"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:170
+#: components/pages/Retirements/SingleRetirement/index.tsx:183
 msgid "retirement.single.retirementCertificate.title"
 msgstr "Certificate"
 
@@ -1191,7 +1195,7 @@ msgstr "Certificate"
 msgid "retirement.single.retirementDate.title"
 msgstr "Date"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:119
+#: components/pages/Retirements/SingleRetirement/index.tsx:132
 msgid "retirement.single.retirementMessage.placeholder"
 msgstr "No retirement message provided"
 
@@ -1199,7 +1203,7 @@ msgstr "No retirement message provided"
 msgid "retirement.single.timestamp.placeholder"
 msgstr "No retirement timestamp provided"
 
-#: components/pages/Retirements/SingleRetirement/index.tsx:220
+#: components/pages/Retirements/SingleRetirement/index.tsx:236
 msgid "retirement.single.view_on_polygon_scan"
 msgstr "View on Polygonscan"
 
@@ -1341,6 +1345,7 @@ msgstr "Infinity"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/TokenRow/index.tsx:40
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:57
+#: components/pages/Retirements/SingleRetirement/index.tsx:36
 msgid "shared.loading"
 msgstr "Loading..."
 

--- a/site/pages/retirements/[beneficiary]/[retirement_index].tsx
+++ b/site/pages/retirements/[beneficiary]/[retirement_index].tsx
@@ -28,8 +28,8 @@ interface Params extends ParsedUrlQuery {
 interface PageProps {
   /** The resolved 0x address */
   beneficiaryAddress: string;
-  retirementTotals: Params["retirement_index"];
   retirement: KlimaRetire | null;
+  retirementIndex: Params["retirement_index"];
   retirementIndexInfo: RetirementIndexInfoResult;
   projectDetails: VerraProjectDetails | null;
   nameserviceDomain: string | null;
@@ -122,14 +122,14 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
 
     return {
       props: {
-        retirement: retirement || null,
-        retirementIndexInfo,
         beneficiaryAddress: beneficiaryAddress,
-        retirementTotals: params.retirement_index,
-        translation,
-        projectDetails,
-        nameserviceDomain: isDomainInURL ? beneficiaryInUrl : null,
         canonicalUrl: `${urls.retirements}/${beneficiaryInUrl}/${params.retirement_index}`,
+        nameserviceDomain: isDomainInURL ? beneficiaryInUrl : null,
+        projectDetails,
+        retirement: retirement || null,
+        retirementIndex: params.retirement_index,
+        retirementIndexInfo,
+        translation,
       },
       revalidate: 240,
     };


### PR DESCRIPTION
## Description

- Add type to retirement certificates
- update certificate filename to following pattern: `retirement_<index>_<beneficiary_address>`
- add loading components to mitigate layout shift on lazy loading


## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #605 #604 

## Changes

<img width="600" alt="image" src="https://user-images.githubusercontent.com/97446324/184776813-f33620c0-4818-4d40-825f-d4e887dbf37d.png">

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
