### PR TITLE
add form fields for multi wallet pledge

### DIFF
--- a/lib/components/Buttons/ButtonBase.tsx
+++ b/lib/components/Buttons/ButtonBase.tsx
@@ -6,7 +6,7 @@ export interface Props {
   className?: string;
   onClick?: () => void;
   href?: string;
-  variant?: "gray" | "icon" | "blue" | "blueRounded" | null;
+  variant?: "gray" | "icon" | "blue" | "blueRounded" | "red" | null;
   link?: Link;
   rel?: string;
   target?: string;

--- a/lib/components/Buttons/ButtonPrimary.tsx
+++ b/lib/components/Buttons/ButtonPrimary.tsx
@@ -9,6 +9,7 @@ export const ButtonPrimary: FC<Props> = (props) => {
     {
       gray: props.variant === "gray",
       blue: props.variant === "blue",
+      red: props.variant === "red",
       blueRounded: props.variant === "blueRounded",
       icon: props.variant === "icon",
     },

--- a/lib/components/Buttons/ButtonSecondary.tsx
+++ b/lib/components/Buttons/ButtonSecondary.tsx
@@ -11,6 +11,7 @@ export const ButtonSecondary: FC<Props> = (props) => {
       blue: props.variant === "blue",
       blueRounded: props.variant === "blueRounded",
       icon: props.variant === "icon",
+      red: props.variant === "red",
     },
     props.className
   );

--- a/lib/components/Buttons/styles.ts
+++ b/lib/components/Buttons/styles.ts
@@ -51,6 +51,11 @@ export const buttonPrimary = css`
     }
   }
 
+  &.red {
+    background-color: var(--warn);
+    color: #fff;
+  }
+
   &.blue,
   &.blueRounded {
     background-color: var(--klima-blue);

--- a/lib/components/Buttons/styles.ts
+++ b/lib/components/Buttons/styles.ts
@@ -95,6 +95,11 @@ export const buttonSecondary = css`
     }
   }
 
+  &.red {
+    border-color: var(--warn);
+    color: var(--warn);
+  }
+
   &.blue,
   &.blueRounded {
     border-color: var(--klima-blue);

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx
@@ -1,16 +1,19 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import { Trans, t } from "@lingui/macro";
 import dynamic from "next/dynamic";
+import Tippy from "@tippyjs/react";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import Link from "next/link";
 import LocalFireDepartmentIcon from "@mui/icons-material/LocalFireDepartment";
 import LaunchIcon from "@mui/icons-material/Launch";
 import { Text } from "@klimadao/lib/components";
-import { trimStringDecimals } from "@klimadao/lib/utils";
+import { trimStringDecimals, concatAddress } from "@klimadao/lib/utils";
 import { RetirementsTotalsAndBalances } from "@klimadao/lib/types/offset";
 
 import { BaseCard } from "../BaseCard";
 import { RetirementsChartProps } from "./RetirementsChart";
 import * as styles from "./styles";
+import { cx } from "@emotion/css";
 
 const RetirementsChart: React.ComponentType<RetirementsChartProps> = dynamic(
   () => import("./RetirementsChart").then((mod) => mod.RetirementsChart),
@@ -20,22 +23,82 @@ const RetirementsChart: React.ComponentType<RetirementsChartProps> = dynamic(
 type Props = {
   pageAddress: string;
   retirements: RetirementsTotalsAndBalances | null;
+  secondaryWallets: any;
+  isPledgeOwner: boolean;
 };
 
 export const RetirementsCard: FC<Props> = (props) => {
+  const [showWallets, setShowWallets] = useState<boolean>(false);
   const totalTonnesRetired =
     props.retirements && Number(props.retirements.totalTonnesRetired) > 0
       ? trimStringDecimals(props.retirements.totalTonnesRetired, 2)
       : 0;
-
+  const content = (
+    <div className={styles.pledge_retirements_wallets}>
+      <span className={styles.pledge_retirements_wallet}>
+        <Text>{concatAddress(props.pageAddress)}</Text>
+        <Link href={`/retirements/${props.pageAddress}`} passHref>
+          <a title="View retirements">
+            <div className={styles.retirementsLink}>
+              <LaunchIcon />
+            </div>
+          </a>
+        </Link>
+      </span>
+      {props.secondaryWallets?.map(
+        (wallet: { address: string; verified: boolean }) => {
+          if (wallet.verified) {
+            return (
+              <span
+                key={wallet.address}
+                className={styles.pledge_retirements_wallet}
+              >
+                <Text>{concatAddress(wallet.address)}</Text>
+                <Link href={`/retirements/${wallet.address}`} passHref>
+                  <a title="View retirements">
+                    <div className={styles.retirementsLink}>
+                      <LaunchIcon />
+                    </div>
+                  </a>
+                </Link>
+              </span>
+            );
+          } else if (props.isPledgeOwner && wallet.verified === false) {
+            return (
+              <span
+                key={wallet.address}
+                className={styles.pledge_retirements_wallet}
+              >
+                <Text>{concatAddress(wallet.address)}</Text>
+                <span className={styles.pledge_wallet_pending}>
+                  <Text t="caption">Pending</Text>
+                </span>
+              </span>
+            );
+          }
+        }
+      )}
+    </div>
+  );
   const linkToRetirements = (
-    <Link href={`/retirements/${props.pageAddress}`} passHref>
-      <a title="View retirements">
-        <div className={styles.retirementsLink}>
-          <LaunchIcon />
-        </div>
-      </a>
-    </Link>
+    <Tippy
+      content={content}
+      interactiveBorder={20}
+      interactive={true}
+      delay={100}
+      onClickOutside={() => setShowWallets(false)}
+      placement="bottom-end"
+      visible={showWallets}
+    >
+      <span onClick={() => setShowWallets((p: boolean) => !p)}>
+        <KeyboardArrowDownIcon
+          fontSize="large"
+          className={cx(styles.arrow_down, {
+            open: showWallets,
+          })}
+        />
+      </span>
+    </Tippy>
   );
 
   return (

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/styles.ts
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/styles.ts
@@ -50,3 +50,41 @@ export const chart_tooltip = css`
   border-radius: 0.6rem;
   border: 0.1rem solid var(--font-03);
 `;
+
+export const pledge_retirements_wallets = css`
+  display: flex;
+  padding: 1.2rem 2.4rem;
+  gap: 0.8rem;
+  flex-direction: column;
+  background: var(--surface-01);
+  box-shadow: 0px 4px 28px rgba(0, 0, 0, 0.26);
+  border-radius: 8px;
+`;
+export const pledge_retirements_wallet = css`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  align-items: center;
+  gap: 4.8rem;
+`;
+
+export const arrow_down = css`
+  transform: rotate(0deg);
+  transition: transform 0.2s linear;
+  &.open {
+    transform: rotate(180deg) !important;
+  }
+`;
+
+export const pledge_wallet_pending = css`
+  background: var(--font-02);
+  border-radius: 0.4rem;
+  padding: 0.8rem;
+  p {
+    font-size: 1rem;
+    line-height: 1rem;
+    color: var(--surface-02) !important;
+    text-transform: uppercase;
+    font-weight: 600;
+  }
+`;

--- a/site/components/pages/Pledge/PledgeDashboard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/index.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { NextPage } from "next";
-import { t } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+
 import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
 import { RetirementsTotalsAndBalances } from "@klimadao/lib/types/offset";
 
@@ -19,7 +21,7 @@ import { PledgeForm } from "../PledgeForm";
 import { PledgeLayout } from "../PledgeLayout";
 import { Holding, Pledge } from "../types";
 import * as styles from "./styles";
-import { ButtonPrimary, ButtonSecondary } from "@klimadao/lib/components";
+import { ButtonPrimary, ButtonSecondary, Text } from "@klimadao/lib/components";
 
 type Props = {
   canonicalUrl: string;
@@ -35,9 +37,10 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
   const [showFormModal, setShowFormModal] = useState(false);
   const [isDeleteMode, setIsDeleteMode] = useState(false);
   const [pledge, setPledge] = useState<Pledge>(props.pledge);
-  const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
+  const [showRemoveConfirmModal, setShowRemoveConfirmModal] = useState(false);
   const [showAcceptModal, setShowAcceptModal] = useState(false);
+  const [showAcceptConfirmModal, setShowAcceptConfirmModal] = useState(false);
 
   const isUnverifiedSecondaryWallet = props.pledge.wallets?.some(
     (wallet) => wallet.address === address && wallet.verified === false
@@ -117,48 +120,134 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
         showModal={showAcceptModal}
         onToggleModal={() => setShowAcceptModal(false)}
       >
-        Pledge Creator has invited you to add your wallet to this pledge. If you
-        accept, then your carbon retirements will count toward Pledge Creator's
-        pledge. You may remove your wallet from this pledge at any time.
-        <ButtonPrimary
-          label="Accept Invitation"
-          onClick={() => {
-            setShowConfirmModal(true);
-            setShowAcceptModal(false);
-          }}
-        />
-        <ButtonSecondary
-          label="Reject Invitation"
-          onClick={() => setShowAcceptModal(false)}
-        />
-        <ButtonSecondary
-          label="Remind me later"
-          onClick={() => setShowAcceptModal(false)}
-        />
+        <Text className={styles.modalMessage} t="body2">
+          <Trans id="pledge.invitation.join_message">
+            {concatAddress(props.pledge.ownerAddress)} has invited you to add
+            your wallet to this pledge. If you accept, then your carbon
+            retirements will count toward{" "}
+            {concatAddress(props.pledge.ownerAddress)}'s pledge. You may remove
+            your wallet from this pledge at any time.
+          </Trans>
+        </Text>
+        <div className={styles.modalButtons}>
+          <ButtonPrimary
+            label={t({
+              id: "pledge.invitation.accept",
+              message: "Accept Invitation",
+            })}
+            onClick={() => {
+              setShowAcceptConfirmModal(true);
+              setShowAcceptModal(false);
+            }}
+          />
+          <ButtonSecondary
+            label={t({
+              id: "pledge.invitation.reject",
+              message: "Reject Invitation",
+            })}
+            onClick={() => setShowAcceptModal(false)}
+            variant="red"
+          />
+          <ButtonSecondary
+            label={t({
+              id: "pledge.invitation.later",
+              message: "Remind me later",
+            })}
+            onClick={() => setShowAcceptModal(false)}
+            variant="gray"
+          />
+        </div>
       </Modal>
       <Modal
-        title="Are you sure?"
-        showModal={showConfirmModal}
-        onToggleModal={() => setShowConfirmModal(false)}
+        title={t({ id: "", message: "Are you sure?" })}
+        showModal={showAcceptConfirmModal}
+        onToggleModal={() => setShowAcceptConfirmModal(false)}
       >
-        Adding your wallet to this pledge will remove your wallet from any
-        existing pledges under your wallet address. Those pledges will be
-        redirected to this new pledge.
-        <ButtonPrimary label="Confirm" />
-        <ButtonSecondary
-          label="Cancel"
-          onClick={() => {
-            setShowConfirmModal(false);
-            setShowAcceptModal(true);
-          }}
-        />
+        <Text t="body2" className={styles.modalMessage}>
+          <Trans id="pledge.modal.wallet_add_confirm">
+            Adding your wallet to this pledge will remove your wallet from any
+            existing pledges under your wallet address. Those pledges will be
+            redirected to this new pledge.
+          </Trans>
+        </Text>
+        <div className={styles.modalButtons}>
+          <ButtonPrimary
+            label={t({ id: "pledge.modal.confirm", message: "Confirm" })}
+          />
+          <ButtonSecondary
+            label={t({ id: "shared.cancel", message: "Cancel" })}
+            onClick={() => {
+              setShowAcceptConfirmModal(false);
+              setShowAcceptModal(true);
+            }}
+            variant="gray"
+          />
+        </div>
       </Modal>
       <Modal
-        title="Edit pledge"
+        title={t({ id: "pledge.modal.edit_pledge", message: "Edit pledge" })}
         showModal={showRemoveModal}
         onToggleModal={() => setShowRemoveModal(false)}
       >
-        verified in here
+        <div className={styles.removeTitleContainer}>
+          <span className={styles.lockIcon}>
+            <LockOutlinedIcon fontSize="large" />
+          </span>
+          <Text t="body2">
+            <Trans id="pledge.modal.unable_to_edit">
+              Only Primary Wallet holders can edit the content of this pledge.
+            </Trans>
+          </Text>
+        </div>
+        <div className={styles.modalButtons}>
+          <ButtonSecondary
+            label={t({
+              id: "pledge.modal.unpin_wallet",
+              message: "unpin my wallet",
+            })}
+            variant="red"
+            onClick={() => {
+              setShowRemoveConfirmModal(true);
+              setShowRemoveModal(false);
+            }}
+          />
+          <ButtonSecondary
+            label={t({ id: "shared.cancel", message: "Cancel" })}
+            onClick={() => setShowRemoveModal(false)}
+            variant="gray"
+          />
+        </div>
+      </Modal>
+      <Modal
+        title={t({
+          id: "pledge.modal.confirm_remove",
+          message: "Confirm Removal",
+        })}
+        showModal={showRemoveConfirmModal}
+        onToggleModal={() => setShowRemoveConfirmModal(false)}
+      >
+        <Text t="body2" className={styles.modalMessage}>
+          <Trans id="pledge.modal.are_you_sure">
+            Are you sure you want to remove your wallet from this pledge?
+          </Trans>
+        </Text>
+        <div className={styles.modalButtons}>
+          <ButtonPrimary
+            label={t({
+              id: "shared.remove",
+              message: "remove",
+            })}
+            onClick={() => {
+              setShowRemoveConfirmModal(false);
+            }}
+            variant="red"
+          />
+          <ButtonSecondary
+            label={t({ id: "shared.cancel", message: "Cancel" })}
+            onClick={() => setShowRemoveModal(false)}
+            variant="gray"
+          />
+        </div>
       </Modal>
 
       <div className={styles.contentContainer}>
@@ -182,6 +271,8 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
           <RetirementsCard
             retirements={props.retirements}
             pageAddress={props.pageAddress}
+            secondaryWallets={pledge.wallets ?? undefined}
+            isPledgeOwner={isPledgeOwner}
           />
         </div>
       </div>

--- a/site/components/pages/Pledge/PledgeDashboard/styles.ts
+++ b/site/components/pages/Pledge/PledgeDashboard/styles.ts
@@ -22,3 +22,24 @@ export const column = css`
     grid-column: span 1;
   }
 `;
+
+export const modalButtons = css`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  justify-items: space-between;
+  gap: 1.2rem;
+`;
+
+export const modalMessage = css`
+  padding: 2rem 0;
+`;
+export const lockIcon = css`
+  padding-top: 0.4rem;
+`;
+
+export const removeTitleContainer = css`
+  display: flex;
+  padding: 2rem 0;
+  gap: 1.2rem;
+`;

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -1,12 +1,16 @@
 import React, { FC, useState } from "react";
 import { Trans, t } from "@lingui/macro";
 import { useRouter } from "next/router";
-import { ButtonPrimary, Text } from "@klimadao/lib/components";
+import { ButtonPrimary, ButtonSecondary, Text } from "@klimadao/lib/components";
 import ClearIcon from "@mui/icons-material/Clear";
 import SaveIcon from "@mui/icons-material/Save";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import { trimWithLocale, useWeb3, concatAddress } from "@klimadao/lib/utils";
 import { yupResolver } from "@hookform/resolvers/yup";
+import Tippy from "@tippyjs/react";
+
 import {
   useForm,
   useFieldArray,
@@ -14,7 +18,6 @@ import {
   Control,
   SubmitHandler,
 } from "react-hook-form";
-
 import { InputField, TextareaField } from "components/Form";
 
 import {
@@ -199,9 +202,38 @@ export const PledgeForm: FC<Props> = (props) => {
             }
           />
           <div className={styles.wallets_section}>
-            <Text t="caption">
-              <Trans id="pledges.form.wallets.label">Secondary Wallet(s)</Trans>
-            </Text>
+            <div className={styles.pledge_form_wallets_title}>
+              <Text t="caption">
+                <Trans id="pledges.form.wallets.label">
+                  Secondary Wallet(s)
+                </Trans>
+              </Text>
+              <Tippy
+                content={
+                  <div className={styles.pledge_form_wallet_info_content}>
+                    <Text t="caption">
+                      <Trans id="pledge.form.wallets.tooltip">
+                        Add other wallets to contribute to your pledge. If the
+                        owner of the wallet accepts your invitation, their
+                        wallet will appear on your pledge dashboard. Any
+                        retirments made by a secondary wallet will contribute
+                        toward your pledge. You'll retain sole ownership and
+                        editing access to this pledge.
+                      </Trans>
+                    </Text>
+                    <ArrowDropDownIcon
+                      className={styles.pledge_tooltip_arrow}
+                      fontSize="large"
+                    />
+                  </div>
+                }
+              >
+                <InfoOutlinedIcon
+                  fontSize="large"
+                  className={styles.pledge_form_wallet_info}
+                />
+              </Tippy>
+            </div>
 
             {walletsFields.map((wallet: Wallet, index: number) => {
               return (
@@ -428,13 +460,19 @@ export const PledgeForm: FC<Props> = (props) => {
         </>
       )}
       {props.isDeleteMode && (
-        <div>
-          <Text>
-            Are you sure you want to remove{" "}
-            {selectedAddress && selectedAddress.address} from your pleadge?
+        <div className={styles.pledge_form_remove_container}>
+          <Text t="caption">
+            <Trans id="pledge.form.wallets.confirm_remove_wallet">
+              Are you sure you want to remove {selectedAddress?.address} from
+              your pledge?
+            </Trans>
           </Text>
           <ButtonPrimary
-            label="remove"
+            label={t({
+              id: "pledges.form.confirm_remove",
+              message: "remove",
+            })}
+            variant="red"
             onClick={() => {
               walletsRemove(
                 selectedAddress ? selectedAddress.index : undefined
@@ -442,8 +480,12 @@ export const PledgeForm: FC<Props> = (props) => {
               props.setIsDeleteMode(false);
             }}
           />
-          <ButtonPrimary
-            label="cancel"
+          <ButtonSecondary
+            label={t({
+              id: "pledges.form.confirm_remove_cancel",
+              message: "cancel",
+            })}
+            variant="gray"
             onClick={() => props.setIsDeleteMode(false)}
           />
         </div>

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -14,7 +14,6 @@ import {
   Control,
   SubmitHandler,
 } from "react-hook-form";
-import ethers from "ethers";
 
 import { InputField, TextareaField } from "components/Form";
 
@@ -207,7 +206,9 @@ export const PledgeForm: FC<Props> = (props) => {
             {walletsFields.map((wallet: Wallet, index: number) => {
               return (
                 <div className={styles.pledge_wallet_row} key={wallet.id}>
-                  {!wallet.saved && (
+                  {(!wallet.saved ||
+                    (wallet.saved &&
+                      errors.wallets?.[index]?.address?.message)) && (
                     <div className={styles.pledge_wallet_address_cell}>
                       <InputField
                         inputProps={{
@@ -216,10 +217,7 @@ export const PledgeForm: FC<Props> = (props) => {
                             message: "0x...",
                           }),
                           type: "text",
-                          ...register(`wallets.${index}.address` as const, {
-                            validate: (address) =>
-                              ethers.utils.isAddress(address),
-                          }),
+                          ...register(`wallets.${index}.address` as const),
                         }}
                         hideLabel
                         label={t({
@@ -227,10 +225,8 @@ export const PledgeForm: FC<Props> = (props) => {
                           message: "Address",
                         })}
                         errorMessage={
-                          !!formState.errors?.wallets?.[index]?.address
-                            ?.message &&
                           pledgeErrorTranslationsMap[
-                            formState?.errors?.wallets?.[index]?.address
+                            errors.wallets?.[index]?.address
                               ?.message as PledgeErrorId
                           ]
                         }
@@ -249,7 +245,7 @@ export const PledgeForm: FC<Props> = (props) => {
                       />
                     </div>
                   )}
-                  {wallet.saved && (
+                  {wallet.saved && !errors.wallets?.[index]?.address?.message && (
                     <div className={styles.pledge_wallet_address_cell}>
                       <Text t="caption">{concatAddress(wallet.address)}</Text>
                       {!wallet.verified && (

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { ButtonPrimary, Text } from "@klimadao/lib/components";
 import ClearIcon from "@mui/icons-material/Clear";
 import SaveIcon from "@mui/icons-material/Save";
+import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import { trimWithLocale, useWeb3, concatAddress } from "@klimadao/lib/utils";
 import { yupResolver } from "@hookform/resolvers/yup";
 import {
@@ -13,6 +14,7 @@ import {
   Control,
   SubmitHandler,
 } from "react-hook-form";
+import ethers from "ethers";
 
 import { InputField, TextareaField } from "components/Form";
 
@@ -197,7 +199,6 @@ export const PledgeForm: FC<Props> = (props) => {
               ]
             }
           />
-          {/* Wallets section */}
           <div className={styles.wallets_section}>
             <Text t="caption">
               <Trans id="pledges.form.wallets.label">Secondary Wallet(s)</Trans>
@@ -205,9 +206,9 @@ export const PledgeForm: FC<Props> = (props) => {
 
             {walletsFields.map((wallet: Wallet, index: number) => {
               return (
-                <div className="pledge-wallet-row" key={wallet.id}>
+                <div className={styles.pledge_wallet_row} key={wallet.id}>
                   {!wallet.saved && (
-                    <>
+                    <div className={styles.pledge_wallet_address_cell}>
                       <InputField
                         inputProps={{
                           placeholder: t({
@@ -215,7 +216,10 @@ export const PledgeForm: FC<Props> = (props) => {
                             message: "0x...",
                           }),
                           type: "text",
-                          ...register(`wallets.${index}.address` as const),
+                          ...register(`wallets.${index}.address` as const, {
+                            validate: (address) =>
+                              ethers.utils.isAddress(address),
+                          }),
                         }}
                         hideLabel
                         label={t({
@@ -233,8 +237,8 @@ export const PledgeForm: FC<Props> = (props) => {
                       />
                       <ButtonPrimary
                         variant="icon"
-                        className={styles.categoryRow_removeButton}
                         label={<SaveIcon fontSize="large" />}
+                        className={styles.pledge_wallet_save}
                         onClick={() =>
                           walletsUpdate(index, {
                             address: wallets![index].address,
@@ -243,17 +247,22 @@ export const PledgeForm: FC<Props> = (props) => {
                           })
                         }
                       />
-                    </>
+                    </div>
                   )}
                   {wallet.saved && (
-                    <Text t="caption" className="" key={wallet.id}>
-                      {concatAddress(wallet.address)}
-                    </Text>
+                    <div className={styles.pledge_wallet_address_cell}>
+                      <Text t="caption">{concatAddress(wallet.address)}</Text>
+                      {!wallet.verified && (
+                        <span className={styles.pledge_wallet_pending}>
+                          <Text t="caption">Pending</Text>
+                        </span>
+                      )}
+                    </div>
                   )}
                   <ButtonPrimary
                     variant="icon"
-                    className={styles.categoryRow_removeButton}
-                    label={<ClearIcon fontSize="large" />}
+                    label={<DeleteOutlineOutlinedIcon fontSize="large" />}
+                    className={styles.pledge_wallet_delete}
                     onClick={() => {
                       props.setIsDeleteMode(true);
                       setSelectedAddress({
@@ -265,7 +274,7 @@ export const PledgeForm: FC<Props> = (props) => {
                 </div>
               );
             })}
-            <div>
+            <div className={styles.pledge_wallet_add}>
               <ButtonPrimary
                 className={styles.categories_appendButton}
                 variant="gray"

--- a/site/components/pages/Pledge/PledgeForm/styles.ts
+++ b/site/components/pages/Pledge/PledgeForm/styles.ts
@@ -29,14 +29,78 @@ export const categories_section = css`
 export const wallets_section = css`
   display: flex;
   flex-direction: column;
-  .pledge-wallet-row {
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
+`;
+
+export const pledge_wallet_address_cell = css`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  align-items: center;
+  padding-right: 1.6rem;
+`;
+
+export const pledge_wallet_pending = css`
+  background: var(--font-01);
+  border-radius: 0.4rem;
+  padding: 0.8rem;
+  p {
+    font-size: 1rem;
+    line-height: 1rem;
+    color: var(--surface-02) !important;
+    text-transform: uppercase;
   }
 `;
 
-export const wallet_table = css``;
+export const pledge_wallet_row = css`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  align-items: center;
+  padding: 0.4rem 0;
+`;
+export const pledge_wallet_icon = css`
+  padding: 0rem;
+  min-height: 3.6rem;
+  height: 3.6rem;
+  width: 3.6rem;
+  border-radius: 1rem;
+  transition: border-color 0.2s ease-in;
+`;
+
+export const pledge_wallet_save = css`
+  ${pledge_wallet_icon};
+  border: 0.175rem solid var(--surface-03);
+  background-color: var(--surface-02);
+  svg {
+    fill: var(--klima-green);
+  }
+  &:focus,
+  &:hover {
+    border-color: var(--klima-green);
+  }
+`;
+export const pledge_wallet_delete = css`
+  ${pledge_wallet_icon};
+  border: 0.175rem solid var(--surface-03);
+  background-color: var(--surface-02);
+
+  svg {
+    fill: var(--warn);
+  }
+
+  &:focus,
+  &:hover {
+    border-color: var(--warn);
+  }
+`;
+
+export const pledge_wallet_add = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding-top: 1.6rem;
+`;
 
 export const categories = css`
   display: grid;
@@ -69,15 +133,10 @@ export const categoryRow_inputs = css`
 `;
 
 export const categoryRow_removeButton = css`
-  padding: 0rem;
+  ${pledge_wallet_icon};
   margin-top: 3.2rem;
-  min-height: 3.6rem;
-  height: 3.6rem;
-  width: 3.6rem;
-  border-radius: 1rem;
   border: 0.175rem solid var(--surface-03);
   background-color: var(--surface-02);
-  transition: border-color 0.2s ease-in;
 
   svg {
     fill: var(--font-02);

--- a/site/components/pages/Pledge/PledgeForm/styles.ts
+++ b/site/components/pages/Pledge/PledgeForm/styles.ts
@@ -40,7 +40,7 @@ export const pledge_wallet_address_cell = css`
 `;
 
 export const pledge_wallet_pending = css`
-  background: var(--font-01);
+  background: var(--font-02);
   border-radius: 0.4rem;
   padding: 0.8rem;
   p {
@@ -48,7 +48,19 @@ export const pledge_wallet_pending = css`
     line-height: 1rem;
     color: var(--surface-02) !important;
     text-transform: uppercase;
+    font-weight: 600;
   }
+`;
+
+export const pledge_form_remove_container = css`
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  gap: 1.2rem;
+`;
+
+export const pledge_form_remove_button = css`
+  width: 100%;
 `;
 
 export const pledge_wallet_row = css`
@@ -58,6 +70,7 @@ export const pledge_wallet_row = css`
   align-items: center;
   padding: 0.4rem 0;
 `;
+
 export const pledge_wallet_icon = css`
   padding: 0rem;
   min-height: 3.6rem;
@@ -65,6 +78,12 @@ export const pledge_wallet_icon = css`
   width: 3.6rem;
   border-radius: 1rem;
   transition: border-color 0.2s ease-in;
+`;
+
+export const pledge_form_wallets_title = css`
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
 `;
 
 export const pledge_wallet_save = css`
@@ -79,6 +98,28 @@ export const pledge_wallet_save = css`
     border-color: var(--klima-green);
   }
 `;
+
+export const pledge_tooltip_arrow = css`
+  position: absolute;
+  bottom: -1.2rem;
+  color: var(--font-01);
+  left: calc(50% - 1rem);
+`;
+
+export const pledge_form_wallet_info = css`
+  color: var(--font-02);
+  cursor: pointer;
+`;
+
+export const pledge_form_wallet_info_content = css`
+  p {
+    color: var(--surface-01);
+  }
+  background: var(--font-01);
+  padding: 1.2rem;
+  border-radius: 0.4rem;
+`;
+
 export const pledge_wallet_delete = css`
   ${pledge_wallet_icon};
   border: 0.175rem solid var(--surface-03);

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -46,6 +46,10 @@ export const pledgeErrorTranslationsMap = {
     id: "pledges.form.errors.categoryQuantity.min",
     message: "Enter a value greater than 0",
   }),
+  ["pledges.form.errors.walletAddress.required"]: t({
+    id: "pledges.form.errors.walletAddress.required",
+    message: "Address required",
+  }),
 } as const;
 
 export type PledgeErrorId = keyof typeof pledgeErrorTranslationsMap;
@@ -70,8 +74,7 @@ export const formSchema = yup
       yup.object({
         address: yup
           .string()
-          .required("pledges.form.errors.secondaryWalletAddress.required")
-          .min(1, "pledges.form.errors.secondaryWalletAddress.min")
+          .required("pledges.form.errors.walletAddress.required")
           .trim(),
         verified: yup.boolean().required(),
         saved: yup.boolean().required(),

--- a/site/components/pages/Pledge/lib/pledgeFormAdapter.ts
+++ b/site/components/pages/Pledge/lib/pledgeFormAdapter.ts
@@ -16,7 +16,7 @@ export const DEFAULT_VALUES: Pledge = {
       categories: [{ name: "", quantity: 0 }],
     },
   ],
-  wallets: [{ address: "", verified: false }],
+  wallets: [{ address: "", verified: false, saved: false }],
 };
 
 export const pledgeFormAdapter = (pledge: Pledge): PledgeFormValues => {

--- a/site/components/pages/Pledge/types/index.ts
+++ b/site/components/pages/Pledge/types/index.ts
@@ -30,7 +30,7 @@ export type Pledge = {
   description: string;
   methodology: string;
   footprint: Footprint[];
-  wallets: Wallet[];
+  wallets?: Wallet[];
   createdAt?: number;
   updatedAt?: number;
 };

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: components/pages/Pledge/PledgeDashboard/index.tsx:162
+msgid ""
+msgstr ""
+
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"
 msgstr ""
@@ -930,6 +934,58 @@ msgstr ""
 msgid "mission.header"
 msgstr ""
 
+#: components/pages/Pledge/PledgeForm/index.tsx:465
+msgid "pledge.form.wallets.confirm_remove_wallet"
+msgstr ""
+
+#: components/pages/Pledge/PledgeForm/index.tsx:215
+msgid "pledge.form.wallets.tooltip"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:134
+msgid "pledge.invitation.accept"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:124
+msgid "pledge.invitation.join_message"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:152
+msgid "pledge.invitation.later"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:144
+msgid "pledge.invitation.reject"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:230
+msgid "pledge.modal.are_you_sure"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:175
+msgid "pledge.modal.confirm"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:222
+msgid "pledge.modal.confirm_remove"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:188
+msgid "pledge.modal.edit_pledge"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:197
+msgid "pledge.modal.unable_to_edit"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:204
+msgid "pledge.modal.unpin_wallet"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:167
+msgid "pledge.modal.wallet_add_confirm"
+msgstr ""
+
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:82
 msgid "pledges.dashboard.assets.title"
 msgstr ""
@@ -950,11 +1006,11 @@ msgstr ""
 msgid "pledges.dashboard.footprint.tooltip.quantity"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:55
+#: components/pages/Pledge/PledgeDashboard/index.tsx:79
 msgid "pledges.dashboard.head.metaTitle"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:51
+#: components/pages/Pledge/PledgeDashboard/index.tsx:75
 msgid "pledges.dashboard.head.title"
 msgstr ""
 
@@ -986,7 +1042,7 @@ msgstr ""
 msgid "pledges.dashboard.profile.pledged_to_offset"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:43
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:106
 msgid "pledges.dashboard.retirements.title"
 msgstr ""
 
@@ -994,7 +1050,7 @@ msgstr ""
 msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:62
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:125
 msgid "pledges.dashboard.retirements.total_tonnes_retired"
 msgstr ""
 
@@ -1002,8 +1058,24 @@ msgstr ""
 msgid "pledges.edit_pledge"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:305
+#: components/pages/Pledge/PledgeForm/index.tsx:422
 msgid "pledges.form.add_footprint_category_button"
+msgstr ""
+
+#: components/pages/Pledge/PledgeForm/index.tsx:309
+msgid "pledges.form.add_wallet_button"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:98
+msgid "pledges.form.confirm_delete"
+msgstr ""
+
+#: components/pages/Pledge/PledgeForm/index.tsx:471
+msgid "pledges.form.confirm_remove"
+msgstr ""
+
+#: components/pages/Pledge/PledgeForm/index.tsx:484
+msgid "pledges.form.confirm_remove_cancel"
 msgstr ""
 
 #: components/pages/Pledge/index.tsx:156
@@ -1054,83 +1126,91 @@ msgstr ""
 msgid "pledges.form.errors.profileImageUrl.url"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:227
+#: components/pages/Pledge/lib/formSchema.ts:49
+msgid "pledges.form.errors.walletAddress.required"
+msgstr ""
+
+#: components/pages/Pledge/PledgeForm/index.tsx:344
 msgid "pledges.form.footprint.label"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:232
+#: components/pages/Pledge/PledgeForm/index.tsx:352
 msgid "pledges.form.footprint.prompt"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:115
+#: components/pages/Pledge/PledgeForm/index.tsx:142
 msgid "pledges.form.generic_error"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:252
+#: components/pages/Pledge/PledgeForm/index.tsx:372
 msgid "pledges.form.input.categoryName.label"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:244
+#: components/pages/Pledge/PledgeForm/index.tsx:364
 msgid "pledges.form.input.categoryName.placeholder"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:275
+#: components/pages/Pledge/PledgeForm/index.tsx:394
 msgid "pledges.form.input.categoryQuantity.label"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:267
+#: components/pages/Pledge/PledgeForm/index.tsx:386
 msgid "pledges.form.input.categoryQuantity.placeholder"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:169
+#: components/pages/Pledge/PledgeForm/index.tsx:194
 msgid "pledges.form.input.description.label"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:162
+#: components/pages/Pledge/PledgeForm/index.tsx:187
 msgid "pledges.form.input.description.placeholder"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:213
+#: components/pages/Pledge/PledgeForm/index.tsx:330
 msgid "pledges.form.input.methodology.label"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:205
+#: components/pages/Pledge/PledgeForm/index.tsx:322
 msgid "pledges.form.input.methodology.placeholder"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:131
+#: components/pages/Pledge/PledgeForm/index.tsx:160
 msgid "pledges.form.input.name.label"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:124
+#: components/pages/Pledge/PledgeForm/index.tsx:153
 msgid "pledges.form.input.name.placeholder"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:147
+#: components/pages/Pledge/PledgeForm/index.tsx:173
 msgid "pledges.form.input.profileImageUrl.label"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:321
+#: components/pages/Pledge/PledgeForm/index.tsx:438
 msgid "pledges.form.input.totalFootprint.label"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:338
+#: components/pages/Pledge/PledgeForm/index.tsx:255
+msgid "pledges.form.input.walletAddress.label"
+msgstr ""
+
+#: components/pages/Pledge/PledgeForm/index.tsx:247
+msgid "pledges.form.input.walletAddress.placeholder"
+msgstr ""
+
+#: components/pages/Pledge/PledgeForm/index.tsx:454
 msgid "pledges.form.submit_button"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:67
+#: components/pages/Pledge/PledgeDashboard/index.tsx:94
 msgid "pledges.form.title"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:46
+#: components/pages/Pledge/PledgeForm/index.tsx:51
 msgid "pledges.form.total_footprint_summary"
 msgstr ""
 
-#: components/pages/Pledge/PledgeForm/index.tsx:196
-msgid "pledges.form.wallets.empty"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:183
+#: components/pages/Pledge/PledgeForm/index.tsx:207
 msgid "pledges.form.wallets.label"
 msgstr ""
 
@@ -1436,6 +1516,12 @@ msgstr ""
 msgid "shared.buy"
 msgstr ""
 
+#: components/pages/Pledge/PledgeDashboard/index.tsx:178
+#: components/pages/Pledge/PledgeDashboard/index.tsx:215
+#: components/pages/Pledge/PledgeDashboard/index.tsx:246
+msgid "shared.cancel"
+msgstr ""
+
 #: components/Navigation/index.tsx:339
 msgid "shared.carbon_dashboard"
 msgstr ""
@@ -1498,7 +1584,7 @@ msgstr ""
 
 #: components/pages/Buy/index.tsx:46
 #: components/pages/Home/index.tsx:68
-#: components/pages/Pledge/PledgeDashboard/index.tsx:59
+#: components/pages/Pledge/PledgeDashboard/index.tsx:83
 #: components/pages/Podcast/index.tsx:34
 #: components/pages/Retirements/index.tsx:59
 #: components/pages/errors/Custom500.tsx:23
@@ -1535,7 +1621,7 @@ msgid "shared.info"
 msgstr ""
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/TokenRow/index.tsx:40
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:57
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:120
 #: components/pages/Retirements/SingleRetirement/index.tsx:36
 msgid "shared.loading"
 msgstr ""
@@ -1559,6 +1645,10 @@ msgstr ""
 #: components/pages/Resources/ResourcesHeader/index.tsx:40
 #: components/pages/Resources/ResourcesHeader/index.tsx:93
 msgid "shared.podcast"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:236
+msgid "shared.remove"
 msgstr ""
 
 #: components/Navigation/index.tsx:177

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: components/pages/Pledge/PledgeDashboard/index.tsx:162
+msgid ""
+msgstr "Are you sure?"
+
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"
 msgstr "Articles"
@@ -930,6 +934,58 @@ msgstr "Invest in the future."
 msgid "mission.header"
 msgstr "KlimaDAO's mission is to democratize climate action"
 
+#: components/pages/Pledge/PledgeForm/index.tsx:465
+msgid "pledge.form.wallets.confirm_remove_wallet"
+msgstr "Are you sure you want to remove {0} from your pledge?"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:215
+msgid "pledge.form.wallets.tooltip"
+msgstr "Add other wallets to contribute to your pledge. If the owner of the wallet accepts your invitation, their wallet will appear on your pledge dashboard. Any retirments made by a secondary wallet will contribute toward your pledge. You'll retain sole ownership and editing access to this pledge."
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:134
+msgid "pledge.invitation.accept"
+msgstr "Accept Invitation"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:124
+msgid "pledge.invitation.join_message"
+msgstr "{0} has invited you to add your wallet to this pledge. If you accept, then your carbon retirements will count toward {1}'s pledge. You may remove your wallet from this pledge at any time."
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:152
+msgid "pledge.invitation.later"
+msgstr "Remind me later"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:144
+msgid "pledge.invitation.reject"
+msgstr "Reject Invitation"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:230
+msgid "pledge.modal.are_you_sure"
+msgstr "Are you sure you want to remove your wallet from this pledge?"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:175
+msgid "pledge.modal.confirm"
+msgstr "Confirm"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:222
+msgid "pledge.modal.confirm_remove"
+msgstr "Confirm Removal"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:188
+msgid "pledge.modal.edit_pledge"
+msgstr "Edit pledge"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:197
+msgid "pledge.modal.unable_to_edit"
+msgstr "Only Primary Wallet holders can edit the content of this pledge."
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:204
+msgid "pledge.modal.unpin_wallet"
+msgstr "unpin my wallet"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:167
+msgid "pledge.modal.wallet_add_confirm"
+msgstr "Adding your wallet to this pledge will remove your wallet from any existing pledges under your wallet address. Those pledges will be redirected to this new pledge."
+
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:82
 msgid "pledges.dashboard.assets.title"
 msgstr "Carbon Assets"
@@ -950,11 +1006,11 @@ msgstr "{0}% of footprint"
 msgid "pledges.dashboard.footprint.tooltip.quantity"
 msgstr "{0} Carbon Tonne(s)"
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:55
+#: components/pages/Pledge/PledgeDashboard/index.tsx:79
 msgid "pledges.dashboard.head.metaTitle"
 msgstr "{pledgeOwnerTitle}'s pledge"
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:51
+#: components/pages/Pledge/PledgeDashboard/index.tsx:75
 msgid "pledges.dashboard.head.title"
 msgstr "KlimaDAO | Pledges"
 
@@ -986,7 +1042,7 @@ msgstr "{0}% of Pledge Met"
 msgid "pledges.dashboard.profile.pledged_to_offset"
 msgstr "Pledged to Offset <0>{0}</0> Carbon Tonnes"
 
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:43
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:106
 msgid "pledges.dashboard.retirements.title"
 msgstr "Retirements"
 
@@ -994,7 +1050,7 @@ msgstr "Retirements"
 msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
 msgstr "{0} Carbon Tonne(s) Retired"
 
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:62
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:125
 msgid "pledges.dashboard.retirements.total_tonnes_retired"
 msgstr "Total Carbon Tonnes Retired"
 
@@ -1002,9 +1058,25 @@ msgstr "Total Carbon Tonnes Retired"
 msgid "pledges.edit_pledge"
 msgstr "Edit Pledge"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:305
+#: components/pages/Pledge/PledgeForm/index.tsx:422
 msgid "pledges.form.add_footprint_category_button"
 msgstr "Add category"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:309
+msgid "pledges.form.add_wallet_button"
+msgstr "Add wallet"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:98
+msgid "pledges.form.confirm_delete"
+msgstr "confirm removal"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:471
+msgid "pledges.form.confirm_remove"
+msgstr "remove"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:484
+msgid "pledges.form.confirm_remove_cancel"
+msgstr "cancel"
 
 #: components/pages/Pledge/index.tsx:156
 msgid "pledges.form.error"
@@ -1054,83 +1126,91 @@ msgstr "Enter a name"
 msgid "pledges.form.errors.profileImageUrl.url"
 msgstr "Enter a valid url"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:227
+#: components/pages/Pledge/lib/formSchema.ts:49
+msgid "pledges.form.errors.walletAddress.required"
+msgstr "Address required"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:344
 msgid "pledges.form.footprint.label"
 msgstr "Footprint"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:232
+#: components/pages/Pledge/PledgeForm/index.tsx:352
 msgid "pledges.form.footprint.prompt"
 msgstr "Add a category and start calculating your carbon footprint"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:115
+#: components/pages/Pledge/PledgeForm/index.tsx:142
 msgid "pledges.form.generic_error"
 msgstr "Something went wrong. Please try again."
 
-#: components/pages/Pledge/PledgeForm/index.tsx:252
+#: components/pages/Pledge/PledgeForm/index.tsx:372
 msgid "pledges.form.input.categoryName.label"
 msgstr "Category"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:244
+#: components/pages/Pledge/PledgeForm/index.tsx:364
 msgid "pledges.form.input.categoryName.placeholder"
 msgstr "Category name"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:275
+#: components/pages/Pledge/PledgeForm/index.tsx:394
 msgid "pledges.form.input.categoryQuantity.label"
 msgstr "Quantity"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:267
+#: components/pages/Pledge/PledgeForm/index.tsx:386
 msgid "pledges.form.input.categoryQuantity.placeholder"
 msgstr "Carbon tonnes"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:169
+#: components/pages/Pledge/PledgeForm/index.tsx:194
 msgid "pledges.form.input.description.label"
 msgstr "Pledge"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:162
+#: components/pages/Pledge/PledgeForm/index.tsx:187
 msgid "pledges.form.input.description.placeholder"
 msgstr "What is your pledge?"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:213
+#: components/pages/Pledge/PledgeForm/index.tsx:330
 msgid "pledges.form.input.methodology.label"
 msgstr "Methodology"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:205
+#: components/pages/Pledge/PledgeForm/index.tsx:322
 msgid "pledges.form.input.methodology.placeholder"
 msgstr "What tools or methodologies did you use to calculate your carbon footprint?"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:131
+#: components/pages/Pledge/PledgeForm/index.tsx:160
 msgid "pledges.form.input.name.label"
 msgstr "Name"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:124
+#: components/pages/Pledge/PledgeForm/index.tsx:153
 msgid "pledges.form.input.name.placeholder"
 msgstr "Name or company name"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:147
+#: components/pages/Pledge/PledgeForm/index.tsx:173
 msgid "pledges.form.input.profileImageUrl.label"
 msgstr "Profile image url (optional)"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:321
+#: components/pages/Pledge/PledgeForm/index.tsx:438
 msgid "pledges.form.input.totalFootprint.label"
 msgstr "Total footprint"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:338
+#: components/pages/Pledge/PledgeForm/index.tsx:255
+msgid "pledges.form.input.walletAddress.label"
+msgstr "Address"
+
+#: components/pages/Pledge/PledgeForm/index.tsx:247
+msgid "pledges.form.input.walletAddress.placeholder"
+msgstr "0x..."
+
+#: components/pages/Pledge/PledgeForm/index.tsx:454
 msgid "pledges.form.submit_button"
 msgstr "Save pledge"
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:67
+#: components/pages/Pledge/PledgeDashboard/index.tsx:94
 msgid "pledges.form.title"
-msgstr "Your Pledge"
+msgstr "Your pledge"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:46
+#: components/pages/Pledge/PledgeForm/index.tsx:51
 msgid "pledges.form.total_footprint_summary"
 msgstr "Total Footprint: {0} Carbon Tonnes"
 
-#: components/pages/Pledge/PledgeForm/index.tsx:196
-msgid "pledges.form.wallets.empty"
-msgstr "No secondary wallets right meow"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:183
+#: components/pages/Pledge/PledgeForm/index.tsx:207
 msgid "pledges.form.wallets.label"
 msgstr "Secondary Wallet(s)"
 
@@ -1436,6 +1516,12 @@ msgstr "Bond Klima"
 msgid "shared.buy"
 msgstr "Buy Klima"
 
+#: components/pages/Pledge/PledgeDashboard/index.tsx:178
+#: components/pages/Pledge/PledgeDashboard/index.tsx:215
+#: components/pages/Pledge/PledgeDashboard/index.tsx:246
+msgid "shared.cancel"
+msgstr "Cancel"
+
 #: components/Navigation/index.tsx:339
 msgid "shared.carbon_dashboard"
 msgstr "Carbon Dashboard"
@@ -1498,7 +1584,7 @@ msgstr "Get Started"
 
 #: components/pages/Buy/index.tsx:46
 #: components/pages/Home/index.tsx:68
-#: components/pages/Pledge/PledgeDashboard/index.tsx:59
+#: components/pages/Pledge/PledgeDashboard/index.tsx:83
 #: components/pages/Podcast/index.tsx:34
 #: components/pages/Retirements/index.tsx:59
 #: components/pages/errors/Custom500.tsx:23
@@ -1535,7 +1621,7 @@ msgid "shared.info"
 msgstr "Info"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/TokenRow/index.tsx:40
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:57
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:120
 #: components/pages/Retirements/SingleRetirement/index.tsx:36
 msgid "shared.loading"
 msgstr "Loading..."
@@ -1560,6 +1646,10 @@ msgstr "Offset"
 #: components/pages/Resources/ResourcesHeader/index.tsx:93
 msgid "shared.podcast"
 msgstr "Podcast"
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:236
+msgid "shared.remove"
+msgstr "remove"
 
 #: components/Navigation/index.tsx:177
 #: components/Navigation/index.tsx:326


### PR DESCRIPTION
## Description
I used useFieldArray to add another dynamic list to the "edit pledge" form. No additional firebase work was needed for the api request to save or edit these fields. Right now we are not validating that the pasted address is a valid eth address because of limitations with custom validation in useFieldArray but I may be incorrect and it is possible. I dont like all the conditionals used so If there is a better way I'm all for it. 
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->
We can QA the feature branch at the end. I think this will be easier than explaining what is test data or only stubbed out.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
