### PR TITLE
Fix: torus refresh loop

### DIFF
--- a/lib/utils/useWeb3Modal/index.tsx
+++ b/lib/utils/useWeb3Modal/index.tsx
@@ -169,7 +169,7 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
         handleReload
       );
       web3state.provider.provider.removeListener("chainChanged", handleReload);
-      web3state.provider.removeListener("disconnect", handleReload);
+      web3state.provider.removeListener("disconnect", handleDisconnect);
     };
   }, [web3state.provider]);
 

--- a/lib/utils/useWeb3Modal/index.tsx
+++ b/lib/utils/useWeb3Modal/index.tsx
@@ -115,6 +115,7 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
       await (web3state.provider?.provider as any).torus.cleanUp();
       // triggers reload via accountsChanged
     } else {
+      console.log("click disconnect");
       window.location.reload();
     }
   };
@@ -151,24 +152,33 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
     const handleDisconnect = () => {
       // when force-disconnecting via metamask ui, prevent an infinite reconnect loop
       web3Modal?.clearCachedProvider();
+      console.log("handleDisconnect");
       window.location.reload();
     };
-    const handleReload = () => {
+    const handleChainChanged = () => {
+      console.log("handleChainChanged");
+      window.location.reload();
+    };
+    const handleAccountsChanged = () => {
+      console.log("handleAccountsChanged");
       window.location.reload();
     };
 
     /** There is a bug where ethers doesn't respond to web3modal events for these two, so we use the nested provider
      * https://github.com/ethers-io/ethers.js/issues/2988 */
-    web3state.provider.provider.on("accountsChanged", handleReload);
-    web3state.provider.provider.on("chainChanged", handleReload);
+    web3state.provider.provider.on("accountsChanged", handleAccountsChanged);
+    web3state.provider.provider.on("chainChanged", handleChainChanged);
     web3state.provider.on("disconnect", handleDisconnect);
 
     return () => {
       web3state.provider.provider.removeListener(
         "accountsChanged",
-        handleReload
+        handleAccountsChanged
       );
-      web3state.provider.provider.removeListener("chainChanged", handleReload);
+      web3state.provider.provider.removeListener(
+        "chainChanged",
+        handleChainChanged
+      );
       web3state.provider.removeListener("disconnect", handleDisconnect);
     };
   }, [web3state.provider]);

--- a/lib/utils/useWeb3Modal/index.tsx
+++ b/lib/utils/useWeb3Modal/index.tsx
@@ -115,7 +115,6 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
       await (web3state.provider?.provider as any).torus.cleanUp();
       // triggers reload via accountsChanged
     } else {
-      console.log("click disconnect");
       window.location.reload();
     }
   };
@@ -152,32 +151,21 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
     const handleDisconnect = () => {
       // when force-disconnecting via metamask ui, prevent an infinite reconnect loop
       web3Modal?.clearCachedProvider();
-      console.log("handleDisconnect");
-      window.location.reload();
-    };
-    const handleChainChanged = () => {
-      console.log("handleChainChanged");
       window.location.reload();
     };
     const handleAccountsChanged = () => {
-      console.log("handleAccountsChanged");
       window.location.reload();
     };
 
     /** There is a bug where ethers doesn't respond to web3modal events for these two, so we use the nested provider
      * https://github.com/ethers-io/ethers.js/issues/2988 */
     web3state.provider.provider.on("accountsChanged", handleAccountsChanged);
-    web3state.provider.provider.on("chainChanged", handleChainChanged);
     web3state.provider.on("disconnect", handleDisconnect);
 
     return () => {
       web3state.provider.provider.removeListener(
         "accountsChanged",
         handleAccountsChanged
-      );
-      web3state.provider.provider.removeListener(
-        "chainChanged",
-        handleChainChanged
       );
       web3state.provider.removeListener("disconnect", handleDisconnect);
     };


### PR DESCRIPTION
## Description
torus triggers the `chainChanged` event when it loads, which causes a refresh, sometimes this becomes an infinite loop, othertimes it only loops 2-3 times before stopping.

This PR removes the chainChanged listener. If users switch away from polygon after the app is loaded, that is their problem now, we no longer show the warning modal. The warning modal still shows the first time the app loads though.

Also I was not cleaning up the disconnect listener in useEffect but this was not the cause of the problem. Fixed anyways.
