### PR TITLE
Single source of truth for locale information

### DIFF
--- a/app/components/ChangeLanguageButton/index.tsx
+++ b/app/components/ChangeLanguageButton/index.tsx
@@ -3,7 +3,6 @@ import { useSelector } from "react-redux";
 import Tippy from "@tippyjs/react";
 import { t } from "@lingui/macro";
 import Language from "@mui/icons-material/Language";
-import { IS_PRODUCTION } from "lib/constants";
 
 import { activate, locales } from "lib/i18n";
 import { selectAppState } from "state/selectors";
@@ -27,23 +26,6 @@ export const ChangeLanguageButton: FC = () => {
     setShowMenu(false);
   };
 
-  // Hint: ensure that this is in sync with locales in 'lib/i18n'
-  const labels: { [key: string]: string } = {
-    en: "English",
-    fr: "Français",
-    de: "Deutsch",
-    ru: "Русский",
-    "zh-CN": "中文",
-    es: "Español",
-    hi: "हिन्दी",
-  };
-
-  // enable 'pseudo' locale only for Staging environment
-  if (!IS_PRODUCTION) {
-    labels["ko"] = "한국어";
-    labels["en-pseudo"] = "Pseudo";
-  }
-
   const content = (
     <div>
       {Object.keys(locales).map((localeKey) => (
@@ -53,7 +35,7 @@ export const ChangeLanguageButton: FC = () => {
           onClick={handleClickMenuItem(localeKey)}
           className={styles.menuItem}
         >
-          {labels[localeKey as keyof typeof labels]}
+          {locales[localeKey].label}
         </button>
       ))}
     </div>

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -1,35 +1,9 @@
 import { i18n } from "@lingui/core";
-import { en, fr, de, ru, zh, ko, es, hi } from "make-plural/plurals";
-import { IS_PRODUCTION, IS_LOCAL_DEVELOPMENT } from "lib/constants";
+import { IS_LOCAL_DEVELOPMENT } from "lib/constants";
 import { urls } from "@klimadao/lib/constants";
+import { getLocales } from "@klimadao/lib/utils";
 
-// TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
-
-// Define locales
-interface ILocales {
-  [locale: string]: {
-    plurals: (
-      n: number | string,
-      ord?: boolean
-    ) => "zero" | "one" | "two" | "few" | "many" | "other";
-    time: string;
-  };
-}
-const locales: ILocales = {
-  en: { plurals: en, time: "en-US" },
-  fr: { plurals: fr, time: "fr-FR" },
-  de: { plurals: de, time: "de-DE" },
-  ru: { plurals: ru, time: "ru-RU" },
-  "zh-CN": { plurals: zh, time: "zh-CN" },
-  es: { plurals: es, time: "es-ES" },
-  hi: { plurals: hi, time: "hi-IN" },
-};
-
-// Add pseudo locale only in development
-if (!IS_PRODUCTION) {
-  locales["ko"] = { plurals: ko, time: "ko-KR" };
-  locales["en-pseudo"] = { plurals: en, time: "en-US" };
-}
+export const locales = getLocales();
 
 // Validate locale language tag
 export const localeExists = (locale: string) =>
@@ -93,4 +67,4 @@ export const createLinkWithLocaleSubPath = (
   return `${url}/${locale}`;
 };
 
-export { locales, activate, initLocale };
+export { activate, initLocale };

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -1,9 +1,9 @@
 import { i18n } from "@lingui/core";
-import { IS_LOCAL_DEVELOPMENT } from "lib/constants";
+import { IS_LOCAL_DEVELOPMENT, IS_PRODUCTION } from "lib/constants";
 import { urls } from "@klimadao/lib/constants";
 import { getLocales } from "@klimadao/lib/utils";
 
-export const locales = getLocales();
+export const locales = getLocales(IS_PRODUCTION);
 
 // Validate locale language tag
 export const localeExists = (locale: string) =>

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -254,3 +254,5 @@ export const verra = {
   projectSearch: `${VERRA_REGISTRY_API}/resource/resource/search?maxResults=2000&$count=true&$skip=0&$top=50`,
   projectDetailPage: `${VERRA_REGISTRY}/app/projectDetail/VCS`, // add ID after VCS like /191
 };
+export const IS_PRODUCTION =
+  process.env.NEXT_PUBLIC_VERCEL_ENV === "production";

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -254,5 +254,3 @@ export const verra = {
   projectSearch: `${VERRA_REGISTRY_API}/resource/resource/search?maxResults=2000&$count=true&$skip=0&$top=50`,
   projectDetailPage: `${VERRA_REGISTRY}/app/projectDetail/VCS`, // add ID after VCS like /191
 };
-export const IS_PRODUCTION =
-  process.env.NEXT_PUBLIC_VERCEL_ENV === "production";

--- a/lib/package.json
+++ b/lib/package.json
@@ -10,6 +10,7 @@
     "@toruslabs/torus-embed": "^1.35.6",
     "@walletconnect/web3-provider": "^1.8.0",
     "ethers": "^5.7.0",
+    "make-plural": "^7.1.0",
     "react": "^17.0.2",
     "web3modal": "^1.9.9"
   },

--- a/lib/utils/getLocales/index.ts
+++ b/lib/utils/getLocales/index.ts
@@ -25,7 +25,6 @@ const productionLocales: ILocales = {
   },
   es: { plurals: es, time: "es-ES", label: "Español" },
   hi: { plurals: hi, time: "hi-IN", label: "हिन्दी" },
-  ko: { plurals: ko, time: "ko-KR", label: "한국어" },
 };
 
 const stagingLocales: ILocales = Object.assign({}, productionLocales, {

--- a/lib/utils/getLocales/index.ts
+++ b/lib/utils/getLocales/index.ts
@@ -1,0 +1,48 @@
+import { en, fr, de, ru, zh, ko, es, hi } from "make-plural/plurals";
+import { IS_PRODUCTION } from "../../constants";
+
+// TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
+// Define locales
+interface ILocales {
+  [locale: string]: {
+    plurals: (
+      n: number | string,
+      ord?: boolean
+    ) => "zero" | "one" | "two" | "few" | "many" | "other";
+    time: string;
+    label: string;
+    production_ready: boolean;
+  };
+}
+
+const locales: ILocales = {
+  en: { plurals: en, time: "en-US", label: "English", production_ready: true },
+  fr: { plurals: fr, time: "fr-FR", label: "Français", production_ready: true },
+  de: { plurals: de, time: "de-DE", label: "Deutsch", production_ready: true },
+  ru: { plurals: ru, time: "ru-RU", label: "Русский", production_ready: true },
+  "zh-CN": {
+    plurals: zh,
+    time: "zh-CN",
+    label: "中文",
+    production_ready: true,
+  },
+  es: { plurals: es, time: "es-ES", label: "Español", production_ready: true },
+  hi: { plurals: hi, time: "hi-IN", label: "हिन्दी", production_ready: true },
+  ko: { plurals: ko, time: "ko-KR", label: "한국어", production_ready: false },
+  "en-pseudo": {
+    plurals: en,
+    time: "en-US",
+    label: "Pseudo",
+    production_ready: false,
+  },
+};
+
+export const getLocales = (): ILocales => {
+  const result: ILocales = {};
+  Object.keys(locales).forEach((locale) => {
+    if (locales[locale].production_ready || !IS_PRODUCTION) {
+      result[locale] = locales[locale];
+    }
+  });
+  return result;
+};

--- a/lib/utils/getLocales/index.ts
+++ b/lib/utils/getLocales/index.ts
@@ -1,5 +1,4 @@
 import { en, fr, de, ru, zh, ko, es, hi } from "make-plural/plurals";
-import { IS_PRODUCTION } from "../../constants";
 
 // TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
 // Define locales
@@ -11,38 +10,33 @@ interface ILocales {
     ) => "zero" | "one" | "two" | "few" | "many" | "other";
     time: string;
     label: string;
-    production_ready: boolean;
   };
 }
 
-const locales: ILocales = {
-  en: { plurals: en, time: "en-US", label: "English", production_ready: true },
-  fr: { plurals: fr, time: "fr-FR", label: "Français", production_ready: true },
-  de: { plurals: de, time: "de-DE", label: "Deutsch", production_ready: true },
-  ru: { plurals: ru, time: "ru-RU", label: "Русский", production_ready: true },
+const productionLocales: ILocales = {
+  en: { plurals: en, time: "en-US", label: "English" },
+  fr: { plurals: fr, time: "fr-FR", label: "Français" },
+  de: { plurals: de, time: "de-DE", label: "Deutsch" },
+  ru: { plurals: ru, time: "ru-RU", label: "Русский" },
   "zh-CN": {
     plurals: zh,
     time: "zh-CN",
     label: "中文",
-    production_ready: true,
   },
-  es: { plurals: es, time: "es-ES", label: "Español", production_ready: true },
-  hi: { plurals: hi, time: "hi-IN", label: "हिन्दी", production_ready: true },
-  ko: { plurals: ko, time: "ko-KR", label: "한국어", production_ready: false },
+  es: { plurals: es, time: "es-ES", label: "Español" },
+  hi: { plurals: hi, time: "hi-IN", label: "हिन्दी" },
+  ko: { plurals: ko, time: "ko-KR", label: "한국어" },
+};
+
+const stagingLocales: ILocales = Object.assign({}, productionLocales, {
+  ko: { plurals: ko, time: "ko-KR", label: "한국어" },
   "en-pseudo": {
     plurals: en,
     time: "en-US",
     label: "Pseudo",
-    production_ready: false,
   },
-};
+});
 
-export const getLocales = (): ILocales => {
-  const result: ILocales = {};
-  Object.keys(locales).forEach((locale) => {
-    if (locales[locale].production_ready || !IS_PRODUCTION) {
-      result[locale] = locales[locale];
-    }
-  });
-  return result;
+export const getLocales = (is_production: boolean): ILocales => {
+  return is_production ? productionLocales : stagingLocales;
 };

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -46,7 +46,7 @@ export {
   KNSContract,
 } from "./kns";
 export { getTransactionOptions } from "./getTransactionOptions";
-
+export { getLocales } from "./getLocales";
 // ENS
 export {
   isENSDomain,

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@toruslabs/torus-embed": "^1.35.6",
         "@walletconnect/web3-provider": "^1.8.0",
         "ethers": "^5.7.0",
+        "make-plural": "^7.1.0",
         "react": "^17.0.2",
         "web3modal": "^1.9.9"
       },
@@ -84,6 +85,11 @@
         "node": ">=14.18.1",
         "npm": ">=8.0.0"
       }
+    },
+    "lib/node_modules/make-plural": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.1.0.tgz",
+      "integrity": "sha512-PKkwVlAxYVo98NrbclaQIT4F5Oy+X58PZM5r2IwUSCe3syya6PXkIRCn2XCdz7p58Scgpp50PBeHmepXVDG3hg=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.0",
@@ -22145,7 +22151,7 @@
     "@klimadao/app": {
       "version": "file:app",
       "requires": {
-        "@emotion/babel-plugin": "11.10.2",
+        "@emotion/babel-plugin": "^11.10.2",
         "@emotion/css": "^11.10.0",
         "@emotion/server": "^11.10.0",
         "@lingui/cli": "^3.13.0",
@@ -22192,16 +22198,24 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-react": "^7.27.1",
         "ethers": "^5.7.0",
+        "make-plural": "*",
         "prettier": "2.5.1",
         "react": "^17.0.2",
         "typescript": "^4.5.4",
         "web3modal": "^1.9.9"
+      },
+      "dependencies": {
+        "make-plural": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.1.0.tgz",
+          "integrity": "sha512-PKkwVlAxYVo98NrbclaQIT4F5Oy+X58PZM5r2IwUSCe3syya6PXkIRCn2XCdz7p58Scgpp50PBeHmepXVDG3hg=="
+        }
       }
     },
     "@klimadao/site": {
       "version": "file:site",
       "requires": {
-        "@emotion/babel-plugin": "11.10.2",
+        "@emotion/babel-plugin": "^11.10.2",
         "@emotion/css": "^11.10.0",
         "@emotion/server": "^11.10.0",
         "@hookform/resolvers": "^2.8.8",

--- a/site/components/ChangeLanguageButton/index.tsx
+++ b/site/components/ChangeLanguageButton/index.tsx
@@ -2,7 +2,6 @@ import React, { FC, useState } from "react";
 import Tippy from "@tippyjs/react";
 import { t } from "@lingui/macro";
 import Language from "@mui/icons-material/Language";
-import { IS_PRODUCTION } from "lib/constants";
 import { locales } from "lib/i18n";
 
 import * as styles from "./styles";
@@ -16,23 +15,6 @@ export const ChangeLanguageButton: FC = () => {
   const router = useRouter();
   const { pathname, asPath, query, locale } = router;
 
-  // Hint: ensure that this is in sync with locales in 'lib/i18n'
-  const labels: { [key: string]: string } = {
-    en: "English",
-    fr: "Français",
-    de: "Deutsch",
-    ru: "Русский",
-    "zh-CN": "中文",
-    es: "Español",
-    hi: "हिन्दी",
-  };
-
-  // enable 'pseudo' locale only for Staging environment
-  if (!IS_PRODUCTION) {
-    labels["ko"] = "한국어";
-    labels["en-pseudo"] = "Pseudo";
-  }
-
   const content = (
     <div className={styles.menuItemContainer}>
       {Object.keys(locales).map((localeKey) => (
@@ -45,7 +27,7 @@ export const ChangeLanguageButton: FC = () => {
             router.push({ pathname, query }, asPath, { locale: localeKey });
           }}
         >
-          {labels[localeKey as keyof typeof labels]}
+          {locales[localeKey].label}
         </button>
       ))}
     </div>

--- a/site/lib/i18n.ts
+++ b/site/lib/i18n.ts
@@ -1,8 +1,8 @@
 import { i18n } from "@lingui/core";
-import { IS_LOCAL_DEVELOPMENT } from "lib/constants";
+import { IS_LOCAL_DEVELOPMENT, IS_PRODUCTION } from "lib/constants";
 import { getLocales } from "@klimadao/lib/utils";
 
-export const locales = getLocales();
+export const locales = getLocales(IS_PRODUCTION);
 
 for (const key in locales) {
   const locale = locales[key];

--- a/site/lib/i18n.ts
+++ b/site/lib/i18n.ts
@@ -1,32 +1,8 @@
 import { i18n } from "@lingui/core";
-import { en, fr, de, ru, zh, ko, es, hi } from "make-plural/plurals";
-import { IS_LOCAL_DEVELOPMENT, IS_PRODUCTION } from "lib/constants";
+import { IS_LOCAL_DEVELOPMENT } from "lib/constants";
+import { getLocales } from "@klimadao/lib/utils";
 
-// TODO: remove NODE_ENV=test hack from package.json https://github.com/lingui/js-lingui/issues/433
-// Define locales
-interface ILocales {
-  [locale: string]: {
-    plurals: (
-      n: number | string,
-      ord?: boolean
-    ) => "zero" | "one" | "two" | "few" | "many" | "other";
-    time: string;
-  };
-}
-const locales: ILocales = {
-  en: { plurals: en, time: "en-US" },
-  fr: { plurals: fr, time: "fr-FR" },
-  de: { plurals: de, time: "de-DE" },
-  ru: { plurals: ru, time: "ru-RU" },
-  "zh-CN": { plurals: zh, time: "zh-CN" },
-  es: { plurals: es, time: "es-ES" },
-  hi: { plurals: hi, time: "hi-IN" },
-};
-// Add pseudo locale only in development
-if (!IS_PRODUCTION) {
-  locales["ko"] = { plurals: ko, time: "ko-KR" };
-  locales["en-pseudo"] = { plurals: en, time: "en-US" };
-}
+export const locales = getLocales();
 
 for (const key in locales) {
   const locale = locales[key];
@@ -49,4 +25,4 @@ async function loadTranslation(locale = "en") {
 export const createLinkWithLocaleQuery = (url: string, locale = "en"): string =>
   `${url}?locale=${locale}`;
 
-export { locales, loadTranslation };
+export { loadTranslation };

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -2,108 +2,104 @@
 
 const IS_PRODUCTION = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
 
-const nextConfig = {
-  reactStrictMode: true,
-  async redirects() {
-    if (IS_PRODUCTION) {
+module.exports = async (phase, { defaultConfig }) => {
+  const getLocales = (await import("../lib/out/utils/getLocales/index.js"))
+    .getLocales;
+
+  return {
+    reactStrictMode: true,
+    async redirects() {
+      if (IS_PRODUCTION) {
+        return [
+          {
+            source: "/resources",
+            destination: "/blog",
+            permanent: true,
+          },
+          {
+            source: "/cms",
+            destination: "https://klimadao.sanity.studio/desk",
+            permanent: true,
+          },
+        ];
+      }
       return [
-        {
-          source: "/resources",
-          destination: "/blog",
-          permanent: true,
-        },
+        // Enable this as soon as the Resources page is live
+        // {
+        //   source: "/blog",
+        //   destination: "/resources",
+        //   permanent: true,
+        // },
         {
           source: "/cms",
           destination: "https://klimadao.sanity.studio/desk",
           permanent: true,
         },
       ];
-    }
-    return [
-      // Enable this as soon as the Resources page is live
-      // {
-      //   source: "/blog",
-      //   destination: "/resources",
-      //   permanent: true,
-      // },
-      {
-        source: "/cms",
-        destination: "https://klimadao.sanity.studio/desk",
-        permanent: true,
-      },
-    ];
-  },
-  async headers() {
-    return [
-      {
-        // from vercel docs example
-        source: "/api/block-rate",
-        headers: [
-          {
-            key: "Access-Control-Allow-Credentials",
-            value: "true",
-          },
-          {
-            key: "Access-Control-Allow-Origin",
-            value: "*",
-          },
-          {
-            key: "Access-Control-Allow-Methods",
-            value: "GET",
-          },
-          {
-            key: "Access-Control-Allow-Headers",
-            value:
-              "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version",
-          },
-        ],
-      },
-      {
-        source: "/:path*",
-        headers: [
-          {
-            key: "Referrer-Policy",
-            value: "strict-origin-when-cross-origin",
-          },
-          {
-            key: "Strict-Transport-Security",
-            value: "max-age=31536000; includeSubDomains",
-          },
-          {
-            key: "Content-Security-Policy",
-            value: "upgrade-insecure-requests",
-          },
-          {
-            key: "X-Content-Type-Options",
-            value: "nosniff",
-          },
-          {
-            key: "X-Frame-Options",
-            value: "SAMEORIGIN",
-          },
-          {
-            key: "X-XSS-Protection",
-            value: "0",
-          },
-        ],
-      },
-    ];
-  },
-  i18n: {
-    locales: ["en", "fr", "de", "ru", "zh-CN", "es"],
-    defaultLocale: "en",
-    localeDetection: true,
-  },
-  images: {
-    domains: ["cdn.sanity.io"],
-  },
-};
-
-if (!IS_PRODUCTION) {
-  nextConfig.i18n = {
-    ...nextConfig.i18n,
-    locales: [...nextConfig.i18n.locales, "ko", "hi", "en-pseudo"],
+    },
+    async headers() {
+      return [
+        {
+          // from vercel docs example
+          source: "/api/block-rate",
+          headers: [
+            {
+              key: "Access-Control-Allow-Credentials",
+              value: "true",
+            },
+            {
+              key: "Access-Control-Allow-Origin",
+              value: "*",
+            },
+            {
+              key: "Access-Control-Allow-Methods",
+              value: "GET",
+            },
+            {
+              key: "Access-Control-Allow-Headers",
+              value:
+                "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version",
+            },
+          ],
+        },
+        {
+          source: "/:path*",
+          headers: [
+            {
+              key: "Referrer-Policy",
+              value: "strict-origin-when-cross-origin",
+            },
+            {
+              key: "Strict-Transport-Security",
+              value: "max-age=31536000; includeSubDomains",
+            },
+            {
+              key: "Content-Security-Policy",
+              value: "upgrade-insecure-requests",
+            },
+            {
+              key: "X-Content-Type-Options",
+              value: "nosniff",
+            },
+            {
+              key: "X-Frame-Options",
+              value: "SAMEORIGIN",
+            },
+            {
+              key: "X-XSS-Protection",
+              value: "0",
+            },
+          ],
+        },
+      ];
+    },
+    i18n: {
+      locales: Object.keys(getLocales(IS_PRODUCTION)),
+      defaultLocale: "en",
+      localeDetection: true,
+    },
+    images: {
+      domains: ["cdn.sanity.io"],
+    },
   };
-}
-
-module.exports = nextConfig;
+};


### PR DESCRIPTION
## Description

Single source of truth for locale information

If we want to have the Opportunity to have differences between app and site we can make the getLocales function parametrized.

## Related Ticket

Resolves #nothing
It is related to @Atmosfearful comment here: https://github.com/KlimaDAO/klimadao/pull/728#pullrequestreview-1125566392

## Changes

None

## Checklist

<!-- Check completed item: [X] -->

- [X] Building the site with `npm run build-site` works without errors
- [X] Building the app with `npm run build-app` works without errors
- [X] I formatted JS and TS files with running `npm run format-all`
