### PR TITLE
hotfix: revert pledge connect button to klima green

### DIFF
--- a/site/components/pages/Pledge/HeaderDesktop/index.tsx
+++ b/site/components/pages/Pledge/HeaderDesktop/index.tsx
@@ -64,7 +64,6 @@ export const HeaderDesktop: FC<Props> = (props) => {
               message: "Connection Error",
             }),
           }}
-          buttonVariant="blue"
           buttonText={t({
             id: "shared.login_connect",
             message: "Login / Connect",


### PR DESCRIPTION
Klima green making a comeback

<img width="800" alt="image" src="https://user-images.githubusercontent.com/97446324/211815376-49e5ff5a-4026-4903-bc25-e6bbeb867a22.png">

Verification:
https://klimadao-site-git-change-pledge-connect-button-26162d-klimadao.vercel.app/pledge/markcuban.klima

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #872 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
