### PR TITLE
Add missing -1 to AKR calc

### DIFF
--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -55,10 +55,8 @@ export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
       const stakingRebase = stakingReward / circSupply;
       const fiveDayRate =
         Math.pow(1 + stakingRebase, 5 * estimatedDailyRebases) - 1;
-      const stakingAnnualPercent = Math.pow(
-        1 + stakingRebase,
-        365 * estimatedDailyRebases
-      );
+      const stakingAnnualPercent =
+        Math.pow(1 + stakingRebase, 365 * estimatedDailyRebases) - 1;
 
       dispatch(
         setAppState({


### PR DESCRIPTION
## Description

It appears we were missing a `-1` to subtract the initial amount of KLIMA staked from the AKR calculation

## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/91024694/190935884-5d221b5b-2c7b-420e-9389-9a1343ccb640.png) |![image](https://user-images.githubusercontent.com/91024694/190935870-0a49e56c-ecc1-436c-a7f3-104b79a90423.png)|

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
