### PR TITLE
Enforce lowercased urls

### DIFF
--- a/site/pages/pledge/[address].tsx
+++ b/site/pages/pledge/[address].tsx
@@ -46,7 +46,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
       return {
         redirect: {
           destination: `/pledge/${address.toLowerCase()}`,
-          permanent: false,
+          permanent: true,
         },
       };
     }

--- a/site/pages/pledge/[address].tsx
+++ b/site/pages/pledge/[address].tsx
@@ -15,10 +15,13 @@ import {
   queryHoldingsByAddress,
 } from "components/pages/Pledge/lib";
 import { Pledge, Holding } from "components/pages/Pledge/types";
+import { redirect } from "next/dist/server/api-utils";
+
 interface Params extends ParsedUrlQuery {
   /** Either an 0x or a nameservice domain like atmosfearful.klima */
   address: string;
 }
+
 interface PageProps {
   canonicalUrl: string;
   domain: string | null;
@@ -38,6 +41,16 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
     let resolvedAddress;
     const isDomainInURL = getIsDomainInURL(address);
     const domain = isDomainInURL ? address : null;
+
+    // enforces lowercase urls
+    if (address !== address.toLowerCase()) {
+      return {
+        redirect: {
+          destination: `/pledge/${address.toLowerCase()}`,
+          permanent: false,
+        },
+      };
+    }
 
     try {
       if (!isDomainInURL && !ethers.utils.isAddress(address))

--- a/site/pages/pledge/[address].tsx
+++ b/site/pages/pledge/[address].tsx
@@ -15,7 +15,6 @@ import {
   queryHoldingsByAddress,
 } from "components/pages/Pledge/lib";
 import { Pledge, Holding } from "components/pages/Pledge/types";
-import { redirect } from "next/dist/server/api-utils";
 
 interface Params extends ParsedUrlQuery {
   /** Either an 0x or a nameservice domain like atmosfearful.klima */

--- a/site/pages/retirements/[beneficiary]/index.tsx
+++ b/site/pages/retirements/[beneficiary]/index.tsx
@@ -42,6 +42,16 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
       throw new Error("No params found");
     }
 
+    // enforces lowercase urls
+    if (params.beneficiary !== params.beneficiary.toLowerCase()) {
+      return {
+        redirect: {
+          destination: `/retirements/${params.beneficiary.toLowerCase()}`,
+          permanent: false,
+        },
+      };
+    }
+
     const beneficiaryInUrl = params.beneficiary;
     const isDomainInURL = getIsDomainInURL(beneficiaryInUrl);
     const isValidAddress =

--- a/site/pages/retirements/[beneficiary]/index.tsx
+++ b/site/pages/retirements/[beneficiary]/index.tsx
@@ -42,16 +42,6 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
       throw new Error("No params found");
     }
 
-    // enforces lowercase urls
-    if (params.beneficiary !== params.beneficiary.toLowerCase()) {
-      return {
-        redirect: {
-          destination: `/retirements/${params.beneficiary.toLowerCase()}`,
-          permanent: false,
-        },
-      };
-    }
-
     const beneficiaryInUrl = params.beneficiary;
     const isDomainInURL = getIsDomainInURL(beneficiaryInUrl);
     const isValidAddress =
@@ -70,6 +60,16 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
         redirect: {
           destination: `/retirements/${nameserviceDomain}`,
           statusCode: 301,
+        },
+      };
+    }
+
+    // enforces lowercase urls
+    if (!isDomainInURL && beneficiaryInUrl !== beneficiaryInUrl.toLowerCase()) {
+      return {
+        redirect: {
+          destination: `/retirements/${beneficiaryInUrl.toLowerCase()}`,
+          permanent: true,
         },
       };
     }


### PR DESCRIPTION
## Description

Redirect to lowercased url if uppercased address or domain is detected.
Also improves caching as caching is url case-sensitive.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #725 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
