### PR TITLE
[selective-retirements] Select from projects with more than 1 tonne remaining

### DIFF
--- a/app/components/views/Offset/ProjectSearch/ProjectSearchForm/index.tsx
+++ b/app/components/views/Offset/ProjectSearch/ProjectSearchForm/index.tsx
@@ -54,7 +54,7 @@ export const ProjectSearchForm: FC<Props> = (props) => {
       (project) =>
         Number(
           project[`balance${selectedRetirementToken}` as BalanceAttribute]
-        ) > 0
+        ) > 1
     );
   };
 


### PR DESCRIPTION
## Description

Only allow projects with more than 1 tonnage remaining to be selected from the advanced selective retirement flow.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #819 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
