### PR TITLE
CMS: add tags for posts and podcasts

### DIFF
--- a/cms/schemas/podcast.js
+++ b/cms/schemas/podcast.js
@@ -39,6 +39,21 @@ export default {
       validation: (Rule) => Rule.required().min(50).max(150),
     },
     {
+      title: "Tags",
+      name: "tags",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: "tag" }],
+        },
+      ],
+      options: {
+        layout: "tags",
+      },
+      validation: (Rule) => Rule.required(),
+    },
+    {
       name: "hideFromProduction",
       title: "Hide From Production (preview mode):",
       description:

--- a/cms/schemas/post.js
+++ b/cms/schemas/post.js
@@ -55,6 +55,21 @@ export default {
       validation: (Rule) => Rule.required().min(50).max(150),
     },
     {
+      title: "Tags",
+      name: "tags",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: "tag" }],
+        },
+      ],
+      options: {
+        layout: "tags",
+      },
+      validation: (Rule) => Rule.required(),
+    },
+    {
       name: "showDisclaimer",
       title: "Show Disclaimer",
       description:

--- a/cms/schemas/schema.js
+++ b/cms/schemas/schema.js
@@ -10,6 +10,7 @@ import post from "./post";
 import author from "./author";
 import fileUpload from "./fileUpload";
 import podcast from "./podcast";
+import tag from "./tag";
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default createSchema({
@@ -20,12 +21,13 @@ export default createSchema({
   types: schemaTypes.concat([
     // The following are document types which will appear
     // in the studio.
+    // When added to this list, object types can be used as
+    // { type: 'typename' } in other document schemas
     post,
     author,
     fileUpload,
-    // When added to this list, object types can be used as
-    // { type: 'typename' } in other document schemas
     blockContent,
     podcast,
+    tag,
   ]),
 });

--- a/cms/schemas/tag.js
+++ b/cms/schemas/tag.js
@@ -4,19 +4,19 @@ export default {
   type: "document",
   fields: [
     {
+      name: "label_en",
+      title: "Label (en)",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    },
+    {
       name: "tag",
       title: "Tag",
       type: "slug",
       options: {
-        source: "title",
+        source: "label_en",
         maxLength: 100,
       },
-      validation: (Rule) => Rule.required(),
-    },
-    {
-      name: "label_en",
-      title: "Label (en)",
-      type: "string",
       validation: (Rule) => Rule.required(),
     },
     {
@@ -28,9 +28,7 @@ export default {
   ],
   preview: {
     select: {
-      title: "title",
-      label_en: "label_en",
-      description_en: "description_en",
+      title: "label_en",
     },
   },
 };

--- a/cms/schemas/tag.js
+++ b/cms/schemas/tag.js
@@ -1,0 +1,36 @@
+export default {
+  name: "tag",
+  title: "Tag",
+  type: "document",
+  fields: [
+    {
+      name: "tag",
+      title: "Tag",
+      type: "slug",
+      options: {
+        source: "title",
+        maxLength: 100,
+      },
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "label_en",
+      title: "Label (en)",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "description_en",
+      title: "Description (en)",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    },
+  ],
+  preview: {
+    select: {
+      title: "title",
+      label_en: "label_en",
+      description_en: "description_en",
+    },
+  },
+};


### PR DESCRIPTION
## Description

This is the first step for the new filtering of blog content and does:

- add new document schema "tag" for sanity
- reference tags in posts and podcasts


### NOTE:
This is not deployed yet! 🔥 

Still the Live project for sanity detected the new field "tags" from my local dev server when running sanity on localhost.
Is this intended?
**And who will deploy this now?**

## Related Ticket

Related to https://github.com/KlimaDAO/klimadao/issues/534

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
