### PR TITLE
Reduce _app bundle size -800kb

### DIFF
--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { utils } from "ethers";
 
 import { Thunk } from "state";
 import { setAppState } from "state/app";
@@ -60,7 +60,7 @@ export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
 
       dispatch(
         setAppState({
-          currentIndex: ethers.utils.formatUnits(currentIndex, "gwei"),
+          currentIndex: utils.formatUnits(currentIndex, "gwei"),
           currentBlock,
           fiveDayRate,
           stakingAnnualPercent,

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -1,4 +1,4 @@
-import { ethers, providers } from "ethers";
+import { providers, Contract, utils, BigNumber } from "ethers";
 import { Thunk } from "state";
 import { setBond } from "state/bonds";
 import { OnStatusHandler } from "./utils";
@@ -52,7 +52,7 @@ const getPairContract = (params: {
   token: TokensForPairContract;
   provider: providers.JsonRpcProvider;
 }) => {
-  return new ethers.Contract(
+  return new Contract(
     addresses["mainnet"][params.token],
     PairContract.abi,
     params.provider
@@ -183,9 +183,9 @@ export const calcBondDetails = (params: {
     const provider = getJsonRpcProvider();
     let amountInWei;
     if (!params.value || params.value === "") {
-      amountInWei = ethers.utils.parseEther("0");
+      amountInWei = utils.parseEther("0");
     } else {
-      amountInWei = ethers.utils.parseEther(params.value);
+      amountInWei = utils.parseEther(params.value);
     }
 
     const bondContract = contractForBond({
@@ -193,7 +193,7 @@ export const calcBondDetails = (params: {
       provider: provider,
     });
     // for SLP bonds
-    const bondCalcContract = new ethers.Contract(
+    const bondCalcContract = new Contract(
       params.bond === "klima_usdc_lp"
         ? addresses["mainnet"].bond_calc_klimaUsdc
         : addresses["mainnet"].bond_calc,
@@ -358,7 +358,7 @@ export const calculateUserBondDetails = (params: {
       getBondAddress({ bond: params.bond })
     );
     // TODO: we can just use the state.user.balance for these values and eliminate this code.
-    const balance = ethers.utils.formatUnits(
+    const balance = utils.formatUnits(
       await reserveContract.balanceOf(params.address),
       "ether"
     );
@@ -372,9 +372,9 @@ export const calculateUserBondDetails = (params: {
       setBond({
         bond: params.bond,
         balance,
-        interestDue: ethers.utils.formatUnits(interestDue, "gwei"),
+        interestDue: utils.formatUnits(interestDue, "gwei"),
         bondMaturationBlock,
-        pendingPayout: ethers.utils.formatUnits(pendingPayout, "gwei"),
+        pendingPayout: utils.formatUnits(pendingPayout, "gwei"),
       })
     );
   };
@@ -402,15 +402,15 @@ export const bondTransaction = async (params: {
         (1 / Number(formatUnits(bondPrice, 6))) *
           Number(params.value) *
           acceptedSlippage;
-      const formattedMinAmountOut = ethers.utils.parseUnits(
+      const formattedMinAmountOut = utils.parseUnits(
         Number(minAmountOut.toFixed(6)).toString(),
         "mwei"
       );
       params.onStatus("userConfirmation", "");
       const address = await signer.getAddress();
-      const formattedValue = ethers.utils.parseUnits(params.value, "gwei");
+      const formattedValue = utils.parseUnits(params.value, "gwei");
       const txn = await contract.deposit(
-        ethers.BigNumber.from(INVERSE_USDC_MARKET_ID),
+        BigNumber.from(INVERSE_USDC_MARKET_ID),
         [formattedValue, formattedMinAmountOut],
         [address, addresses.mainnet.daoMultiSig]
       );
@@ -436,7 +436,7 @@ export const bondTransaction = async (params: {
       const calculatePremium = await contract.bondPrice();
       const acceptedSlippage = params.slippage / 100 || 0.02; // 2%
       const maxPremium = Math.round(calculatePremium * (1 + acceptedSlippage));
-      const valueInWei = ethers.utils.parseUnits(params.value, "ether");
+      const valueInWei = utils.parseUnits(params.value, "ether");
       const address = await signer.getAddress();
       params.onStatus("userConfirmation", "");
       const txn = await contract.deposit(valueInWei, maxPremium, address);

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -1,4 +1,4 @@
-import { ethers, providers } from "ethers";
+import { utils, providers } from "ethers";
 import { Thunk } from "state";
 import { setCarbonRetiredBalances, updateAllowances } from "state/user";
 import { getJsonRpcProvider, getTransactionOptions } from "@klimadao/lib/utils";
@@ -103,7 +103,7 @@ export const getOffsetConsumptionCost = async (params: {
     contractName: "retirementAggregator",
     provider: getJsonRpcProvider(),
   });
-  const parsed = ethers.utils.parseUnits(
+  const parsed = utils.parseUnits(
     params.quantity,
     getTokenDecimals(params.retirementToken)
   );
@@ -175,7 +175,7 @@ export const retireCarbonTransaction = async (params: {
       txn = await retireContract.retireCarbonSpecific(
         addresses["mainnet"][params.inputToken],
         addresses["mainnet"][params.retirementToken],
-        ethers.utils.parseUnits(
+        utils.parseUnits(
           params.quantity,
           getTokenDecimals(params.retirementToken)
         ),
@@ -190,7 +190,7 @@ export const retireCarbonTransaction = async (params: {
       txn = await retireContract.retireCarbon(
         addresses["mainnet"][params.inputToken],
         addresses["mainnet"][params.retirementToken],
-        ethers.utils.parseUnits(
+        utils.parseUnits(
           params.quantity,
           getTokenDecimals(params.retirementToken)
         ),

--- a/app/actions/pklima.ts
+++ b/app/actions/pklima.ts
@@ -1,4 +1,4 @@
-import { ethers, providers } from "ethers";
+import { utils, providers } from "ethers";
 
 import { OnStatusHandler } from "./utils";
 import { Thunk } from "state";
@@ -62,7 +62,7 @@ export const exerciseTransaction = async (params: {
     });
     params.onStatus("userConfirmation", "");
     const txn = await contract.exercise(
-      ethers.utils.parseUnits(params.value, "ether")
+      utils.parseUnits(params.value, "ether")
     );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);

--- a/app/actions/stake.ts
+++ b/app/actions/stake.ts
@@ -1,4 +1,4 @@
-import { ethers, providers } from "ethers";
+import { utils, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
 import { formatUnits, getContract } from "@klimadao/lib/utils";
 
@@ -9,7 +9,7 @@ export const changeStakeTransaction = async (params: {
   action: "stake" | "unstake";
 }) => {
   try {
-    const parsedValue = ethers.utils.parseUnits(params.value, "gwei");
+    const parsedValue = utils.parseUnits(params.value, "gwei");
     const contract = {
       stake: getContract({
         contractName: "staking_helper",

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -1,4 +1,4 @@
-import { providers, ethers } from "ethers";
+import { providers, Contract } from "ethers";
 import { Thunk } from "state";
 
 import {
@@ -40,7 +40,7 @@ type TokenValueFormatted = {
 
 const getBalance = async (params: {
   token: Asset;
-  contract: ethers.Contract;
+  contract: Contract;
   address: string;
 }): Promise<string> => {
   try {
@@ -54,7 +54,7 @@ const getBalance = async (params: {
 };
 
 type ContractsObject = {
-  [key in Asset]: ethers.Contract;
+  [key in Asset]: Contract;
 };
 
 export const loadAccountDetails = (params: {

--- a/app/actions/utils.ts
+++ b/app/actions/utils.ts
@@ -1,6 +1,6 @@
 import { AppNotificationStatus, TxnStatus } from "state/app";
 import { t } from "@lingui/macro";
-import { ethers, providers } from "ethers";
+import { utils, providers } from "ethers";
 import {
   formatUnits,
   getTokenDecimals,
@@ -57,7 +57,7 @@ export const changeApprovalTransaction = async (params: {
       provider: params.provider.getSigner(),
     });
     const decimals = getTokenDecimals(params.token);
-    const parsedValue = ethers.utils.parseUnits(params.value, decimals);
+    const parsedValue = utils.parseUnits(params.value, decimals);
     params.onStatus("userConfirmation", "");
     const txn = await contract.approve(
       addresses["mainnet"][params.spender],

--- a/app/actions/wrap.ts
+++ b/app/actions/wrap.ts
@@ -1,4 +1,4 @@
-import { ethers, providers } from "ethers";
+import { utils, providers } from "ethers";
 import { OnStatusHandler } from "./utils";
 import { getContract, getTokenDecimals } from "@klimadao/lib/utils";
 
@@ -17,7 +17,7 @@ export const wrapTransaction = async (params: {
     params.onStatus("userConfirmation", "");
     const decimal = getTokenDecimals(params.token);
     const txn = await contract[params.action](
-      ethers.utils.parseUnits(params.value, decimal)
+      utils.parseUnits(params.value, decimal)
     );
     params.onStatus("networkConfirmation", "");
     await txn.wait(1);

--- a/app/components/views/Wrap/index.tsx
+++ b/app/components/views/Wrap/index.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from "react";
 import { useSelector } from "react-redux";
-import { ethers } from "ethers";
+import { providers } from "ethers";
 import InfoOutlined from "@mui/icons-material/InfoOutlined";
 import FlipOutlined from "@mui/icons-material/FlipOutlined";
 
@@ -38,7 +38,7 @@ import * as styles from "components/views/Stake/styles";
 import { Trans, defineMessage } from "@lingui/macro";
 
 interface Props {
-  provider?: ethers.providers.Web3Provider;
+  provider?: providers.Web3Provider;
   address?: string;
   isConnected?: boolean;
   loadWeb3Modal: () => Promise<void>;

--- a/app/lib/hooks/useENS.ts
+++ b/app/lib/hooks/useENS.ts
@@ -1,4 +1,4 @@
-import { getDefaultProvider } from "@ethersproject/providers";
+import { getDefaultProvider } from "ethers";
 import { useEffect, useState } from "react";
 
 const useENS = (address: string | null | undefined) => {

--- a/lib/package.json
+++ b/lib/package.json
@@ -7,7 +7,7 @@
     "@coinbase/wallet-sdk": "^3.5.2",
     "@emotion/css": "^11.5.0",
     "@tippyjs/react": "^4.2.6",
-    "@toruslabs/torus-embed": "^1.35.6",
+    "@toruslabs/torus-embed": "^1.37.0",
     "@walletconnect/web3-provider": "^1.8.0",
     "ethers": "^5.7.0",
     "make-plural": "^7.1.0",

--- a/lib/utils/createLazyWeb3Modal/index.ts
+++ b/lib/utils/createLazyWeb3Modal/index.ts
@@ -1,0 +1,71 @@
+import Web3Modal from "web3modal";
+import WalletConnectProvider from "@walletconnect/web3-provider";
+import CoinbaseWalletSDK from "@coinbase/wallet-sdk";
+import Torus from "@toruslabs/torus-embed";
+import { urls } from "../../constants";
+import { Web3ModalStrings } from "../../components/Web3Context/types";
+
+/** NOTE: only invoke client-side */
+const createLazyWeb3Modal = async (
+  strings: Web3ModalStrings
+): Promise<Web3Modal> => {
+  // BUG: @klimadao/lib transpilation does not properly re-export the Web3Modal or coinbase libraries, probably because we don't use babel in here.
+  // Babel automatically adds a default export for interoperability reasons, which is why this isn't a problem in /site and /app (nextjs uses babel)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const untypedWeb3Modal = Web3Modal as any;
+  const untypedCoinbase = CoinbaseWalletSDK as any;
+  const TypedWeb3Modal = untypedWeb3Modal.default as typeof Web3Modal;
+  const TypedCoinbaseWallet =
+    untypedCoinbase.default as typeof CoinbaseWalletSDK;
+  return new TypedWeb3Modal({
+    cacheProvider: true,
+    providerOptions: {
+      walletconnect: {
+        package: WalletConnectProvider, // required
+        options: {
+          rpc: { 137: urls.polygonMainnetRpc },
+        },
+        display: {
+          description: strings.walletconnect_desc,
+        },
+      },
+      coinbasewallet: {
+        package: TypedCoinbaseWallet, // Required
+        options: {
+          appName: "KlimaDAO App", // Required
+          rpc: urls.polygonMainnetRpc, // Optional if `infuraId` is provided; otherwise it's required
+          chainId: 137, // Optional. It defaults to 1 if not provided
+          darkMode: false, // Optional. Use dark theme, defaults to false
+        },
+      },
+      injected: {
+        display: {
+          description: strings.injected_desc,
+        },
+        package: null,
+      },
+      torus: {
+        package: Torus,
+        options: {
+          networkParams: {
+            host: "matic", // optional
+            chainId: 137,
+            networkName: "Polygon",
+          },
+          config: {
+            buildEnv: "production",
+            showTorusButton: false,
+          },
+        },
+        display: {
+          name: strings.torus_name,
+          description: strings.torus_desc,
+          // Taken from https://mui.com/material-ui/material-icons/?query=email&selected=MailOutline
+          logo: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiBox-root css-10cscxr' focusable='false' aria-hidden='true' viewBox='0 0 24 24' data-testid='MailOutlineIcon'%3E%3Cpath stroke-width='.1' stroke='%23999999' fill='%23999999' d='M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z'%3E%3C/path%3E%3C/svg%3E",
+        },
+      },
+    },
+  });
+};
+
+export default createLazyWeb3Modal;

--- a/lib/utils/formatUnits/index.ts
+++ b/lib/utils/formatUnits/index.ts
@@ -1,6 +1,6 @@
-import { ethers, BigNumber } from "ethers";
+import { utils, BigNumber } from "ethers";
 
 /** Klima and sklima are 9 decimals, USDC 6, all others 18 */
 export const formatUnits = (value: BigNumber, decimals: 6 | 9 | 18 = 18) => {
-  return ethers.utils.formatUnits(value, decimals);
+  return utils.formatUnits(value, decimals);
 };

--- a/lib/utils/getAllowance/index.ts
+++ b/lib/utils/getAllowance/index.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers } from "ethers";
+import { BigNumber, Contract } from "ethers";
 import { addresses, allowancesContracts } from "../../constants";
 import { getTokenDecimals, formatUnits } from "../";
 import {
@@ -15,7 +15,7 @@ export const isSpenderInAddresses = (spender: string): boolean => {
 };
 
 export const getAllowance = async (params: {
-  contract: ethers.Contract;
+  contract: Contract;
   address: string;
   spender: AllowancesSpender;
   token: AllowancesToken;

--- a/lib/utils/getContract/index.ts
+++ b/lib/utils/getContract/index.ts
@@ -1,4 +1,4 @@
-import { ethers, providers, Signer } from "ethers";
+import { Contract, providers, Signer } from "ethers";
 
 import { addresses } from "../../constants";
 import IERC20 from "../../abi/IERC20.json";
@@ -82,7 +82,7 @@ const getContractAbiByName = (name: ContractName) => {
 export const getContract = (params: {
   contractName: ContractName;
   provider: providers.JsonRpcProvider | Signer;
-}): ethers.Contract => {
+}): Contract => {
   const abi = getContractAbiByName(params.contractName);
   if (!abi)
     throw new Error(`Unknown abi for contractName: ${params.contractName}`);
@@ -92,7 +92,7 @@ export const getContract = (params: {
     throw new Error(`Unknown contract name in mainnet: ${nameInAddresses}`);
   }
 
-  return new ethers.Contract(
+  return new Contract(
     addresses["mainnet"][nameInAddresses],
     abi,
     params.provider

--- a/lib/utils/getInteger/index.ts
+++ b/lib/utils/getInteger/index.ts
@@ -1,7 +1,7 @@
-import { ethers, BigNumber } from "ethers";
+import { utils, BigNumber } from "ethers";
 
 // Converts BigNumber to an integer (number) at the given unit
 export const getInteger = (num: BigNumber, unit: string | number = "ether") => {
-  const str = ethers.utils.formatUnits(num, unit);
+  const str = utils.formatUnits(num, unit);
   return Math.floor(Number(str));
 };

--- a/lib/utils/getIsValidAddress/index.ts
+++ b/lib/utils/getIsValidAddress/index.ts
@@ -1,10 +1,8 @@
-import { ethers } from "ethers";
+import { utils } from "ethers";
 
 // contract methods return this address on not found
 const EMPTY_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export const getIsValidAddress = (address: string) => {
-  return (
-    !!address && address !== EMPTY_ADDRESS && ethers.utils.isAddress(address)
-  );
+  return !!address && address !== EMPTY_ADDRESS && utils.isAddress(address);
 };

--- a/lib/utils/getTransactionOptions/index.ts
+++ b/lib/utils/getTransactionOptions/index.ts
@@ -1,8 +1,8 @@
-import { ethers } from "ethers";
+import { utils } from "ethers";
 import { urls } from "../../constants";
 
 const convertGasInfoFromPolyscan = (value: string) =>
-  ethers.utils.parseUnits((parseFloat(value) * 1.1).toFixed(2).toString(), 9);
+  utils.parseUnits((parseFloat(value) * 1.1).toFixed(2).toString(), 9);
 
 /** Returns gas info from polygonscan plus 10 percent*/
 const getGasInfo = async () => {
@@ -19,7 +19,7 @@ const getGasInfo = async () => {
     console.error(error);
   }
   console.error("Error contacting Polyscan API for Gas estimation");
-  const fallbackFee = ethers.utils.parseUnits("60", 9); // 60 gwei
+  const fallbackFee = utils.parseUnits("60", 9); // 60 gwei
   return { maxFeePerGas: fallbackFee, maxPriorityFeePerGas: fallbackFee };
 };
 

--- a/lib/utils/getWeb3Modal/index.ts
+++ b/lib/utils/getWeb3Modal/index.ts
@@ -1,23 +1,21 @@
-import Web3Modal from "web3modal";
+import web3Modal from "web3modal";
 import WalletConnectProvider from "@walletconnect/web3-provider";
-import CoinbaseWalletSDK from "@coinbase/wallet-sdk";
+import coinbaseWalletSDK from "@coinbase/wallet-sdk";
 import Torus from "@toruslabs/torus-embed";
 import { urls } from "../../constants";
 import { Web3ModalStrings } from "../../components/Web3Context/types";
 
+// BUG: @klimadao/lib transpilation does not properly re-export the Web3Modal or coinbase libraries, probably because we don't use babel in here.
+// Babel automatically adds a default export for interoperability reasons, which is why this isn't a problem in /site and /app (nextjs uses babel)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Web3Modal: typeof web3Modal = (web3Modal as any).default;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const CoinbaseWallet: typeof coinbaseWalletSDK = (coinbaseWalletSDK as any)
+  .default;
+
 /** NOTE: only invoke client-side */
-const createLazyWeb3Modal = async (
-  strings: Web3ModalStrings
-): Promise<Web3Modal> => {
-  // BUG: @klimadao/lib transpilation does not properly re-export the Web3Modal or coinbase libraries, probably because we don't use babel in here.
-  // Babel automatically adds a default export for interoperability reasons, which is why this isn't a problem in /site and /app (nextjs uses babel)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const untypedWeb3Modal = Web3Modal as any;
-  const untypedCoinbase = CoinbaseWalletSDK as any;
-  const TypedWeb3Modal = untypedWeb3Modal.default as typeof Web3Modal;
-  const TypedCoinbaseWallet =
-    untypedCoinbase.default as typeof CoinbaseWalletSDK;
-  return new TypedWeb3Modal({
+export const getWeb3Modal = (strings: Web3ModalStrings) =>
+  new Web3Modal({
     cacheProvider: true,
     providerOptions: {
       walletconnect: {
@@ -30,7 +28,7 @@ const createLazyWeb3Modal = async (
         },
       },
       coinbasewallet: {
-        package: TypedCoinbaseWallet, // Required
+        package: CoinbaseWallet, // Required
         options: {
           appName: "KlimaDAO App", // Required
           rpc: urls.polygonMainnetRpc, // Optional if `infuraId` is provided; otherwise it's required
@@ -66,6 +64,3 @@ const createLazyWeb3Modal = async (
       },
     },
   });
-};
-
-export default createLazyWeb3Modal;

--- a/lib/utils/useWeb3Modal/index.tsx
+++ b/lib/utils/useWeb3Modal/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { ethers } from "ethers";
+import { providers } from "ethers";
 import Web3Modal from "web3modal";
 import WalletConnectProvider from "@walletconnect/web3-provider";
 import CoinbaseWalletSDK from "@coinbase/wallet-sdk";
@@ -122,7 +122,7 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
   const connect = async () => {
     if (!web3Modal) return;
     const wrappedProvider = await web3Modal.connect();
-    const provider = new ethers.providers.Web3Provider(
+    const provider = new providers.Web3Provider(
       wrappedProvider
     ) as unknown as TypedProvider; // assert for better typings, see event handlers below
     const signer = provider.getSigner();

--- a/lib/utils/useWeb3Modal/index.tsx
+++ b/lib/utils/useWeb3Modal/index.tsx
@@ -30,9 +30,7 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
   };
 
   const downloadModal = async () => {
-    const createLazyWeb3Modal = (await import("../createLazyWeb3Modal"))
-      .default;
-    const newModal = await createLazyWeb3Modal(strings);
+    const newModal = (await import("../getWeb3Modal")).getWeb3Modal(strings);
     setPrevStrings(strings);
     return newModal;
   };

--- a/lib/utils/useWeb3Modal/index.tsx
+++ b/lib/utils/useWeb3Modal/index.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useRef, useState } from "react";
+import type Web3Modal from "web3modal";
 import { providers } from "ethers";
-import Web3Modal from "web3modal";
-import WalletConnectProvider from "@walletconnect/web3-provider";
-import CoinbaseWalletSDK from "@coinbase/wallet-sdk";
-import Torus from "@toruslabs/torus-embed";
-
-import { urls } from "../../constants";
 import {
   web3InitialState,
   ConnectedWeb3State,
@@ -15,100 +10,15 @@ import {
   TypedProvider,
 } from "../../components/Web3Context/types";
 
-/** NOTE: only invoke client-side */
-const createWeb3Modal = (strings: Web3ModalStrings): Web3Modal => {
-  // BUG: @klimadao/lib transpilation does not properly re-export the Web3Modal or coinbase libraries, probably because we don't use babel in here.
-  // Babel automatically adds a default export for interoperability reasons, which is why this isn't a problem in /site and /app (nextjs uses babel)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const untypedWeb3Modal = Web3Modal as any;
-  const untypedCoinbase = CoinbaseWalletSDK as any;
-  const TypedWeb3Modal = untypedWeb3Modal.default as typeof Web3Modal;
-  const TypedCoinbaseWallet =
-    untypedCoinbase.default as typeof CoinbaseWalletSDK;
-  return new TypedWeb3Modal({
-    cacheProvider: true,
-    providerOptions: {
-      walletconnect: {
-        package: WalletConnectProvider, // required
-        options: {
-          rpc: { 137: urls.polygonMainnetRpc },
-        },
-        display: {
-          description: strings.walletconnect_desc,
-        },
-      },
-      coinbasewallet: {
-        package: TypedCoinbaseWallet, // Required
-        options: {
-          appName: "KlimaDAO App", // Required
-          rpc: urls.polygonMainnetRpc, // Optional if `infuraId` is provided; otherwise it's required
-          chainId: 137, // Optional. It defaults to 1 if not provided
-          darkMode: false, // Optional. Use dark theme, defaults to false
-        },
-      },
-      injected: {
-        display: {
-          description: strings.injected_desc,
-        },
-        package: null,
-      },
-      torus: {
-        package: Torus,
-        options: {
-          networkParams: {
-            host: "matic", // optional
-            chainId: 137,
-            networkName: "Polygon",
-          },
-          config: {
-            buildEnv: "production",
-            showTorusButton: false,
-          },
-        },
-        display: {
-          name: strings.torus_name,
-          description: strings.torus_desc,
-          // Taken from https://mui.com/material-ui/material-icons/?query=email&selected=MailOutline
-          logo: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiBox-root css-10cscxr' focusable='false' aria-hidden='true' viewBox='0 0 24 24' data-testid='MailOutlineIcon'%3E%3Cpath stroke-width='.1' stroke='%23999999' fill='%23999999' d='M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z'%3E%3C/path%3E%3C/svg%3E",
-        },
-      },
-    },
-  });
-};
-
-/**
- * Compare strings to see if locale changed, then instantiate a new modal if needed.
- */
-const useLocalizedModal = (
-  strings: Web3ModalStrings
-): Web3Modal | undefined => {
-  const modalRef = useRef<Web3Modal>();
-  const [prevStrings, setPrevStrings] = useState<Web3ModalStrings>(strings);
-
-  useEffect(() => {
-    if (strings.torus_name !== prevStrings.torus_name) {
-      modalRef.current = createWeb3Modal(strings);
-      setPrevStrings(strings);
-    }
-  }, [strings]);
-
-  if (typeof window === "undefined") {
-    return;
-  }
-  if (!modalRef.current) {
-    modalRef.current = createWeb3Modal(strings);
-  }
-  return modalRef.current;
-};
-
 /** React Hook to create and manage the web3Modal lifecycle */
 export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
   const [web3state, setWeb3State] = useState<Web3State>(web3InitialState);
-  const web3Modal = useLocalizedModal(strings);
+  const modalRef = useRef<Web3Modal>();
+  const [prevStrings, setPrevStrings] = useState<Web3ModalStrings>(strings);
 
   const disconnect = async () => {
-    if (web3Modal?.cachedProvider) {
-      web3Modal.clearCachedProvider();
+    if (modalRef.current?.cachedProvider) {
+      modalRef.current.clearCachedProvider();
     }
     // setWeb3State(web3InitialState);
     if (web3state && (web3state.provider?.provider as any)?.isTorus === true) {
@@ -119,9 +29,19 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
     }
   };
 
+  const downloadModal = async () => {
+    const createLazyWeb3Modal = (await import("../createLazyWeb3Modal"))
+      .default;
+    const newModal = await createLazyWeb3Modal(strings);
+    setPrevStrings(strings);
+    return newModal;
+  };
+
   const connect = async () => {
-    if (!web3Modal) return;
-    const wrappedProvider = await web3Modal.connect();
+    if (!modalRef.current || strings.torus_name !== prevStrings.torus_name) {
+      modalRef.current = await downloadModal();
+    }
+    const wrappedProvider = await modalRef.current.connect();
     const provider = new providers.Web3Provider(
       wrappedProvider
     ) as unknown as TypedProvider; // assert for better typings, see event handlers below
@@ -138,11 +58,17 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
     setWeb3State(newState);
   };
 
-  // Auto connect to the cached provider
+  // Auto download dependencies and connect to the cached provider
   useEffect(() => {
-    if (web3Modal && web3Modal.cachedProvider) {
-      connect();
-    }
+    const init = async () => {
+      if (!modalRef.current) {
+        modalRef.current = await downloadModal();
+      }
+      if (modalRef.current.cachedProvider) {
+        connect();
+      }
+    };
+    init();
   }, []);
 
   // EIP-1193 events
@@ -150,7 +76,7 @@ export const useWeb3Modal = (strings: Web3ModalStrings): Web3ModalState => {
     if (!web3state.provider) return;
     const handleDisconnect = () => {
       // when force-disconnecting via metamask ui, prevent an infinite reconnect loop
-      web3Modal?.clearCachedProvider();
+      modalRef.current?.clearCachedProvider();
       window.location.reload();
     };
     const handleAccountsChanged = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@coinbase/wallet-sdk": "^3.5.2",
         "@emotion/css": "^11.5.0",
         "@tippyjs/react": "^4.2.6",
-        "@toruslabs/torus-embed": "^1.35.6",
+        "@toruslabs/torus-embed": "^1.37.0",
         "@walletconnect/web3-provider": "^1.8.0",
         "ethers": "^5.7.0",
         "make-plural": "^7.1.0",
@@ -5577,57 +5577,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@toruslabs/eccrypto": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@toruslabs/eccrypto/-/eccrypto-1.1.8.tgz",
-      "integrity": "sha512-5dIrO2KVqvnAPOPfJ2m6bnjp9vav9GIcCZXiXRW/bJuIDRLVxJhVvRlleF4oaEZPq5yX5piHq5jVHagNNS0jOQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "acorn": "^8.4.1",
-        "elliptic": "^6.5.4",
-        "es6-promise": "^4.2.8",
-        "nan": "^2.14.2"
-      },
-      "optionalDependencies": {
-        "secp256k1": "^3.8.0"
-      }
-    },
-    "node_modules/@toruslabs/eccrypto/node_modules/secp256k1": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.5.2",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@toruslabs/fetch-node-details": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@toruslabs/fetch-node-details/-/fetch-node-details-7.0.2.tgz",
-      "integrity": "sha512-k4Ep4Gh56CCVWuHwO3zjh4Mq2cp/6JGV7tWafi3DIers2TIAI9Vdz8syTxi+jMVvSj2a9csJZF737ynqtZCkzw==",
-      "dependencies": {
-        "web3-eth-contract": "^1.7.4",
-        "web3-utils": "^1.7.4"
-      },
-      "engines": {
-        "node": ">=14.17.0",
-        "npm": ">=6.x"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "7.x"
-      }
-    },
     "node_modules/@toruslabs/http-helpers": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-3.2.0.tgz",
@@ -5690,15 +5639,13 @@
       }
     },
     "node_modules/@toruslabs/torus-embed": {
-      "version": "1.35.6",
-      "resolved": "https://registry.npmjs.org/@toruslabs/torus-embed/-/torus-embed-1.35.6.tgz",
-      "integrity": "sha512-Oeqht3vl9Q2YerKHihRq36FpNOe3ui/eZGDsRgvUhwESj1eElVVUYeS+meYP8aJxgfr02bi1pJh1urIt/YcFWg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/torus-embed/-/torus-embed-1.37.0.tgz",
+      "integrity": "sha512-XtyKqWHl54SpcqAkRf05gmOkEr1vUf5Vh62chm7g+aZXgi1EMryRQl9iJGHChDmRu3rB/DSKgtIt5nL7Xv/jxQ==",
       "dependencies": {
         "@metamask/obs-store": "^7.0.0",
-        "@toruslabs/fetch-node-details": "^7.0.2",
-        "@toruslabs/http-helpers": "^3.1.0",
-        "@toruslabs/openlogin-jrpc": "^2.5.0",
-        "@toruslabs/torus.js": "^6.1.0",
+        "@toruslabs/http-helpers": "^3.2.0",
+        "@toruslabs/openlogin-jrpc": "^2.6.0",
         "create-hash": "^1.2.0",
         "end-of-stream": "^1.4.4",
         "eth-rpc-errors": "^4.0.3",
@@ -5724,33 +5671,6 @@
       "dependencies": {
         "fast-safe-stringify": "^2.0.6"
       }
-    },
-    "node_modules/@toruslabs/torus.js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/torus.js/-/torus.js-6.1.0.tgz",
-      "integrity": "sha512-HI6zShOcG44pV382dHyhvdNawUxHtdP/HD9IE3ofasIrL308n/Wa/VuTS/VlaoYuQoBtPQZ1HYrKxlyIy2vXLA==",
-      "dependencies": {
-        "@toruslabs/eccrypto": "^1.1.8",
-        "@toruslabs/http-helpers": "^3.0.0",
-        "bn.js": "^5.2.1",
-        "elliptic": "^6.5.4",
-        "json-stable-stringify": "^1.0.1",
-        "keccak": "^3.0.2",
-        "loglevel": "^1.8.0",
-        "web3-utils": "^1.7.4"
-      },
-      "engines": {
-        "node": ">=14.17.0",
-        "npm": ">=6.x"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "7.x"
-      }
-    },
-    "node_modules/@toruslabs/torus.js/node_modules/bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/@translation/lingui": {
       "version": "1.0.0",
@@ -6564,11 +6484,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/abortcontroller-polyfill": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
-      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
-    },
     "node_modules/absolute-path": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
@@ -6597,6 +6512,7 @@
     },
     "node_modules/acorn": {
       "version": "8.7.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -7285,6 +7201,7 @@
     "node_modules/bignumber.js": {
       "version": "9.0.2",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -7307,15 +7224,6 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/bl": {
@@ -7507,6 +7415,7 @@
       "version": "4.0.6",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -8253,15 +8162,6 @@
       "version": "3.0.10",
       "license": "MIT"
     },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "node_modules/d3-array": {
       "version": "2.12.1",
       "license": "BSD-3-Clause",
@@ -8582,20 +8482,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "optional": true,
-      "dependencies": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "dev": true,
@@ -8851,30 +8737,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -8886,15 +8748,6 @@
       "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
       "dependencies": {
         "es6-promise": "^4.0.3"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
       }
     },
     "node_modules/escalade": {
@@ -9583,14 +9436,6 @@
         "ethereumjs-util": "^5.1.1"
       }
     },
-    "node_modules/ethereum-bloom-filters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
-      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
-      "dependencies": {
-        "js-sha3": "^0.8.0"
-      }
-    },
     "node_modules/ethereum-common": {
       "version": "0.2.0",
       "license": "MIT"
@@ -9808,24 +9653,6 @@
         "@ethersproject/web": "5.7.0",
         "@ethersproject/wordlists": "5.7.0"
       }
-    },
-    "node_modules/ethjs-unit": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "number-to-bn": "1.7.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-unit/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
     },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
@@ -10108,19 +9935,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "peer": true
-    },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "dependencies": {
-        "type": "^2.7.2"
-      }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -11295,11 +11109,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/http-https": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-      "integrity": "sha512-o0PWwVCSp3O0wS6FvNr6xfBCHgt0m1tvPLFOCc2iFDKTRAXhB7m8klDf7ErowFH8POa6dVdGatKU5I1YYwzUyg=="
     },
     "node_modules/http-parser-js": {
       "version": "0.5.6",
@@ -13339,9 +13148,9 @@
       }
     },
     "node_modules/loglevel": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -14733,11 +14542,6 @@
       "version": "0.0.8",
       "license": "ISC"
     },
-    "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
-    },
     "node_modules/nano-pubsub": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-1.0.2.tgz",
@@ -14845,11 +14649,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.5",
@@ -15011,24 +14810,6 @@
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
       "peer": true
-    },
-    "node_modules/number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/number-to-bn/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
@@ -15252,14 +15033,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/oboe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
-      "integrity": "sha512-zRFWiF+FoicxEs3jNI/WYUrVEgA7DeET/InK0XQuudGHRg8iIob3cNPrJTKaz4004uaA9Pbe+Dwa8iluhjLZWA==",
-      "dependencies": {
-        "http-https": "^1.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -18479,11 +18252,6 @@
       "version": "0.14.5",
       "license": "Unlicense"
     },
-    "node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -18793,17 +18561,13 @@
       "version": "5.0.9",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
       "engines": {
         "node": ">=6.14.2"
       }
-    },
-    "node_modules/utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "node_modules/util": {
       "version": "0.12.4",
@@ -18914,166 +18678,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web3-core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.5.tgz",
-      "integrity": "sha512-UgOWXZr1fR/3cUQJKWbfMwRxj1/N7o6RSd/dHqdXBlOD+62EjNZItFmLRg5veq5kp9YfXzrNw9bnDkXfsL+nKQ==",
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "@types/node": "^12.12.6",
-        "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-core-requestmanager": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-core-helpers": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.5.tgz",
-      "integrity": "sha512-lDDjTks6Q6aNUO87RYrY2xub3UWTKr/RIWxpHJODEqkLxZS1dWdyliJ6aIx3031VQwsNT5HE7NvABe/t0p3iDQ==",
-      "dependencies": {
-        "web3-eth-iban": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-core-method": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.5.tgz",
-      "integrity": "sha512-ApTvq1Llzlbxmy0n4L7QaE6NodIsR80VJqk8qN4kLg30SGznt/pNJFebryLI2kpyDmxSgj1TjEWzmHJBp6FhYg==",
-      "dependencies": {
-        "@ethersproject/transactions": "^5.6.2",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-promievent": "1.7.5",
-        "web3-core-subscriptions": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-core-promievent": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.5.tgz",
-      "integrity": "sha512-uZ1VRErVuhiLtHlyt3oEH/JSvAf6bWPndChHR9PG7i1Zfqm6ZVCeM91ICTPmiL8ddsGQOxASpnJk4vhApcTIww==",
-      "dependencies": {
-        "eventemitter3": "4.0.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-core-promievent/node_modules/eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-    },
-    "node_modules/web3-core-requestmanager": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.5.tgz",
-      "integrity": "sha512-3KpfxW/wVH4mgwWEsSJGHKrtRVoijWlDxtUrm17xgtqRNZ2mFolifKnHAUKa0fY48C9CrxmcCiMIi3W4G6WYRw==",
-      "dependencies": {
-        "util": "^0.12.0",
-        "web3-core-helpers": "1.7.5",
-        "web3-providers-http": "1.7.5",
-        "web3-providers-ipc": "1.7.5",
-        "web3-providers-ws": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-core-subscriptions": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.5.tgz",
-      "integrity": "sha512-YK6utQ7Wwjbe4XZOIA8quWGBPi1lFDS1A+jQYwxKKrCvm6BloBNc3FhvrcSYlDhLe/kOy8+2Je8i9amndgT4ww==",
-      "dependencies": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-core-subscriptions/node_modules/eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-    },
-    "node_modules/web3-core/node_modules/@types/bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/web3-core/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-    },
-    "node_modules/web3-eth-abi": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.5.tgz",
-      "integrity": "sha512-qWHvF7sayxql9BD1yqK9sZRLBQ66eJzGeaU53Y1PRq2iFPrhY6NUWxQ3c3ps0rg+dyObvRbloviWpKXcS4RE/A==",
-      "dependencies": {
-        "@ethersproject/abi": "^5.6.3",
-        "web3-utils": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-eth-contract": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.5.tgz",
-      "integrity": "sha512-qab7NPJRKRlTs58ozsqK8YIEwWpxIm3vD/okSIKBGkFx5gIHWW+vGmMh5PDSfefLJM9rCd+T+Lc0LYvtME7uqg==",
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "web3-core": "1.7.5",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-core-promievent": "1.7.5",
-        "web3-core-subscriptions": "1.7.5",
-        "web3-eth-abi": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-eth-contract/node_modules/@types/bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/web3-eth-iban": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.5.tgz",
-      "integrity": "sha512-mn2W5t/1IpL8OZvzAabLKT4kvwRnZSJ9K0tctndl9sDNWkfITYQibEEhUaNNA50Q5fJKgVudHI/m0gwIVTyG8Q==",
-      "dependencies": {
-        "bn.js": "^5.2.1",
-        "web3-utils": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-eth-iban/node_modules/bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-    },
     "node_modules/web3-provider-engine": {
       "version": "16.0.1",
       "license": "MIT",
@@ -19145,103 +18749,6 @@
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
-      }
-    },
-    "node_modules/web3-providers-http": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.5.tgz",
-      "integrity": "sha512-vPgr4Kzy0M3CHtoP/Bh7qwK/D9h2fhjpoqctdMWVJseOfeTgfOphCKN0uwV8w2VpZgDPXA8aeTdBx5OjmDdStA==",
-      "dependencies": {
-        "abortcontroller-polyfill": "^1.7.3",
-        "cross-fetch": "^3.1.4",
-        "es6-promise": "^4.2.8",
-        "web3-core-helpers": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-providers-http/node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dependencies": {
-        "node-fetch": "2.6.7"
-      }
-    },
-    "node_modules/web3-providers-ipc": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.5.tgz",
-      "integrity": "sha512-aNHx+RAROzO+apDEzy8Zncj78iqWBadIXtpmFDg7uiTn8i+oO+IcP1Yni7jyzkltsysVJHgHWG4kPx50ANCK3Q==",
-      "dependencies": {
-        "oboe": "2.1.5",
-        "web3-core-helpers": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-providers-ws": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.5.tgz",
-      "integrity": "sha512-9uJNVVkIGC8PmM9kNbgPth56HDMSSsxZh3ZEENdwO3LNWemaADiQYUDCsD/dMVkn0xsGLHP5dgAy4Q5msqySLg==",
-      "dependencies": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.7.5",
-        "websocket": "^1.0.32"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-providers-ws/node_modules/eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-    },
-    "node_modules/web3-utils": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.5.tgz",
-      "integrity": "sha512-9AqNOziQky4wNQadEwEfHiBdOZqopIHzQQVzmvvv6fJwDSMhP+khqmAZC7YTiGjs0MboyZ8tWNivqSO1699XQw==",
-      "dependencies": {
-        "bn.js": "^5.2.1",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-utils/node_modules/@types/bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/web3-utils/node_modules/bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-    },
-    "node_modules/web3-utils/node_modules/ethereumjs-util": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/web3modal": {
@@ -19476,22 +18983,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/websocket": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
-      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-      "dependencies": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "license": "Apache-2.0",
@@ -19510,19 +19001,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/websocket/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/websocket/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/whatwg-fetch": {
       "version": "2.0.4",
@@ -19720,14 +19198,6 @@
       "optional": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
-      "engines": {
-        "node": ">=0.10.32"
       }
     },
     "node_modules/yallist": {
@@ -22190,7 +21660,7 @@
         "@coinbase/wallet-sdk": "^3.5.2",
         "@emotion/css": "^11.5.0",
         "@tippyjs/react": "^4.2.6",
-        "@toruslabs/torus-embed": "^1.35.6",
+        "@toruslabs/torus-embed": "1.37.0",
         "@types/node": "^16.11.6",
         "@types/react": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^5.7.0",
@@ -23699,45 +23169,6 @@
       "version": "2.0.0",
       "optional": true
     },
-    "@toruslabs/eccrypto": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@toruslabs/eccrypto/-/eccrypto-1.1.8.tgz",
-      "integrity": "sha512-5dIrO2KVqvnAPOPfJ2m6bnjp9vav9GIcCZXiXRW/bJuIDRLVxJhVvRlleF4oaEZPq5yX5piHq5jVHagNNS0jOQ==",
-      "requires": {
-        "acorn": "^8.4.1",
-        "elliptic": "^6.5.4",
-        "es6-promise": "^4.2.8",
-        "nan": "^2.14.2",
-        "secp256k1": "^3.8.0"
-      },
-      "dependencies": {
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
-        }
-      }
-    },
-    "@toruslabs/fetch-node-details": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@toruslabs/fetch-node-details/-/fetch-node-details-7.0.2.tgz",
-      "integrity": "sha512-k4Ep4Gh56CCVWuHwO3zjh4Mq2cp/6JGV7tWafi3DIers2TIAI9Vdz8syTxi+jMVvSj2a9csJZF737ynqtZCkzw==",
-      "requires": {
-        "web3-eth-contract": "^1.7.4",
-        "web3-utils": "^1.7.4"
-      }
-    },
     "@toruslabs/http-helpers": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-3.2.0.tgz",
@@ -23783,15 +23214,13 @@
       }
     },
     "@toruslabs/torus-embed": {
-      "version": "1.35.6",
-      "resolved": "https://registry.npmjs.org/@toruslabs/torus-embed/-/torus-embed-1.35.6.tgz",
-      "integrity": "sha512-Oeqht3vl9Q2YerKHihRq36FpNOe3ui/eZGDsRgvUhwESj1eElVVUYeS+meYP8aJxgfr02bi1pJh1urIt/YcFWg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/torus-embed/-/torus-embed-1.37.0.tgz",
+      "integrity": "sha512-XtyKqWHl54SpcqAkRf05gmOkEr1vUf5Vh62chm7g+aZXgi1EMryRQl9iJGHChDmRu3rB/DSKgtIt5nL7Xv/jxQ==",
       "requires": {
         "@metamask/obs-store": "^7.0.0",
-        "@toruslabs/fetch-node-details": "^7.0.2",
-        "@toruslabs/http-helpers": "^3.1.0",
-        "@toruslabs/openlogin-jrpc": "^2.5.0",
-        "@toruslabs/torus.js": "^6.1.0",
+        "@toruslabs/http-helpers": "^3.2.0",
+        "@toruslabs/openlogin-jrpc": "^2.6.0",
         "create-hash": "^1.2.0",
         "end-of-stream": "^1.4.4",
         "eth-rpc-errors": "^4.0.3",
@@ -23809,28 +23238,6 @@
           "requires": {
             "fast-safe-stringify": "^2.0.6"
           }
-        }
-      }
-    },
-    "@toruslabs/torus.js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/torus.js/-/torus.js-6.1.0.tgz",
-      "integrity": "sha512-HI6zShOcG44pV382dHyhvdNawUxHtdP/HD9IE3ofasIrL308n/Wa/VuTS/VlaoYuQoBtPQZ1HYrKxlyIy2vXLA==",
-      "requires": {
-        "@toruslabs/eccrypto": "^1.1.8",
-        "@toruslabs/http-helpers": "^3.0.0",
-        "bn.js": "^5.2.1",
-        "elliptic": "^6.5.4",
-        "json-stable-stringify": "^1.0.1",
-        "keccak": "^3.0.2",
-        "loglevel": "^1.8.0",
-        "web3-utils": "^1.7.4"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
         }
       }
     },
@@ -24476,11 +23883,6 @@
         "event-target-shim": "^5.0.0"
       }
     },
-    "abortcontroller-polyfill": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
-      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
-    },
     "absolute-path": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
@@ -24504,7 +23906,8 @@
       }
     },
     "acorn": {
-      "version": "8.7.0"
+      "version": "8.7.0",
+      "dev": true
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
@@ -24978,7 +24381,8 @@
       }
     },
     "bignumber.js": {
-      "version": "9.0.2"
+      "version": "9.0.2",
+      "optional": true
     },
     "binary-extensions": {
       "version": "2.2.0"
@@ -24994,15 +24398,6 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "requires": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "bl": {
@@ -25142,6 +24537,7 @@
     },
     "bufferutil": {
       "version": "4.0.6",
+      "optional": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -25700,15 +25096,6 @@
     "csstype": {
       "version": "3.0.10"
     },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "d3-array": {
       "version": "2.12.1",
       "requires": {
@@ -25929,17 +25316,6 @@
         }
       }
     },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "optional": true,
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
     "duplexer": {
       "version": "0.1.2",
       "dev": true
@@ -26142,26 +25518,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "requires": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -26173,15 +25529,6 @@
       "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
       "requires": {
         "es6-promise": "^4.0.3"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
       }
     },
     "escalade": {
@@ -26654,14 +26001,6 @@
         "ethereumjs-util": "^5.1.1"
       }
     },
-    "ethereum-bloom-filters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
-      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
-      "requires": {
-        "js-sha3": "^0.8.0"
-      }
-    },
     "ethereum-common": {
       "version": "0.2.0"
     },
@@ -26861,22 +26200,6 @@
         "@ethersproject/wallet": "5.7.0",
         "@ethersproject/web": "5.7.0",
         "@ethersproject/wordlists": "5.7.0"
-      }
-    },
-    "ethjs-unit": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
-      "requires": {
-        "bn.js": "4.11.6",
-        "number-to-bn": "1.7.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
-        }
       }
     },
     "ethjs-util": {
@@ -27094,21 +26417,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "peer": true
-        }
-      }
-    },
-    "ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "requires": {
-        "type": "^2.7.2"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
         }
       }
     },
@@ -27964,11 +27272,6 @@
           "peer": true
         }
       }
-    },
-    "http-https": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-      "integrity": "sha512-o0PWwVCSp3O0wS6FvNr6xfBCHgt0m1tvPLFOCc2iFDKTRAXhB7m8klDf7ErowFH8POa6dVdGatKU5I1YYwzUyg=="
     },
     "http-parser-js": {
       "version": "0.5.6"
@@ -29404,9 +28707,9 @@
       }
     },
     "loglevel": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg=="
     },
     "long": {
       "version": "4.0.0",
@@ -30577,11 +29880,6 @@
     "mute-stream": {
       "version": "0.0.8"
     },
-    "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
-    },
     "nano-pubsub": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-1.0.2.tgz",
@@ -30656,11 +29954,6 @@
           }
         }
       }
-    },
-    "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -30761,22 +30054,6 @@
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
       "peer": true
-    },
-    "number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
-      "requires": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
-        }
-      }
     },
     "oauth-sign": {
       "version": "0.9.0"
@@ -30928,14 +30205,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
-      }
-    },
-    "oboe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
-      "integrity": "sha512-zRFWiF+FoicxEs3jNI/WYUrVEgA7DeET/InK0XQuudGHRg8iIob3cNPrJTKaz4004uaA9Pbe+Dwa8iluhjLZWA==",
-      "requires": {
-        "http-https": "^1.0.0"
       }
     },
     "on-finished": {
@@ -33202,11 +32471,6 @@
     "tweetnacl": {
       "version": "0.14.5"
     },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -33420,14 +32684,10 @@
     },
     "utf-8-validate": {
       "version": "5.0.9",
+      "optional": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
-    },
-    "utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "util": {
       "version": "0.12.4",
@@ -33518,149 +32778,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "web3-core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.5.tgz",
-      "integrity": "sha512-UgOWXZr1fR/3cUQJKWbfMwRxj1/N7o6RSd/dHqdXBlOD+62EjNZItFmLRg5veq5kp9YfXzrNw9bnDkXfsL+nKQ==",
-      "requires": {
-        "@types/bn.js": "^5.1.0",
-        "@types/node": "^12.12.6",
-        "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-core-requestmanager": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-          "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "@types/node": {
-          "version": "12.20.55",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-        }
-      }
-    },
-    "web3-core-helpers": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.5.tgz",
-      "integrity": "sha512-lDDjTks6Q6aNUO87RYrY2xub3UWTKr/RIWxpHJODEqkLxZS1dWdyliJ6aIx3031VQwsNT5HE7NvABe/t0p3iDQ==",
-      "requires": {
-        "web3-eth-iban": "1.7.5",
-        "web3-utils": "1.7.5"
-      }
-    },
-    "web3-core-method": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.5.tgz",
-      "integrity": "sha512-ApTvq1Llzlbxmy0n4L7QaE6NodIsR80VJqk8qN4kLg30SGznt/pNJFebryLI2kpyDmxSgj1TjEWzmHJBp6FhYg==",
-      "requires": {
-        "@ethersproject/transactions": "^5.6.2",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-promievent": "1.7.5",
-        "web3-core-subscriptions": "1.7.5",
-        "web3-utils": "1.7.5"
-      }
-    },
-    "web3-core-promievent": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.5.tgz",
-      "integrity": "sha512-uZ1VRErVuhiLtHlyt3oEH/JSvAf6bWPndChHR9PG7i1Zfqm6ZVCeM91ICTPmiL8ddsGQOxASpnJk4vhApcTIww==",
-      "requires": {
-        "eventemitter3": "4.0.4"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        }
-      }
-    },
-    "web3-core-requestmanager": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.5.tgz",
-      "integrity": "sha512-3KpfxW/wVH4mgwWEsSJGHKrtRVoijWlDxtUrm17xgtqRNZ2mFolifKnHAUKa0fY48C9CrxmcCiMIi3W4G6WYRw==",
-      "requires": {
-        "util": "^0.12.0",
-        "web3-core-helpers": "1.7.5",
-        "web3-providers-http": "1.7.5",
-        "web3-providers-ipc": "1.7.5",
-        "web3-providers-ws": "1.7.5"
-      }
-    },
-    "web3-core-subscriptions": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.5.tgz",
-      "integrity": "sha512-YK6utQ7Wwjbe4XZOIA8quWGBPi1lFDS1A+jQYwxKKrCvm6BloBNc3FhvrcSYlDhLe/kOy8+2Je8i9amndgT4ww==",
-      "requires": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.7.5"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        }
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.5.tgz",
-      "integrity": "sha512-qWHvF7sayxql9BD1yqK9sZRLBQ66eJzGeaU53Y1PRq2iFPrhY6NUWxQ3c3ps0rg+dyObvRbloviWpKXcS4RE/A==",
-      "requires": {
-        "@ethersproject/abi": "^5.6.3",
-        "web3-utils": "1.7.5"
-      }
-    },
-    "web3-eth-contract": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.5.tgz",
-      "integrity": "sha512-qab7NPJRKRlTs58ozsqK8YIEwWpxIm3vD/okSIKBGkFx5gIHWW+vGmMh5PDSfefLJM9rCd+T+Lc0LYvtME7uqg==",
-      "requires": {
-        "@types/bn.js": "^5.1.0",
-        "web3-core": "1.7.5",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-core-promievent": "1.7.5",
-        "web3-core-subscriptions": "1.7.5",
-        "web3-eth-abi": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-          "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
-          "requires": {
-            "@types/node": "*"
-          }
-        }
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.5.tgz",
-      "integrity": "sha512-mn2W5t/1IpL8OZvzAabLKT4kvwRnZSJ9K0tctndl9sDNWkfITYQibEEhUaNNA50Q5fJKgVudHI/m0gwIVTyG8Q==",
-      "requires": {
-        "bn.js": "^5.2.1",
-        "web3-utils": "1.7.5"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-        }
-      }
-    },
     "web3-provider-engine": {
       "version": "16.0.1",
       "requires": {
@@ -33722,94 +32839,6 @@
           "version": "5.2.3",
           "requires": {
             "async-limiter": "~1.0.0"
-          }
-        }
-      }
-    },
-    "web3-providers-http": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.5.tgz",
-      "integrity": "sha512-vPgr4Kzy0M3CHtoP/Bh7qwK/D9h2fhjpoqctdMWVJseOfeTgfOphCKN0uwV8w2VpZgDPXA8aeTdBx5OjmDdStA==",
-      "requires": {
-        "abortcontroller-polyfill": "^1.7.3",
-        "cross-fetch": "^3.1.4",
-        "es6-promise": "^4.2.8",
-        "web3-core-helpers": "1.7.5"
-      },
-      "dependencies": {
-        "cross-fetch": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-          "requires": {
-            "node-fetch": "2.6.7"
-          }
-        }
-      }
-    },
-    "web3-providers-ipc": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.5.tgz",
-      "integrity": "sha512-aNHx+RAROzO+apDEzy8Zncj78iqWBadIXtpmFDg7uiTn8i+oO+IcP1Yni7jyzkltsysVJHgHWG4kPx50ANCK3Q==",
-      "requires": {
-        "oboe": "2.1.5",
-        "web3-core-helpers": "1.7.5"
-      }
-    },
-    "web3-providers-ws": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.5.tgz",
-      "integrity": "sha512-9uJNVVkIGC8PmM9kNbgPth56HDMSSsxZh3ZEENdwO3LNWemaADiQYUDCsD/dMVkn0xsGLHP5dgAy4Q5msqySLg==",
-      "requires": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.7.5",
-        "websocket": "^1.0.32"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        }
-      }
-    },
-    "web3-utils": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.5.tgz",
-      "integrity": "sha512-9AqNOziQky4wNQadEwEfHiBdOZqopIHzQQVzmvvv6fJwDSMhP+khqmAZC7YTiGjs0MboyZ8tWNivqSO1699XQw==",
-      "requires": {
-        "bn.js": "^5.2.1",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-          "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "bn.js": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-        },
-        "ethereumjs-util": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-          "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
           }
         }
       }
@@ -33972,34 +33001,6 @@
       "dev": true,
       "peer": true
     },
-    "websocket": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
-      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-      "requires": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
-      }
-    },
     "websocket-driver": {
       "version": "0.7.4",
       "requires": {
@@ -34136,11 +33137,6 @@
     "y18n": {
       "version": "5.0.8",
       "optional": true
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/site/components/pages/Pledge/index.tsx
+++ b/site/components/pages/Pledge/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ethers } from "ethers";
+import { utils } from "ethers";
 import { useRouter } from "next/router";
 import { NextPage } from "next";
 import { t } from "@lingui/macro";
@@ -28,7 +28,7 @@ export const Pledge: NextPage = () => {
 
     const address = event.currentTarget.address.value;
 
-    if (ethers.utils.isAddress(address) || getIsDomainInURL(address)) {
+    if (utils.isAddress(address) || getIsDomainInURL(address)) {
       await router.push(`/pledge/${address}`);
     } else {
       setError(true);

--- a/site/components/pages/Pledge/lib/verifyGnosisSafeMultisig.ts
+++ b/site/components/pages/Pledge/lib/verifyGnosisSafeMultisig.ts
@@ -1,4 +1,4 @@
-import { Contract, ethers, utils } from "ethers";
+import { Contract, utils } from "ethers";
 import { polygonNetworks } from "@klimadao/lib/constants";
 import GnosisSafeSignMessageLib from "@klimadao/lib/abi/GnosisSafeSignMessageLib.json";
 import { getJsonRpcProvider } from "@klimadao/lib/utils";
@@ -10,12 +10,12 @@ export const waitForGnosisSignature = async (params: {
   address: string;
 }): Promise<void> => {
   const provider = getJsonRpcProvider();
-  const gnosisSafeContract = new ethers.Contract(
+  const gnosisSafeContract = new Contract(
     params.address,
     GnosisSafeSignMessageLib.abi,
     provider
   );
-  const messageHash = ethers.utils.hashMessage(params.message);
+  const messageHash = utils.hashMessage(params.message);
   const getMessageHash = await gnosisSafeContract.getMessageHash(messageHash);
   const signedEvent = gnosisSafeContract.filters.SignMsg(getMessageHash);
 
@@ -46,7 +46,7 @@ const calculateSafeMessageHash = (safe: Contract, message: string): string => {
       chainId: polygonNetworks.mainnet.chainId,
     },
     EIP712_SAFE_MESSAGE_TYPE,
-    { message: ethers.utils.hashMessage(message) }
+    { message: utils.hashMessage(message) }
   );
 };
 
@@ -57,7 +57,7 @@ export const verifyGnosisSignature = async (params: {
   address: string;
 }) => {
   const provider = getJsonRpcProvider();
-  const gnosisSafeContract = new ethers.Contract(
+  const gnosisSafeContract = new Contract(
     params.address,
     GnosisSafeSignMessageLib.abi,
     provider

--- a/site/components/pages/Pledge/lib/verifySignature.ts
+++ b/site/components/pages/Pledge/lib/verifySignature.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { utils } from "ethers";
 import { editPledgeMessage, verifyGnosisSignature } from ".";
 
 interface Params {
@@ -12,10 +12,7 @@ const verifyWalletSignature = (params: {
   signature: string;
   message: string;
 }) => {
-  const decodedAddress = ethers.utils.verifyMessage(
-    params.message,
-    params.signature
-  );
+  const decodedAddress = utils.verifyMessage(params.message, params.signature);
 
   if (decodedAddress.toLowerCase() !== params.address.toLowerCase()) {
     throw new Error("Invalid signature");

--- a/site/lib/getAddressByDomain.ts
+++ b/site/lib/getAddressByDomain.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { utils } from "ethers";
 import {
   isKNSDomain,
   getAddressByKNS,
@@ -15,7 +15,7 @@ export const getAddressByDomain = async (domain: string): Promise<string> => {
       (await getAddressByENS(domain, getInfuraUrlEther())); // Caution: needs to be InfuraUrl for Ether here
     const address = kns || ens;
 
-    if (!address || !ethers.utils.isAddress(address)) {
+    if (!address || !utils.isAddress(address)) {
       throw new Error("Not a valid address");
     }
     return address.toLowerCase();

--- a/site/pages/api/event-demo/index.ts
+++ b/site/pages/api/event-demo/index.ts
@@ -1,6 +1,6 @@
 import { addresses } from "@klimadao/lib/constants";
 import { formSchema } from "components/pages/EventDemo/lib/formSchema";
-import { Contract, ContractTransaction, ethers, utils, Wallet } from "ethers";
+import { Contract, ContractTransaction, utils, Wallet } from "ethers";
 import { getInfuraUrlPolygon } from "lib/getInfuraUrl";
 import { NextApiHandler } from "next";
 import { LIVE_OFFSET_WALLET_MNEMONIC } from "@klimadao/site/lib/secrets";
@@ -80,7 +80,7 @@ const eventDemo: NextApiHandler<RetirementData | APIDefaultResponse> = async (
     const response = retirementDataSchema.validateSync({
       index,
       beneficiaryAddress,
-      quantity: ethers.utils.formatUnits(quantity, 18),
+      quantity: utils.formatUnits(quantity, 18),
       transactionHash: receipt.transactionHash,
     });
 

--- a/site/pages/pledge/[address].tsx
+++ b/site/pages/pledge/[address].tsx
@@ -1,5 +1,5 @@
 import { GetStaticProps } from "next";
-import { ethers } from "ethers";
+import { utils } from "ethers";
 import { ParsedUrlQuery } from "querystring";
 import { urls } from "@klimadao/lib/constants";
 import { getRetirementTotalsAndBalances } from "@klimadao/lib/utils";
@@ -52,7 +52,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
     }
 
     try {
-      if (!isDomainInURL && !ethers.utils.isAddress(address))
+      if (!isDomainInURL && !utils.isAddress(address))
         throw new Error("Invalid address");
 
       if (isDomainInURL) {

--- a/site/pages/retirements/[beneficiary]/[retirement_index].tsx
+++ b/site/pages/retirements/[beneficiary]/[retirement_index].tsx
@@ -1,6 +1,6 @@
 import { GetStaticProps } from "next";
 import { ParsedUrlQuery } from "querystring";
-import { ethers } from "ethers";
+import { utils } from "ethers";
 
 import {
   queryKlimaRetireByIndex,
@@ -58,8 +58,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
 
     const beneficiaryInUrl = params.beneficiary;
     const isDomainInURL = getIsDomainInURL(beneficiaryInUrl);
-    const isValidAddress =
-      !isDomainInURL && ethers.utils.isAddress(beneficiaryInUrl);
+    const isValidAddress = !isDomainInURL && utils.isAddress(beneficiaryInUrl);
 
     if (!isDomainInURL && !isValidAddress) {
       throw new Error("Not a valid beneficiary address");

--- a/site/pages/retirements/[beneficiary]/index.tsx
+++ b/site/pages/retirements/[beneficiary]/index.tsx
@@ -1,6 +1,6 @@
 import { GetStaticProps } from "next";
 import { ParsedUrlQuery } from "querystring";
-import { ethers } from "ethers";
+import { utils } from "ethers";
 
 import { getInfuraUrlPolygon } from "lib/getInfuraUrl";
 
@@ -44,8 +44,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
 
     const beneficiaryInUrl = params.beneficiary;
     const isDomainInURL = getIsDomainInURL(beneficiaryInUrl);
-    const isValidAddress =
-      !isDomainInURL && ethers.utils.isAddress(beneficiaryInUrl);
+    const isValidAddress = !isDomainInURL && utils.isAddress(beneficiaryInUrl);
 
     if (!isDomainInURL && !isValidAddress) {
       throw new Error("Not a valid beneficiary address");


### PR DESCRIPTION
## Description

1. Lazyload `web3modal` and all wallet provider dependencies (`coinbase`, `torus-embed`, `wallet-connect`) only after page mount, and only on pages where the web3 hook is used. We should maintain this pattern for #660 
2. upgrade @torus-embed which does reduce the size of the lazy-loaded bundle by ~200kb
3. don't import entire ethers object (this did not end up reducing any kb)
4. remove @ethersproject import (this also had no impact)

Follow my commit history for easier review.

## Before
First Load JS shared by all 1.01 MB

## After
First Load JS shared by all 221 kB

## Related Ticket

#720 

This will conflict with work on #660 

* [ ] Need to test and make sure I didn't break the login/connect experience
* [ ] Need to re-run bundle analyzer and see if further improvements can be made