### PR TITLE
Retirement Certificate: Handle <0.01 carbon tonne retirements

### DIFF
--- a/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/generateCertificate.ts
+++ b/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/generateCertificate.ts
@@ -101,13 +101,14 @@ export const generateCertificate = (params: Params): void => {
   };
 
   const printRetirementDetails = (): void => {
+    const retirementAmount =
+      Number(params.retirement.amount) < 0.01
+        ? "< 0.01"
+        : trimWithLocale(params.retirement.amount, 2, "en");
+
     doc.setFont("Poppins", "ExtraLight");
     doc.setFontSize(28);
-    doc.text(
-      `${trimWithLocale(params.retirement.amount, 2, "en")} tonnes`,
-      spacing.margin,
-      70
-    );
+    doc.text(`${retirementAmount} tonnes`, spacing.margin, 70);
 
     doc.setFont("Poppins", "Bold");
     doc.setLineHeightFactor(1);


### PR DESCRIPTION
## Description

Retirement certificates for amounts less than <0.01 round to 0.
This change updates certificates to show "< 0.01 tonnes" instead of 0.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #612 


## Changes

| Before  | After  |
|---------|--------|
|<img width="804" alt="image" src="https://user-images.githubusercontent.com/97446324/185273425-aaf3fe01-ed2d-4032-aa51-1388b05333f5.png">|<img width="967" alt="image" src="https://user-images.githubusercontent.com/97446324/185271028-bc3cd904-af25-4885-bbf0-48883ce681e7.png">|


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
