### PR TITLE
Goats/580 video overlay

### DIFF
--- a/site/components/YoutubeEmbed/index.tsx
+++ b/site/components/YoutubeEmbed/index.tsx
@@ -1,0 +1,100 @@
+import { FC, useState } from "react";
+import { toNumber } from "lodash";
+import * as styles from "./styles";
+import Image, { ImageProps } from "next/image";
+import { cx } from "@emotion/css";
+
+/**
+ * For more information about the available youtube embed parameters see:
+ * https://developers.google.com/youtube/player_parameters#release_notes_08_23_2018
+ */
+type YoutubeEmbedProps = {
+  videoId: string;
+  autoplay?: boolean;
+  showSubtitles?: boolean;
+  hideControls?: boolean;
+  hideFullscreen?: boolean;
+  posterImg?: {
+    src: ImageProps["src"];
+    alt: string;
+  };
+};
+
+/**
+ * A wrapper around a youtube IFrame to provide a poster overlay
+ * @note auto play does not function on mobile devices
+ * see: https://stackoverflow.com/questions/15090782/youtube-autoplay-not-working-on-mobile-devices-with-embedded-html5-player
+ */
+export const YoutubeEmbed: FC<YoutubeEmbedProps> = (props) => {
+  // If a poster image is defined then track the play behaviour
+  const [playInitiated, setPlayInitiated] = useState(!props.posterImg);
+
+  // Build the src url
+  const src = `https://www.youtube.com/embed/${props.videoId}?\
+autoplay=${toNumber(!!(props.autoplay || playInitiated))}&\
+controls=${toNumber(!props.hideControls)}&\
+fs=${toNumber(!props.hideFullscreen)}&\
+frameborder="0"&\
+iv_load_policy=3&\
+rel=0&\
+cc_load_policy=${toNumber(!!props.showSubtitles)}`;
+
+  return (
+    <div className={styles.youtubeEmbed}>
+      <iframe
+        src={src}
+        title="YouTube video player"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        className="youtubeEmbed_iframe"
+        allowFullScreen
+      ></iframe>
+
+      {/* Video overlay */}
+      {props.posterImg && (
+        // The computed image height determines the height of the container (and the embedded video)
+        // Because of this we are keeping the image in the DOM after click but hiding and setting
+        // it behind the video
+        <div
+          className={cx(
+            { [styles.posterOverlay_hidden]: playInitiated },
+            styles.posterOverlay
+          )}
+        >
+          <Image src={props.posterImg.src} alt={props.posterImg.alt} />
+          <button
+            className="youtubeEmbed_posterBtn"
+            onClick={() => setPlayInitiated(true)}
+          >
+            <div className="youtubeEmbed_playIconContainer">
+              <PlayIcon />
+            </div>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/** Simple play icon to allow currentColor styling */
+const PlayIcon = () => (
+  <svg
+    className={styles.playIcon}
+    width="80"
+    height="80"
+    viewBox="0 0 121 121"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx="60.5"
+      cy="60.5"
+      r="55.5"
+      stroke="currentColor"
+      strokeWidth="10"
+    />
+    <path
+      d="M92 57.0359C94.6667 58.5755 94.6667 62.4245 92 63.9641L47.75 89.5118C45.0833 91.0514 41.75 89.1269 41.75 86.0477L41.75 34.9522C41.75 31.873 45.0833 29.9485 47.75 31.4881L92 57.0359Z"
+      fill="currentColor"
+    />
+  </svg>
+);

--- a/site/components/YoutubeEmbed/index.tsx
+++ b/site/components/YoutubeEmbed/index.tsx
@@ -27,7 +27,8 @@ type YoutubeEmbedProps = {
  */
 export const YoutubeEmbed: FC<YoutubeEmbedProps> = (props) => {
   // If a poster image is defined then track the play behaviour
-  const [playInitiated, setPlayInitiated] = useState(!props.posterImg);
+  const [playInitiated, setPlayInitiated] = useState(false);
+  const handleClick = () => setPlayInitiated(true);
 
   // Build the src url
   const src = `https://www.youtube.com/embed/${props.videoId}?\
@@ -54,17 +55,9 @@ cc_load_policy=${toNumber(!!props.showSubtitles)}`;
         // The computed image height determines the height of the container (and the embedded video)
         // Because of this we are keeping the image in the DOM after click but hiding and setting
         // it behind the video
-        <div
-          className={cx(
-            { [styles.posterOverlay_hidden]: playInitiated },
-            styles.posterOverlay
-          )}
-        >
+        <div className={cx(styles.posterOverlay, { hidden: playInitiated })}>
           <Image src={props.posterImg.src} alt={props.posterImg.alt} />
-          <button
-            className="youtubeEmbed_posterBtn"
-            onClick={() => setPlayInitiated(true)}
-          >
+          <button className="youtubeEmbed_posterBtn" onClick={handleClick}>
             <div className="youtubeEmbed_playIconContainer">
               <PlayIcon />
             </div>

--- a/site/components/YoutubeEmbed/styles.ts
+++ b/site/components/YoutubeEmbed/styles.ts
@@ -1,0 +1,57 @@
+import { css } from "@emotion/css";
+
+export const youtubeEmbed = css`
+  position: relative;
+  width: 100%;
+  border-radius: 16px;
+  overflow: hidden;
+
+  .youtubeEmbed_iframe {
+    border: none;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+  }
+
+  .youtubeEmbed_posterBtn {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  .youtubeEmbed_playIconContainer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+`;
+
+export const posterOverlay = css`
+  width: 100%;
+  top: 0;
+  left: 0;
+  // This ensures the video is still controllable
+  pointer-events: none;
+  > span:first-of-type {
+    //Unfortunately this is necessary because of NextJS Image inline styling
+    height: 100% !important;
+    display: block !important;
+  }
+`;
+
+export const posterOverlay_hidden = css`
+  opacity: 0;
+  z-index: -1;
+`;
+
+export const playIcon = css`
+  z-index: 1;
+  opacity: 0.8;
+`;

--- a/site/components/YoutubeEmbed/styles.ts
+++ b/site/components/YoutubeEmbed/styles.ts
@@ -37,18 +37,17 @@ export const posterOverlay = css`
   width: 100%;
   top: 0;
   left: 0;
-  // This ensures the video is still controllable
-  pointer-events: none;
+  &.hidden {
+    opacity: 0;
+    z-index: -1;
+    // This ensures the video is still controllable
+    pointer-events: none;
+  }
   > span:first-of-type {
     //Unfortunately this is necessary because of NextJS Image inline styling
     height: 100% !important;
     display: block !important;
   }
-`;
-
-export const posterOverlay_hidden = css`
-  opacity: 0;
-  z-index: -1;
 `;
 
 export const playIcon = css`

--- a/site/components/pages/Infinity/index.tsx
+++ b/site/components/pages/Infinity/index.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from "react";
-import { cx } from "@emotion/css";
 import { NextPage } from "next";
 import Image from "next/image";
 import { Trans, t } from "@lingui/macro";
-import { urls } from "@klimadao/lib/constants";
 import {
   Section,
   ButtonPrimary,
@@ -34,6 +32,10 @@ import logoPolygonInfinity from "public/logo-polygon-infinity.png";
 
 import { CardsSlider } from "./Cards/CardsSlider";
 import * as styles from "./styles";
+
+import { urls } from "@klimadao/lib/constants";
+import { YoutubeEmbed } from "components/YoutubeEmbed";
+import { cx } from "@emotion/css";
 
 const linkToBlogUserGuide = `${urls.siteBlog}/klima-infinity-user-guide`;
 const linkToBlogFAQ = `${urls.siteBlog}/klima-infinity-faqs`;
@@ -216,10 +218,14 @@ export const Infinity: NextPage<Props> = ({ fixedThemeName }) => {
             </Text>
           </div>
           <div className="why_right_container">
-            <Image
-              src={infiniteNightCliffs}
-              alt="flashlight shining on dark cliffs"
-              className="why_right_img"
+            <YoutubeEmbed
+              videoId="eRmmDh1ingU"
+              hideControls
+              hideFullscreen
+              posterImg={{
+                src: infiniteNightCliffs,
+                alt: "flashlight shining on dark cliffs",
+              }}
             />
           </div>
         </div>

--- a/site/components/pages/Infinity/styles.ts
+++ b/site/components/pages/Infinity/styles.ts
@@ -279,11 +279,12 @@ export const whySection = css`
   }
   .why_right_container {
     width: 100%;
-    height: 100%;
+    height: auto;
     padding-left: 0;
     ${breakpoints.large} {
       padding-left: 6.4rem;
       width: 65%;
+      height: 100%;
     }
   }
   .why_right_img {


### PR DESCRIPTION
## Description
This commit fixes a css bug causing the image to not disappear when clicked. Most of the code was reviewed in this PR https://github.com/KlimaDAO/klimadao/pull/587
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #580 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
