### PR TITLE
[resources] Resource centre ui enhancements

### DIFF
--- a/site/components/Form/InputField/index.tsx
+++ b/site/components/Form/InputField/index.tsx
@@ -11,6 +11,7 @@ interface Props {
   label: string;
   hideLabel?: boolean;
   errorMessage?: string;
+  icon?: JSX.Element;
 }
 
 export const InputField = React.forwardRef<HTMLInputElement, Props>(
@@ -19,6 +20,7 @@ export const InputField = React.forwardRef<HTMLInputElement, Props>(
       styles.baseStyles,
       {
         [styles.errorStyles]: !!props.errorMessage,
+        [styles.withIcon]: !!props.icon,
       },
       props.inputProps.className
     );
@@ -32,6 +34,8 @@ export const InputField = React.forwardRef<HTMLInputElement, Props>(
         <label htmlFor={props.id} className={visuallyHidden}>
           <Text t="caption">{props.label}</Text>
         </label>
+
+        {!!props.icon && <div className={styles.icon}>{props.icon}</div>}
 
         <input
           id={props.id}

--- a/site/components/Form/InputField/styles.ts
+++ b/site/components/Form/InputField/styles.ts
@@ -3,6 +3,7 @@ import breakpoints from "@klimadao/lib/theme/breakpoints";
 import * as typography from "@klimadao/lib/theme/typography";
 
 export const container = css`
+  position: relative;
   display: grid;
   align-content: start;
   gap: 0.75rem;
@@ -69,4 +70,18 @@ export const errorMessage = css`
     line-height: 1.6rem;
     margin-bottom: 0.8rem;
   }
+`;
+
+export const icon = css`
+  position: absolute;
+  top: 1.3rem;
+  left: 1rem;
+
+  svg {
+    fill: var(--font-03);
+  }
+`;
+
+export const withIcon = css`
+  padding-left: 3.4rem;
 `;

--- a/site/components/pages/Pledge/PledgeForm/index.tsx
+++ b/site/components/pages/Pledge/PledgeForm/index.tsx
@@ -589,9 +589,9 @@ export const PledgeForm: FC<Props> = (props) => {
 
           <TotalFootprint control={control} setValue={setValue} />
 
-          {/* better to use an input type=submit */}
           <ButtonPrimary
             disabled={!isDirty}
+            type="submit"
             label={
               submitting ? (
                 <SubmittingLabel />

--- a/site/components/pages/Resources/FeaturedArticles/Article.tsx
+++ b/site/components/pages/Resources/FeaturedArticles/Article.tsx
@@ -43,7 +43,7 @@ export const Article: FC<Props> = (props) => {
         <div className={styles.stackContent}>
           <Text t="h5" className={styles.articleText}>
             <Link href={`/blog/${props.article.slug}`} passHref>
-              Read more...
+              Read more
             </Link>
           </Text>
         </div>

--- a/site/components/pages/Resources/FeaturedArticles/Article.tsx
+++ b/site/components/pages/Resources/FeaturedArticles/Article.tsx
@@ -41,9 +41,9 @@ export const Article: FC<Props> = (props) => {
           <Text className={styles.articleText}>{props.article.summary}</Text>
         </div>
         <div className={styles.stackContent}>
-          <Text t="h4" className={styles.articleText}>
+          <Text t="h5" className={styles.articleText}>
             <Link href={`/blog/${props.article.slug}`} passHref>
-              Read more
+              Read more...
             </Link>
           </Text>
         </div>

--- a/site/components/pages/Resources/FeaturedArticles/ArticlesSlider.tsx
+++ b/site/components/pages/Resources/FeaturedArticles/ArticlesSlider.tsx
@@ -56,7 +56,7 @@ export const ArticlesSlider: FC<Props> = (props) => {
     // start autoslide on mount
     const intervalId = setInterval(() => {
       setCurrentScrollLeft((csl) => csl + 1);
-    }, 3000);
+    }, 6000);
 
     scrollInterval.current = intervalId;
 

--- a/site/components/pages/Resources/FeaturedArticles/styles.ts
+++ b/site/components/pages/Resources/FeaturedArticles/styles.ts
@@ -55,6 +55,7 @@ export const sliderItem = css`
   flex-shrink: 0;
   padding: 0 1rem;
   overflow: hidden;
+  scroll-snap-align: start;
 `;
 
 export const sliderContainerInner = css`

--- a/site/components/pages/Resources/ResourcesList/index.tsx
+++ b/site/components/pages/Resources/ResourcesList/index.tsx
@@ -203,7 +203,7 @@ export const ResourcesList: FC<Props> = (props) => {
                   message: "Sort by",
                 })}
               />
-              <Text>
+              <Text t="body4">
                 <Trans id="shared.resources.sort_by.header">Sort by:</Trans>
               </Text>
               <SortyByDropDown control={control} setValue={setValue} />

--- a/site/components/pages/Resources/ResourcesList/index.tsx
+++ b/site/components/pages/Resources/ResourcesList/index.tsx
@@ -210,6 +210,7 @@ export const ResourcesList: FC<Props> = (props) => {
             </div>
           </div>
         </div>
+
         <div className={styles.main}>
           <div className={styles.filtersContainer}>
             <ResourcesFilters

--- a/site/components/pages/Resources/ResourcesList/index.tsx
+++ b/site/components/pages/Resources/ResourcesList/index.tsx
@@ -163,10 +163,11 @@ export const ResourcesList: FC<Props> = (props) => {
             <div className={styles.searchInputContainer}>
               <InputField
                 id="search"
+                icon={<SearchIcon fontSize="large" />}
                 inputProps={{
                   placeholder: t({
                     id: "resources.form.input.search.placeholder",
-                    message: "Search",
+                    message: "Search...",
                   }),
                   type: "search",
                   autoComplete: "off",
@@ -178,12 +179,6 @@ export const ResourcesList: FC<Props> = (props) => {
                   message: "Search",
                 })}
                 hideLabel
-              />
-              <ButtonPrimary
-                icon={<SearchIcon fontSize="large" />}
-                type="submit"
-                className={styles.searchInputSubmit}
-                onClick={handleSubmit(onSearchSubmit)}
               />
             </div>
           </form>

--- a/site/components/pages/Resources/ResourcesList/styles.ts
+++ b/site/components/pages/Resources/ResourcesList/styles.ts
@@ -28,7 +28,7 @@ export const searchInput = css`
 
   &:focus,
   &:hover {
-    border-color: var(--surface-01);
+    border-color: var(--klima-green);
   }
 
   // remove ugly clear icon
@@ -37,16 +37,6 @@ export const searchInput = css`
   &::-webkit-search-results-button,
   &::-webkit-search-results-decoration {
     -webkit-appearance: none;
-  }
-`;
-
-export const searchInputSubmit = css`
-  border-radius: 0 1rem 1rem 0;
-  background-color: var(--surface-01);
-  padding: 0rem 1.6rem;
-
-  svg {
-    fill: var(--font-03);
   }
 `;
 

--- a/site/components/pages/Resources/ResourcesList/styles.ts
+++ b/site/components/pages/Resources/ResourcesList/styles.ts
@@ -23,7 +23,7 @@ export const searchInputContainer = css`
 export const searchInput = css`
   background-color: var(--surface-01);
   -webkit-appearance: none; // remove default border radius for iOS
-  border-radius: 1rem 0 0 1rem;
+  border-radius: 1rem;
   border: 0.175rem solid var(--surface-01);
 
   &:focus,

--- a/site/components/pages/Resources/SortyByDropDown/index.tsx
+++ b/site/components/pages/Resources/SortyByDropDown/index.tsx
@@ -1,11 +1,12 @@
 import { t } from "@lingui/macro";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 import Tippy from "@tippyjs/react";
 import { FC, useEffect, useState } from "react";
 import { Control, useWatch } from "react-hook-form";
+
 import { sortedByQueries, SortQuery } from "../lib/cmsDataMap";
 import { FormValues } from "../ResourcesList";
-
 import { SortByButton } from "../SortByButton";
 
 import * as styles from "./styles";
@@ -64,7 +65,11 @@ export const SortyByDropDown: FC<Props> = (props) => {
           })}
         >
           {label}
-          <ArrowDropDownIcon />
+          {isOpen ? (
+            <ArrowDropUpIcon fontSize="large" />
+          ) : (
+            <ArrowDropDownIcon fontSize="large" />
+          )}
         </button>
       </Tippy>
     </div>

--- a/site/components/pages/Resources/SortyByDropDown/styles.ts
+++ b/site/components/pages/Resources/SortyByDropDown/styles.ts
@@ -6,7 +6,7 @@ export const dropdownHeader = css`
   gap: 0.8rem;
   background-color: var(--surface-01);
   border-radius: 1rem;
-  padding: 1rem;
+  padding: 1rem 0.8rem 1rem 1.4rem;
   min-height: 4.8rem;
   justify-content: center;
 

--- a/site/components/pages/Resources/styles.ts
+++ b/site/components/pages/Resources/styles.ts
@@ -2,11 +2,17 @@ import { css } from "@emotion/css";
 import breakpoints from "@klimadao/lib/theme/breakpoints";
 
 export const sectionHead = css`
-  padding: 8.4rem 0rem 4rem 0 !important;
+  padding: 12rem 0rem 6rem 0rem !important;
+
   ${breakpoints.medium} {
-    padding: 8.4rem 0rem !important;
+    padding: 12rem 0rem 8.4rem 0rem !important;
+  }
+
+  ${breakpoints.desktopLarge} {
+    padding: 8.4rem 0rem 8.4rem 0rem !important;
   }
 `;
+
 export const header = css`
   grid-column: main;
   display: flex;

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1416,15 +1416,15 @@ msgstr "Select one or more"
 msgid "resources.form.filters.clear_all"
 msgstr "Clear All"
 
-#: components/pages/Resources/ResourcesList/index.tsx:176
+#: components/pages/Resources/ResourcesList/index.tsx:177
 msgid "resources.form.input.search.label"
 msgstr "Search"
 
-#: components/pages/Resources/ResourcesList/index.tsx:167
+#: components/pages/Resources/ResourcesList/index.tsx:168
 msgid "resources.form.input.search.placeholder"
-msgstr "Search"
+msgstr "Search..."
 
-#: components/pages/Resources/ResourcesList/index.tsx:206
+#: components/pages/Resources/ResourcesList/index.tsx:207
 msgid "resources.form.input.sort_by.label"
 msgstr "Sort by"
 
@@ -1516,11 +1516,11 @@ msgstr "Oldest First"
 msgid "resources.list.sort_by.z-a"
 msgstr "Z-A"
 
-#: components/pages/Resources/ResourcesList/index.tsx:306
+#: components/pages/Resources/ResourcesList/index.tsx:307
 msgid "resources.mobile_modal.button.show_results"
 msgstr "Show Results"
 
-#: components/pages/Resources/ResourcesList/index.tsx:279
+#: components/pages/Resources/ResourcesList/index.tsx:280
 msgid "resources.mobile_modal.title"
 msgstr "Sort By"
 
@@ -1536,19 +1536,19 @@ msgstr "Featured Articles"
 msgid "resources.page.list.header"
 msgstr "Explore All"
 
-#: components/pages/Resources/ResourcesList/index.tsx:244
+#: components/pages/Resources/ResourcesList/index.tsx:245
 msgid "resources.page.list.no_search_results.title"
 msgstr "Sorry. We couldn't find any matching results."
 
-#: components/pages/Resources/ResourcesList/index.tsx:236
+#: components/pages/Resources/ResourcesList/index.tsx:237
 msgid "resources.page.list.on_fetch_error"
 msgstr "Sorry! Something went wrong."
 
-#: components/pages/Resources/ResourcesList/index.tsx:257
+#: components/pages/Resources/ResourcesList/index.tsx:258
 msgid "resources.page.list.search_submit.no_filter_results"
 msgstr "Please use a different filter combination."
 
-#: components/pages/Resources/ResourcesList/index.tsx:250
+#: components/pages/Resources/ResourcesList/index.tsx:251
 msgid "resources.page.list.search_submit.no_search_results"
 msgstr "Check your search for typos or try a different search term."
 
@@ -1929,7 +1929,7 @@ msgstr "Resource Center"
 msgid "shared.resources"
 msgstr "Resources"
 
-#: components/pages/Resources/ResourcesList/index.tsx:212
+#: components/pages/Resources/ResourcesList/index.tsx:213
 msgid "shared.resources.sort_by.header"
 msgstr "Sort by:"
 

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -1424,11 +1424,11 @@ msgstr "Search"
 msgid "resources.form.input.search.placeholder"
 msgstr "Search..."
 
-#: components/pages/Resources/ResourcesList/index.tsx:207
+#: components/pages/Resources/ResourcesList/index.tsx:201
 msgid "resources.form.input.sort_by.label"
 msgstr "Sort by"
 
-#: components/pages/Resources/SortyByDropDown/index.tsx:20
+#: components/pages/Resources/SortyByDropDown/index.tsx:21
 msgid "resources.form.input.sort_by.select"
 msgstr "Select"
 
@@ -1496,7 +1496,7 @@ msgstr "Blog"
 msgid "resources.list.filter.type.podcast"
 msgstr "Podcast"
 
-#: components/pages/Resources/SortyByDropDown/index.tsx:61
+#: components/pages/Resources/SortyByDropDown/index.tsx:62
 msgid "resources.list.select.sort_by.toggle"
 msgstr "Toggle Sorted by menu"
 
@@ -1516,11 +1516,11 @@ msgstr "Oldest First"
 msgid "resources.list.sort_by.z-a"
 msgstr "Z-A"
 
-#: components/pages/Resources/ResourcesList/index.tsx:307
+#: components/pages/Resources/ResourcesList/index.tsx:302
 msgid "resources.mobile_modal.button.show_results"
 msgstr "Show Results"
 
-#: components/pages/Resources/ResourcesList/index.tsx:280
+#: components/pages/Resources/ResourcesList/index.tsx:275
 msgid "resources.mobile_modal.title"
 msgstr "Sort By"
 
@@ -1536,19 +1536,19 @@ msgstr "Featured Articles"
 msgid "resources.page.list.header"
 msgstr "Explore All"
 
-#: components/pages/Resources/ResourcesList/index.tsx:245
+#: components/pages/Resources/ResourcesList/index.tsx:240
 msgid "resources.page.list.no_search_results.title"
 msgstr "Sorry. We couldn't find any matching results."
 
-#: components/pages/Resources/ResourcesList/index.tsx:237
+#: components/pages/Resources/ResourcesList/index.tsx:232
 msgid "resources.page.list.on_fetch_error"
 msgstr "Sorry! Something went wrong."
 
-#: components/pages/Resources/ResourcesList/index.tsx:258
+#: components/pages/Resources/ResourcesList/index.tsx:253
 msgid "resources.page.list.search_submit.no_filter_results"
 msgstr "Please use a different filter combination."
 
-#: components/pages/Resources/ResourcesList/index.tsx:251
+#: components/pages/Resources/ResourcesList/index.tsx:246
 msgid "resources.page.list.search_submit.no_search_results"
 msgstr "Check your search for typos or try a different search term."
 
@@ -1929,7 +1929,7 @@ msgstr "Resource Center"
 msgid "shared.resources"
 msgstr "Resources"
 
-#: components/pages/Resources/ResourcesList/index.tsx:213
+#: components/pages/Resources/ResourcesList/index.tsx:207
 msgid "shared.resources.sort_by.header"
 msgstr "Sort by:"
 


### PR DESCRIPTION
## Description

Noticed the resource centre was looking a bit off so went on a small rabbit hole of various enhancements.
Note the rounded button in the image below. I don't recall it being designed like that 🤔
<img width="400" alt="image" src="https://user-images.githubusercontent.com/97446324/211012488-644ad946-58c4-429f-8014-356baaa773a1.png">

Summary of changes:
- Resource search field updated to include focus styles & add icon to left of input
- Added padding to header on various viewports
- Add `scroll-snap-align: start` to featured articles so a full featured article is always in view

Regressions discovered:
- Buttons with icons automatically shaped as a circle => #861 
- Site modal no longer has a dimmed background overlay => #862 


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
