### PR TITLE
Site: refactor Form Elements (Pledge)

### DIFF
--- a/site/components/Form/InputField/index.tsx
+++ b/site/components/Form/InputField/index.tsx
@@ -1,19 +1,15 @@
 import React, { InputHTMLAttributes } from "react";
 import { cx } from "@emotion/css";
-import { FieldError } from "react-hook-form";
 
 import { Text } from "@klimadao/lib/components";
 
 import * as styles from "./styles";
 
-import { PledgeErrorId } from "components/pages/Pledge/lib/formSchema";
-
 interface Props {
   inputProps: InputHTMLAttributes<HTMLInputElement>;
   label: string;
   hideLabel?: boolean;
-  errors?: { message?: FieldError["message"] };
-  errorMessageMap: (id: PledgeErrorId) => string;
+  errorMessage: false | string;
 }
 
 export const InputField = React.forwardRef<HTMLInputElement, Props>(
@@ -21,7 +17,7 @@ export const InputField = React.forwardRef<HTMLInputElement, Props>(
     const inputStyles = cx(
       styles.baseStyles,
       {
-        [styles.errorStyles]: Boolean(props.errors),
+        [styles.errorStyles]: !!props.errorMessage,
       },
       props.inputProps.className
     );
@@ -39,14 +35,14 @@ export const InputField = React.forwardRef<HTMLInputElement, Props>(
         <input
           id={props.inputProps.id}
           ref={ref}
-          aria-invalid={Boolean(props.errors)}
+          aria-invalid={Boolean(props.errorMessage)}
           {...props.inputProps}
           className={inputStyles}
         />
 
-        {props.errors && props.errors.message && (
+        {!!props.errorMessage && (
           <Text t="caption" className={styles.errorMessage}>
-            {props.errorMessageMap(props.errors.message as PledgeErrorId)}
+            {props.errorMessage}
           </Text>
         )}
       </div>

--- a/site/components/Form/InputField/index.tsx
+++ b/site/components/Form/InputField/index.tsx
@@ -4,7 +4,8 @@ import { Text } from "@klimadao/lib/components";
 
 import * as styles from "./styles";
 
-interface Props extends InputHTMLAttributes<HTMLInputElement> {
+interface Props {
+  inputProps: InputHTMLAttributes<HTMLInputElement>;
   label: string;
   hideLabel?: boolean;
   errors?: { message?: string };
@@ -13,40 +14,32 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 export const InputField = React.forwardRef<HTMLInputElement, Props>(
-  (
-    { errors, id, label, hideLabel, errorMessageMap, className, ...props },
-    ref
-  ) => {
-    const inputStyles = cx(
-      styles.baseStyles,
-      {
-        [styles.errorStyles]: Boolean(errors),
-      },
-      className
-    );
-
+  (props, ref) => {
+    const inputStyles = cx(styles.baseStyles, {
+      [styles.errorStyles]: Boolean(props.errors),
+    });
     // for a11y if we don't want visually show labels
     const visuallyHidden = cx({
-      [styles.visuallyHidden]: Boolean(hideLabel),
+      [styles.visuallyHidden]: Boolean(props.hideLabel),
     });
 
     return (
       <div className={styles.container}>
-        <label htmlFor={id} className={visuallyHidden}>
-          <Text t="caption">{label}</Text>
+        <label htmlFor={props.inputProps.id} className={visuallyHidden}>
+          <Text t="caption">{props.label}</Text>
         </label>
 
         <input
-          id={id}
+          id={props.inputProps.id}
           className={inputStyles}
           ref={ref}
-          aria-invalid={Boolean(errors)}
-          {...props}
+          aria-invalid={Boolean(props.errors)}
+          {...props.inputProps}
         />
 
-        {errors && errors.message && (
+        {props.errors && props.errors.message && (
           <Text t="caption" className={styles.errorMessage}>
-            {errorMessageMap(errors.message)}
+            {props.errorMessageMap(props.errors.message)}
           </Text>
         )}
       </div>

--- a/site/components/Form/InputField/index.tsx
+++ b/site/components/Form/InputField/index.tsx
@@ -1,16 +1,19 @@
 import React, { InputHTMLAttributes } from "react";
 import { cx } from "@emotion/css";
+import { FieldError } from "react-hook-form";
+
 import { Text } from "@klimadao/lib/components";
 
 import * as styles from "./styles";
+
+import { PledgeErrorId } from "components/pages/Pledge/lib/formSchema";
 
 interface Props {
   inputProps: InputHTMLAttributes<HTMLInputElement>;
   label: string;
   hideLabel?: boolean;
-  errors?: { message?: string };
-  errorMessageMap: (id: string) => string;
-  className?: string;
+  errors?: { message?: FieldError["message"] };
+  errorMessageMap: (id: PledgeErrorId) => string;
 }
 
 export const InputField = React.forwardRef<HTMLInputElement, Props>(
@@ -39,7 +42,7 @@ export const InputField = React.forwardRef<HTMLInputElement, Props>(
 
         {props.errors && props.errors.message && (
           <Text t="caption" className={styles.errorMessage}>
-            {props.errorMessageMap(props.errors.message)}
+            {props.errorMessageMap(props.errors.message as PledgeErrorId)}
           </Text>
         )}
       </div>

--- a/site/components/Form/InputField/index.tsx
+++ b/site/components/Form/InputField/index.tsx
@@ -18,9 +18,13 @@ interface Props {
 
 export const InputField = React.forwardRef<HTMLInputElement, Props>(
   (props, ref) => {
-    const inputStyles = cx(styles.baseStyles, {
-      [styles.errorStyles]: Boolean(props.errors),
-    });
+    const inputStyles = cx(
+      styles.baseStyles,
+      {
+        [styles.errorStyles]: Boolean(props.errors),
+      },
+      props.inputProps.className
+    );
     // for a11y if we don't want visually show labels
     const visuallyHidden = cx({
       [styles.visuallyHidden]: Boolean(props.hideLabel),
@@ -34,10 +38,10 @@ export const InputField = React.forwardRef<HTMLInputElement, Props>(
 
         <input
           id={props.inputProps.id}
-          className={inputStyles}
           ref={ref}
           aria-invalid={Boolean(props.errors)}
           {...props.inputProps}
+          className={inputStyles}
         />
 
         {props.errors && props.errors.message && (

--- a/site/components/Form/TextareaField/index.tsx
+++ b/site/components/Form/TextareaField/index.tsx
@@ -1,14 +1,16 @@
 import React, { TextareaHTMLAttributes } from "react";
 import { cx } from "@emotion/css";
+import { FieldError } from "react-hook-form";
 import { Text } from "@klimadao/lib/components";
 
+import { PledgeErrorId } from "components/pages/Pledge/lib/formSchema";
 import * as styles from "./styles";
 
 interface Props {
   textareaProps: TextareaHTMLAttributes<HTMLTextAreaElement>;
   label: string;
-  errors?: { message?: string };
-  errorMessageMap: (id: string) => string;
+  errors?: { message?: FieldError["message"] };
+  errorMessageMap: (id: PledgeErrorId) => string;
 }
 
 export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
@@ -33,7 +35,7 @@ export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
 
         {props.errors && props.errors.message && (
           <Text t="caption" className={styles.errorMessage}>
-            {props.errorMessageMap(props.errors.message)}
+            {props.errorMessageMap(props.errors.message as PledgeErrorId)}
           </Text>
         )}
       </div>

--- a/site/components/Form/TextareaField/index.tsx
+++ b/site/components/Form/TextareaField/index.tsx
@@ -1,16 +1,13 @@
 import React, { TextareaHTMLAttributes } from "react";
 import { cx } from "@emotion/css";
-import { FieldError } from "react-hook-form";
 import { Text } from "@klimadao/lib/components";
 
-import { PledgeErrorId } from "components/pages/Pledge/lib/formSchema";
 import * as styles from "./styles";
 
 interface Props {
   textareaProps: TextareaHTMLAttributes<HTMLTextAreaElement>;
   label: string;
-  errors?: { message?: FieldError["message"] };
-  errorMessageMap: (id: PledgeErrorId) => string;
+  errorMessage: false | string;
 }
 
 export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
@@ -18,7 +15,7 @@ export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
     const inputStyles = cx(
       styles.baseStyles,
       {
-        [styles.errorStyles]: Boolean(props.errors),
+        [styles.errorStyles]: !!props.errorMessage,
       },
       props.textareaProps.className
     );
@@ -32,14 +29,14 @@ export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
         <textarea
           id={props.textareaProps.id}
           ref={ref}
-          aria-invalid={Boolean(props.errors)}
+          aria-invalid={!!props.errorMessage}
           {...props.textareaProps}
           className={inputStyles}
         />
 
-        {props.errors && props.errors.message && (
+        {!!props.errorMessage && (
           <Text t="caption" className={styles.errorMessage}>
-            {props.errorMessageMap(props.errors.message as PledgeErrorId)}
+            {props.errorMessage}
           </Text>
         )}
       </div>

--- a/site/components/Form/TextareaField/index.tsx
+++ b/site/components/Form/TextareaField/index.tsx
@@ -1,40 +1,39 @@
-import React, { InputHTMLAttributes } from "react";
+import React, { TextareaHTMLAttributes } from "react";
 import { cx } from "@emotion/css";
 import { Text } from "@klimadao/lib/components";
 
 import * as styles from "./styles";
 
-interface Props extends InputHTMLAttributes<HTMLTextAreaElement> {
+interface Props {
+  textareaProps: TextareaHTMLAttributes<HTMLTextAreaElement>;
   label: string;
-  rows: number;
   errors?: { message?: string };
   errorMessageMap: (id: string) => string;
 }
 
 export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
-  ({ errors, id, label, ...props }, ref) => {
+  (props, ref) => {
     const inputStyles = cx(styles.baseStyles, {
-      [styles.errorStyles]: Boolean(errors),
+      [styles.errorStyles]: Boolean(props.errors),
     });
 
     return (
       <div className={styles.container}>
-        <label htmlFor={id}>
-          <Text t="caption">{label}</Text>
+        <label htmlFor={props.textareaProps.id}>
+          <Text t="caption">{props.label}</Text>
         </label>
 
         <textarea
-          id={id}
+          id={props.textareaProps.id}
           ref={ref}
-          type="textarea"
           className={inputStyles}
-          aria-invalid={Boolean(errors)}
-          {...props}
+          aria-invalid={Boolean(props.errors)}
+          {...props.textareaProps}
         />
 
-        {errors && errors.message && (
+        {props.errors && props.errors.message && (
           <Text t="caption" className={styles.errorMessage}>
-            {props.errorMessageMap(errors.message)}
+            {props.errorMessageMap(props.errors.message)}
           </Text>
         )}
       </div>

--- a/site/components/Form/TextareaField/index.tsx
+++ b/site/components/Form/TextareaField/index.tsx
@@ -15,9 +15,13 @@ interface Props {
 
 export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
   (props, ref) => {
-    const inputStyles = cx(styles.baseStyles, {
-      [styles.errorStyles]: Boolean(props.errors),
-    });
+    const inputStyles = cx(
+      styles.baseStyles,
+      {
+        [styles.errorStyles]: Boolean(props.errors),
+      },
+      props.textareaProps.className
+    );
 
     return (
       <div className={styles.container}>
@@ -28,9 +32,9 @@ export const TextareaField = React.forwardRef<HTMLTextAreaElement, Props>(
         <textarea
           id={props.textareaProps.id}
           ref={ref}
-          className={inputStyles}
           aria-invalid={Boolean(props.errors)}
           {...props.textareaProps}
+          className={inputStyles}
         />
 
         {props.errors && props.errors.message && (

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -142,15 +142,17 @@ export const PledgeForm: FC<Props> = (props) => {
       />
 
       <TextareaField
-        id="pledge"
-        rows={2}
+        textareaProps={{
+          id: "pledge",
+          placeholder: t({
+            id: "pledges.form.input.description.placeholder",
+            message: "What is your pledge?",
+          }),
+          rows: 2,
+        }}
         label={t({
           id: "pledges.form.input.description.label",
           message: "Pledge",
-        })}
-        placeholder={t({
-          id: "pledges.form.input.description.placeholder",
-          message: "What is your pledge?",
         })}
         errors={formState.errors.description}
         errorMessageMap={getPledgeFormErrorTranslations}
@@ -158,16 +160,18 @@ export const PledgeForm: FC<Props> = (props) => {
       />
 
       <TextareaField
-        id="methodology"
-        rows={6}
+        textareaProps={{
+          id: "methodology",
+          placeholder: t({
+            id: "pledges.form.input.methodology.placeholder",
+            message:
+              "What tools or methodologies did you use to calculate your carbon footprint?",
+          }),
+          rows: 6,
+        }}
         label={t({
           id: "pledges.form.input.methodology.label",
           message: "Methodology",
-        })}
-        placeholder={t({
-          id: "pledges.form.input.methodology.placeholder",
-          message:
-            "What tools or methodologies did you use to calculate your carbon footprint?",
         })}
         errors={formState.errors.methodology}
         errorMessageMap={getPledgeFormErrorTranslations}

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -119,11 +119,11 @@ export const PledgeForm: FC<Props> = (props) => {
             message: "Name or company name",
           }),
           type: "text",
+          ...register("name"),
         }}
         label={t({ id: "pledges.form.input.name.label", message: "Name" })}
         errors={formState.errors.name}
         errorMessageMap={getPledgeFormErrorTranslations}
-        {...register("name")}
       />
 
       <InputField
@@ -131,6 +131,7 @@ export const PledgeForm: FC<Props> = (props) => {
           id: "profileImageUrl",
           placeholder: "https://",
           type: "text",
+          ...register("profileImageUrl"),
         }}
         label={t({
           id: "pledges.form.input.profileImageUrl.label",
@@ -138,7 +139,6 @@ export const PledgeForm: FC<Props> = (props) => {
         })}
         errors={formState.errors.profileImageUrl}
         errorMessageMap={getPledgeFormErrorTranslations}
-        {...register("profileImageUrl")}
       />
 
       <TextareaField
@@ -149,6 +149,7 @@ export const PledgeForm: FC<Props> = (props) => {
             message: "What is your pledge?",
           }),
           rows: 2,
+          ...register("description"),
         }}
         label={t({
           id: "pledges.form.input.description.label",
@@ -156,7 +157,6 @@ export const PledgeForm: FC<Props> = (props) => {
         })}
         errors={formState.errors.description}
         errorMessageMap={getPledgeFormErrorTranslations}
-        {...register("description")}
       />
 
       <TextareaField
@@ -168,6 +168,7 @@ export const PledgeForm: FC<Props> = (props) => {
               "What tools or methodologies did you use to calculate your carbon footprint?",
           }),
           rows: 6,
+          ...register("methodology"),
         }}
         label={t({
           id: "pledges.form.input.methodology.label",
@@ -175,7 +176,6 @@ export const PledgeForm: FC<Props> = (props) => {
         })}
         errors={formState.errors.methodology}
         errorMessageMap={getPledgeFormErrorTranslations}
-        {...register("methodology")}
       />
 
       <div className={styles.categories_section}>
@@ -202,6 +202,7 @@ export const PledgeForm: FC<Props> = (props) => {
                       message: "Category name",
                     }),
                     type: "text",
+                    ...register(`categories.${index}.name` as const),
                   }}
                   hideLabel
                   label={t({
@@ -210,7 +211,6 @@ export const PledgeForm: FC<Props> = (props) => {
                   })}
                   errors={formState.errors.categories?.[index]?.name}
                   errorMessageMap={getPledgeFormErrorTranslations}
-                  {...register(`categories.${index}.name` as const)}
                 />
 
                 <InputField
@@ -220,6 +220,7 @@ export const PledgeForm: FC<Props> = (props) => {
                       message: "Carbon tonnes",
                     }),
                     type: "number",
+                    ...register(`categories.${index}.quantity` as const),
                   }}
                   hideLabel
                   label={t({
@@ -228,7 +229,6 @@ export const PledgeForm: FC<Props> = (props) => {
                   })}
                   errors={formState.errors.categories?.[index]?.quantity}
                   errorMessageMap={getPledgeFormErrorTranslations}
-                  {...register(`categories.${index}.quantity` as const)}
                 />
               </div>
 
@@ -260,6 +260,7 @@ export const PledgeForm: FC<Props> = (props) => {
       <InputField
         inputProps={{
           type: "hidden",
+          ...register("footprint"),
         }}
         hideLabel
         label={t({
@@ -268,7 +269,6 @@ export const PledgeForm: FC<Props> = (props) => {
         })}
         errors={formState.errors.footprint}
         errorMessageMap={getPledgeFormErrorTranslations}
-        {...register("footprint")}
       />
 
       <TotalFootprint control={control} setValue={setValue} />

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -250,9 +250,10 @@ export const PledgeForm: FC<Props> = (props) => {
                     message: "Quantity",
                   })}
                   errorMessage={
-                    !!formState.errors?.categories?.[index]?.name?.message &&
+                    !!formState.errors?.categories?.[index]?.quantity
+                      ?.message &&
                     pledgeErrorTranslationsMap[
-                      formState?.errors?.categories?.[index]?.name
+                      formState?.errors?.categories?.[index]?.quantity
                         ?.message as PledgeErrorId
                     ]
                   }

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -18,7 +18,8 @@ import { InputField, TextareaField } from "components/Form";
 import {
   editPledgeSignature,
   formSchema,
-  getPledgeFormErrorTranslations,
+  pledgeErrorTranslationsMap,
+  PledgeErrorId,
   putPledge,
   pledgeFormAdapter,
 } from "../lib";
@@ -122,8 +123,12 @@ export const PledgeForm: FC<Props> = (props) => {
           ...register("name"),
         }}
         label={t({ id: "pledges.form.input.name.label", message: "Name" })}
-        errors={formState.errors.name}
-        errorMessageMap={getPledgeFormErrorTranslations}
+        errorMessage={
+          !!formState.errors.name?.message &&
+          pledgeErrorTranslationsMap[
+            formState.errors.name.message as PledgeErrorId
+          ]
+        }
       />
 
       <InputField
@@ -137,8 +142,12 @@ export const PledgeForm: FC<Props> = (props) => {
           id: "pledges.form.input.profileImageUrl.label",
           message: "Profile image url (optional)",
         })}
-        errors={formState.errors.profileImageUrl}
-        errorMessageMap={getPledgeFormErrorTranslations}
+        errorMessage={
+          !!formState.errors.profileImageUrl?.message &&
+          pledgeErrorTranslationsMap[
+            formState.errors.profileImageUrl.message as PledgeErrorId
+          ]
+        }
       />
 
       <TextareaField
@@ -155,8 +164,12 @@ export const PledgeForm: FC<Props> = (props) => {
           id: "pledges.form.input.description.label",
           message: "Pledge",
         })}
-        errors={formState.errors.description}
-        errorMessageMap={getPledgeFormErrorTranslations}
+        errorMessage={
+          !!formState.errors.description?.message &&
+          pledgeErrorTranslationsMap[
+            formState.errors.description.message as PledgeErrorId
+          ]
+        }
       />
 
       <TextareaField
@@ -174,8 +187,12 @@ export const PledgeForm: FC<Props> = (props) => {
           id: "pledges.form.input.methodology.label",
           message: "Methodology",
         })}
-        errors={formState.errors.methodology}
-        errorMessageMap={getPledgeFormErrorTranslations}
+        errorMessage={
+          !!formState.errors.methodology?.message &&
+          pledgeErrorTranslationsMap[
+            formState.errors.methodology.message as PledgeErrorId
+          ]
+        }
       />
 
       <div className={styles.categories_section}>
@@ -209,8 +226,13 @@ export const PledgeForm: FC<Props> = (props) => {
                     id: "pledges.form.input.categoryName.label",
                     message: "Category",
                   })}
-                  errors={formState.errors.categories?.[index]?.name}
-                  errorMessageMap={getPledgeFormErrorTranslations}
+                  errorMessage={
+                    !!formState.errors?.categories?.[index]?.name?.message &&
+                    pledgeErrorTranslationsMap[
+                      formState?.errors?.categories?.[index]?.name
+                        ?.message as PledgeErrorId
+                    ]
+                  }
                 />
 
                 <InputField
@@ -227,8 +249,13 @@ export const PledgeForm: FC<Props> = (props) => {
                     id: "pledges.form.input.categoryQuantity.label",
                     message: "Quantity",
                   })}
-                  errors={formState.errors.categories?.[index]?.quantity}
-                  errorMessageMap={getPledgeFormErrorTranslations}
+                  errorMessage={
+                    !!formState.errors?.categories?.[index]?.name?.message &&
+                    pledgeErrorTranslationsMap[
+                      formState?.errors?.categories?.[index]?.name
+                        ?.message as PledgeErrorId
+                    ]
+                  }
                 />
               </div>
 
@@ -267,8 +294,12 @@ export const PledgeForm: FC<Props> = (props) => {
           id: "pledges.form.input.totalFootprint.label",
           message: "Total footprint",
         })}
-        errors={formState.errors.footprint}
-        errorMessageMap={getPledgeFormErrorTranslations}
+        errorMessage={
+          !!formState.errors.footprint?.message &&
+          pledgeErrorTranslationsMap[
+            formState.errors.footprint.message as PledgeErrorId
+          ]
+        }
       />
 
       <TotalFootprint control={control} setValue={setValue} />

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -112,26 +112,30 @@ export const PledgeForm: FC<Props> = (props) => {
       )}
 
       <InputField
-        id="name"
+        inputProps={{
+          id: "name",
+          placeholder: t({
+            id: "pledges.form.input.name.placeholder",
+            message: "Name or company name",
+          }),
+          type: "text",
+        }}
         label={t({ id: "pledges.form.input.name.label", message: "Name" })}
-        placeholder={t({
-          id: "pledges.form.input.name.placeholder",
-          message: "Name or company name",
-        })}
-        type="text"
         errors={formState.errors.name}
         errorMessageMap={getPledgeFormErrorTranslations}
         {...register("name")}
       />
 
       <InputField
-        id="profileImageUrl"
+        inputProps={{
+          id: "profileImageUrl",
+          placeholder: "https://",
+          type: "text",
+        }}
         label={t({
           id: "pledges.form.input.profileImageUrl.label",
           message: "Profile image url (optional)",
         })}
-        placeholder="https://"
-        type="text"
         errors={formState.errors.profileImageUrl}
         errorMessageMap={getPledgeFormErrorTranslations}
         {...register("profileImageUrl")}
@@ -188,32 +192,36 @@ export const PledgeForm: FC<Props> = (props) => {
             <div className={styles.categoryRow} key={field.id}>
               <div className={styles.categoryRow_inputs}>
                 <InputField
+                  inputProps={{
+                    placeholder: t({
+                      id: "pledges.form.input.categoryName.placeholder",
+                      message: "Category name",
+                    }),
+                    type: "text",
+                  }}
                   hideLabel
                   label={t({
                     id: "pledges.form.input.categoryName.label",
                     message: "Category",
                   })}
-                  placeholder={t({
-                    id: "pledges.form.input.categoryName.placeholder",
-                    message: "Category name",
-                  })}
-                  type="text"
                   errors={formState.errors.categories?.[index]?.name}
                   errorMessageMap={getPledgeFormErrorTranslations}
                   {...register(`categories.${index}.name` as const)}
                 />
 
                 <InputField
+                  inputProps={{
+                    placeholder: t({
+                      id: "pledges.form.input.categoryQuantity.placeholder",
+                      message: "Carbon tonnes",
+                    }),
+                    type: "number",
+                  }}
                   hideLabel
                   label={t({
                     id: "pledges.form.input.categoryQuantity.label",
                     message: "Quantity",
                   })}
-                  placeholder={t({
-                    id: "pledges.form.input.categoryQuantity.placeholder",
-                    message: "Carbon tonnes",
-                  })}
-                  type="number"
                   errors={formState.errors.categories?.[index]?.quantity}
                   errorMessageMap={getPledgeFormErrorTranslations}
                   {...register(`categories.${index}.quantity` as const)}
@@ -246,12 +254,14 @@ export const PledgeForm: FC<Props> = (props) => {
       </div>
 
       <InputField
+        inputProps={{
+          type: "hidden",
+        }}
         hideLabel
         label={t({
           id: "pledges.form.input.totalFootprint.label",
           message: "Total footprint",
         })}
-        type="hidden"
         errors={formState.errors.footprint}
         errorMessageMap={getPledgeFormErrorTranslations}
         {...register("footprint")}

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -1,7 +1,7 @@
 import { t } from "@lingui/macro";
 import * as yup from "yup";
 
-const ERROR_MAP = {
+export const pledgeErrorTranslationsMap = {
   ["pledges.form.errors.name.required"]: t({
     id: "pledges.form.errors.name.required",
     message: "Enter a name",
@@ -46,13 +46,9 @@ const ERROR_MAP = {
     id: "pledges.form.errors.categoryQuantity.min",
     message: "Enter a value greater than 0",
   }),
-};
+} as const;
 
-export type PledgeErrorId = keyof typeof ERROR_MAP;
-
-export const getPledgeFormErrorTranslations = (id: PledgeErrorId): string => {
-  return ERROR_MAP[id];
-};
+export type PledgeErrorId = keyof typeof pledgeErrorTranslationsMap;
 
 export const formSchema = yup
   .object({

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -1,55 +1,57 @@
 import { t } from "@lingui/macro";
 import * as yup from "yup";
 
-export const getPledgeFormErrorTranslations = (id: string) => {
-  const ERROR_MAP = {
-    ["pledges.form.errors.name.required"]: t({
-      id: "pledges.form.errors.name.required",
-      message: "Enter a name",
-    }),
-    ["pledges.form.errors.profileImageUrl.url"]: t({
-      id: "pledges.form.errors.profileImageUrl.url",
-      message: "Enter a valid url",
-    }),
-    ["pledges.form.errors.description.required"]: t({
-      id: "pledges.form.errors.description.required",
-      message: "Enter a pledge",
-    }),
-    ["pledges.form.errors.description.max"]: t({
-      id: "pledges.form.errors.description.max",
-      message: "Enter less than 500 characters",
-    }),
-    ["pledges.form.errors.methodology.required"]: t({
-      id: "pledges.form.errors.methodology.required",
-      message: "Enter a methodology",
-    }),
-    ["pledges.form.errors.methodology.max"]: t({
-      id: "pledges.form.errors.methodology.max",
-      message: "Enter less than 1000 characters",
-    }),
-    ["pledges.form.errors.footprint.generic_error"]: t({
-      id: "pledges.form.errors.footprint.generic_error",
-      message: "Enter a carbon tonne estimate",
-    }),
-    ["pledges.form.errors.footprint.min"]: t({
-      id: "pledges.form.errors.footprint.min",
-      message: "Enter a value greater than 0",
-    }),
-    ["pledges.form.errors.categoryName.required"]: t({
-      id: "pledges.form.errors.categoryName.required",
-      message: "Enter a category",
-    }),
-    ["pledges.form.errors.categoryName.max"]: t({
-      id: "pledges.form.errors.categoryName.max",
-      message: "Enter less than 32 characters",
-    }),
-    ["pledges.form.errors.categoryQuantity.min"]: t({
-      id: "pledges.form.errors.categoryQuantity.min",
-      message: "Enter a value greater than 0",
-    }),
-  };
+const ERROR_MAP = {
+  ["pledges.form.errors.name.required"]: t({
+    id: "pledges.form.errors.name.required",
+    message: "Enter a name",
+  }),
+  ["pledges.form.errors.profileImageUrl.url"]: t({
+    id: "pledges.form.errors.profileImageUrl.url",
+    message: "Enter a valid url",
+  }),
+  ["pledges.form.errors.description.required"]: t({
+    id: "pledges.form.errors.description.required",
+    message: "Enter a pledge",
+  }),
+  ["pledges.form.errors.description.max"]: t({
+    id: "pledges.form.errors.description.max",
+    message: "Enter less than 500 characters",
+  }),
+  ["pledges.form.errors.methodology.required"]: t({
+    id: "pledges.form.errors.methodology.required",
+    message: "Enter a methodology",
+  }),
+  ["pledges.form.errors.methodology.max"]: t({
+    id: "pledges.form.errors.methodology.max",
+    message: "Enter less than 1000 characters",
+  }),
+  ["pledges.form.errors.footprint.generic_error"]: t({
+    id: "pledges.form.errors.footprint.generic_error",
+    message: "Enter a carbon tonne estimate",
+  }),
+  ["pledges.form.errors.footprint.min"]: t({
+    id: "pledges.form.errors.footprint.min",
+    message: "Enter a value greater than 0",
+  }),
+  ["pledges.form.errors.categoryName.required"]: t({
+    id: "pledges.form.errors.categoryName.required",
+    message: "Enter a category",
+  }),
+  ["pledges.form.errors.categoryName.max"]: t({
+    id: "pledges.form.errors.categoryName.max",
+    message: "Enter less than 32 characters",
+  }),
+  ["pledges.form.errors.categoryQuantity.min"]: t({
+    id: "pledges.form.errors.categoryQuantity.min",
+    message: "Enter a value greater than 0",
+  }),
+};
 
-  return ERROR_MAP[id as keyof typeof ERROR_MAP];
+export type PledgeErrorId = keyof typeof ERROR_MAP;
+
+export const getPledgeFormErrorTranslations = (id: PledgeErrorId): string => {
+  return ERROR_MAP[id];
 };
 
 export const formSchema = yup

--- a/site/components/pages/Pledge/lib/index.tsx
+++ b/site/components/pages/Pledge/lib/index.tsx
@@ -1,5 +1,6 @@
 export { editPledgeSignature } from "./editPledgeSignature";
-export { formSchema, getPledgeFormErrorTranslations } from "./formSchema";
+export { formSchema, pledgeErrorTranslationsMap } from "./formSchema";
+export type { PledgeErrorId } from "./formSchema";
 export { DEFAULT_NONCE, generateNonce } from "./generateNonce";
 export {
   createPledgeAttributes,

--- a/site/components/pages/Resources/ResourcesList/index.tsx
+++ b/site/components/pages/Resources/ResourcesList/index.tsx
@@ -66,27 +66,29 @@ export const ResourcesList: FC<Props> = (props) => {
           onSubmit={handleSubmit(onSubmit)}
         >
           <InputField
-            id="search"
+            inputProps={{
+              id: "search",
+              placeholder: t({
+                id: "resources.form.input.search.placeholder",
+                message: "Search",
+              }),
+              type: "search",
+              autoComplete: "off",
+              className: styles.searchInput,
+              ...register("search", {
+                required: {
+                  value: false,
+                  message: "resources.form.input.search.error.required",
+                },
+              }),
+            }}
             label={t({
               id: "resources.form.input.search.label",
               message: "Search",
             })}
-            placeholder={t({
-              id: "resources.form.input.search.placeholder",
-              message: "Search",
-            })}
-            type="search"
-            autoComplete="off"
             hideLabel
-            className={styles.searchInput}
             errors={errors.search}
             errorMessageMap={getResourcesListErrorTranslations}
-            {...register("search", {
-              required: {
-                value: false,
-                message: "resources.form.input.search.error.required",
-              },
-            })}
           />
           <ButtonPrimary
             variant="icon"

--- a/site/components/pages/Resources/ResourcesList/index.tsx
+++ b/site/components/pages/Resources/ResourcesList/index.tsx
@@ -7,7 +7,10 @@ import { Text, Section, ButtonPrimary } from "@klimadao/lib/components";
 import { Card } from "components/Card";
 import { PodcastCard } from "components/PodcastCard";
 import { InputField } from "components/Form";
-import { getResourcesListErrorTranslations } from "../lib/getResourcesListErrorTranslations";
+import {
+  resourcesErrorTranslationsMap,
+  ResourcesErrorId,
+} from "../lib/getResourcesListErrorTranslations";
 
 import { fetchCMSContent } from "lib/fetchCMSContent";
 
@@ -87,8 +90,12 @@ export const ResourcesList: FC<Props> = (props) => {
               message: "Search",
             })}
             hideLabel
-            errors={errors.search}
-            errorMessageMap={getResourcesListErrorTranslations}
+            errorMessage={
+              !!errors.search?.message &&
+              resourcesErrorTranslationsMap[
+                errors.search.message as ResourcesErrorId
+              ]
+            }
           />
           <ButtonPrimary
             variant="icon"

--- a/site/components/pages/Resources/lib/getResourcesListErrorTranslations.ts
+++ b/site/components/pages/Resources/lib/getResourcesListErrorTranslations.ts
@@ -1,12 +1,10 @@
 import { t } from "@lingui/macro";
 
-const ERROR_MAP = {
+export const resourcesErrorTranslationsMap = {
   ["resources.form.input.search.error.required"]: t({
     id: "resources.form.input.search.error.required",
     message: "Enter a search term",
   }),
-};
+} as const;
 
-export const getResourcesListErrorTranslations = (id: string) => {
-  return ERROR_MAP[id as keyof typeof ERROR_MAP];
-};
+export type ResourcesErrorId = keyof typeof resourcesErrorTranslationsMap;


### PR DESCRIPTION
## Description

This PR is a side work while working on the new Resources page which will have some new input elements (checkboxes, selects).

Because this PR is touching **all inputs on the PLEDGE site**, I separated this PR from the other one.

- improve types for InputField and TextAreaField (=> see [review comment here](https://github.com/KlimaDAO/klimadao/pull/666#discussion_r960910080))
- improve input fiel error mapping types (=> see [review comment here](https://github.com/KlimaDAO/klimadao/pull/666#discussion_r960928853))
- simplify errors translation mappings for Form components

## Related Ticket

Preparation for https://github.com/KlimaDAO/klimadao/issues/534


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
