### PR TITLE
Pledge form error translations

### DIFF
--- a/site/components/Form/InputField/index.tsx
+++ b/site/components/Form/InputField/index.tsx
@@ -8,6 +8,7 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   hideLabel?: boolean;
   errors?: { message?: string };
+  errorMessageMap: (id: string) => string;
 }
 
 export const InputField = React.forwardRef<HTMLInputElement, Props>(
@@ -34,9 +35,9 @@ export const InputField = React.forwardRef<HTMLInputElement, Props>(
           {...props}
         />
 
-        {errors && (
+        {errors && errors.message && (
           <Text t="caption" className={styles.errorMessage}>
-            {errors.message}
+            {props.errorMessageMap(errors.message)}
           </Text>
         )}
       </div>

--- a/site/components/Form/InputField/styles.ts
+++ b/site/components/Form/InputField/styles.ts
@@ -62,10 +62,11 @@ export const errorMessage = css`
   font-weight: 400;
   color: var(--warn);
   margin-bottom: 0.2rem;
+  word-break: break-word;
 
   ${breakpoints.large} {
     font-size: 1.4rem;
-    line-height: 1.2rem;
+    line-height: 1.6rem;
     margin-bottom: 0.8rem;
   }
 `;

--- a/site/components/Form/TextareaField/index.tsx
+++ b/site/components/Form/TextareaField/index.tsx
@@ -8,6 +8,7 @@ interface Props extends InputHTMLAttributes<HTMLTextAreaElement> {
   label: string;
   rows: number;
   errors?: { message?: string };
+  errorMessageMap: (id: string) => string;
 }
 
 export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
@@ -31,9 +32,9 @@ export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
           {...props}
         />
 
-        {errors && (
+        {errors && errors.message && (
           <Text t="caption" className={styles.errorMessage}>
-            {errors.message}
+            {props.errorMessageMap(errors.message)}
           </Text>
         )}
       </div>

--- a/site/components/Modal/index.tsx
+++ b/site/components/Modal/index.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 import Close from "@mui/icons-material/Close";
 
 import * as styles from "./styles";
+import { Text } from "@klimadao/lib/components";
 
 type ModalWrapperProps = {
   showModal: boolean;
@@ -41,7 +42,9 @@ export const Modal: FC<Props> = (props) => {
       <div className={styles.modalContainer}>
         <div className={styles.modalContent}>
           <div className="title">
-            {props.title}
+            <Text t="h4" uppercase={true}>
+              {props.title}
+            </Text>
 
             {showCloseButton && (
               <button onClick={props.onToggleModal}>

--- a/site/components/Modal/styles.ts
+++ b/site/components/Modal/styles.ts
@@ -49,7 +49,6 @@ export const modalContent = css`
     justify-content: space-between;
     align-items: center;
     width: 100%;
-    text-transform: uppercase;
 
     button {
       display: flex;

--- a/site/components/pages/Pledge/PledgeDashboard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/index.tsx
@@ -64,7 +64,10 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
         canonicalUrl={props.canonicalUrl}
       />
       <Modal
-        title="Your pledge"
+        title={t({
+          id: "pledges.form.title",
+          message: "Your pledge",
+        })}
         showModal={showModal}
         onToggleModal={() => setShowModal(!showModal)}
       >

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -18,6 +18,7 @@ import { InputField, TextareaField } from "components/Form";
 import {
   editPledgeSignature,
   formSchema,
+  getPledgeFormErrorTranslations,
   putPledge,
   pledgeFormAdapter,
 } from "../lib";
@@ -119,6 +120,7 @@ export const PledgeForm: FC<Props> = (props) => {
         })}
         type="text"
         errors={formState.errors.name}
+        errorMessageMap={getPledgeFormErrorTranslations}
         {...register("name")}
       />
 
@@ -131,6 +133,7 @@ export const PledgeForm: FC<Props> = (props) => {
         placeholder="https://"
         type="text"
         errors={formState.errors.profileImageUrl}
+        errorMessageMap={getPledgeFormErrorTranslations}
         {...register("profileImageUrl")}
       />
 
@@ -146,6 +149,7 @@ export const PledgeForm: FC<Props> = (props) => {
           message: "What is your pledge?",
         })}
         errors={formState.errors.description}
+        errorMessageMap={getPledgeFormErrorTranslations}
         {...register("description")}
       />
 
@@ -162,6 +166,7 @@ export const PledgeForm: FC<Props> = (props) => {
             "What tools or methodologies did you use to calculate your carbon footprint?",
         })}
         errors={formState.errors.methodology}
+        errorMessageMap={getPledgeFormErrorTranslations}
         {...register("methodology")}
       />
 
@@ -194,6 +199,7 @@ export const PledgeForm: FC<Props> = (props) => {
                   })}
                   type="text"
                   errors={formState.errors.categories?.[index]?.name}
+                  errorMessageMap={getPledgeFormErrorTranslations}
                   {...register(`categories.${index}.name` as const)}
                 />
 
@@ -209,6 +215,7 @@ export const PledgeForm: FC<Props> = (props) => {
                   })}
                   type="number"
                   errors={formState.errors.categories?.[index]?.quantity}
+                  errorMessageMap={getPledgeFormErrorTranslations}
                   {...register(`categories.${index}.quantity` as const)}
                 />
               </div>
@@ -246,6 +253,7 @@ export const PledgeForm: FC<Props> = (props) => {
         })}
         type="hidden"
         errors={formState.errors.footprint}
+        errorMessageMap={getPledgeFormErrorTranslations}
         {...register("footprint")}
       />
 

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -1,42 +1,97 @@
+import { t } from "@lingui/macro";
 import * as yup from "yup";
+
+export const getPledgeFormErrorTranslations = (id: string) => {
+  const ERROR_MAP = {
+    ["pledges.form.errors.name.required"]: t({
+      id: "pledges.form.errors.name.required",
+      message: "Enter a name",
+    }),
+    ["pledges.form.errors.profileImageUrl.url"]: t({
+      id: "pledges.form.errors.profileImageUrl.url",
+      message: "Enter a valid url",
+    }),
+    ["pledges.form.errors.description.required"]: t({
+      id: "pledges.form.errors.description.required",
+      message: "Enter a pledge",
+    }),
+    ["pledges.form.errors.description.max"]: t({
+      id: "pledges.form.errors.description.max",
+      message: "Enter less than 500 characters",
+    }),
+    ["pledges.form.errors.methodology.required"]: t({
+      id: "pledges.form.errors.methodology.required",
+      message: "Enter a methodology",
+    }),
+    ["pledges.form.errors.methodology.max"]: t({
+      id: "pledges.form.errors.methodology.max",
+      message: "Enter less than 1000 characters",
+    }),
+    ["pledges.form.errors.footprint.generic_error"]: t({
+      id: "pledges.form.errors.footprint.generic_error",
+      message: "Enter a carbon tonne estimate",
+    }),
+    ["pledges.form.errors.footprint.min"]: t({
+      id: "pledges.form.errors.footprint.min",
+      message: "Enter a value greater than 0",
+    }),
+    ["pledges.form.errors.categoryName.required"]: t({
+      id: "pledges.form.errors.categoryName.required",
+      message: "Enter a category",
+    }),
+    ["pledges.form.errors.categoryName.max"]: t({
+      id: "pledges.form.errors.categoryName.max",
+      message: "Enter less than 32 characters",
+    }),
+    ["pledges.form.errors.categoryQuantity.min"]: t({
+      id: "pledges.form.errors.categoryQuantity.min",
+      message: "Enter a value greater than 0",
+    }),
+  };
+
+  return ERROR_MAP[id as keyof typeof ERROR_MAP];
+};
 
 export const formSchema = yup
   .object({
     id: yup.string().nullable(),
     ownerAddress: yup.string().required().trim(),
     nonce: yup.string().required().trim(),
-    name: yup.string().required("Enter a name").trim(),
-    profileImageUrl: yup.string().url("Enter a valid url").trim().ensure(),
+    name: yup.string().required("pledges.form.errors.name.required").trim(),
+    profileImageUrl: yup
+      .string()
+      .url("pledges.form.errors.profileImageUrl.url")
+      .trim()
+      .ensure(),
     description: yup
       .string()
-      .required("Enter a pledge")
-      .max(500, "Enter less than 500 characters")
+      .required("pledges.form.errors.description.required")
+      .max(500, "pledges.form.errors.description.max")
       .trim(),
     methodology: yup
       .string()
-      .required("Enter a methodology")
-      .max(1000, "Enter less than 1000 characters")
+      .required("pledges.form.errors.methodology.required")
+      .max(1000, "pledges.form.errors.methodology.max")
       .trim(),
     footprint: yup
       .number()
-      .required("Enter a carbon tonne estimate")
-      .typeError("Enter a carbon tonne estimate")
-      .required("Enter a carbon tonne estimate")
-      .min(0, "Value needs to be greater than 0"),
+      .required("pledges.form.errors.footprint.generic_error")
+      .typeError("pledges.form.errors.footprint.generic_error")
+      .min(0, "pledges.form.errors.footprint.min"),
     categories: yup
       .array()
       .of(
         yup.object({
           name: yup
             .string()
-            .required("Enter a category")
-            .max(32, "Enter less than 32 characters")
+            .required("pledges.form.errors.categoryName.required")
+            .max(32, "pledges.form.errors.categoryName.max")
             .trim(),
           quantity: yup
             .number()
-            .required("Enter a carbon tonne estimate")
-            .typeError("Enter a carbon tonne estimate")
-            .min(0, "Value needs to be greater than 0"),
+            .required("pledges.form.errors.footprint.generic_error")
+            .typeError("pledges.form.errors.footprint.generic_error")
+            .min(0, "pledges.form.errors.categoryQuantity.min"),
         })
       )
       .required(),

--- a/site/components/pages/Pledge/lib/index.tsx
+++ b/site/components/pages/Pledge/lib/index.tsx
@@ -1,5 +1,5 @@
 export { editPledgeSignature } from "./editPledgeSignature";
-export { formSchema } from "./formSchema";
+export { formSchema, getPledgeFormErrorTranslations } from "./formSchema";
 export { DEFAULT_NONCE, generateNonce } from "./generateNonce";
 export {
   createPledgeAttributes,

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -982,75 +982,119 @@ msgstr "Total Carbon Tonnes Retired"
 msgid "pledges.edit_pledge"
 msgstr "Edit Pledge"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:231
+#: components/pages/Pledge/PledgeForm/index.tsx:238
 msgid "pledges.form.add_footprint_category_button"
 msgstr "Add category"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:170
+#: components/pages/Pledge/lib/formSchema.ts:42
+msgid "pledges.form.errors.categoryName.max"
+msgstr "Enter less than 32 characters"
+
+#: components/pages/Pledge/lib/formSchema.ts:38
+msgid "pledges.form.errors.categoryName.required"
+msgstr "Enter a category"
+
+#: components/pages/Pledge/lib/formSchema.ts:46
+msgid "pledges.form.errors.categoryQuantity.min"
+msgstr "Enter a value greater than 0"
+
+#: components/pages/Pledge/lib/formSchema.ts:18
+msgid "pledges.form.errors.description.max"
+msgstr "Enter less than 500 characters"
+
+#: components/pages/Pledge/lib/formSchema.ts:14
+msgid "pledges.form.errors.description.required"
+msgstr "Enter a pledge"
+
+#: components/pages/Pledge/lib/formSchema.ts:30
+msgid "pledges.form.errors.footprint.generic_error"
+msgstr "Enter a carbon tonne estimate"
+
+#: components/pages/Pledge/lib/formSchema.ts:34
+msgid "pledges.form.errors.footprint.min"
+msgstr "Enter a value greater than 0"
+
+#: components/pages/Pledge/lib/formSchema.ts:26
+msgid "pledges.form.errors.methodology.max"
+msgstr "Enter less than 1000 characters"
+
+#: components/pages/Pledge/lib/formSchema.ts:22
+msgid "pledges.form.errors.methodology.required"
+msgstr "Enter a methodology"
+
+#: components/pages/Pledge/lib/formSchema.ts:6
+msgid "pledges.form.errors.name.required"
+msgstr "Enter a name"
+
+#: components/pages/Pledge/lib/formSchema.ts:10
+msgid "pledges.form.errors.profileImageUrl.url"
+msgstr "Enter a valid url"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:175
 msgid "pledges.form.footprint.label"
 msgstr "Footprint"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:175
+#: components/pages/Pledge/PledgeForm/index.tsx:180
 msgid "pledges.form.footprint.prompt"
 msgstr "Add a category and start calculating your carbon footprint"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:107
+#: components/pages/Pledge/PledgeForm/index.tsx:108
 msgid "pledges.form.generic_error"
 msgstr "Something went wrong. Please try again."
 
-#: components/pages/Pledge/PledgeForm/index.tsx:187
+#: components/pages/Pledge/PledgeForm/index.tsx:192
 msgid "pledges.form.input.categoryName.label"
 msgstr "Category"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:191
+#: components/pages/Pledge/PledgeForm/index.tsx:196
 msgid "pledges.form.input.categoryName.placeholder"
 msgstr "Category name"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:202
+#: components/pages/Pledge/PledgeForm/index.tsx:208
 msgid "pledges.form.input.categoryQuantity.label"
 msgstr "Quantity"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:206
+#: components/pages/Pledge/PledgeForm/index.tsx:212
 msgid "pledges.form.input.categoryQuantity.placeholder"
 msgstr "Carbon tonnes"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:140
+#: components/pages/Pledge/PledgeForm/index.tsx:143
 msgid "pledges.form.input.description.label"
 msgstr "Pledge"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:144
+#: components/pages/Pledge/PledgeForm/index.tsx:147
 msgid "pledges.form.input.description.placeholder"
 msgstr "What is your pledge?"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:155
+#: components/pages/Pledge/PledgeForm/index.tsx:159
 msgid "pledges.form.input.methodology.label"
 msgstr "Methodology"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:159
+#: components/pages/Pledge/PledgeForm/index.tsx:163
 msgid "pledges.form.input.methodology.placeholder"
 msgstr "What tools or methodologies did you use to calculate your carbon footprint?"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:115
+#: components/pages/Pledge/PledgeForm/index.tsx:116
 msgid "pledges.form.input.name.label"
 msgstr "Name"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:116
+#: components/pages/Pledge/PledgeForm/index.tsx:117
 msgid "pledges.form.input.name.placeholder"
 msgstr "Name or company name"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:127
+#: components/pages/Pledge/PledgeForm/index.tsx:129
 msgid "pledges.form.input.profileImageUrl.label"
 msgstr "Profile image url (optional)"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:243
+#: components/pages/Pledge/PledgeForm/index.tsx:250
 msgid "pledges.form.input.totalFootprint.label"
 msgstr "Total footprint"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:257
+#: components/pages/Pledge/PledgeForm/index.tsx:265
 msgid "pledges.form.submit_button"
 msgstr "Save pledge"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:44
+#: components/pages/Pledge/PledgeForm/index.tsx:45
 msgid "pledges.form.total_footprint_summary"
 msgstr "Total Footprint: {0} Carbon Tonnes"
 

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1094,6 +1094,10 @@ msgstr "Total footprint"
 msgid "pledges.form.submit_button"
 msgstr "Save pledge"
 
+#: components/pages/Pledge/PledgeDashboard/index.tsx:67
+msgid "pledges.form.title"
+msgstr "Your pledge"
+
 #: components/pages/Pledge/PledgeForm/index.tsx:45
 msgid "pledges.form.total_footprint_summary"
 msgstr "Total Footprint: {0} Carbon Tonnes"


### PR DESCRIPTION
## Description

Form error messages can not be directly translated where we define the form `yups` schema.
To work with this constraint, we return the translation id as the "error message", which is then mapped to a function that returns translated strings based on the id.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #606 

## Changes

<img width="450" alt="image" src="https://user-images.githubusercontent.com/97446324/184789756-2c56d864-1035-4b49-8085-503168ccb343.png">

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
