### PR TITLE
[site] add yup.string.isAddress custom validation

### DIFF
--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -20,10 +20,6 @@ export const pledgeErrorTranslationsMap = {
     id: "pledges.form.errors.name.required",
     message: "Enter a name",
   }),
-  ["pledges.form.errors.name.isAddress"]: t({
-    id: "pledges.form.errors.name.isAddress",
-    message: "Enter a valid address",
-  }),
   ["pledges.form.errors.profileImageUrl.url"]: t({
     id: "pledges.form.errors.profileImageUrl.url",
     message: "Enter a valid url",

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -1,10 +1,28 @@
 import { t } from "@lingui/macro";
+import { ethers } from "ethers";
 import * as yup from "yup";
+
+// extends yup.string schema with custom validation methods
+yup.addMethod<yup.StringSchema>(
+  yup.string,
+  "isAddress",
+  function (errorMessage: string) {
+    return this.test("is-address", errorMessage, function (value: any) {
+      if (ethers.utils.isAddress(value)) return true;
+
+      return this.createError({ message: errorMessage });
+    });
+  }
+);
 
 export const pledgeErrorTranslationsMap = {
   ["pledges.form.errors.name.required"]: t({
     id: "pledges.form.errors.name.required",
     message: "Enter a name",
+  }),
+  ["pledges.form.errors.name.isAddress"]: t({
+    id: "pledges.form.errors.name.isAddress",
+    message: "Enter a valid address",
   }),
   ["pledges.form.errors.profileImageUrl.url"]: t({
     id: "pledges.form.errors.profileImageUrl.url",
@@ -55,7 +73,11 @@ export const formSchema = yup
     id: yup.string().nullable(),
     ownerAddress: yup.string().required().trim(),
     nonce: yup.string().required().trim(),
-    name: yup.string().required("pledges.form.errors.name.required").trim(),
+    name: yup
+      .string()
+      .required("pledges.form.errors.name.required")
+      .isAddress("pledges.form.errors.name.isAddress")
+      .trim(),
     profileImageUrl: yup
       .string()
       .url("pledges.form.errors.profileImageUrl.url")

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -1,5 +1,5 @@
 import { t } from "@lingui/macro";
-import { ethers } from "ethers";
+import { utils } from "ethers";
 import * as yup from "yup";
 
 // extends yup.string schema with custom validation methods
@@ -8,7 +8,7 @@ yup.addMethod<yup.StringSchema>(
   "isAddress",
   function (errorMessage: string) {
     return this.test("is-address", errorMessage, function (value: any) {
-      if (ethers.utils.isAddress(value)) return true;
+      if (utils.isAddress(value)) return true;
 
       return this.createError({ message: errorMessage });
     });

--- a/site/components/pages/Pledge/lib/formSchema.ts
+++ b/site/components/pages/Pledge/lib/formSchema.ts
@@ -73,11 +73,7 @@ export const formSchema = yup
     id: yup.string().nullable(),
     ownerAddress: yup.string().required().trim(),
     nonce: yup.string().required().trim(),
-    name: yup
-      .string()
-      .required("pledges.form.errors.name.required")
-      .isAddress("pledges.form.errors.name.isAddress")
-      .trim(),
+    name: yup.string().required("pledges.form.errors.name.required").trim(),
     profileImageUrl: yup
       .string()
       .url("pledges.form.errors.profileImageUrl.url")

--- a/site/types/yup.d.ts
+++ b/site/types/yup.d.ts
@@ -1,0 +1,17 @@
+import * as yup from "yup";
+import { AnyObject, Maybe } from "yup/lib/types";
+
+// https://github.com/jquense/yup/issues/312#issuecomment-1104404924
+// Extend ts declarations to support custom form validaton methods
+
+declare module "yup" {
+  interface StringSchema<
+    TType extends Maybe<string> = string | undefined,
+    TContext extends AnyObject = AnyObject,
+    TOut extends TType = TType
+  > extends yup.BaseSchema<TType, TContext, TOut> {
+    isAddress(errorMessage: string): StringSchema<TType, TContext>;
+  }
+}
+
+export default yup;


### PR DESCRIPTION
## Description

Extend `yup.string` validation methods to include custom `.isAddress()` method
Throws a validation error if string is not an ethereum address

#### Usage
```ts
// Using the name attribute as an example
yup.object({
    name: yup
      .string()
      .isAddress("pledges.form.errors.name.isAddress")
 })
```
| Invalid Address  | Valid address  |
|---------|--------|
|<img width="523" alt="image" src="https://user-images.githubusercontent.com/97446324/199631231-5056fe5d-d79d-4b12-b029-e5d3609f67b9.png">|<img width="540" alt="image" src="https://user-images.githubusercontent.com/97446324/199631151-6134781b-02ce-4b6f-bc4b-9ac192611dc0.png">|

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
