### PR TITLE
Moving calcBondDetails out of initApp

### DIFF
--- a/app/components/views/ChooseBond/index.tsx
+++ b/app/components/views/ChooseBond/index.tsx
@@ -1,8 +1,8 @@
 import { cx } from "@emotion/css";
 import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
-import React from "react";
-import { RootState } from "state";
+import React, { useEffect } from "react";
+import { RootState, useAppDispatch } from "state";
 import { selectAppState, selectLocale } from "state/selectors";
 import { Bond } from "@klimadao/lib/constants";
 import { trimWithPlaceholder } from "@klimadao/lib/utils";
@@ -12,7 +12,7 @@ import { Text } from "@klimadao/lib/components";
 import * as styles from "./styles";
 import SpaOutlined from "@mui/icons-material/SpaOutlined";
 import { Image } from "components/Image";
-import { getIsInverse } from "actions/bonds";
+import { calcBondDetails, getIsInverse } from "actions/bonds";
 
 // put inverse into bonds array and add to useBond
 
@@ -32,7 +32,7 @@ export const useBond = (bond: Bond) => {
     klima_mco2_lp: true,
     ubo: true,
     nbo: true,
-    inverse_usdc: false,
+    inverse_usdc: true,
   };
 
   if (getIsInverse(bond) && Number(bondState?.capacity) < 1) {
@@ -72,7 +72,7 @@ export const useBond = (bond: Bond) => {
       klima_mco2_lp: "KLIMA/MCO2 LP",
       inverse_usdc: "KLIMA (inverse)",
       // future bond names go here
-    }[bond],
+    }[bond] as Bond,
     description: {
       ubo: t({
         id: "choose_bond.ubo.description",
@@ -153,6 +153,7 @@ export const useBond = (bond: Bond) => {
 };
 
 export function ChooseBond() {
+  const dispatch = useAppDispatch();
   const locale = useSelector(selectLocale);
   const inverse_usdc = useBond("inverse_usdc");
   const klimaBctLp = useBond("klima_bct_lp");
@@ -175,6 +176,19 @@ export function ChooseBond() {
     klimaMco2Lp,
     klimaUsdcLp,
   ];
+
+  useEffect(() => {
+    bonds.forEach((bond) => {
+      if (bond && !bond.disabled) {
+        dispatch(
+          calcBondDetails({
+            bond: bond.name,
+          })
+        );
+      }
+    });
+  }, []);
+
   return (
     <>
       <div className={styles.chooseBondCard}>

--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -7,7 +7,6 @@ import { useSelector } from "react-redux";
 import { useLocaleFromParams } from "lib/hooks/useLocaleFromParams";
 import { selectAppState } from "state/selectors";
 import { loadAppDetails } from "actions/app";
-import { calcBondDetails } from "actions/bonds";
 import { loadAccountDetails } from "actions/user";
 
 import { Stake } from "components/views/Stake";
@@ -96,13 +95,6 @@ export const Home: FC = () => {
         onRPCError: handleRPCError,
       })
     );
-    bonds.forEach((bond) => {
-      dispatch(
-        calcBondDetails({
-          bond,
-        })
-      );
-    });
   };
 
   useEffect(() => {

--- a/app/locale/de/messages.po
+++ b/app/locale/de/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:664
 msgid "Beneficiary 0x address (optional)"
@@ -275,16 +281,16 @@ msgstr "⚠️ Überprüfe diese URL und richte sie dir als Lesezeichen ein!"
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr "Toucan Base Carbon Tonne"
 
-#: components/views/ChooseBond/index.tsx:184
+#: components/views/ChooseBond/index.tsx:198
 msgid "choose_bond.bond_carbon"
 msgstr "CO2 bonden"
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:187
+#: components/views/ChooseBond/index.tsx:201
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr "Der beste Weg, KLIMA zu kaufen. Übertrage CO2-Tokens in unsere Schatzkammer und bekomme dafür vergünstigtes KLIMA. Alle Bonds (außer Inverse Bonds) haben eine obligatorische Sperrfrist von fünf Tagen."
 
-#: components/views/ChooseBond/index.tsx:211
+#: components/views/ChooseBond/index.tsx:225
 msgid "choose_bond.choose_bond"
 msgstr "Bond auswählen"
 
@@ -312,15 +318,15 @@ msgstr "KLIMA/MCO2 Quickswap-Liquidität"
 msgid "choose_bond.nbo.description"
 msgstr "C3 Nature Based Offset"
 
-#: components/views/ChooseBond/index.tsx:214
+#: components/views/ChooseBond/index.tsx:228
 msgid "choose_bond.percent_discount"
 msgstr "% Rabatt"
 
-#: components/views/ChooseBond/index.tsx:240
+#: components/views/ChooseBond/index.tsx:254
 msgid "choose_bond.sold_out"
 msgstr "AUSVERKAUFT"
 
-#: components/views/ChooseBond/index.tsx:201
+#: components/views/ChooseBond/index.tsx:215
 msgid "choose_bond.treasury_balance"
 msgstr "Schatzkammerguthaben"
 

--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:664
 msgid "Beneficiary 0x address (optional)"
@@ -273,16 +279,16 @@ msgstr ""
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:184
+#: components/views/ChooseBond/index.tsx:198
 msgid "choose_bond.bond_carbon"
 msgstr ""
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:187
+#: components/views/ChooseBond/index.tsx:201
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:211
+#: components/views/ChooseBond/index.tsx:225
 msgid "choose_bond.choose_bond"
 msgstr ""
 
@@ -310,15 +316,15 @@ msgstr ""
 msgid "choose_bond.nbo.description"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:214
+#: components/views/ChooseBond/index.tsx:228
 msgid "choose_bond.percent_discount"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:240
+#: components/views/ChooseBond/index.tsx:254
 msgid "choose_bond.sold_out"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:201
+#: components/views/ChooseBond/index.tsx:215
 msgid "choose_bond.treasury_balance"
 msgstr ""
 

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -279,16 +279,16 @@ msgstr "⚠️ Verify the URL and bookmark this page!"
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr "Toucan Base Carbon Tonne"
 
-#: components/views/ChooseBond/index.tsx:184
+#: components/views/ChooseBond/index.tsx:198
 msgid "choose_bond.bond_carbon"
 msgstr "Bond Carbon"
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:187
+#: components/views/ChooseBond/index.tsx:201
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr "The best way to buy KLIMA. Commit carbon to our treasury, and receive KLIMA at a discount. All bonds (except inverse bonds) have a mandatory 5 day vesting period."
 
-#: components/views/ChooseBond/index.tsx:211
+#: components/views/ChooseBond/index.tsx:225
 msgid "choose_bond.choose_bond"
 msgstr "Choose a bond"
 
@@ -316,15 +316,15 @@ msgstr "KLIMA/MCO2 Quickswap Liquidity"
 msgid "choose_bond.nbo.description"
 msgstr "C3 Nature Based Offset"
 
-#: components/views/ChooseBond/index.tsx:214
+#: components/views/ChooseBond/index.tsx:228
 msgid "choose_bond.percent_discount"
 msgstr "% Discount"
 
-#: components/views/ChooseBond/index.tsx:240
+#: components/views/ChooseBond/index.tsx:254
 msgid "choose_bond.sold_out"
 msgstr "SOLD OUT"
 
-#: components/views/ChooseBond/index.tsx:201
+#: components/views/ChooseBond/index.tsx:215
 msgid "choose_bond.treasury_balance"
 msgstr "Treasury Balance"
 

--- a/app/locale/es/messages.po
+++ b/app/locale/es/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: es\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:664
 msgid "Beneficiary 0x address (optional)"
@@ -273,16 +279,16 @@ msgstr "⚠️ ¡Verifica la URL y marca esta página!"
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr "Toucan Base Carbon Tonne"
 
-#: components/views/ChooseBond/index.tsx:184
+#: components/views/ChooseBond/index.tsx:198
 msgid "choose_bond.bond_carbon"
 msgstr "Vincular bono de carbono"
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:187
+#: components/views/ChooseBond/index.tsx:201
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr "La mejor manera de comprar KLIMA. Deposite carbono en nuestra tesorería y reciba KLIMA con descuento. Todos los bonos (excepto los bonos inversos) tienen un periodo de concesión obligatorio de 5 días."
 
-#: components/views/ChooseBond/index.tsx:211
+#: components/views/ChooseBond/index.tsx:225
 msgid "choose_bond.choose_bond"
 msgstr "Elige un bono"
 
@@ -310,15 +316,15 @@ msgstr "Liquidez BCT/USDC Sushiswap"
 msgid "choose_bond.nbo.description"
 msgstr "Compensación basada en la naturaleza C3"
 
-#: components/views/ChooseBond/index.tsx:214
+#: components/views/ChooseBond/index.tsx:228
 msgid "choose_bond.percent_discount"
 msgstr "% Descuento"
 
-#: components/views/ChooseBond/index.tsx:240
+#: components/views/ChooseBond/index.tsx:254
 msgid "choose_bond.sold_out"
 msgstr "AGOTADO"
 
-#: components/views/ChooseBond/index.tsx:201
+#: components/views/ChooseBond/index.tsx:215
 msgid "choose_bond.treasury_balance"
 msgstr "Saldo de la Tesorería"
 

--- a/app/locale/fr/messages.po
+++ b/app/locale/fr/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:664
 msgid "Beneficiary 0x address (optional)"
@@ -273,16 +279,16 @@ msgstr "⚠️ Vérifiez l'URL et mettez cette page en signet !"
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr "Tonne de Carbone de base Toucan"
 
-#: components/views/ChooseBond/index.tsx:184
+#: components/views/ChooseBond/index.tsx:198
 msgid "choose_bond.bond_carbon"
 msgstr "Obligation carbone"
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:187
+#: components/views/ChooseBond/index.tsx:201
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr "La meilleure façon d'acheter des KLIMA. Déposez des équivalents carbone dans notre trésorerie et recevez des KLIMA à prix réduit. Toutes les obligations (sauf celles à taux variable inversé) ont une période de maturation obligatoire de 5 jours."
 
-#: components/views/ChooseBond/index.tsx:211
+#: components/views/ChooseBond/index.tsx:225
 msgid "choose_bond.choose_bond"
 msgstr "Choisissez une obligation"
 
@@ -310,15 +316,15 @@ msgstr "Liquidité Quickswap KLIMA/MCO2"
 msgid "choose_bond.nbo.description"
 msgstr "Compensation C3 basée sur la nature"
 
-#: components/views/ChooseBond/index.tsx:214
+#: components/views/ChooseBond/index.tsx:228
 msgid "choose_bond.percent_discount"
 msgstr "% Remise"
 
-#: components/views/ChooseBond/index.tsx:240
+#: components/views/ChooseBond/index.tsx:254
 msgid "choose_bond.sold_out"
 msgstr "ÉPUISÉ"
 
-#: components/views/ChooseBond/index.tsx:201
+#: components/views/ChooseBond/index.tsx:215
 msgid "choose_bond.treasury_balance"
 msgstr "Solde de la trésorerie"
 

--- a/app/locale/hi/messages.po
+++ b/app/locale/hi/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: hi\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:664
 msgid "Beneficiary 0x address (optional)"
@@ -273,16 +279,16 @@ msgstr "️ ⚠️ URL (यूआरएल) सत्यापित करे�
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr "Toucan (टूकन) Base Carbon Tonne (बेस कार्बन टन)"
 
-#: components/views/ChooseBond/index.tsx:184
+#: components/views/ChooseBond/index.tsx:198
 msgid "choose_bond.bond_carbon"
 msgstr "कार्बन बांधें"
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:187
+#: components/views/ChooseBond/index.tsx:201
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr "KLIMA ख़रीदने का सबसे बढ़िया तरीक़ा। हमारी ट्रेज़री में कार्बन जमा करें, और छूट के साथ KLIMA प्राप्त करें। सभी बॉन्ड्स (इनवर्स बॉन्ड्स के अलावा) में 5 दिनों की अनिवार्य निहित अवधि होती है।"
 
-#: components/views/ChooseBond/index.tsx:211
+#: components/views/ChooseBond/index.tsx:225
 msgid "choose_bond.choose_bond"
 msgstr "एक बॉन्ड चुनें"
 
@@ -310,15 +316,15 @@ msgstr "KLIMA/MCO2 (एमसीओ2) Quickswap (क्विकस्वैप)
 msgid "choose_bond.nbo.description"
 msgstr "C3 प्रकृति आधारित ऑफ़सेट"
 
-#: components/views/ChooseBond/index.tsx:214
+#: components/views/ChooseBond/index.tsx:228
 msgid "choose_bond.percent_discount"
 msgstr "% छूट"
 
-#: components/views/ChooseBond/index.tsx:240
+#: components/views/ChooseBond/index.tsx:254
 msgid "choose_bond.sold_out"
 msgstr "बिक चुका है"
 
-#: components/views/ChooseBond/index.tsx:201
+#: components/views/ChooseBond/index.tsx:215
 msgid "choose_bond.treasury_balance"
 msgstr "ट्रेज़री बैलेंस"
 

--- a/app/locale/ko/messages.po
+++ b/app/locale/ko/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ko\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:664
 msgid "Beneficiary 0x address (optional)"
@@ -273,16 +279,16 @@ msgstr ""
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:184
+#: components/views/ChooseBond/index.tsx:198
 msgid "choose_bond.bond_carbon"
 msgstr ""
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:187
+#: components/views/ChooseBond/index.tsx:201
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:211
+#: components/views/ChooseBond/index.tsx:225
 msgid "choose_bond.choose_bond"
 msgstr ""
 
@@ -310,15 +316,15 @@ msgstr ""
 msgid "choose_bond.nbo.description"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:214
+#: components/views/ChooseBond/index.tsx:228
 msgid "choose_bond.percent_discount"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:240
+#: components/views/ChooseBond/index.tsx:254
 msgid "choose_bond.sold_out"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:201
+#: components/views/ChooseBond/index.tsx:215
 msgid "choose_bond.treasury_balance"
 msgstr ""
 

--- a/app/locale/ru/messages.po
+++ b/app/locale/ru/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ru\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:664
 msgid "Beneficiary 0x address (optional)"
@@ -277,16 +283,16 @@ msgstr "⚠️ Проверьте URL и добавьте эту страниц�
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr "Toucan Базовая тонна углерода"
 
-#: components/views/ChooseBond/index.tsx:184
+#: components/views/ChooseBond/index.tsx:198
 msgid "choose_bond.bond_carbon"
 msgstr "Бонд Карбон"
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:187
+#: components/views/ChooseBond/index.tsx:201
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr "Лучший способ купить KLIMA. Вложите углерод в нашу казну и получите KLIMA со скидкой. Все облигации (кроме обратных облигаций) имеют обязательный 5-дневный период наделения правами."
 
-#: components/views/ChooseBond/index.tsx:211
+#: components/views/ChooseBond/index.tsx:225
 msgid "choose_bond.choose_bond"
 msgstr "Выберите бонд"
 
@@ -314,17 +320,17 @@ msgstr "KLIMA/MCO2 Quickswap ликвидность"
 msgid "choose_bond.nbo.description"
 msgstr "СЗ Природный офсет"
 
-#: components/views/ChooseBond/index.tsx:214
+#: components/views/ChooseBond/index.tsx:228
 msgid "choose_bond.percent_discount"
 msgstr ""
 "% Дисконт\n"
 ""
 
-#: components/views/ChooseBond/index.tsx:240
+#: components/views/ChooseBond/index.tsx:254
 msgid "choose_bond.sold_out"
 msgstr "РАСПРОДАННЫЙ"
 
-#: components/views/ChooseBond/index.tsx:201
+#: components/views/ChooseBond/index.tsx:215
 msgid "choose_bond.treasury_balance"
 msgstr "Баланс казначейства"
 

--- a/app/locale/zh-CN/messages.po
+++ b/app/locale/zh-CN/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:664
 msgid "Beneficiary 0x address (optional)"
@@ -273,16 +279,16 @@ msgstr "⚠️ 验证 URL 并将此页面添加为书签！"
 msgid "choose_bond.bct.toucan_base_carbon_tonne"
 msgstr "Toucan基地碳吨"
 
-#: components/views/ChooseBond/index.tsx:184
+#: components/views/ChooseBond/index.tsx:198
 msgid "choose_bond.bond_carbon"
 msgstr "碳债券"
 
 #. Long sentence
-#: components/views/ChooseBond/index.tsx:187
+#: components/views/ChooseBond/index.tsx:201
 msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
 msgstr "购买 KLIMA 的最佳方式。将碳汇入我们的国库，并以折扣价获得 KLIMA。所有债券（反向债券除外）都有 5 天的强制性归属期。"
 
-#: components/views/ChooseBond/index.tsx:211
+#: components/views/ChooseBond/index.tsx:225
 msgid "choose_bond.choose_bond"
 msgstr "选择一款债券"
 
@@ -310,15 +316,15 @@ msgstr "KLIMA/MCO2 Quickswap 流动性"
 msgid "choose_bond.nbo.description"
 msgstr "C3 基于自然抵消"
 
-#: components/views/ChooseBond/index.tsx:214
+#: components/views/ChooseBond/index.tsx:228
 msgid "choose_bond.percent_discount"
 msgstr "％ 折扣"
 
-#: components/views/ChooseBond/index.tsx:240
+#: components/views/ChooseBond/index.tsx:254
 msgid "choose_bond.sold_out"
 msgstr "售罄"
 
-#: components/views/ChooseBond/index.tsx:201
+#: components/views/ChooseBond/index.tsx:215
 msgid "choose_bond.treasury_balance"
 msgstr "国库余额"
 

--- a/site/locale/de/messages.po
+++ b/site/locale/de/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"

--- a/site/locale/es/messages.po
+++ b/site/locale/es/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: es\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"

--- a/site/locale/fr/messages.po
+++ b/site/locale/fr/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"

--- a/site/locale/hi/messages.po
+++ b/site/locale/hi/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: hi\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"

--- a/site/locale/ko/messages.po
+++ b/site/locale/ko/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ko\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"

--- a/site/locale/ru/messages.po
+++ b/site/locale/ru/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ru\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"

--- a/site/locale/zh-CN/messages.po
+++ b/site/locale/zh-CN/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

We were calculating all bonds on `initApp` even though they're all now currently disabled. This PR moves the looping through active bonds to an on mount useEffect on ChooseBond, as well as disables `inverse_usdc`. So even though there are no active bonds at the moment, if in the future we need to add some, we just need to set the `disabled` flag to `false`.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #759

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
