### PR TITLE
reset modal to connect state when opening

### DIFF
--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -26,6 +26,7 @@ export const ConnectModal = (props: Props) => {
 
   useEffect(() => {
     if (showModal) {
+      setStep("connect");
       document.body.style.overflow = "hidden";
     } else {
       document.body.style.overflow = "";

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -31,15 +31,6 @@ export const ConnectModal = (props: Props) => {
       document.body.style.overflow = "";
     }
   }, [showModal]);
-<<<<<<< HEAD
-=======
-  useEffect(() => {
-    if (showModal) {
-      setStep("connect");
-    }
-  }, [showModal]);
-  const { address, connect, disconnect, isConnected } = useWeb3();
->>>>>>> 6f1b03ce (reset modal to connect state when opening)
 
   const handleConnect = async (params: {
     wallet: "coinbase" | "torus" | "walletConnect" | "metamask" | "brave";

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -31,6 +31,15 @@ export const ConnectModal = (props: Props) => {
       document.body.style.overflow = "";
     }
   }, [showModal]);
+<<<<<<< HEAD
+=======
+  useEffect(() => {
+    if (showModal) {
+      setStep("connect");
+    }
+  }, [showModal]);
+  const { address, connect, disconnect, isConnected } = useWeb3();
+>>>>>>> 6f1b03ce (reset modal to connect state when opening)
 
   const handleConnect = async (params: {
     wallet: "coinbase" | "torus" | "walletConnect" | "metamask" | "brave";


### PR DESCRIPTION
## Description
The modal gets stuck in an error state if the user closes the modal in error state and re opens it. 
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] Building the site with `npm run build-site` works without errors
- [ ] Building the app with `npm run build-app` works without errors
- [ ] I formatted JS and TS files with running `npm run format-all`
