### PR TITLE
Add 1% to approval value for offset

### DIFF
--- a/app/components/TransactionModal/index.tsx
+++ b/app/components/TransactionModal/index.tsx
@@ -15,6 +15,7 @@ import * as styles from "./styles";
 interface Props {
   title: ReactNode;
   value: string;
+  approvalValue?: string;
   token: AllowancesToken;
   spender: AllowancesSpender;
   onCloseModal: () => void;
@@ -63,7 +64,7 @@ export const TransactionModal: FC<Props> = (props) => {
         </div>
         {view === "approve" && (
           <Approve
-            value={props.value}
+            value={props.approvalValue || props.value}
             token={props.token}
             spender={props.spender}
             onApproval={props.onApproval}

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -244,9 +244,6 @@ export const Offset = (props: Props) => {
       const token = selectedInputToken;
       const spender = "retirementAggregator";
 
-      console.log("COST", cost);
-      console.log("APPROVAL", getApprovalValue());
-
       const approvedValue = await changeApprovalTransaction({
         value: getApprovalValue(),
         provider: props.provider,

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -49,6 +49,8 @@ import {
   urls,
 } from "@klimadao/lib/constants";
 
+import { getTokenDecimals } from "@klimadao/lib/utils";
+
 import { tokenInfo } from "lib/getTokenInfo";
 
 import { CarbonTonnesRetiredCard } from "components/CarbonTonnesRetiredCard";
@@ -234,7 +236,8 @@ export const Offset = (props: Props) => {
   const getApprovalValue = (): string => {
     const costAsNumber = Number(cost);
     const costPlusOnePercent = costAsNumber + costAsNumber * APPROVAL_SLIPPAGE;
-    return costPlusOnePercent.toFixed(18); // ethers does not like more than 18 digits and returns with "underflow" otherwise
+    const decimals = getTokenDecimals(selectedInputToken);
+    return costPlusOnePercent.toFixed(decimals); // ethers throws with "underflow" if decimals exceeds
   };
 
   const handleApprove = async () => {

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -196,6 +196,7 @@ export const Offset = (props: Props) => {
         provider: props.provider,
         getSpecific: !!validSpecificAddresses.length,
       });
+
       setCost(consumptionCost);
     };
     awaitGetOffsetConsumptionCost();
@@ -229,17 +230,24 @@ export const Offset = (props: Props) => {
   const handleApprove = async () => {
     try {
       if (!props.provider) return;
-      const value = cost.toString();
+
+      // We need to approve a little bit extra (here 1%)
+      // it's possible the price can slip upward between approval and final transaction
+      const costAsNumber = Number(cost);
+      const onePercent = costAsNumber / 100;
+      const approvalValue = (costAsNumber + onePercent).toFixed(18); // ethers does not like more than 18 digits and returns with "underflow" otherwise
+
       const token = selectedInputToken;
       const spender = "retirementAggregator";
 
       const approvedValue = await changeApprovalTransaction({
-        value,
+        value: approvalValue,
         provider: props.provider,
         token,
         spender,
         onStatus: setStatus,
       });
+
       dispatch(
         setAllowance({
           token,


### PR DESCRIPTION
## Description

As described in the ticket https://github.com/KlimaDAO/klimadao/issues/615 the price between approval and final transaction can change. To not create a bad user experience which would result in errors in metamask, let's rather increase the approval amount.

The TXN modal is extended now to accept `approvalValue` for the first screen. 
And falls back to the actual `value` if missing.

## Related Ticket


Resolves https://github.com/KlimaDAO/klimadao/issues/615


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
