### PR TITLE
519 better gas price estimations

### DIFF
--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -1,6 +1,7 @@
 import { ethers, providers } from "ethers";
 import { Thunk } from "state";
 import { setCarbonRetiredBalances, updateAllowances } from "state/user";
+import { getTransactionOptions } from "@klimadao/lib/utils";
 
 import {
   addresses,
@@ -160,6 +161,7 @@ export const retireCarbonTransaction = async (params: {
     // add + 1 now as this number is only passed on if transaction succeeded
     const formattedTotals = totals.toNumber();
     const retirementTotals = formattedTotals + 1;
+    const transactionOptions = await getTransactionOptions();
 
     // retire transaction
     const retireContract = getContract({
@@ -182,7 +184,8 @@ export const retireCarbonTransaction = async (params: {
         params.beneficiaryAddress || params.address,
         params.beneficiaryName,
         params.retirementMessage,
-        params.specificAddresses
+        params.specificAddresses,
+        transactionOptions
       );
     } else {
       txn = await retireContract.retireCarbon(
@@ -195,7 +198,8 @@ export const retireCarbonTransaction = async (params: {
         params.amountInCarbon,
         params.beneficiaryAddress || params.address,
         params.beneficiaryName,
-        params.retirementMessage
+        params.retirementMessage,
+        transactionOptions
       );
     }
 

--- a/app/actions/stake.ts
+++ b/app/actions/stake.ts
@@ -1,6 +1,5 @@
 import { ethers, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
-import { getTransactionOptions } from "@klimadao/lib/utils";
 import { formatUnits, getContract } from "@klimadao/lib/utils";
 
 export const changeStakeTransaction = async (params: {
@@ -11,7 +10,6 @@ export const changeStakeTransaction = async (params: {
 }) => {
   try {
     const parsedValue = ethers.utils.parseUnits(params.value, "gwei");
-    const transactionOptions = await getTransactionOptions();
     const contract = {
       stake: getContract({
         contractName: "staking_helper",
@@ -25,7 +23,7 @@ export const changeStakeTransaction = async (params: {
     params.onStatus("userConfirmation", "");
     const txn =
       params.action === "stake"
-        ? await contract.stake(parsedValue, transactionOptions)
+        ? await contract.stake(parsedValue)
         : await contract.unstake(parsedValue, true); // always trigger rebase because gas is cheap
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -139,8 +139,7 @@ export const urls = {
     "https://transferto.xyz/showcase/etherspot-klima?fromChain=eth&toChain=pol&toToken=0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
   lifiOffset:
     "https://transferto.xyz/showcase/carbon-offset?fromChain=eth&toChain=pol&toToken=0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
-  polyscanGasTracker:
-    "https://api.polygonscan.com/api?module=gastracker&action=gasoracle",
+  polyscanGasStation: "https://gasstation-mainnet.matic.network/v2",
 };
 
 export const polygonNetworks = {

--- a/lib/utils/getTransactionOptions/index.ts
+++ b/lib/utils/getTransactionOptions/index.ts
@@ -1,26 +1,29 @@
 import { ethers } from "ethers";
 import { urls } from "../../constants";
 
-/** Returns the fast gas price from polygonscan plus 10 percent*/
-export const getGasPrice = async () => {
+const convertGasInfoFromPolyscan = (value: string) =>
+  ethers.utils.parseUnits((parseFloat(value) * 1.1).toFixed(2).toString(), 9);
+
+/** Returns gas info from polygonscan plus 10 percent*/
+const getGasInfo = async () => {
   try {
-    const response = await fetch(urls.polyscanGasTracker);
+    const response = await fetch(urls.polyscanGasStation);
     const data = await response.json();
-    if (data.message == "OK") {
-      const targetGasPrice = (
-        parseFloat(data.result.FastGasPrice) * 1.1
-      ).toFixed(2);
-      return ethers.utils.parseUnits(targetGasPrice.toString(), 9);
-    }
+    const gasInfo = data.fast;
+    const maxFeePerGas = convertGasInfoFromPolyscan(gasInfo.maxFee);
+    const maxPriorityFeePerGas = convertGasInfoFromPolyscan(
+      gasInfo.maxPriorityFee
+    );
+    return { maxFeePerGas, maxPriorityFeePerGas };
   } catch (error) {
     console.error(error);
   }
   console.error("Error contacting Polyscan API for Gas estimation");
-  return undefined;
+  const fallbackFee = ethers.utils.parseUnits("60", 9); // 60 gwei
+  return { maxFeePerGas: fallbackFee, maxPriorityFeePerGas: fallbackFee };
 };
 
 /** Returns the transaction options */
 export const getTransactionOptions = async () => {
-  const gasPrice = await getGasPrice();
-  return gasPrice ? { gasPrice } : {};
+  return await getGasInfo();
 };

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -45,7 +45,7 @@ export {
   isKNSDomain,
   KNSContract,
 } from "./kns";
-export { getTransactionOptions, getGasPrice } from "./getTransactionOptions";
+export { getTransactionOptions } from "./getTransactionOptions";
 
 // ENS
 export {


### PR DESCRIPTION
## Description

Fetch transaction options from polyscanGasStation (maxFeePerGas & maxPriorityFeePerGas) for offset retirement transactions only.

From @Atmosfearful in https://github.com/KlimaDAO/klimadao/pull/541
- [X] let's only do this for the offset retirement transaction. I've realized the others like Stake and wrap etc. fail much more rarely. Another reason I only want to try on the offset aggregator for now is I noticed values fluctuate wildly from the gas station so I am skeptical that this will really help.
- [X] For the offset view, fallback to `60 gwei` if the gas station API fails.
- [X] Keep the 10% increase as before
- [X] NOTE that the property names are different `maxFee (gas station) -> maxFeePerGas (ethers)`
- [X] I recommend just close this PR and start fresh from the latest staging (sorry!)
- [X] be sure to update the other ones that we already changed on production

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #519

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|
![image](https://user-images.githubusercontent.com/11857992/187173061-049b24e3-1341-494e-8b68-53f854063b32.png)
 |
![image](https://user-images.githubusercontent.com/11857992/187172524-eeb80b91-5bbc-4437-9655-6a2332cb77f1.png)
|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
