### PR TITLE
object fit for icon

### DIFF
--- a/site/components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx
@@ -18,7 +18,13 @@ export const RetirementValue: FC<Props> = ({ value, label, icon }) => {
         <Trans id="retirement.single.quantity">QUANTITY RETIRED</Trans>
       </Text>
       <div className={styles.tokenInfo}>
-        <Image alt={label} src={icon} width={48} height={48} />
+        <Image
+          alt={label}
+          src={icon}
+          width={48}
+          height={48}
+          objectFit="contain"
+        />
         <Text t="h3" as="h2" align="center" className="amount">
           {value} {label}
         </Text>


### PR DESCRIPTION
## Description
Add `objectFit="contain"` to retirement token icon for app
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->
@ShimonD-KlimaDAO  here is the PR
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #769 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
