### PR TITLE
useFocusTrap & fix button outlines while tabbing

### DIFF
--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -122,30 +122,6 @@ export const Home: FC = () => {
     }
   }, [web3.isConnected]);
 
-  /**
-   * Outline manager for a11y
-   * So we can hide outlines when clicking, only show them when tabbing
-   */
-  useEffect(() => {
-    const handleMousedown = () => {
-      document.body.removeEventListener("mousedown", handleMousedown);
-      document.body.classList.remove("user-is-tabbing");
-      document.body.addEventListener("keydown", handleKeydown);
-    };
-    const handleKeydown = (e: KeyboardEvent) => {
-      if (e.keyCode === 9) {
-        document.body.removeEventListener("keydown", handleKeydown);
-        document.body.classList.add("user-is-tabbing");
-        document.body.addEventListener("mousedown", handleMousedown);
-      }
-    };
-    document.body.addEventListener("keydown", handleKeydown);
-    return () => {
-      document.body.removeEventListener("keydown", handleKeydown);
-      document.body.removeEventListener("mousedown", handleMousedown);
-    };
-  }, []);
-
   return (
     <>
       <Global

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -6,9 +6,11 @@ import { StyledEngineProvider } from "@mui/material/styles";
 
 import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
+import { useTabListener } from "@klimadao/lib/utils";
 
 // StyledEngineProvider allows us to pass "injectFirst", which makes it easier to override mui styles in our css
 function MyApp({ Component, pageProps }: AppProps) {
+  useTabListener();
   return (
     <StyledEngineProvider injectFirst>
       <I18nProvider i18n={i18n} forceRenderOnLocaleChange={false}>

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -55,4 +55,5 @@ export {
   getENSProfile,
 } from "./ens";
 export { useWeb3 } from "./useWeb3";
+export { useFocusTrap } from "./useFocusTrap";
 export { useTabListener } from "./useTabListener";

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -55,3 +55,4 @@ export {
   getENSProfile,
 } from "./ens";
 export { useWeb3 } from "./useWeb3";
+export { useTabListener } from "./useTabListener";

--- a/lib/utils/useFocusTrap/index.tsx
+++ b/lib/utils/useFocusTrap/index.tsx
@@ -1,0 +1,33 @@
+const focusableElements =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+type EventHandler = (evt: FocusEvent) => void;
+type RefCallback = (el: HTMLElement | null) => void;
+
+/**
+ * Pass the ref into a container element, and it will trap tab focus within that container until it is unmounted.
+ *
+ * Note: this returns a new instance on every rerender, but this doesn't seem to cause problems as callback refs are only invoked on mount/unmount
+ * We don't need to cleanup listeners because we assume the element is removed from the DOM
+ */
+export const useFocusTrap = (): RefCallback => (el) => {
+  if (el) {
+    const focusableChildren = el.querySelectorAll(focusableElements);
+    const first = focusableChildren[0] as HTMLElement; // always going to be an HTMLElement because we don't have XML elements
+    const last = focusableChildren[focusableChildren.length - 1];
+
+    if (first) {
+      // auto-focus the first element in the container
+      first.focus();
+    }
+
+    const handleFocusout: EventHandler = (evt) => {
+      // if the element that lost focus was the last item, go back to top
+      if (last && evt.target === last) {
+        first.focus();
+      }
+    };
+
+    el.addEventListener("focusout", handleFocusout);
+  }
+};

--- a/lib/utils/useTabListener/index.tsx
+++ b/lib/utils/useTabListener/index.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+/**
+ * Outline manager for a11y, sets and unsets the .user-is-tabbing class on body
+ * so we can fine-tune outlines and focus throughout the app and site
+ */
+export const useTabListener = () => {
+  useEffect(() => {
+    const handleMousedown = () => {
+      document.body.removeEventListener("mousedown", handleMousedown);
+      document.body.classList.remove("user-is-tabbing");
+      document.body.addEventListener("keydown", handleKeydown);
+    };
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (e.keyCode === 9) {
+        document.body.removeEventListener("keydown", handleKeydown);
+        document.body.classList.add("user-is-tabbing");
+        document.body.addEventListener("mousedown", handleMousedown);
+      }
+    };
+    document.body.addEventListener("keydown", handleKeydown);
+    return () => {
+      document.body.removeEventListener("keydown", handleKeydown);
+      document.body.removeEventListener("mousedown", handleMousedown);
+    };
+  }, []);
+};

--- a/site/components/Modal/index.tsx
+++ b/site/components/Modal/index.tsx
@@ -1,18 +1,9 @@
 import React, { useEffect, FC } from "react";
-import styled from "@emotion/styled";
 import Close from "@mui/icons-material/Close";
 
 import * as styles from "./styles";
 import { Text } from "@klimadao/lib/components";
-
-type ModalWrapperProps = {
-  showModal: boolean;
-};
-
-export const ModalWrapper = styled.div`
-  display: ${(props: ModalWrapperProps) =>
-    props.showModal ? "block" : "none"};
-`;
+import { useFocusTrap } from "@klimadao/lib/utils";
 
 export interface Props {
   showModal: boolean;
@@ -23,6 +14,7 @@ export interface Props {
 
 export const Modal: FC<Props> = (props) => {
   const showCloseButton = !!props.onToggleModal;
+  const focusTrapRef = useFocusTrap();
 
   useEffect(() => {
     if (props.showModal) {
@@ -36,11 +28,13 @@ export const Modal: FC<Props> = (props) => {
     ? props.onToggleModal
     : undefined;
 
+  if (!props.showModal) return null;
+
   return (
-    <ModalWrapper showModal={props.showModal} aria-modal={true}>
+    <div aria-modal={true}>
       <div className={styles.modalBackground} onClick={handleBackgroundClick} />
       <div className={styles.modalContainer}>
-        <div className={styles.modalContent}>
+        <div className={styles.modalContent} ref={focusTrapRef}>
           <div className="title">
             <Text t="h4" uppercase={true}>
               {props.title}
@@ -56,6 +50,6 @@ export const Modal: FC<Props> = (props) => {
           {props.children}
         </div>
       </div>
-    </ModalWrapper>
+    </div>
   );
 };

--- a/site/components/pages/Infinity/Cards/styles.ts
+++ b/site/components/pages/Infinity/Cards/styles.ts
@@ -14,6 +14,10 @@ export const sliderHeader = css`
   align-items: center;
   height: 100%;
   width: 100%;
+  gap: 1.6rem;
+  ${breakpoints.desktop} {
+    gap: 3.2rem;
+  }
 `;
 
 export const sliderTitle = css`

--- a/site/pages/_app.tsx
+++ b/site/pages/_app.tsx
@@ -8,6 +8,7 @@ import { I18nProvider } from "@lingui/react";
 import { i18n } from "@lingui/core";
 import { GridContainer, Web3ContextProvider } from "@klimadao/lib/components";
 import { getWeb3ModalStrings } from "lib/getWeb3ModalStrings";
+import { useTabListener } from "@klimadao/lib/utils";
 
 const loadFallbackOnServer = async () => {
   if (typeof window === "undefined") {
@@ -21,6 +22,8 @@ const loadFallbackOnServer = async () => {
 // TODO: throw if env vars are unset
 
 function MyApp({ Component, pageProps, router }: AppProps) {
+  useTabListener();
+
   const firstRender = useRef(true);
   const { translation, fixedThemeName } = pageProps;
 


### PR DESCRIPTION
## Description

Along the way I discovered that outlines werent working on any button, because we never brought over the `user-is-tabbing` logic from the `app`

useFocusTrap ended up being too painful to use on mobile menu, because we can only trap focus there when its open. But I think that's OK because I can still tab through the menu pretty easily.

Modals seem to be working great!

## Related Ticket
Resolves #684 
