### PR TITLE
Hotfix: pledge form inputs & new line character support

### DIFF
--- a/site/components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from "react";
+import { css } from "@emotion/css";
 import { t } from "@lingui/macro";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import { Text } from "@klimadao/lib/components";
@@ -23,7 +24,14 @@ export const MethodologyCard: FC<Props> = (props) => {
       })}
       icon={<DescriptionOutlinedIcon fontSize="large" />}
     >
-      <Text t="body2">{props.methodology || defaultText}</Text>
+      <Text
+        t="body2"
+        className={css`
+          white-space: pre-line;
+        `}
+      >
+        {props.methodology || defaultText}
+      </Text>
     </BaseCard>
   );
 };

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from "react";
+import { css } from "@emotion/css";
 import { t } from "@lingui/macro";
 import MailOutlineIcon from "@mui/icons-material/MailOutline";
 import { Text } from "@klimadao/lib/components";
@@ -23,7 +24,12 @@ export const PledgeCard: FC<Props> = (props) => {
       })}
       icon={<MailOutlineIcon fontSize="large" />}
     >
-      <Text t="body2">
+      <Text
+        t="body2"
+        className={css`
+          white-space: pre-line;
+        `}
+      >
         <em>"{props.pledge || defaultText}"</em>
       </Text>
     </BaseCard>

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -65,7 +65,7 @@ export const PledgeForm: FC<Props> = (props) => {
       defaultValues: pledgeFormAdapter(props.pledge),
       resolver: yupResolver(formSchema),
     });
-  const { isDirty, isValid } = formState;
+  const { isDirty } = formState;
 
   const { fields, append, remove } = useFieldArray({
     name: "categories",

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -261,7 +261,7 @@ export const PledgeForm: FC<Props> = (props) => {
 
       {/* better to use an input type=submit */}
       <ButtonPrimary
-        disabled={!isDirty || !isValid}
+        disabled={!isDirty}
         label={t({
           id: "pledges.form.submit_button",
           message: "Save pledge",

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -94,6 +94,7 @@ export const formSchema = yup
             .min(0, "pledges.form.errors.categoryQuantity.min"),
         })
       )
-      .required(),
+      .required()
+      .min(1, "pledges.form.errors.footprint.generic_error"),
   })
   .noUnknown();


### PR DESCRIPTION
## Description

- Allow user to submit pledge form with invalid data and let form library to validate and display errors if input is invalid.
    - Current pledges that were previously valid until the introduction of character limits may have issues updating their pledge. This ux pattern will surface invalid inputs for the user to correct.
- Support user entered new line characters in textarea fields

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #634
Partial fix for #629(?)

## Changes

| Before  | After  |
|---------|--------|
|<img width="500" alt="image" src="https://user-images.githubusercontent.com/97446324/185878040-bcbb6512-988c-4186-8800-c1e28ace66e0.png">|<img width="500" alt="image" src="https://user-images.githubusercontent.com/97446324/185878074-bd5a5c93-5f44-4b38-8e00-bd2a91f87b84.png">|


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
