### PR TITLE
Add Resources page (Staging only)

### DIFF
--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Bond/index.tsx:677
 msgid "Capacity"

--- a/site/components/pages/Resources/index.tsx
+++ b/site/components/pages/Resources/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NextPage } from "next";
-import { t } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
 import { Text, Section } from "@klimadao/lib/components";
 import * as styles from "./styles";
 
@@ -39,8 +39,14 @@ export const Resources: NextPage<Props> = ({ documents }) => {
 
       <Section variant="gray">
         <div className={styles.header}>
-          <Text t="h3" align="center">
-            Resources Page - Hidden on Production
+          <Text t="h1" align="center">
+            <Trans id="resources.page.header.title">Featured Articles</Trans>
+          </Text>
+          <Text t="body3" align="center">
+            <Trans id="resources.page.header.subline">
+              Updates and thought leadership from the founders, DAO
+              contributors, advisors and community.
+            </Trans>
           </Text>
         </div>
         <div className={styles.list}>

--- a/site/components/pages/Resources/index.tsx
+++ b/site/components/pages/Resources/index.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { NextPage } from "next";
+import { t } from "@lingui/macro";
+import { Text, Section } from "@klimadao/lib/components";
+import * as styles from "./styles";
+
+import { Footer } from "components/Footer";
+import { Navigation } from "components/Navigation";
+import { PageHead } from "components/PageHead";
+import { Card } from "components/Card";
+import { PodcastCard } from "components/PodcastCard";
+
+import { Document } from "lib/queries";
+
+export interface Props {
+  documents: Document[];
+}
+
+export const Resources: NextPage<Props> = ({ documents }) => {
+  return (
+    <>
+      <PageHead
+        title={t({
+          id: "resources.head.title",
+          message: "KlimaDAO | Klima Resources",
+        })}
+        mediaTitle={t({
+          id: "resources.head.metaTitle",
+          message: `Klima Resources - Go beyond Carbon neutral`,
+        })}
+        metaDescription={t({
+          id: "resources.head.metaDescription",
+          message:
+            "Updates and thought leadership from the founders, DAO contributors, advisors and community.",
+        })}
+      />
+
+      <Navigation activePage="Resources" />
+
+      <Section variant="black">
+        <div className={styles.header}>
+          <Text t="h3" align="center">
+            Resources Page - Hidden on Production
+          </Text>
+        </div>
+        <div className={styles.list}>
+          {documents.map((doc) => {
+            if (doc.type === "post") {
+              return <Card key={doc.slug} post={doc} />;
+            }
+            return <PodcastCard podcast={doc} key={doc.slug} />;
+          })}
+        </div>
+      </Section>
+
+      <Footer />
+    </>
+  );
+};

--- a/site/components/pages/Resources/index.tsx
+++ b/site/components/pages/Resources/index.tsx
@@ -37,7 +37,7 @@ export const Resources: NextPage<Props> = ({ documents }) => {
 
       <Navigation activePage="Resources" />
 
-      <Section variant="black">
+      <Section variant="gray">
         <div className={styles.header}>
           <Text t="h3" align="center">
             Resources Page - Hidden on Production

--- a/site/components/pages/Resources/index.tsx
+++ b/site/components/pages/Resources/index.tsx
@@ -22,11 +22,11 @@ export const Resources: NextPage<Props> = ({ documents }) => {
       <PageHead
         title={t({
           id: "resources.head.title",
-          message: "KlimaDAO | Klima Resources",
+          message: "KlimaDAO | Resources",
         })}
         mediaTitle={t({
           id: "resources.head.metaTitle",
-          message: `Klima Resources - Go beyond Carbon neutral`,
+          message: `KlimaDAO Resources - Go beyond Carbon neutral`,
         })}
         metaDescription={t({
           id: "resources.head.metaDescription",

--- a/site/components/pages/Resources/styles.ts
+++ b/site/components/pages/Resources/styles.ts
@@ -2,7 +2,13 @@ import { css } from "@emotion/css";
 
 export const header = css`
   grid-column: main;
-  margin-bottom: 4rem;
+  margin-bottom: 5.5rem;
+  display: flex;
+  align-items: center;
+  gap: 3.2rem;
+  max-width: 62rem;
+  justify-self: center;
+  flex-direction: column;
 `;
 
 export const list = css`

--- a/site/components/pages/Resources/styles.ts
+++ b/site/components/pages/Resources/styles.ts
@@ -1,0 +1,13 @@
+import { css } from "@emotion/css";
+
+export const header = css`
+  grid-column: main;
+  margin-bottom: 4rem;
+`;
+
+export const list = css`
+  padding-bottom: 5rem;
+  display: grid;
+  row-gap: 4.8rem;
+  grid-column: main;
+`;

--- a/site/lib/queries.ts
+++ b/site/lib/queries.ts
@@ -98,7 +98,6 @@ export type PodcastDetails = {
   slug: string;
   publishedAt: string;
   title: string;
-  host: { name: string };
   summary: string;
   embed?: string;
 };

--- a/site/lib/queries.ts
+++ b/site/lib/queries.ts
@@ -11,6 +11,20 @@ export const queryFilter = IS_PRODUCTION
   : "true";
 
 export const queries = {
+  /** fetch all blog posts and podcasts, sorted by publishedAt, limit to 20 */
+  allDocuments: /* groq */ `
+    *[_type in ["post", "podcast"] && ${queryFilter}][0...20] | order(publishedAt desc) {
+      "type": _type,
+      publishedAt, 
+      title, 
+      summary, 
+      "slug": slug.current, 
+      author->,
+      "imageUrl": mainImage.asset->url,
+      "embed": embedCode
+    }
+  `,
+
   /** fetch all blog posts, sorted by publishedAt */
   allPosts: /* groq */ `
     *[_type == "post" && hideFromProduction != true] | order(publishedAt desc) {
@@ -102,7 +116,19 @@ export type Post = {
   showDisclaimer?: boolean;
 };
 
+export type Document = {
+  type: "post" | "podcast";
+  publishedAt: string;
+  title: string;
+  summary: string;
+  slug: string;
+  author: { name: string };
+  imageUrl?: string;
+  embed?: string;
+};
+
 export interface QueryContent {
+  allDocuments: Document[];
   allPosts: AllPosts;
   latestPost: LatestPost;
   post: Post;

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -1133,6 +1133,26 @@ msgstr ""
 msgid "podcast.head.title"
 msgstr ""
 
+#: components/pages/Resources/index.tsx:31
+msgid "resources.head.metaDescription"
+msgstr ""
+
+#: components/pages/Resources/index.tsx:27
+msgid "resources.head.metaTitle"
+msgstr ""
+
+#: components/pages/Resources/index.tsx:23
+msgid "resources.head.title"
+msgstr ""
+
+#: components/pages/Resources/index.tsx:46
+msgid "resources.page.header.subline"
+msgstr ""
+
+#: components/pages/Resources/index.tsx:43
+msgid "resources.page.header.title"
+msgstr ""
+
 #: components/pages/Retirements/Footer/index.tsx:26
 msgid "retirement.footer.aboutKlima.left"
 msgstr ""

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1145,11 +1145,11 @@ msgstr "Updates and thought leadership from the founders, DAO contributors, advi
 
 #: components/pages/Resources/index.tsx:27
 msgid "resources.head.metaTitle"
-msgstr "Klima Resources - Go beyond Carbon neutral"
+msgstr "KlimaDAO Resources - Go beyond Carbon neutral"
 
 #: components/pages/Resources/index.tsx:23
 msgid "resources.head.title"
-msgstr "KlimaDAO | Klima Resources"
+msgstr "KlimaDAO | Resources"
 
 #: components/pages/Resources/index.tsx:46
 msgid "resources.page.header.subline"

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1139,6 +1139,26 @@ msgstr "Podcast"
 msgid "podcast.head.title"
 msgstr "KlimaDAO Podcast"
 
+#: components/pages/Resources/index.tsx:31
+msgid "resources.head.metaDescription"
+msgstr "Updates and thought leadership from the founders, DAO contributors, advisors and community."
+
+#: components/pages/Resources/index.tsx:27
+msgid "resources.head.metaTitle"
+msgstr "Klima Resources - Go beyond Carbon neutral"
+
+#: components/pages/Resources/index.tsx:23
+msgid "resources.head.title"
+msgstr "KlimaDAO | Klima Resources"
+
+#: components/pages/Resources/index.tsx:46
+msgid "resources.page.header.subline"
+msgstr "Updates and thought leadership from the founders, DAO contributors, advisors and community."
+
+#: components/pages/Resources/index.tsx:43
+msgid "resources.page.header.title"
+msgstr "Featured Articles"
+
 #: components/pages/Retirements/Footer/index.tsx:26
 msgid "retirement.footer.aboutKlima.left"
 msgstr "KlimaDAO is incentivizing sustainability and catalyzing a more transparent and liquid carbon market. Our tools make it possible for any individual or businesses to trade and retire quality carbon assets on the blockchain."

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -99,15 +99,11 @@ const nextConfig = {
   },
 };
 
-console.log("nextConfig", nextConfig);
-
 if (!IS_PRODUCTION) {
   nextConfig.i18n = {
     ...nextConfig.i18n,
     locales: [...nextConfig.i18n.locales, "ko", "hi", "en-pseudo"],
   };
 }
-
-console.log("nextConfig 2", nextConfig);
 
 module.exports = nextConfig;

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -5,12 +5,27 @@ const IS_PRODUCTION = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
 const nextConfig = {
   reactStrictMode: true,
   async redirects() {
+    if (IS_PRODUCTION) {
+      return [
+        {
+          source: "/resources",
+          destination: "/blog",
+          permanent: true,
+        },
+        {
+          source: "/cms",
+          destination: "https://klimadao.sanity.studio/desk",
+          permanent: true,
+        },
+      ];
+    }
     return [
-      {
-        source: "/resources",
-        destination: "/blog",
-        permanent: true,
-      },
+      // Enable this as soon as the Resources page is live
+      // {
+      //   source: "/blog",
+      //   destination: "/resources",
+      //   permanent: true,
+      // },
       {
         source: "/cms",
         destination: "https://klimadao.sanity.studio/desk",
@@ -84,11 +99,15 @@ const nextConfig = {
   },
 };
 
+console.log("nextConfig", nextConfig);
+
 if (!IS_PRODUCTION) {
   nextConfig.i18n = {
     ...nextConfig.i18n,
     locales: [...nextConfig.i18n.locales, "ko", "hi", "en-pseudo"],
   };
 }
+
+console.log("nextConfig 2", nextConfig);
 
 module.exports = nextConfig;

--- a/site/pages/resources/index.tsx
+++ b/site/pages/resources/index.tsx
@@ -21,11 +21,13 @@ export async function getStaticProps(ctx: GetStaticPropsContext) {
     };
   } catch (e) {
     console.error("RESOURCES getStaticProps error: ", e);
+    throw e;
 
-    return {
-      notFound: true,
-      revalidate: 240,
-    };
+    // enable below before Go Live
+    // return {
+    //   notFound: true,
+    //   revalidate: 240,
+    // };
   }
 }
 

--- a/site/pages/resources/index.tsx
+++ b/site/pages/resources/index.tsx
@@ -1,0 +1,32 @@
+import { Resources } from "components/pages/Resources";
+import { fetchCMSContent } from "lib/fetchCMSContent";
+import { loadTranslation } from "lib/i18n";
+import { GetStaticPropsContext } from "next";
+
+export async function getStaticProps(ctx: GetStaticPropsContext) {
+  try {
+    const documents = await fetchCMSContent("allDocuments");
+
+    const translation = await loadTranslation(ctx.locale);
+    if (!documents) {
+      throw new Error("No documents found");
+    }
+
+    return {
+      props: {
+        documents,
+        translation,
+      },
+      revalidate: 240,
+    };
+  } catch (e) {
+    console.error("RESOURCES getStaticProps error: ", e);
+
+    return {
+      notFound: true,
+      revalidate: 240,
+    };
+  }
+}
+
+export default Resources;


### PR DESCRIPTION
## Description

This is the first set-up for the new Resources Page:

- add NEXTJS page "Resources"
- hide this page on Production (keep redirect from "resources" -> "blog")
- show this page on Staging and Preview Links (remove redirect)
- add new query for all podcasts and posts, sorted desc, limit to 20
- add basic Page and render a list of podcasts and posts

### PREVIEW
- https://klimadao-site-git-resources-page-klimadao.vercel.app/resources


## Related Ticket

Part of https://github.com/KlimaDAO/klimadao/issues/534

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
