### PR TITLE
Remaining enhancements to complete beta (#712)

### DIFF
--- a/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
-import { t } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import CloudQueueIcon from "@mui/icons-material/CloudQueue";
 import map from "lodash/map";
 import groupBy from "lodash/groupBy";
@@ -67,11 +67,6 @@ export const AssetBalanceCard: FC<Props> = (props) => {
 
   const holdingsByToken = groupBy(props.holdings, "token");
 
-  const emptyBalanceText = t({
-    id: "pledges.dashboard.assets.emptyBalance",
-    message: "No carbon assets to show.",
-  });
-
   /** Hide tokens with no balance
    * @todo hide token with no transaction history*/
   const tokenHoldingAndBalances = map(TOKEN_MAP, (token, key) => ({
@@ -110,10 +105,13 @@ export const AssetBalanceCard: FC<Props> = (props) => {
             )}
           </div>
         ))}
-
-        {tokenHoldingAndBalances.length === 0 ? (
-          <Text t="body2">{emptyBalanceText}</Text>
-        ) : null}
+        {tokenHoldingAndBalances.length === 0 && (
+          <Text t="body2">
+            <Trans id="pledges.dashboard.assets.emptyBalance">
+              No carbon assets to show.
+            </Trans>
+          </Text>
+        )}
       </div>
     </BaseCard>
   );

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
@@ -3,7 +3,6 @@ import { t, Trans } from "@lingui/macro";
 import CloudQueueIcon from "@mui/icons-material/CloudQueue";
 import map from "lodash/map";
 import groupBy from "lodash/groupBy";
-import toNumber from "lodash/toNumber";
 
 import BCTIcon from "public/icons/BCT.png";
 import KLIMAIcon from "public/icons/KLIMA.png";
@@ -73,7 +72,7 @@ export const AssetBalanceCard: FC<Props> = (props) => {
     ...token,
     balance: balances && balances[key as BalanceToken],
     holdings: holdingsByToken[token.label],
-  })).filter(({ balance }) => !!toNumber(balance));
+  })).filter(({ balance }) => !!Number(balance));
 
   useEffect(() => {
     (async () => {

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
@@ -3,6 +3,7 @@ import { t } from "@lingui/macro";
 import CloudQueueIcon from "@mui/icons-material/CloudQueue";
 import map from "lodash/map";
 import groupBy from "lodash/groupBy";
+import toNumber from "lodash/toNumber";
 
 import BCTIcon from "public/icons/BCT.png";
 import KLIMAIcon from "public/icons/KLIMA.png";
@@ -16,7 +17,6 @@ import { Holding } from "components/pages/Pledge/types";
 import { BaseCard } from "../BaseCard";
 import { TokenRow } from "./TokenRow";
 import * as styles from "./styles";
-import { toNumber } from "lodash";
 
 type Props = {
   pageAddress: string;

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
@@ -16,6 +16,7 @@ import { Holding } from "components/pages/Pledge/types";
 import { BaseCard } from "../BaseCard";
 import { TokenRow } from "./TokenRow";
 import * as styles from "./styles";
+import { toNumber } from "lodash";
 
 type Props = {
   pageAddress: string;
@@ -86,20 +87,24 @@ export const AssetBalanceCard: FC<Props> = (props) => {
       icon={<CloudQueueIcon fontSize="large" />}
     >
       <div className={styles.tokenCardContainer}>
-        {map(tokenHoldingAndBalances, (token, index) => (
-          <div className={styles.tokenRowContainer} key={index}>
-            <TokenRow
-              label={token.label}
-              icon={token.icon}
-              balance={token.balance}
-              holdings={token.holdings}
-            />
+        {tokenHoldingAndBalances
+          /** Hide tokens with no balance
+           * @todo hide token with no transaction history*/
+          .filter(({ balance }) => !!toNumber(balance))
+          .map((token, index) => (
+            <div className={styles.tokenRowContainer} key={index}>
+              <TokenRow
+                label={token.label}
+                icon={token.icon}
+                balance={token.balance}
+                holdings={token.holdings}
+              />
 
-            {tokenHoldingAndBalances.length - 1 !== index && (
-              <div className={styles.divider} />
-            )}
-          </div>
-        ))}
+              {tokenHoldingAndBalances.length - 1 !== index && (
+                <div className={styles.divider} />
+              )}
+            </div>
+          ))}
       </div>
     </BaseCard>
   );

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx
@@ -17,6 +17,7 @@ import { Holding } from "components/pages/Pledge/types";
 import { BaseCard } from "../BaseCard";
 import { TokenRow } from "./TokenRow";
 import * as styles from "./styles";
+import { Text } from "@klimadao/lib/components";
 
 type Props = {
   pageAddress: string;
@@ -65,11 +66,19 @@ export const AssetBalanceCard: FC<Props> = (props) => {
   const [balances, setBalances] = useState<Balances | null>(null);
 
   const holdingsByToken = groupBy(props.holdings, "token");
+
+  const emptyBalanceText = t({
+    id: "pledges.dashboard.assets.emptyBalance",
+    message: "No carbon assets to show.",
+  });
+
+  /** Hide tokens with no balance
+   * @todo hide token with no transaction history*/
   const tokenHoldingAndBalances = map(TOKEN_MAP, (token, key) => ({
     ...token,
     balance: balances && balances[key as BalanceToken],
     holdings: holdingsByToken[token.label],
-  }));
+  })).filter(({ balance }) => !!toNumber(balance));
 
   useEffect(() => {
     (async () => {
@@ -87,24 +96,24 @@ export const AssetBalanceCard: FC<Props> = (props) => {
       icon={<CloudQueueIcon fontSize="large" />}
     >
       <div className={styles.tokenCardContainer}>
-        {tokenHoldingAndBalances
-          /** Hide tokens with no balance
-           * @todo hide token with no transaction history*/
-          .filter(({ balance }) => !!toNumber(balance))
-          .map((token, index) => (
-            <div className={styles.tokenRowContainer} key={index}>
-              <TokenRow
-                label={token.label}
-                icon={token.icon}
-                balance={token.balance}
-                holdings={token.holdings}
-              />
+        {tokenHoldingAndBalances.map((token, index) => (
+          <div className={styles.tokenRowContainer} key={index}>
+            <TokenRow
+              label={token.label}
+              icon={token.icon}
+              balance={token.balance}
+              holdings={token.holdings}
+            />
 
-              {tokenHoldingAndBalances.length - 1 !== index && (
-                <div className={styles.divider} />
-              )}
-            </div>
-          ))}
+            {tokenHoldingAndBalances.length - 1 !== index && (
+              <div className={styles.divider} />
+            )}
+          </div>
+        ))}
+
+        {tokenHoldingAndBalances.length === 0 ? (
+          <Text t="body2">{emptyBalanceText}</Text>
+        ) : null}
       </div>
     </BaseCard>
   );

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
@@ -24,16 +24,16 @@ const PlaceholderFootprintChart: React.ComponentType = dynamic(
 
 /** This palette is defined at https://www.figma.com/file/moDUIfGjQaISUGDjLxyko4?node-id=1:3#286886177 */
 const COLOR_PALETTE = [
-  "#0BA1FF",
-  "#8997FF",
-  "#CE87F4",
-  "#FF76D4",
-  "#FF6CA8",
-  "#FF7377",
-  "#FF8A46",
-  "#FFA600",
-  "#1B4659",
   "#00CC33",
+  "#1B4659",
+  "#FFA600",
+  "#FF8A46",
+  "#FF7377",
+  "#FF6CA8",
+  "#FF76D4",
+  "#CE87F4",
+  "#8997FF",
+  "#0BA1FF",
 ];
 
 type Props = {
@@ -49,18 +49,15 @@ const calculateFootprintPercent = (
   total: number,
   categories: Category[]
 ): CategoryWithPercent[] =>
-  categories
-    /**Sort the categories from largest to smallest for the correct color order */
-    .sort((cat1, cat2) => cat2.quantity - cat1.quantity)
-    .map((category, index) => {
-      /** compute the color index based on the categories index */
-      const paletteIndex = Math.ceil(index % COLOR_PALETTE.length);
-      return {
-        ...category,
-        percent: (category.quantity / total) * 100,
-        fill: COLOR_PALETTE[paletteIndex],
-      };
-    });
+  categories.map((category, index) => {
+    /** Ensure the color is computed from largest asset first */
+    const paletteIndex = categories.length - 1 - index;
+    return {
+      ...category,
+      percent: (category.quantity / total) * 100,
+      fill: COLOR_PALETTE[paletteIndex],
+    };
+  });
 
 export const FootprintCard: FC<Props> = (props) => {
   const { locale } = useRouter();

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
@@ -22,8 +22,19 @@ const PlaceholderFootprintChart: React.ComponentType = dynamic(
   { ssr: false }
 );
 
-/** This palette is defined at https://www.figma.com/file/moDUIfGjQaISUGDjLxyko4/Multi-Wallet-Pledge?node-id=7%3A161 */
-const COLOR_PALETTE = ["#0BA1FF", "#E081EB", "#FF6F88", "#FFA600"].reverse();
+/** This palette is defined at https://www.figma.com/file/moDUIfGjQaISUGDjLxyko4?node-id=1:3#286886177 */
+const COLOR_PALETTE = [
+  "#0BA1FF",
+  "#8997FF",
+  "#CE87F4",
+  "#FF76D4",
+  "#FF6CA8",
+  "#FF7377",
+  "#FF8A46",
+  "#FFA600",
+  "#1B4659",
+  "#00CC33",
+];
 
 type Props = {
   footprint: Footprint[];
@@ -38,15 +49,18 @@ const calculateFootprintPercent = (
   total: number,
   categories: Category[]
 ): CategoryWithPercent[] =>
-  categories.map((category, index) => {
-    /** compute the color index based on the categories index */
-    const paletteIndex = Math.ceil(index % 4);
-    return {
-      ...category,
-      percent: (category.quantity / total) * 100,
-      fill: COLOR_PALETTE[paletteIndex],
-    };
-  });
+  categories
+    /**Sort the categories from largest to smallest for the correct color order */
+    .sort((cat1, cat2) => cat2.quantity - cat1.quantity)
+    .map((category, index) => {
+      /** compute the color index based on the categories index */
+      const paletteIndex = Math.ceil(index % COLOR_PALETTE.length);
+      return {
+        ...category,
+        percent: (category.quantity / total) * 100,
+        fill: COLOR_PALETTE[paletteIndex],
+      };
+    });
 
 export const FootprintCard: FC<Props> = (props) => {
   const { locale } = useRouter();

--- a/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx
@@ -22,18 +22,8 @@ const PlaceholderFootprintChart: React.ComponentType = dynamic(
   { ssr: false }
 );
 
-const COLOR_PALETTE = [
-  "#147b11",
-  "#2c8e18",
-  "#4aa11f",
-  "#6db524",
-  "#96cb27",
-  "#c0dc30",
-  "#e3e541",
-  "#eedc51",
-  "#f6d562",
-  "#fdd175",
-];
+/** This palette is defined at https://www.figma.com/file/moDUIfGjQaISUGDjLxyko4/Multi-Wallet-Pledge?node-id=7%3A161 */
+const COLOR_PALETTE = ["#0BA1FF", "#E081EB", "#FF6F88", "#FFA600"].reverse();
 
 type Props = {
   footprint: Footprint[];
@@ -47,13 +37,16 @@ export interface CategoryWithPercent extends Category {
 const calculateFootprintPercent = (
   total: number,
   categories: Category[]
-): CategoryWithPercent[] => {
-  return categories.map((category, index) => ({
-    ...category,
-    percent: (category.quantity / total) * 100,
-    fill: COLOR_PALETTE[index],
-  }));
-};
+): CategoryWithPercent[] =>
+  categories.map((category, index) => {
+    /** compute the color index based on the categories index */
+    const paletteIndex = Math.ceil(index % 4);
+    return {
+      ...category,
+      percent: (category.quantity / total) * 100,
+      fill: COLOR_PALETTE[paletteIndex],
+    };
+  });
 
 export const FootprintCard: FC<Props> = (props) => {
   const { locale } = useRouter();

--- a/site/components/pages/Pledge/PledgeDashboard/Profile/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/Profile/index.tsx
@@ -76,18 +76,12 @@ export const Profile: FC<Props> = (props) => {
 
   return (
     <div className={styles.profile}>
-      {hasProfileImage ? (
-        <>
-          <img
-            className="profileImage"
-            src={props.pledge.profileImageUrl || profileData?.imageUrl}
-            alt="Profile image"
-          />
-        </>
-      ) : (
-        <Text t="h3" className="profileImage" align="center">
-          -
-        </Text>
+      {hasProfileImage && (
+        <img
+          className="profileImage"
+          src={props.pledge.profileImageUrl || profileData?.imageUrl}
+          alt="Profile image"
+        />
       )}
 
       <Text t="h2">

--- a/site/components/pages/Pledge/PledgeDashboard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/index.tsx
@@ -92,12 +92,12 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
         </div>
 
         <div className={styles.column}>
-          <AssetBalanceCard
-            holdings={props.holdings}
-            pageAddress={props.pageAddress}
-          />
           <RetirementsCard
             retirements={props.retirements}
+            pageAddress={props.pageAddress}
+          />
+          <AssetBalanceCard
+            holdings={props.holdings}
             pageAddress={props.pageAddress}
           />
         </div>

--- a/site/components/pages/Pledge/lib/mockPledge.ts
+++ b/site/components/pages/Pledge/lib/mockPledge.ts
@@ -1,0 +1,27 @@
+import { DEFAULT_NONCE } from "components/pages/Pledge/lib";
+import { Pledge } from "components/pages/Pledge/types";
+
+/** A mock pledge for testing purposes */
+export const MockPledge = (resolvedAddress: string): Pledge => ({
+  id: "Some Id",
+  ownerAddress: resolvedAddress,
+  name: "Senkusha",
+  nonce: DEFAULT_NONCE,
+  profileImageUrl: "https://i.pravatar.cc/300",
+  description:
+    "“The team over at Senkusha loves the initiative behind Klima! We can’t wait to be a part of this journey for years to come.”",
+  methodology:
+    "Senkusha calculated its carbon footprint by considering the expected emissions for the year. This takes into consideration of average consumption of the office based in Auckland, the travel demand, material waste and the average minting/transferring cost of our NFT projects. At the end of the year, when new projects are released and published, Senkusha will add them to our carbon footprint according to their conditions.",
+  footprint: [
+    {
+      timestamp: Date.now(),
+      total: 140.48,
+      categories: [
+        { name: "Material Waste", quantity: 0.38 },
+        { name: "Travel", quantity: 2.9 },
+        { name: "Energy Consumption", quantity: 3.4 },
+        { name: "NFT Project", quantity: 133.8 },
+      ],
+    },
+  ],
+});

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/pages/Blog/index.tsx:35
 msgid "Articles"
@@ -924,15 +930,19 @@ msgstr ""
 msgid "mission.header"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:82
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:70
+msgid "pledges.dashboard.assets.emptyBalance"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:92
 msgid "pledges.dashboard.assets.title"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:73
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
 msgid "pledges.dashboard.footprint.title"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:90
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
 msgid "pledges.dashboard.footprint.tonnes"
 msgstr ""
 
@@ -976,7 +986,7 @@ msgstr ""
 msgid "pledges.dashboard.profile.pledge_progress"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:101
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:95
 msgid "pledges.dashboard.profile.pledged_to_offset"
 msgstr ""
 

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -930,15 +930,19 @@ msgstr "Invest in the future."
 msgid "mission.header"
 msgstr "KlimaDAO's mission is to democratize climate action"
 
-#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:82
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:70
+msgid "pledges.dashboard.assets.emptyBalance"
+msgstr "No carbon assets to show."
+
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:92
 msgid "pledges.dashboard.assets.title"
 msgstr "Carbon Assets"
 
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:73
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
 msgid "pledges.dashboard.footprint.title"
 msgstr "Footprint"
 
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:90
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
 msgid "pledges.dashboard.footprint.tonnes"
 msgstr "Tonnes"
 
@@ -982,7 +986,7 @@ msgstr "≥ 100% of Pledge Met"
 msgid "pledges.dashboard.profile.pledge_progress"
 msgstr "{0}% of Pledge Met"
 
-#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:101
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:95
 msgid "pledges.dashboard.profile.pledged_to_offset"
 msgstr "Pledged to Offset <0>{0}</0> Carbon Tonnes"
 


### PR DESCRIPTION
## Description
Complete the following tasks on the PledgeDashboard

- [x] Move the carbon assets card to the bottom
- [ ] Only show the assets with a history to graph (assets that have never been owned will be hidden) 
^ **Since fetching transaction history per contract was not a simple task a compromise here was to only show assets with balance > 0**
- [x] Hide image profile placeholder is the user does not have one
- [x] Change Footprint graph colour scheme to support accessibility for colour blind users. HEX values available in the [figma design](https://www.figma.com/file/moDUIfGjQaISUGDjLxyko4/Multi-Wallet-Pledge?node-id=9%3A621)

**Note:**
* Please test with number of categories greater than 4 (for the FootprintCard and it's graph)
* @jabby09 font sizes seem larger in the app than in designs

## Related Ticket

Resolves #712 

## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/7104689/195721710-df1a4e9a-08ed-443a-86b9-84bc1e7fcd93.png)|![image](https://user-images.githubusercontent.com/7104689/195721766-8acc8e8d-a46b-40fe-bfc0-ff77baed4691.png)|


## Checklist

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
