### PR TITLE
fix focus trap

### DIFF
--- a/lib/utils/useFocusTrap/index.tsx
+++ b/lib/utils/useFocusTrap/index.tsx
@@ -1,3 +1,5 @@
+import { useRef } from "react";
+
 const focusableElements =
   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
@@ -10,24 +12,32 @@ type RefCallback = (el: HTMLElement | null) => void;
  * Note: this returns a new instance on every rerender, but this doesn't seem to cause problems as callback refs are only invoked on mount/unmount
  * We don't need to cleanup listeners because we assume the element is removed from the DOM
  */
-export const useFocusTrap = (): RefCallback => (el) => {
-  if (el) {
-    const focusableChildren = el.querySelectorAll(focusableElements);
-    const first = focusableChildren[0] as HTMLElement; // always going to be an HTMLElement because we don't have XML elements
-    const last = focusableChildren[focusableChildren.length - 1];
+export const useFocusTrap = (): RefCallback => {
+  const ref = useRef<RefCallback>();
+  if (ref.current) {
+    return ref.current;
+  }
+  ref.current = (el: HTMLElement | null) => {
+    if (el) {
+      const focusableChildren = el.querySelectorAll(focusableElements);
+      const first = focusableChildren[0] as HTMLElement; // always going to be an HTMLElement because we don't have XML elements
+      const last = focusableChildren[focusableChildren.length - 1];
 
-    if (first) {
-      // auto-focus the first element in the container
-      first.focus();
-    }
-
-    const handleFocusout: EventHandler = (evt) => {
-      // if the element that lost focus was the last item, go back to top
-      if (last && evt.target === last) {
+      if (first) {
+        // auto-focus the first element in the container
         first.focus();
       }
-    };
 
-    el.addEventListener("focusout", handleFocusout);
-  }
+      const handleFocusout: EventHandler = (evt) => {
+        // if the element that lost focus was the last item, go back to top
+        if (last && evt.target === last) {
+          first.focus();
+        }
+      };
+
+      el.addEventListener("focusout", handleFocusout);
+    }
+  };
+
+  return ref.current;
 };


### PR DESCRIPTION
## Description

Focus trap was causing modals to jump to the top. 

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
