### PR TITLE
Copy Address Button in App Nav (#824)

### DIFF
--- a/app/components/NavMenu/index.tsx
+++ b/app/components/NavMenu/index.tsx
@@ -6,6 +6,7 @@ import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
 import {
   Anchor as A,
+  CopyAddressButton,
   DiscordIcon,
   GithubIcon,
   LinkedInIcon,
@@ -61,7 +62,10 @@ const Address: FC<AddressProps> = (props) => {
       ) : (
         <Text t="caption" color="lightest">
           {props.address ? (
-            concatAddress(props.address)
+            <CopyAddressButton
+              label={concatAddress(props.address)}
+              address={props.address}
+            />
           ) : (
             <Trans id="menu.not_connected">NOT CONNECTED</Trans>
           )}


### PR DESCRIPTION
## Description

Replace static string with CopyAddressButton in `app/components/NavMenu`

## Related Ticket

Resolves #824

## Changes

| Before  | After  |
|---------|--------|
|<img width="256" alt="image" src="https://user-images.githubusercontent.com/7104689/208531341-fdeeed2f-3061-4192-8bf9-e253a45157e5.png">|<img width="223" alt="image" src="https://user-images.githubusercontent.com/7104689/208531434-d99be00b-325e-4f0c-8a74-3494d39dd251.png">|

## Checklist

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
