### PR TITLE
fix: allow connect modal to set button style variant

### DIFF
--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -3,7 +3,7 @@ import { ButtonPrimary } from "../Buttons/ButtonPrimary";
 import { concatAddress, useWeb3 } from "../../utils";
 import { ConnectContent } from "./ConnectContent";
 
-export const ConnectModal = (props: {
+interface Props {
   errorMessage: string;
   torusText: string;
   titles: {
@@ -13,10 +13,17 @@ export const ConnectModal = (props: {
   };
   buttonText: string;
   buttonClassName?: string;
+  buttonVariant?: "lightGray" | "gray" | "blue" | "red" | "transparent" | null;
   onClose?: () => void;
-}) => {
+}
+
+export const ConnectModal = (props: Props) => {
   const [showModal, setShowModal] = useState(false);
   const [step, setStep] = useState<"connect" | "error" | "loading">("connect");
+  const { address, connect, disconnect, isConnected } = useWeb3();
+
+  const buttonVariant = props.buttonVariant ?? null;
+
   useEffect(() => {
     if (showModal) {
       document.body.style.overflow = "hidden";
@@ -24,7 +31,6 @@ export const ConnectModal = (props: {
       document.body.style.overflow = "";
     }
   }, [showModal]);
-  const { address, connect, disconnect, isConnected } = useWeb3();
 
   const handleConnect = async (params: {
     wallet: "coinbase" | "torus" | "walletConnect" | "metamask" | "brave";
@@ -58,7 +64,7 @@ export const ConnectModal = (props: {
         <ButtonPrimary
           label={concatAddress(address)}
           onClick={disconnect}
-          variant="blue"
+          variant={buttonVariant}
         />
       ) : (
         <ButtonPrimary
@@ -66,10 +72,11 @@ export const ConnectModal = (props: {
           onClick={() => {
             setShowModal(true);
           }}
-          variant="blue"
+          variant={buttonVariant}
           className={props.buttonClassName}
         />
       )}
+
       <ConnectContent
         showModal={showModal}
         handleConnect={handleConnect}

--- a/site/components/pages/Pledge/HeaderDesktop/index.tsx
+++ b/site/components/pages/Pledge/HeaderDesktop/index.tsx
@@ -36,6 +36,7 @@ export const HeaderDesktop: FC<Props> = (props) => {
           <ButtonPrimary
             key="toggleModal"
             label={t({ id: "pledges.edit_pledge", message: "Edit Pledge" })}
+            variant="blue"
             onClick={() => props.toggleEditModal?.(true)}
           />
         )}

--- a/site/components/pages/Pledge/HeaderDesktop/index.tsx
+++ b/site/components/pages/Pledge/HeaderDesktop/index.tsx
@@ -63,6 +63,7 @@ export const HeaderDesktop: FC<Props> = (props) => {
             }),
           }}
           buttonText={t({ id: "shared.connect", message: "Connect" })}
+          buttonVariant="blue"
         />
       </div>
     </div>

--- a/site/components/pages/Pledge/HeaderMobile/index.tsx
+++ b/site/components/pages/Pledge/HeaderMobile/index.tsx
@@ -62,6 +62,7 @@ export const HeaderMobile: FC<Props> = (props) => {
               }),
             }}
             buttonText={t({ id: "shared.connect", message: "Connect" })}
+            buttonVariant="blue"
           />
         </div>
       </header>

--- a/site/components/pages/Pledge/index.tsx
+++ b/site/components/pages/Pledge/index.tsx
@@ -136,6 +136,7 @@ export const Pledge: NextPage = () => {
                       message: "Create a pledge",
                       id: "pledges.home.hero.create",
                     })}
+                    buttonVariant="blue"
                     onClose={handleCreatePledge}
                   />
                 )}
@@ -352,6 +353,7 @@ export const Pledge: NextPage = () => {
                   message: "Create a pledge",
                   id: "pledges.home.hero.create",
                 })}
+                buttonVariant="blue"
                 onClose={handleCreatePledge}
               />
             )}
@@ -406,6 +408,7 @@ export const Pledge: NextPage = () => {
                     message: "Create a pledge",
                     id: "pledges.home.hero.create",
                   })}
+                  buttonVariant="blue"
                   onClose={handleCreatePledge}
                 />
               )}


### PR DESCRIPTION
## Description

The blue connect modal button theming does not match the klima green in /app.
This seems like a regression. 
This PR extends `<ConnectModal />` to take a prop to configure button style variant.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #846 

## Changes

| Before  | After  |
|---------|--------|
|<img width="600" alt="image" src="https://user-images.githubusercontent.com/97446324/209342529-8fa2a829-f45c-4858-bc9b-2ba004aee9f0.png">|<img width="600" alt="image" src="https://user-images.githubusercontent.com/97446324/209342568-5db68b01-8487-4322-a23c-fca4ee6ce71e.png">|


## Checklist

<!-- Check completed item: [X] -->

- [x] Building the site with `npm run build-site` works without errors
- [x] Building the app with `npm run build-app` works without errors
- [x] I formatted JS and TS files with running `npm run format-all`
