### PR TITLE
Fix LiFi cross-chain retirement link

### DIFF
--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -455,8 +455,8 @@ export const Offset = (props: Props) => {
           <Text t="caption" color="lightest">
             <FiberNewRoundedIcon className={styles.newReleasesIcon} />
             <Trans id="offset.lifi">
-              Cross-chain offsetting is now available through
-              <A href={urls.lifiStake}>LI.FI</A>, with support for dozens of
+              Cross-chain retirement is now available through
+              <A href={urls.lifiRetire}>LI.FI</A>, with support for dozens of
               tokens!
             </Trans>
           </Text>

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -137,6 +137,8 @@ export const urls = {
   mediaImage: "https://www.klimadao.finance/og-media.png",
   lifiStake:
     "https://transferto.xyz/embed/stake-klima?fromChain=eth&fromToken=0x0000000000000000000000000000000000000000&toChain=pol&toToken=0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+  lifiRetire:
+    "https://develop.transferto.xyz/showcase/carbon-offset?toChain=pol&toToken=0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
   polyscanGasTracker:
     "https://api.polygonscan.com/api?module=gastracker&action=gasoracle",
 };


### PR DESCRIPTION
## Description

The link was the same as the stake interface, updated to actually point to the beta cross-chain retirement interface

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
