### PR TITLE
[urgent] hotfix: retirement certificate showing wrong retirement month

### DIFF
--- a/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/generateCertificate.ts
+++ b/site/components/pages/Retirements/SingleRetirement/DownloadCertificateButton/generateCertificate.ts
@@ -173,7 +173,9 @@ export const generateCertificate = (params: Params): void => {
   const printProjectDetails = (): void => {
     const project = params.projectDetails?.value[0];
     const retirementDate = new Date(Number(params.retirement.timestamp) * 1000);
-    const formattedRetirementDate = `${retirementDate.getDate()}/${retirementDate.getMonth()}/${retirementDate.getFullYear()}`;
+    const formattedRetirementDate = `${retirementDate.getDate()}/${
+      retirementDate.getMonth() + 1
+    }/${retirementDate.getFullYear()}`;
     let projectDetails = [
       {
         label: "Project",


### PR DESCRIPTION
## Description

Generated retirement date on certificate did not account for month starting on 0 😓 

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #753 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
