### PR TITLE
pledge: form error message refactor

### DIFF
--- a/site/components/Modal/index.tsx
+++ b/site/components/Modal/index.tsx
@@ -36,9 +36,7 @@ export const Modal: FC<Props> = (props) => {
       <div className={styles.modalContainer}>
         <div className={styles.modalContent} ref={focusTrapRef}>
           <div className="title">
-            <Text t="h4" uppercase={true}>
-              {props.title}
-            </Text>
+            <Text t="h4">{props.title}</Text>
 
             {showCloseButton && (
               <button onClick={props.onToggleModal}>

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/BaseCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/BaseCard/index.tsx
@@ -14,9 +14,7 @@ export const BaseCard: React.FC<CardProps> = (props) => (
     <div className={styles.cardHeader}>
       <div className={styles.title}>
         {props.icon}
-        <Text t="h3" uppercase>
-          {props.title}
-        </Text>
+        <Text t="h3">{props.title}</Text>
       </div>
 
       {props.action && <div>{props.action}</div>}

--- a/site/components/pages/Pledge/PledgeDashboard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/index.tsx
@@ -66,7 +66,7 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
       <Modal
         title={t({
           id: "pledges.form.title",
-          message: "Your pledge",
+          message: "Your Pledge",
         })}
         showModal={showModal}
         onToggleModal={() => setShowModal(!showModal)}

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -66,7 +66,7 @@ export const PledgeForm: FC<Props> = (props) => {
       defaultValues: pledgeFormAdapter(props.pledge),
       resolver: yupResolver(formSchema),
     });
-  const { isDirty } = formState;
+  const { isDirty, errors } = formState;
 
   const { fields, append, remove } = useFieldArray({
     name: "categories",
@@ -124,10 +124,7 @@ export const PledgeForm: FC<Props> = (props) => {
         }}
         label={t({ id: "pledges.form.input.name.label", message: "Name" })}
         errorMessage={
-          !!formState.errors.name?.message &&
-          pledgeErrorTranslationsMap[
-            formState.errors.name.message as PledgeErrorId
-          ]
+          pledgeErrorTranslationsMap[errors.name?.message as PledgeErrorId]
         }
       />
 
@@ -143,9 +140,8 @@ export const PledgeForm: FC<Props> = (props) => {
           message: "Profile image url (optional)",
         })}
         errorMessage={
-          !!formState.errors.profileImageUrl?.message &&
           pledgeErrorTranslationsMap[
-            formState.errors.profileImageUrl.message as PledgeErrorId
+            errors.profileImageUrl?.message as PledgeErrorId
           ]
         }
       />
@@ -165,9 +161,8 @@ export const PledgeForm: FC<Props> = (props) => {
           message: "Pledge",
         })}
         errorMessage={
-          !!formState.errors.description?.message &&
           pledgeErrorTranslationsMap[
-            formState.errors.description.message as PledgeErrorId
+            errors.description?.message as PledgeErrorId
           ]
         }
       />
@@ -188,9 +183,8 @@ export const PledgeForm: FC<Props> = (props) => {
           message: "Methodology",
         })}
         errorMessage={
-          !!formState.errors.methodology?.message &&
           pledgeErrorTranslationsMap[
-            formState.errors.methodology.message as PledgeErrorId
+            errors.methodology?.message as PledgeErrorId
           ]
         }
       />
@@ -227,10 +221,8 @@ export const PledgeForm: FC<Props> = (props) => {
                     message: "Category",
                   })}
                   errorMessage={
-                    !!formState.errors?.categories?.[index]?.name?.message &&
                     pledgeErrorTranslationsMap[
-                      formState?.errors?.categories?.[index]?.name
-                        ?.message as PledgeErrorId
+                      errors.categories?.[index]?.name?.message as PledgeErrorId
                     ]
                   }
                 />
@@ -250,10 +242,8 @@ export const PledgeForm: FC<Props> = (props) => {
                     message: "Quantity",
                   })}
                   errorMessage={
-                    !!formState.errors?.categories?.[index]?.quantity
-                      ?.message &&
                     pledgeErrorTranslationsMap[
-                      formState?.errors?.categories?.[index]?.quantity
+                      errors.categories?.[index]?.quantity
                         ?.message as PledgeErrorId
                     ]
                   }
@@ -296,10 +286,7 @@ export const PledgeForm: FC<Props> = (props) => {
           message: "Total footprint",
         })}
         errorMessage={
-          !!formState.errors.footprint?.message &&
-          pledgeErrorTranslationsMap[
-            formState.errors.footprint.message as PledgeErrorId
-          ]
+          pledgeErrorTranslationsMap[errors.footprint?.message as PledgeErrorId]
         }
       />
 

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1002,7 +1002,7 @@ msgstr "Total Carbon Tonnes Retired"
 msgid "pledges.edit_pledge"
 msgstr "Edit Pledge"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:278
+#: components/pages/Pledge/PledgeForm/index.tsx:268
 msgid "pledges.form.add_footprint_category_button"
 msgstr "Add category"
 
@@ -1054,11 +1054,11 @@ msgstr "Enter a name"
 msgid "pledges.form.errors.profileImageUrl.url"
 msgstr "Enter a valid url"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:200
+#: components/pages/Pledge/PledgeForm/index.tsx:194
 msgid "pledges.form.footprint.label"
 msgstr "Footprint"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:205
+#: components/pages/Pledge/PledgeForm/index.tsx:199
 msgid "pledges.form.footprint.prompt"
 msgstr "Add a category and start calculating your carbon footprint"
 
@@ -1066,35 +1066,35 @@ msgstr "Add a category and start calculating your carbon footprint"
 msgid "pledges.form.generic_error"
 msgstr "Something went wrong. Please try again."
 
-#: components/pages/Pledge/PledgeForm/index.tsx:225
+#: components/pages/Pledge/PledgeForm/index.tsx:219
 msgid "pledges.form.input.categoryName.label"
 msgstr "Category"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:217
+#: components/pages/Pledge/PledgeForm/index.tsx:211
 msgid "pledges.form.input.categoryName.placeholder"
 msgstr "Category name"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:248
+#: components/pages/Pledge/PledgeForm/index.tsx:240
 msgid "pledges.form.input.categoryQuantity.label"
 msgstr "Quantity"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:240
+#: components/pages/Pledge/PledgeForm/index.tsx:232
 msgid "pledges.form.input.categoryQuantity.placeholder"
 msgstr "Carbon tonnes"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:163
+#: components/pages/Pledge/PledgeForm/index.tsx:159
 msgid "pledges.form.input.description.label"
 msgstr "Pledge"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:156
+#: components/pages/Pledge/PledgeForm/index.tsx:152
 msgid "pledges.form.input.description.placeholder"
 msgstr "What is your pledge?"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:186
+#: components/pages/Pledge/PledgeForm/index.tsx:181
 msgid "pledges.form.input.methodology.label"
 msgstr "Methodology"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:178
+#: components/pages/Pledge/PledgeForm/index.tsx:173
 msgid "pledges.form.input.methodology.placeholder"
 msgstr "What tools or methodologies did you use to calculate your carbon footprint?"
 
@@ -1106,21 +1106,21 @@ msgstr "Name"
 msgid "pledges.form.input.name.placeholder"
 msgstr "Name or company name"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:141
+#: components/pages/Pledge/PledgeForm/index.tsx:138
 msgid "pledges.form.input.profileImageUrl.label"
 msgstr "Profile image url (optional)"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:294
+#: components/pages/Pledge/PledgeForm/index.tsx:284
 msgid "pledges.form.input.totalFootprint.label"
 msgstr "Total footprint"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:311
+#: components/pages/Pledge/PledgeForm/index.tsx:298
 msgid "pledges.form.submit_button"
 msgstr "Save pledge"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:67
 msgid "pledges.form.title"
-msgstr "Your pledge"
+msgstr "Your Pledge"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:46
 msgid "pledges.form.total_footprint_summary"


### PR DESCRIPTION
## Description

Iterating on ladytrekker's refactor of how we display i18n error strings.

Form field components conditionally display error strings when its present so we can delegate the responsibility there :)
```js
// InputField.tsx & TextareaField.tsx

{!!props.errorMessage && (
  <Text t="caption" className={styles.errorMessage}>
    {props.errorMessage}
  </Text>
)}
```

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
