### PR TITLE
Update infinity nav to include pledge (#722)

### DIFF
--- a/site/components/Navigation/index.tsx
+++ b/site/components/Navigation/index.tsx
@@ -168,11 +168,20 @@ export const Navigation: FC<Props> = ({
             url={createLinkWithLocaleQuery(urls.info, locale)}
           />
         </DropdownItemDesktop>
-        <LinkItemDesktop
+        <DropdownItemDesktop
           name={t({ message: "Infinity", id: "shared.infinity" })}
-          active={activePage === "Infinity"}
-          url="/infinity"
-        />
+        >
+          <LinkItemDesktop
+            name={t({ message: "Introduction", id: "shared.infinity_intro" })}
+            active={activePage === "Infinity"}
+            url="/infinity"
+          />
+          <LinkItemDesktop
+            name={t({ message: "How to pledge", id: "shared.pledge" })}
+            active={activePage === "Pledges"}
+            url="/pledge"
+          />
+        </DropdownItemDesktop>
         <LinkItemDesktop
           url={urls.loveletter}
           name={t({ message: "Love Letters", id: "shared.loveletters" })}
@@ -316,10 +325,24 @@ export const Navigation: FC<Props> = ({
                 />,
               ]}
             />
+
             <NavItemMobile
               name={t({ message: "Infinity", id: "shared.infinity" })}
-              url="/infinity"
-              id="Infinity"
+              subMenu={[
+                <NavItemMobile
+                  name={t({
+                    message: "Introduction",
+                    id: "shared.infinity_intro",
+                  })}
+                  key="infinity"
+                  url="/infinity"
+                />,
+                <NavItemMobile
+                  name={t({ message: "How to pledge", id: "shared.pledge" })}
+                  key="pledges"
+                  url="/pledge"
+                />,
+              ]}
             />
             <NavItemMobile
               name={t({ message: "Love Letters", id: "shared.loveletters" })}


### PR DESCRIPTION
## Description

As per #722 the Infinity nav item is now a multi option drop down containing links to `/infinity` and `/pledge`

## Related Ticket

Resolves [#722](https://github.com/KlimaDAO/klimadao/issues/722)

## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/7104689/194744117-d9272790-b99f-4992-a87f-6488f1459ae8.png)|![image](https://user-images.githubusercontent.com/7104689/194744090-31b1c7fb-c44a-4ef1-b548-7effc1a74f07.png)|


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
