### PR TITLE
Goats/643 typography

### DIFF
--- a/lib/theme/typography.ts
+++ b/lib/theme/typography.ts
@@ -125,6 +125,11 @@ export const body7 = css`
     line-height: 3.6rem;
   }
 `;
+export const body8 = css`
+  font-weight: 400;
+  font-size: 1.6rem;
+  line-height: 2.2rem;
+`;
 export const caption = css`
   font-size: 1.4rem;
   line-height: 1.6rem;

--- a/site/components/pages/Infinity/Cards/Card.tsx
+++ b/site/components/pages/Infinity/Cards/Card.tsx
@@ -54,7 +54,7 @@ export const Card: FC<Props> = (props) => {
         </Anchor>
       </div>
       <div className={styles.cardContent}>
-        <Text className={styles.cardMessage}>“{props.card.description}”</Text>
+        <Text t="body8" className={styles.cardMessage}>“{props.card.description}”</Text>
         <div className={styles.cardFooter}>
           <div>
             <Text t="h3">

--- a/site/components/pages/Infinity/Cards/Card.tsx
+++ b/site/components/pages/Infinity/Cards/Card.tsx
@@ -54,7 +54,9 @@ export const Card: FC<Props> = (props) => {
         </Anchor>
       </div>
       <div className={styles.cardContent}>
-        <Text t="body8" className={styles.cardMessage}>“{props.card.description}”</Text>
+        <Text t="body8" className={styles.cardMessage}>
+          “{props.card.description}”
+        </Text>
         <div className={styles.cardFooter}>
           <div>
             <Text t="h3">

--- a/site/components/pages/Infinity/Cards/styles.ts
+++ b/site/components/pages/Infinity/Cards/styles.ts
@@ -129,8 +129,6 @@ export const cardContent = css`
 
 export const cardMessage = css`
   padding-top: 1.6rem;
-  font-size: 1.6rem !important;
-  line-height: 2.2rem !important;
 `;
 
 export const cardFooter = css`


### PR DESCRIPTION
## Description
Added `body8` to typography for infinity card descriptions. `body4` in figma
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->
no
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #643 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
