### PR TITLE
pledge: on-demand revalidation

### DIFF
--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -59,7 +59,7 @@ type Props = {
 
 export const PledgeForm: FC<Props> = (props) => {
   const [serverError, setServerError] = useState(false);
-  const { asPath } = useRouter();
+  const { pathname } = useRouter();
   const { signer } = useWeb3();
   const { control, register, handleSubmit, formState, reset, setValue } =
     useForm<PledgeFormValues>({
@@ -87,7 +87,7 @@ export const PledgeForm: FC<Props> = (props) => {
         pageAddress: props.pageAddress,
         pledge: values,
         signature,
-        urlPath: asPath,
+        urlPath: pathname,
       });
       const data = await response.json();
 

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -59,7 +59,7 @@ type Props = {
 
 export const PledgeForm: FC<Props> = (props) => {
   const [serverError, setServerError] = useState(false);
-  const { pathname } = useRouter();
+  const { pathname, query } = useRouter();
   const { signer } = useWeb3();
   const { control, register, handleSubmit, formState, reset, setValue } =
     useForm<PledgeFormValues>({
@@ -82,7 +82,7 @@ export const PledgeForm: FC<Props> = (props) => {
       const signature = await signer.signMessage(
         editPledgeSignature(values.nonce)
       );
-
+      console.log({ pathname, query });
       const response = await putPledge({
         pageAddress: props.pageAddress,
         pledge: values,

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -59,7 +59,7 @@ type Props = {
 
 export const PledgeForm: FC<Props> = (props) => {
   const [serverError, setServerError] = useState(false);
-  const { pathname, query } = useRouter();
+  const { query } = useRouter();
   const { signer } = useWeb3();
   const { control, register, handleSubmit, formState, reset, setValue } =
     useForm<PledgeFormValues>({
@@ -82,12 +82,11 @@ export const PledgeForm: FC<Props> = (props) => {
       const signature = await signer.signMessage(
         editPledgeSignature(values.nonce)
       );
-      console.log({ pathname, query });
       const response = await putPledge({
         pageAddress: props.pageAddress,
         pledge: values,
         signature,
-        urlPath: pathname,
+        urlPath: `/pledge/${query.address}`,
       });
       const data = await response.json();
 

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -59,6 +59,7 @@ type Props = {
 
 export const PledgeForm: FC<Props> = (props) => {
   const [serverError, setServerError] = useState(false);
+  const { asPath } = useRouter();
   const { signer } = useWeb3();
   const { control, register, handleSubmit, formState, reset, setValue } =
     useForm<PledgeFormValues>({
@@ -86,6 +87,7 @@ export const PledgeForm: FC<Props> = (props) => {
         pageAddress: props.pageAddress,
         pledge: values,
         signature,
+        urlPath: asPath,
       });
       const data = await response.json();
 

--- a/site/components/pages/Pledge/lib/firebase.ts
+++ b/site/components/pages/Pledge/lib/firebase.ts
@@ -1,7 +1,7 @@
 import * as admin from "firebase-admin";
 
 import { FIREBASE_ADMIN_CERT } from "lib/secrets";
-import { Pledge, putPledgeParams } from "../types";
+import { Pledge, PledgeFormValues } from "../types";
 import {
   DEFAULT_NONCE,
   createPledgeAttributes,
@@ -40,8 +40,14 @@ export const getPledgeByAddress = async (address: string): Promise<Pledge> => {
   return pledgeRef.data();
 };
 
+export interface findOrCreatePledgeParams {
+  pledge: PledgeFormValues;
+  pageAddress: string;
+  signature: string;
+}
+
 export const findOrCreatePledge = async (
-  params: putPledgeParams
+  params: findOrCreatePledgeParams
 ): Promise<Pledge | null> => {
   const db = initFirebaseAdmin();
   const pledgeCollectionRef = db.collection(

--- a/site/components/pages/Pledge/lib/putPledge.ts
+++ b/site/components/pages/Pledge/lib/putPledge.ts
@@ -4,6 +4,7 @@ export interface putPledgeParams {
   pledge: PledgeFormValues;
   pageAddress: string;
   signature: string;
+  urlPath: string;
 }
 
 export const putPledge = (params: putPledgeParams): Promise<Response> =>
@@ -16,5 +17,6 @@ export const putPledge = (params: putPledgeParams): Promise<Response> =>
     body: JSON.stringify({
       pageAddress: params.pageAddress,
       pledge: params.pledge,
+      urlPath: params.urlPath,
     }),
   });

--- a/site/pages/api/pledge/index.ts
+++ b/site/pages/api/pledge/index.ts
@@ -26,7 +26,7 @@ export default async function handler(
           );
         }
 
-        await res.unstable_revalidate(`/pledge/${req.body.pageAddress}`);
+        await res.unstable_revalidate(req.body.urlPath);
         res.status(200).json({ pledge });
       } catch ({ message }) {
         console.error("Request failed:", message);

--- a/site/pages/api/pledge/index.ts
+++ b/site/pages/api/pledge/index.ts
@@ -26,7 +26,7 @@ export default async function handler(
           );
         }
 
-        res.unstable_revalidate(`/pledge/${req.body.pageAddress}`);
+        await res.unstable_revalidate(`/pledge/${req.body.pageAddress}`);
         res.status(200).json({ pledge });
       } catch ({ message }) {
         console.error("Request failed:", message);

--- a/site/pages/api/pledge/index.ts
+++ b/site/pages/api/pledge/index.ts
@@ -26,6 +26,7 @@ export default async function handler(
           );
         }
 
+        res.unstable_revalidate(`/pledge/${req.body.pageAddress}`);
         res.status(200).json({ pledge });
       } catch ({ message }) {
         console.error("Request failed:", message);


### PR DESCRIPTION
## Description

Implements on-demand revalidation users successfully updates their pledge.

#### What does this solve?
Pages are cached globally and are regenerated at an interval configured in our app (for `/pledges/[address].tsx` it's approximately 4 mins).
This means an out of date page can be served until the page is regenerated.


## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #466 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
