### PR TITLE
Hotfix: Infinity pages

### DIFF
--- a/site/components/Header/styles.ts
+++ b/site/components/Header/styles.ts
@@ -9,9 +9,9 @@ export const headerDesktop = css`
   justify-content: center;
   align-items: center;
   background: var(--surface-02);
-  padding-top: 2.4rem;
-  height: calc(var(--header-height) * 2);
+  padding-top: 3.6rem;
   z-index: 10; /* so the drop-shadow is visible over next section, 10 to make opened Translation menu flow over main content */
+
   ${breakpoints.desktop} {
     display: grid;
   }
@@ -27,8 +27,8 @@ export const menuDesktop = css`
 `;
 
 export const headerInfinityDesktop = css`
-  background: transparent !important;
   ${headerDesktop}
+  background: transparent !important;
 `;
 
 export const headerMobileWrap = css`

--- a/site/components/Header/styles.ts
+++ b/site/components/Header/styles.ts
@@ -10,6 +10,7 @@ export const headerDesktop = css`
   align-items: center;
   background: var(--surface-02);
   padding-top: 3.6rem;
+  height: var(--header-height);
   z-index: 10; /* so the drop-shadow is visible over next section, 10 to make opened Translation menu flow over main content */
 
   ${breakpoints.desktop} {

--- a/site/components/Navigation/index.tsx
+++ b/site/components/Navigation/index.tsx
@@ -44,6 +44,7 @@ export const Navigation: FC<Props> = ({
     NavItemMobileID | undefined
   >(undefined);
   const { locale } = useRouter();
+
   return (
     <>
       <HeaderDesktop
@@ -423,7 +424,7 @@ export const Navigation: FC<Props> = ({
               href={createLinkWithLocaleQuery(urls.app, locale)}
               className={styles.navMain_MobileButton}
             />
-            <ThemeToggle key="ThemeToggle" />
+            {showThemeToggle && <ThemeToggle />}
           </div>
         </div>
       </HeaderMobile>

--- a/site/components/pages/Infinity/index.tsx
+++ b/site/components/pages/Infinity/index.tsx
@@ -69,7 +69,7 @@ export const Infinity: NextPage<Props> = ({ fixedThemeName }) => {
         })}
       />
 
-      <Navigation activePage="Infinity" showThemeToggle={!fixedThemeName} />
+      <Navigation activePage="Infinity" showThemeToggle={false} />
 
       <Section variant="black" className={styles.gradientBackgroundTop}>
         <div className={styles.heroSection}>

--- a/site/components/pages/Infinity/index.tsx
+++ b/site/components/pages/Infinity/index.tsx
@@ -45,7 +45,7 @@ export interface Props {
   fixedThemeName: string;
 }
 
-export const Infinity: NextPage<Props> = ({ fixedThemeName }) => {
+export const Infinity: NextPage<Props> = () => {
   const [currentOpenQuestions, setCurrentOpenQuestions] = useState({
     1: false,
     2: false,

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1334,43 +1334,43 @@ msgstr "Retirement Totals By Asset"
 msgid "shared.404"
 msgstr "404 - Page Not Found"
 
-#: components/Navigation/index.tsx:75
-#: components/Navigation/index.tsx:246
+#: components/Navigation/index.tsx:76
+#: components/Navigation/index.tsx:247
 msgid "shared.about"
 msgstr "About"
 
-#: components/Navigation/index.tsx:107
-#: components/Navigation/index.tsx:281
+#: components/Navigation/index.tsx:108
+#: components/Navigation/index.tsx:282
 msgid "shared.app"
 msgstr "App"
 
 #: components/Footer/index.tsx:54
-#: components/Navigation/index.tsx:78
-#: components/Navigation/index.tsx:252
+#: components/Navigation/index.tsx:79
+#: components/Navigation/index.tsx:253
 #: components/pages/Resources/ResourcesHeader/index.tsx:29
 #: components/pages/Resources/ResourcesHeader/index.tsx:75
 msgid "shared.blog"
 msgstr "Blog"
 
 #: components/Footer/index.tsx:47
-#: components/Navigation/index.tsx:126
-#: components/Navigation/index.tsx:300
+#: components/Navigation/index.tsx:127
+#: components/Navigation/index.tsx:301
 msgid "shared.bond"
 msgstr "BOND KLIMA"
 
 #: components/Footer/index.tsx:40
-#: components/Navigation/index.tsx:110
-#: components/Navigation/index.tsx:287
+#: components/Navigation/index.tsx:111
+#: components/Navigation/index.tsx:288
 msgid "shared.buy"
 msgstr "BUY KLIMA"
 
-#: components/Navigation/index.tsx:212
-#: components/Navigation/index.tsx:393
+#: components/Navigation/index.tsx:213
+#: components/Navigation/index.tsx:394
 msgid "shared.carbon_dashboards"
 msgstr "CARBON DASHBOARDS"
 
-#: components/Navigation/index.tsx:87
-#: components/Navigation/index.tsx:261
+#: components/Navigation/index.tsx:88
+#: components/Navigation/index.tsx:262
 #: components/pages/Resources/ResourcesHeader/index.tsx:51
 #: components/pages/Resources/ResourcesHeader/index.tsx:81
 msgid "shared.community"
@@ -1382,18 +1382,18 @@ msgid "shared.connect"
 msgstr "Connect"
 
 #: components/Footer/index.tsx:59
-#: components/Navigation/index.tsx:270
+#: components/Navigation/index.tsx:271
 #: components/pages/Resources/ResourcesHeader/index.tsx:87
 msgid "shared.contact"
 msgstr "Contact"
 
-#: components/Navigation/index.tsx:63
+#: components/Navigation/index.tsx:64
 #: components/pages/Infinity/index.tsx:112
 #: components/pages/Infinity/index.tsx:678
 msgid "shared.contact_sales"
 msgstr "Contact Sales"
 
-#: components/Navigation/index.tsx:96
+#: components/Navigation/index.tsx:97
 #: components/pages/Resources/Community/index.tsx:110
 #: components/pages/Resources/Community/index.tsx:405
 #: components/pages/Resources/ResourcesHeader/index.tsx:62
@@ -1401,18 +1401,18 @@ msgid "shared.contact_us"
 msgstr "Contact Us"
 
 #: components/Footer/index.tsx:64
-#: components/Navigation/index.tsx:220
-#: components/Navigation/index.tsx:401
+#: components/Navigation/index.tsx:221
+#: components/Navigation/index.tsx:402
 msgid "shared.disclaimer"
 msgstr "DISCLAIMER"
 
 #: components/Footer/index.tsx:50
-#: components/Navigation/index.tsx:229
-#: components/Navigation/index.tsx:410
+#: components/Navigation/index.tsx:230
+#: components/Navigation/index.tsx:411
 msgid "shared.docs"
 msgstr "DOCS"
 
-#: components/Navigation/index.tsx:56
+#: components/Navigation/index.tsx:57
 #: components/pages/Home/index.tsx:110
 msgid "shared.enter_app"
 msgstr "Enter App"
@@ -1430,13 +1430,13 @@ msgstr "Drive climate action and earn rewards with a carbon-backed digital curre
 msgid "shared.home"
 msgstr "Home"
 
-#: components/Navigation/index.tsx:203
-#: components/Navigation/index.tsx:384
+#: components/Navigation/index.tsx:204
+#: components/Navigation/index.tsx:385
 msgid "shared.how_to_buy"
 msgstr "HOW TO BUY KLIMA"
 
-#: components/Navigation/index.tsx:160
-#: components/Navigation/index.tsx:334
+#: components/Navigation/index.tsx:161
+#: components/Navigation/index.tsx:335
 msgid "shared.infinity"
 msgstr "Infinity"
 
@@ -1446,8 +1446,8 @@ msgstr "Infinity"
 msgid "shared.infinity.get_started"
 msgstr "Get Started"
 
-#: components/Navigation/index.tsx:150
-#: components/Navigation/index.tsx:324
+#: components/Navigation/index.tsx:151
+#: components/Navigation/index.tsx:325
 msgid "shared.info"
 msgstr "INFO"
 
@@ -1457,13 +1457,13 @@ msgstr "INFO"
 msgid "shared.loading"
 msgstr "Loading..."
 
-#: components/Navigation/index.tsx:196
-#: components/Navigation/index.tsx:371
+#: components/Navigation/index.tsx:197
+#: components/Navigation/index.tsx:372
 msgid "shared.loveletters"
 msgstr "Love Letters"
 
-#: components/Navigation/index.tsx:142
-#: components/Navigation/index.tsx:316
+#: components/Navigation/index.tsx:143
+#: components/Navigation/index.tsx:317
 msgid "shared.offset"
 msgstr "OFFSET"
 
@@ -1472,14 +1472,14 @@ msgstr "OFFSET"
 msgid "shared.podcast"
 msgstr "Podcast"
 
-#: components/Navigation/index.tsx:199
-#: components/Navigation/index.tsx:378
+#: components/Navigation/index.tsx:200
+#: components/Navigation/index.tsx:379
 msgid "shared.resources"
 msgstr "Resources"
 
 #: components/Footer/index.tsx:44
-#: components/Navigation/index.tsx:118
-#: components/Navigation/index.tsx:292
+#: components/Navigation/index.tsx:119
+#: components/Navigation/index.tsx:293
 msgid "shared.stake"
 msgstr "STAKE KLIMA"
 
@@ -1487,8 +1487,8 @@ msgstr "STAKE KLIMA"
 msgid "shared.visit_klimadao_blog"
 msgstr "Visit the KlimaDAO Blog"
 
-#: components/Navigation/index.tsx:134
-#: components/Navigation/index.tsx:308
+#: components/Navigation/index.tsx:135
+#: components/Navigation/index.tsx:309
 msgid "shared.wrap"
 msgstr "WRAP SKLIMA"
 


### PR DESCRIPTION
## Description

- Fix white bar appearing above header on /infinity page
- Do not render `<ThemeToggle />` on /infinity
  - useEffect in `<ThemeToggle />` will set the theme to what has been stored in the browsers local storage, overriding the page's theme override
  
  
### Testing
- set site theme to light mode
- navigate to /infinity and refresh page
- /infinity page should not render with light mode

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #669 
Resolves #670 

## Changes

| Before  | After  |
|---------|--------|
|<img width="400" alt="image" src="https://user-images.githubusercontent.com/97446324/187711809-95f493f5-510c-4f2e-a67d-dfee2e9edc6b.png">|<img width="400" alt="image" src="https://user-images.githubusercontent.com/97446324/187712217-34d0bbb0-9b95-4159-b4a6-9b9ace0bbdfd.png">|

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
