### PR TITLE
Upgrade emotion, support sourcemaps in site

### DIFF
--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -3,7 +3,6 @@ import { Route, useLocation } from "react-router-dom";
 import { useAppDispatch } from "state";
 import { bonds } from "@klimadao/lib/constants";
 import { useSelector } from "react-redux";
-import { Global, css } from "@emotion/react";
 
 import { useLocaleFromParams } from "lib/hooks/useLocaleFromParams";
 import { selectAppState } from "state/selectors";
@@ -124,15 +123,6 @@ export const Home: FC = () => {
 
   return (
     <>
-      <Global
-        styles={css`
-          .MuiSvgIcon-root {
-            font-size: 2.4rem;
-            width: 2.4rem;
-            height: 2.4rem;
-          }
-        `}
-      />
       <div className={styles.container} data-scrolllock={showMobileMenu}>
         <div className={styles.desktopNavMenu}>
           <NavMenu address={web3.address} />

--- a/app/package.json
+++ b/app/package.json
@@ -14,9 +14,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.10.0",
-    "@emotion/react": "^11.7.0",
     "@emotion/server": "^11.10.0",
-    "@emotion/styled": "^11.6.0",
     "@lingui/core": "^3.13.0",
     "@lingui/react": "^3.13.0",
     "@mui/icons-material": "^5.2.1",

--- a/app/package.json
+++ b/app/package.json
@@ -13,9 +13,9 @@
     "postinstall": "npm run lingui:compile"
   },
   "dependencies": {
-    "@emotion/css": "^11.7.1",
+    "@emotion/css": "^11.10.0",
     "@emotion/react": "^11.7.0",
-    "@emotion/server": "^11.4.0",
+    "@emotion/server": "^11.10.0",
     "@emotion/styled": "^11.6.0",
     "@lingui/core": "^3.13.0",
     "@lingui/react": "^3.13.0",

--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "react-router-dom": "^6.1.0"
   },
   "devDependencies": {
-    "@emotion/babel-plugin": "^11.7.2",
+    "@emotion/babel-plugin": "^11.10.2",
     "@lingui/cli": "^3.13.0",
     "@lingui/macro": "^3.13.0",
     "@next/bundle-analyzer": "^12.0.7",

--- a/lib/theme/globals.css
+++ b/lib/theme/globals.css
@@ -25,6 +25,10 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+body.scrollLock {
+  overflow-y: hidden;
+}
+
 svg {
   display: block;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       "name": "@klimadao/app",
       "hasInstallScript": true,
       "dependencies": {
-        "@emotion/css": "^11.7.1",
+        "@emotion/css": "^11.10.0",
         "@emotion/react": "^11.7.0",
-        "@emotion/server": "^11.4.0",
+        "@emotion/server": "^11.10.0",
         "@emotion/styled": "^11.6.0",
         "@lingui/core": "^3.13.0",
         "@lingui/react": "^3.13.0",
@@ -1863,8 +1863,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.2",
-      "license": "MIT",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -2003,16 +2004,17 @@
       }
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.7.2",
-      "license": "MIT",
+      "version": "11.10.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz",
+      "integrity": "sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/runtime": "^7.13.10",
-        "@emotion/hash": "^0.8.0",
-        "@emotion/memoize": "^0.7.5",
-        "@emotion/serialize": "^1.0.2",
-        "babel-plugin-macros": "^2.6.1",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.17.12",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/serialize": "^1.1.0",
+        "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
         "find-root": "^1.1.0",
@@ -2023,49 +2025,43 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@emotion/babel-plugin/node_modules/babel-plugin-macros": {
-      "version": "2.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
-      }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
     "node_modules/@emotion/cache": {
-      "version": "11.7.1",
-      "license": "MIT",
+      "version": "11.10.3",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
+      "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
       "dependencies": {
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/sheet": "^1.1.0",
-        "@emotion/utils": "^1.0.0",
-        "@emotion/weak-memoize": "^0.2.5",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
         "stylis": "4.0.13"
       }
     },
+    "node_modules/@emotion/cache/node_modules/@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "node_modules/@emotion/cache/node_modules/@emotion/weak-memoize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
+    },
     "node_modules/@emotion/css": {
-      "version": "11.7.1",
-      "license": "MIT",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.0.tgz",
+      "integrity": "sha512-dH9f+kSCucc8ilMg0MUA1AemabcyzYpe5EKX24F528PJjD7HyIY/VBNJHxfUdc8l400h2ncAjR6yEDu+DBj2cg==",
       "dependencies": {
-        "@emotion/babel-plugin": "^11.7.1",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/serialize": "^1.0.0",
-        "@emotion/sheet": "^1.0.3",
-        "@emotion/utils": "^1.0.0"
+        "@emotion/babel-plugin": "^11.10.0",
+        "@emotion/cache": "^11.10.0",
+        "@emotion/serialize": "^1.1.0",
+        "@emotion/sheet": "^1.2.0",
+        "@emotion/utils": "^1.2.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -2077,8 +2073,9 @@
       }
     },
     "node_modules/@emotion/hash": {
-      "version": "0.8.0",
-      "license": "MIT"
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.1.1",
@@ -2117,21 +2114,33 @@
       }
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.0.2",
-      "license": "MIT",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
       "dependencies": {
-        "@emotion/hash": "^0.8.0",
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/unitless": "^0.7.5",
-        "@emotion/utils": "^1.0.0",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/unitless": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+    },
     "node_modules/@emotion/server": {
-      "version": "11.4.0",
-      "license": "MIT",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.10.0.tgz",
+      "integrity": "sha512-MTvJ21JPo9aS02GdjFW4nhdwOi2tNNpMmAM/YED0pkxzjDNi5WbiTwXqaCnvLc2Lr8NFtjhT0az1vTJyLIHYcw==",
       "dependencies": {
-        "@emotion/utils": "^1.0.0",
+        "@emotion/utils": "^1.2.0",
         "html-tokenize": "^2.0.0",
         "multipipe": "^1.0.2",
         "through": "^2.3.8"
@@ -2146,8 +2155,9 @@
       }
     },
     "node_modules/@emotion/sheet": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
+      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
     },
     "node_modules/@emotion/styled": {
       "version": "11.6.0",
@@ -2182,8 +2192,9 @@
       "license": "MIT"
     },
     "node_modules/@emotion/utils": {
-      "version": "1.0.0",
-      "license": "MIT"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.2.5",
@@ -19782,8 +19793,8 @@
       "name": "@klimadao/site",
       "hasInstallScript": true,
       "dependencies": {
-        "@emotion/css": "^11.7.1",
-        "@emotion/server": "^11.4.0",
+        "@emotion/css": "^11.10.0",
+        "@emotion/server": "^11.10.0",
         "@hookform/resolvers": "^2.8.8",
         "@lingui/core": "^3.13.0",
         "@lingui/react": "^3.13.0",
@@ -21026,7 +21037,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.2",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -21130,15 +21143,17 @@
       }
     },
     "@emotion/babel-plugin": {
-      "version": "11.7.2",
+      "version": "11.10.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz",
+      "integrity": "sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==",
       "requires": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/runtime": "^7.13.10",
-        "@emotion/hash": "^0.8.0",
-        "@emotion/memoize": "^0.7.5",
-        "@emotion/serialize": "^1.0.2",
-        "babel-plugin-macros": "^2.6.1",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.17.12",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/serialize": "^1.1.0",
+        "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
         "find-root": "^1.1.0",
@@ -21146,48 +21161,53 @@
         "stylis": "4.0.13"
       },
       "dependencies": {
-        "babel-plugin-macros": {
-          "version": "2.8.0",
-          "requires": {
-            "@babel/runtime": "^7.7.2",
-            "cosmiconfig": "^6.0.0",
-            "resolve": "^1.12.0"
-          }
-        },
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          }
+        "@emotion/memoize": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+          "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
         }
       }
     },
     "@emotion/cache": {
-      "version": "11.7.1",
+      "version": "11.10.3",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
+      "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
       "requires": {
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/sheet": "^1.1.0",
-        "@emotion/utils": "^1.0.0",
-        "@emotion/weak-memoize": "^0.2.5",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
         "stylis": "4.0.13"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+          "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+        },
+        "@emotion/weak-memoize": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+          "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
+        }
       }
     },
     "@emotion/css": {
-      "version": "11.7.1",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.0.tgz",
+      "integrity": "sha512-dH9f+kSCucc8ilMg0MUA1AemabcyzYpe5EKX24F528PJjD7HyIY/VBNJHxfUdc8l400h2ncAjR6yEDu+DBj2cg==",
       "requires": {
-        "@emotion/babel-plugin": "^11.7.1",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/serialize": "^1.0.0",
-        "@emotion/sheet": "^1.0.3",
-        "@emotion/utils": "^1.0.0"
+        "@emotion/babel-plugin": "^11.10.0",
+        "@emotion/cache": "^11.10.0",
+        "@emotion/serialize": "^1.1.0",
+        "@emotion/sheet": "^1.2.0",
+        "@emotion/utils": "^1.2.0"
       }
     },
     "@emotion/hash": {
-      "version": "0.8.0"
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
     },
     "@emotion/is-prop-valid": {
       "version": "1.1.1",
@@ -21211,26 +21231,44 @@
       }
     },
     "@emotion/serialize": {
-      "version": "1.0.2",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
       "requires": {
-        "@emotion/hash": "^0.8.0",
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/unitless": "^0.7.5",
-        "@emotion/utils": "^1.0.0",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
         "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+          "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+        },
+        "@emotion/unitless": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+          "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+        }
       }
     },
     "@emotion/server": {
-      "version": "11.4.0",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.10.0.tgz",
+      "integrity": "sha512-MTvJ21JPo9aS02GdjFW4nhdwOi2tNNpMmAM/YED0pkxzjDNi5WbiTwXqaCnvLc2Lr8NFtjhT0az1vTJyLIHYcw==",
       "requires": {
-        "@emotion/utils": "^1.0.0",
+        "@emotion/utils": "^1.2.0",
         "html-tokenize": "^2.0.0",
         "multipipe": "^1.0.2",
         "through": "^2.3.8"
       }
     },
     "@emotion/sheet": {
-      "version": "1.1.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
+      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
     },
     "@emotion/styled": {
       "version": "11.6.0",
@@ -21249,7 +21287,9 @@
       "version": "0.7.5"
     },
     "@emotion/utils": {
-      "version": "1.0.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
     },
     "@emotion/weak-memoize": {
       "version": "0.2.5"
@@ -22095,9 +22135,9 @@
       "version": "file:app",
       "requires": {
         "@emotion/babel-plugin": "^11.7.2",
-        "@emotion/css": "^11.7.1",
+        "@emotion/css": "^11.10.0",
         "@emotion/react": "^11.7.0",
-        "@emotion/server": "^11.4.0",
+        "@emotion/server": "11.10.0",
         "@emotion/styled": "^11.6.0",
         "@lingui/cli": "^3.13.0",
         "@lingui/core": "^3.13.0",
@@ -22152,8 +22192,8 @@
     "@klimadao/site": {
       "version": "file:site",
       "requires": {
-        "@emotion/css": "^11.7.1",
-        "@emotion/server": "^11.4.0",
+        "@emotion/css": "^11.10.0",
+        "@emotion/server": "11.10.0",
         "@hookform/resolvers": "^2.8.8",
         "@lingui/cli": "^3.13.0",
         "@lingui/core": "^3.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "react-router-dom": "^6.1.0"
       },
       "devDependencies": {
-        "@emotion/babel-plugin": "^11.7.2",
+        "@emotion/babel-plugin": "^11.10.2",
         "@lingui/cli": "^3.13.0",
         "@lingui/macro": "^3.13.0",
         "@next/bundle-analyzer": "^12.0.7",
@@ -19818,6 +19818,7 @@
         "yup": "^0.32.11"
       },
       "devDependencies": {
+        "@emotion/babel-plugin": "^11.10.2",
         "@lingui/cli": "^3.13.0",
         "@lingui/loader": "^3.13.0",
         "@lingui/macro": "^3.13.0",
@@ -22144,7 +22145,7 @@
     "@klimadao/app": {
       "version": "file:app",
       "requires": {
-        "@emotion/babel-plugin": "^11.7.2",
+        "@emotion/babel-plugin": "11.10.2",
         "@emotion/css": "^11.10.0",
         "@emotion/server": "^11.10.0",
         "@lingui/cli": "^3.13.0",
@@ -22200,6 +22201,7 @@
     "@klimadao/site": {
       "version": "file:site",
       "requires": {
+        "@emotion/babel-plugin": "11.10.2",
         "@emotion/css": "^11.10.0",
         "@emotion/server": "^11.10.0",
         "@hookform/resolvers": "^2.8.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/css": "^11.10.0",
-        "@emotion/react": "^11.7.0",
         "@emotion/server": "^11.10.0",
-        "@emotion/styled": "^11.6.0",
         "@lingui/core": "^3.13.0",
         "@lingui/react": "^3.13.0",
         "@mui/icons-material": "^5.2.1",
@@ -2091,6 +2089,8 @@
     "node_modules/@emotion/react": {
       "version": "11.7.1",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@emotion/cache": "^11.7.1",
@@ -2162,6 +2162,8 @@
     "node_modules/@emotion/styled": {
       "version": "11.6.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@emotion/babel-plugin": "^11.3.0",
@@ -2198,7 +2200,9 @@
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.2.5",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",
@@ -21220,6 +21224,8 @@
     },
     "@emotion/react": {
       "version": "11.7.1",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@emotion/cache": "^11.7.1",
@@ -21272,6 +21278,8 @@
     },
     "@emotion/styled": {
       "version": "11.6.0",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@emotion/babel-plugin": "^11.3.0",
@@ -21292,7 +21300,9 @@
       "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
     },
     "@emotion/weak-memoize": {
-      "version": "0.2.5"
+      "version": "0.2.5",
+      "optional": true,
+      "peer": true
     },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",
@@ -22136,9 +22146,7 @@
       "requires": {
         "@emotion/babel-plugin": "^11.7.2",
         "@emotion/css": "^11.10.0",
-        "@emotion/react": "^11.7.0",
-        "@emotion/server": "11.10.0",
-        "@emotion/styled": "^11.6.0",
+        "@emotion/server": "^11.10.0",
         "@lingui/cli": "^3.13.0",
         "@lingui/core": "^3.13.0",
         "@lingui/macro": "^3.13.0",
@@ -22193,7 +22201,7 @@
       "version": "file:site",
       "requires": {
         "@emotion/css": "^11.10.0",
-        "@emotion/server": "11.10.0",
+        "@emotion/server": "^11.10.0",
         "@hookform/resolvers": "^2.8.8",
         "@lingui/cli": "^3.13.0",
         "@lingui/core": "^3.13.0",

--- a/site/.babelrc
+++ b/site/.babelrc
@@ -10,5 +10,17 @@
       }
     ]
   ],
-  "plugins": ["macros"]
+  "plugins": [
+    "macros",
+    [
+      "@emotion",
+      {
+        // sourceMap is on by default but source maps are dead code eliminated in production
+        "sourceMap": true,
+        "autoLabel": "dev-only",
+        "labelFormat": "[local]",
+        "cssPropOptimization": true
+      }
+    ]
+  ]
 }

--- a/site/components/Header/HeaderMobile.tsx
+++ b/site/components/Header/HeaderMobile.tsx
@@ -1,6 +1,5 @@
-import React, { FC, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import * as styles from "./styles";
-import { Global, css } from "@emotion/react";
 
 import { LogoWithClaim } from "@klimadao/lib/components";
 import Link from "next/link";
@@ -13,6 +12,13 @@ interface Props {
 
 export const HeaderMobile: FC<Props> = (props) => {
   const [isToggled, setIsToggled] = useState(false);
+
+  useEffect(() => {
+    isToggled
+      ? document.body.classList.add("scrollLock")
+      : document.body.classList.remove("scrollLock");
+  }, [isToggled]);
+
   return (
     <div
       className={
@@ -35,15 +41,6 @@ export const HeaderMobile: FC<Props> = (props) => {
           onClick={() => setIsToggled(!isToggled)}
         />
       </header>
-      {isToggled && (
-        <Global
-          styles={css`
-            body {
-              overflow-y: hidden;
-            }
-          `}
-        />
-      )}
       <NavMobile isToggled={isToggled}>{props.children}</NavMobile>
     </div>
   );

--- a/site/package.json
+++ b/site/package.json
@@ -12,8 +12,8 @@
     "postinstall": "npm run lingui:compile"
   },
   "dependencies": {
-    "@emotion/css": "^11.7.1",
-    "@emotion/server": "^11.4.0",
+    "@emotion/css": "^11.10.0",
+    "@emotion/server": "^11.10.0",
     "@hookform/resolvers": "^2.8.8",
     "@lingui/core": "^3.13.0",
     "@lingui/react": "^3.13.0",

--- a/site/package.json
+++ b/site/package.json
@@ -33,6 +33,7 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
+    "@emotion/babel-plugin": "^11.10.2",
     "@lingui/cli": "^3.13.0",
     "@lingui/loader": "^3.13.0",
     "@lingui/macro": "^3.13.0",


### PR DESCRIPTION
## Description

Remove two libs `@emotion/react` and `@emotion/styled` that we don't need anymore

## Related Ticket

Replaces #583 

## Checklist

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
