### PR TITLE
fix: better button props if hasApproval is true

### DIFF
--- a/app/components/views/Stake/index.tsx
+++ b/app/components/views/Stake/index.tsx
@@ -254,6 +254,14 @@ export const Stake = (props: Props) => {
         onClick: undefined,
         disabled: true,
       };
+    } else if (!hasApproval()) {
+      return {
+        label: <Trans id="shared.approve">APPROVE</Trans>,
+        onClick: () => {
+          setShowTransactionModal(true);
+        },
+        disabled: false,
+      };
     } else if (view === "stake") {
       return {
         label: value ? (

--- a/app/components/views/Wrap/index.tsx
+++ b/app/components/views/Wrap/index.tsx
@@ -222,6 +222,14 @@ export const Wrap: FC<Props> = (props) => {
         onClick: undefined,
         disabled: true,
       };
+    } else if (!hasApproval()) {
+      return {
+        label: <Trans id="shared.approve">APPROVE</Trans>,
+        onClick: () => {
+          setShowTransactionModal(true);
+        },
+        disabled: false,
+      };
     } else if (view === WRAP) {
       return {
         label: WRAP,


### PR DESCRIPTION
## Description

Small improvement on button props:

If `hasApproval` is true => show "APPROVE" on main button which triggers the TXN Modal.

This is now aligned with all views which render the TXN Modal

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Part of Ticket https://github.com/KlimaDAO/klimadao/issues/625


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
