### PR TITLE
fix: do not pass buttonStyle to anchor props

### DIFF
--- a/lib/components/Buttons/ButtonBase.tsx
+++ b/lib/components/Buttons/ButtonBase.tsx
@@ -18,18 +18,22 @@ interface BaseProps extends Props {
   buttonStyle: string;
 }
 
-export const BaseButton: FC<BaseProps> = ({ link: LinkElement, ...props }) => {
+export const BaseButton: FC<BaseProps> = ({
+  link: LinkElement,
+  buttonStyle,
+  ...props
+}) => {
   if (props.href) {
     if (LinkElement) {
       return (
         <LinkElement href={props.href}>
-          <a className={props.buttonStyle}>{props.label}</a>
+          <a className={buttonStyle}>{props.label}</a>
         </LinkElement>
       );
     }
 
     return (
-      <a {...props} className={props.buttonStyle} href={props.href}>
+      <a {...props} className={buttonStyle} href={props.href}>
         {props.label}
       </a>
     );
@@ -38,7 +42,7 @@ export const BaseButton: FC<BaseProps> = ({ link: LinkElement, ...props }) => {
   return (
     <button
       type="button"
-      className={props.buttonStyle}
+      className={buttonStyle}
       onClick={props.onClick}
       disabled={props.disabled}
     >


### PR DESCRIPTION
## Description

A minor fix to remove the error warning from nextJS:

```
next-dev.js?878b:32 Warning: React does not recognize the `buttonStyle` prop on a DOM element. 
If you intentionally want it to appear in the DOM as a custom attribute, 
spell it as lowercase `buttonstyle` instead. 
If you accidentally passed it from a parent component, remove it from the DOM element.
    at a
    at BaseButton ....
```

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
