### PR TITLE
fix(app): don't allow fractional quantities when fiat

### DIFF
--- a/app/components/DropdownWithModal/index.tsx
+++ b/app/components/DropdownWithModal/index.tsx
@@ -90,7 +90,7 @@ const DropdownModal = (props: DropdownModalProps) => {
           key={item.label}
           className={styles.select_button}
           data-active={item.label === props.currentItem.label && !item.disabled}
-          // disabled={item.disabled}
+          disabled={item.disabled}
         >
           <div className="start_content">
             <Image alt={item.label} src={item.icon} width={48} height={48} />

--- a/app/components/DropdownWithModal/index.tsx
+++ b/app/components/DropdownWithModal/index.tsx
@@ -90,7 +90,7 @@ const DropdownModal = (props: DropdownModalProps) => {
           key={item.label}
           className={styles.select_button}
           data-active={item.label === props.currentItem.label && !item.disabled}
-          disabled={item.disabled}
+          // disabled={item.disabled}
         >
           <div className="start_content">
             <Image alt={item.label} src={item.icon} width={48} height={48} />

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -94,7 +94,7 @@ export const Offset = (props: Props) => {
   const [isRetireTokenModalOpen, setRetireTokenModalOpen] = useState(false);
   const [isInputTokenModalOpen, setInputTokenModalOpen] = useState(false);
   const [isInvalidFractionalQtyFiat, setIsInvalidFractionalQtyFiat] =
-    useState<boolean>(false);
+    useState(false);
   const [paymentMethod, setPaymentMethod] =
     useState<OffsetPaymentMethod>("fiat");
   const [selectedRetirementToken, setSelectedRetirementToken] =

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -93,8 +93,6 @@ export const Offset = (props: Props) => {
   // local state
   const [isRetireTokenModalOpen, setRetireTokenModalOpen] = useState(false);
   const [isInputTokenModalOpen, setInputTokenModalOpen] = useState(false);
-  const [isInvalidFractionalQtyFiat, setIsInvalidFractionalQtyFiat] =
-    useState(false);
   const [paymentMethod, setPaymentMethod] =
     useState<OffsetPaymentMethod>("fiat");
   const [selectedRetirementToken, setSelectedRetirementToken] =
@@ -146,8 +144,14 @@ export const Offset = (props: Props) => {
       setProjectAddress(params.projectTokens);
     }
     if (params.quantity) {
-      setQuantity(params.quantity);
-      setDebouncedQuantity(params.quantity);
+      // handles the case where a decimal value for quantity is passed
+      // as a query param - we convert it to a whole number (1.123 -> 2)
+      const quantity =
+        paymentMethod === "fiat"
+          ? Math.ceil(Number(params.quantity)).toString()
+          : params.quantity;
+      setQuantity(quantity);
+      setDebouncedQuantity(quantity);
     }
   }, [params]);
 
@@ -172,10 +176,11 @@ export const Offset = (props: Props) => {
 
   // effects
   useEffect(() => {
-    // round the value for the edge case where a user inputs a fractional value
-    // when fiat isn't selected to pay. Example (100.5 -> 101)
-    if (paymentMethod === "fiat" && !Number.isInteger(parseFloat(quantity))) {
-      setQuantity(Math.round(Number(quantity)).toString());
+    // handles the case where a user inputs a decimal value when a non credit
+    // card payment method is selected, they then choose to pay by credit card,
+    // we convert the value to a whole number (1.123 -> 2)
+    if (paymentMethod === "fiat") {
+      setQuantity(Math.ceil(Number(quantity)).toString());
     }
     // if input token changes, force a compatible retirement token
     if (
@@ -324,10 +329,10 @@ export const Offset = (props: Props) => {
     if (!props.address || !props.provider || paymentMethod !== "fiat") return;
 
     const reqParams = {
+      quantity,
       beneficiary_address: beneficiaryAddress || props.address, // don't pass empty string
       beneficiary_name: beneficiary,
       retirement_message: retirementMessage,
-      quantity: Math.ceil(Number(quantity)).toString(), // temp fix: increment to next largest whole tonne
       project_address: projectAddress || null,
       retirement_token: selectedRetirementToken,
     };
@@ -471,9 +476,6 @@ export const Offset = (props: Props) => {
   };
 
   const handleChangeQuantity = (e: ChangeEvent<HTMLInputElement>) => {
-    // reset the state on each change event
-    setIsInvalidFractionalQtyFiat(false);
-
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
     }
@@ -489,6 +491,8 @@ export const Offset = (props: Props) => {
       Number(e.target.value) < 0.0001
     ) {
       setQuantity("0.0001");
+    } else if (paymentMethod === "fiat") {
+      setQuantity(Math.ceil(Number(e.target.value)).toString());
     } else {
       setQuantity(e.target.value);
     }
@@ -620,41 +624,23 @@ export const Offset = (props: Props) => {
                 min={paymentMethod === "fiat" ? "1" : "0"}
                 value={quantity}
                 onKeyDown={(e) => {
-                  // don't allow decimal values when fiat payment method is selected
+                  // prevent a user from entering a decimal value when credit card is selected
                   if (paymentMethod === "fiat" && ["."].includes(e.key)) {
                     e.preventDefault();
-                    setIsInvalidFractionalQtyFiat(true);
                   }
                   // dont let user enter these special characters into the number input
                   if (["e", "E", "+", "-"].includes(e.key)) {
                     e.preventDefault();
                   }
                 }}
-                data-error={
-                  invalidCost ||
-                  invalidRetirementQuantity ||
-                  isInvalidFractionalQtyFiat
-                }
+                data-error={invalidCost || invalidRetirementQuantity}
                 onChange={handleChangeQuantity}
-                onBlur={() => setIsInvalidFractionalQtyFiat(false)}
                 placeholder={t({
                   id: "offset.offset_quantity",
                   message: "Enter quantity to offset",
                 })}
               />
             </div>
-
-            {isInvalidFractionalQtyFiat && paymentMethod === "fiat" && (
-              <Text
-                t="caption"
-                color="lightest"
-                className="invalid_project_tonnage"
-              >
-                <Trans id="offset.invalid_fractional_quantity_fiat">
-                  Cannot use a fractional quantity when paying with credit card!
-                </Trans>
-              </Text>
-            )}
             {invalidRetirementQuantity && (
               <Text
                 t="caption"
@@ -669,7 +655,7 @@ export const Offset = (props: Props) => {
             {!invalidRetirementQuantity && paymentMethod === "fiat" && (
               <Text t="body8" color="lightest">
                 <Trans id="offset.min_quantity_fiat">
-                  Minimum 1-tonne purchase for credit cards
+                  Minimum 1-tonne purchase. Whole integers only.
                 </Trans>
               </Text>
             )}

--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -6,12 +6,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
-#: components/views/Offset/index.tsx:669
+#: components/views/Offset/index.tsx:701
 msgid "Beneficiary 0x address (optional)"
 msgstr ""
 
-#: components/views/Offset/index.tsx:657
+#: components/views/Offset/index.tsx:689
 msgid "Beneficiary name"
 msgstr ""
 
@@ -336,7 +342,7 @@ msgstr ""
 msgid "connect_modal.sign_in"
 msgstr ""
 
-#: components/views/Offset/index.tsx:722
+#: components/views/Offset/index.tsx:754
 msgid "fiat.max_quantity"
 msgstr ""
 
@@ -455,11 +461,11 @@ msgstr ""
 msgid "nav.back"
 msgstr ""
 
-#: components/views/Offset/index.tsx:706
+#: components/views/Offset/index.tsx:738
 msgid "offset.aggregation_fee_tooltip"
 msgstr ""
 
-#: components/views/Offset/index.tsx:602
+#: components/views/Offset/index.tsx:612
 msgid "offset.amount_in_tonnes"
 msgstr ""
 
@@ -467,19 +473,19 @@ msgstr ""
 msgid "offset.breakdown"
 msgstr ""
 
-#: components/views/Offset/index.tsx:448
+#: components/views/Offset/index.tsx:455
 msgid "offset.checkout"
 msgstr ""
 
-#: components/views/Offset/index.tsx:672
+#: components/views/Offset/index.tsx:704
 msgid "offset.default_retirement_address"
 msgstr ""
 
-#: components/views/Offset/index.tsx:744
+#: components/views/Offset/index.tsx:776
 msgid "offset.dropdown_payWith.label"
 msgstr ""
 
-#: components/views/Offset/index.tsx:575
+#: components/views/Offset/index.tsx:585
 msgid "offset.dropdown_retire.label"
 msgstr ""
 
@@ -491,35 +497,39 @@ msgstr ""
 msgid "offset.enter_address"
 msgstr ""
 
-#: components/views/Offset/index.tsx:556
+#: components/views/Offset/index.tsx:566
 msgid "offset.go_carbon_neutral"
 msgstr ""
 
-#: components/views/Offset/index.tsx:532
+#: components/views/Offset/index.tsx:542
 msgid "offset.incompatible"
 msgstr ""
 
-#: components/views/Offset/index.tsx:411
+#: components/views/Offset/index.tsx:418
 msgid "offset.insufficient_project_tonnage"
 msgstr ""
 
-#: components/views/Offset/index.tsx:632
+#: components/views/Offset/index.tsx:653
+msgid "offset.invalid_fractional_quantity_fiat"
+msgstr ""
+
+#: components/views/Offset/index.tsx:664
 msgid "offset.invalid_project_tonnage"
 msgstr ""
 
-#: components/views/Offset/index.tsx:564
+#: components/views/Offset/index.tsx:574
 msgid "offset.lifi"
 msgstr ""
 
-#: components/views/Offset/index.tsx:639
+#: components/views/Offset/index.tsx:671
 msgid "offset.min_quantity_fiat"
 msgstr ""
 
-#: components/views/Offset/index.tsx:748
+#: components/views/Offset/index.tsx:780
 msgid "offset.modal_payWith.title"
 msgstr ""
 
-#: components/views/Offset/index.tsx:579
+#: components/views/Offset/index.tsx:589
 msgid "offset.modal_retire.title"
 msgstr ""
 
@@ -527,12 +537,12 @@ msgstr ""
 msgid "offset.number_of_retirements"
 msgstr ""
 
-#: components/views/Offset/index.tsx:620
+#: components/views/Offset/index.tsx:640
 msgid "offset.offset_quantity"
 msgstr ""
 
-#: components/views/Offset/index.tsx:553
-#: components/views/Offset/index.tsx:791
+#: components/views/Offset/index.tsx:563
+#: components/views/Offset/index.tsx:823
 msgid "offset.retire_carbon"
 msgstr ""
 
@@ -544,19 +554,19 @@ msgstr ""
 msgid "offset.retire_specific_tooltip"
 msgstr ""
 
-#: components/views/Offset/index.tsx:649
+#: components/views/Offset/index.tsx:681
 msgid "offset.retirement_credit"
 msgstr ""
 
-#: components/views/Offset/index.tsx:683
+#: components/views/Offset/index.tsx:715
 msgid "offset.retirement_message"
 msgstr ""
 
-#: components/views/Offset/index.tsx:692
+#: components/views/Offset/index.tsx:724
 msgid "offset.retirement_purpose"
 msgstr ""
 
-#: components/views/Offset/index.tsx:734
+#: components/views/Offset/index.tsx:766
 msgid "offset.retiring"
 msgstr ""
 
@@ -660,11 +670,11 @@ msgstr ""
 msgid "offset.you_have_retired"
 msgstr ""
 
-#: components/views/Offset/index.tsx:702
+#: components/views/Offset/index.tsx:734
 msgid "offset_cost"
 msgstr ""
 
-#: components/views/Offset/index.tsx:764
+#: components/views/Offset/index.tsx:796
 msgid "offset_disclaimer"
 msgstr ""
 
@@ -734,7 +744,7 @@ msgstr ""
 
 #: components/TransactionModal/Approve.tsx:97
 #: components/views/Bond/index.tsx:454
-#: components/views/Offset/index.tsx:443
+#: components/views/Offset/index.tsx:450
 #: components/views/Stake/index.tsx:253
 #: components/views/Wrap/index.tsx:230
 msgid "shared.approve"
@@ -767,18 +777,18 @@ msgstr ""
 msgid "shared.enter_amount"
 msgstr ""
 
-#: components/views/Offset/index.tsx:387
+#: components/views/Offset/index.tsx:394
 msgid "shared.enter_beneficiary"
 msgstr ""
 
 #: components/views/Bond/index.tsx:417
-#: components/views/Offset/index.tsx:382
+#: components/views/Offset/index.tsx:389
 #: components/views/Stake/index.tsx:240
 #: components/views/Wrap/index.tsx:209
 msgid "shared.enter_quantity"
 msgstr ""
 
-#: components/views/Offset/index.tsx:395
+#: components/views/Offset/index.tsx:402
 msgid "shared.enter_retirement_message"
 msgstr ""
 
@@ -789,21 +799,21 @@ msgstr ""
 msgid "shared.error"
 msgstr ""
 
-#: components/views/Offset/index.tsx:435
+#: components/views/Offset/index.tsx:442
 #: components/views/Stake/index.tsx:245
 #: components/views/Wrap/index.tsx:222
 msgid "shared.insufficient_balance"
 msgstr ""
 
-#: components/views/Offset/index.tsx:403
+#: components/views/Offset/index.tsx:410
 msgid "shared.invalid_beneficiary_addr"
 msgstr ""
 
-#: components/views/Offset/index.tsx:427
+#: components/views/Offset/index.tsx:434
 msgid "shared.invalid_project_address"
 msgstr ""
 
-#: components/views/Offset/index.tsx:419
+#: components/views/Offset/index.tsx:426
 msgid "shared.invalid_quantity"
 msgstr ""
 
@@ -812,8 +822,8 @@ msgstr ""
 #: components/RebaseCard/index.tsx:69
 #: components/views/Bond/index.tsx:411
 #: components/views/Loading/index.tsx:11
-#: components/views/Offset/index.tsx:369
-#: components/views/Offset/index.tsx:511
+#: components/views/Offset/index.tsx:376
+#: components/views/Offset/index.tsx:521
 #: components/views/PKlima/index.tsx:158
 #: components/views/Stake/index.tsx:431
 #: components/views/Stake/index.tsx:438
@@ -825,7 +835,7 @@ msgstr ""
 #: components/views/Bond/index.tsx:397
 #: components/views/Buy/index.tsx:63
 #: components/views/Home/index.tsx:154
-#: components/views/Offset/index.tsx:361
+#: components/views/Offset/index.tsx:368
 #: components/views/PKlima/index.tsx:150
 #: components/views/Stake/index.tsx:227
 #: components/views/Wrap/index.tsx:196
@@ -839,11 +849,11 @@ msgstr ""
 msgid "shared.max"
 msgstr ""
 
-#: components/views/Offset/index.tsx:374
+#: components/views/Offset/index.tsx:381
 msgid "shared.redirecting_checkout"
 msgstr ""
 
-#: components/views/Offset/index.tsx:453
+#: components/views/Offset/index.tsx:460
 msgid "shared.retire"
 msgstr ""
 

--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/views/Offset/index.tsx:701
+#: components/views/Offset/index.tsx:687
 msgid "Beneficiary 0x address (optional)"
 msgstr ""
 
-#: components/views/Offset/index.tsx:689
+#: components/views/Offset/index.tsx:675
 msgid "Beneficiary name"
 msgstr ""
 
@@ -342,7 +342,7 @@ msgstr ""
 msgid "connect_modal.sign_in"
 msgstr ""
 
-#: components/views/Offset/index.tsx:754
+#: components/views/Offset/index.tsx:740
 msgid "fiat.max_quantity"
 msgstr ""
 
@@ -461,11 +461,11 @@ msgstr ""
 msgid "nav.back"
 msgstr ""
 
-#: components/views/Offset/index.tsx:738
+#: components/views/Offset/index.tsx:724
 msgid "offset.aggregation_fee_tooltip"
 msgstr ""
 
-#: components/views/Offset/index.tsx:612
+#: components/views/Offset/index.tsx:616
 msgid "offset.amount_in_tonnes"
 msgstr ""
 
@@ -473,19 +473,19 @@ msgstr ""
 msgid "offset.breakdown"
 msgstr ""
 
-#: components/views/Offset/index.tsx:455
+#: components/views/Offset/index.tsx:460
 msgid "offset.checkout"
 msgstr ""
 
-#: components/views/Offset/index.tsx:704
+#: components/views/Offset/index.tsx:690
 msgid "offset.default_retirement_address"
 msgstr ""
 
-#: components/views/Offset/index.tsx:776
+#: components/views/Offset/index.tsx:762
 msgid "offset.dropdown_payWith.label"
 msgstr ""
 
-#: components/views/Offset/index.tsx:585
+#: components/views/Offset/index.tsx:589
 msgid "offset.dropdown_retire.label"
 msgstr ""
 
@@ -497,39 +497,35 @@ msgstr ""
 msgid "offset.enter_address"
 msgstr ""
 
-#: components/views/Offset/index.tsx:566
+#: components/views/Offset/index.tsx:570
 msgid "offset.go_carbon_neutral"
 msgstr ""
 
-#: components/views/Offset/index.tsx:542
+#: components/views/Offset/index.tsx:546
 msgid "offset.incompatible"
 msgstr ""
 
-#: components/views/Offset/index.tsx:418
+#: components/views/Offset/index.tsx:423
 msgid "offset.insufficient_project_tonnage"
 msgstr ""
 
-#: components/views/Offset/index.tsx:653
-msgid "offset.invalid_fractional_quantity_fiat"
-msgstr ""
-
-#: components/views/Offset/index.tsx:664
+#: components/views/Offset/index.tsx:650
 msgid "offset.invalid_project_tonnage"
 msgstr ""
 
-#: components/views/Offset/index.tsx:574
+#: components/views/Offset/index.tsx:578
 msgid "offset.lifi"
 msgstr ""
 
-#: components/views/Offset/index.tsx:671
+#: components/views/Offset/index.tsx:657
 msgid "offset.min_quantity_fiat"
 msgstr ""
 
-#: components/views/Offset/index.tsx:780
+#: components/views/Offset/index.tsx:766
 msgid "offset.modal_payWith.title"
 msgstr ""
 
-#: components/views/Offset/index.tsx:589
+#: components/views/Offset/index.tsx:593
 msgid "offset.modal_retire.title"
 msgstr ""
 
@@ -537,12 +533,12 @@ msgstr ""
 msgid "offset.number_of_retirements"
 msgstr ""
 
-#: components/views/Offset/index.tsx:640
+#: components/views/Offset/index.tsx:638
 msgid "offset.offset_quantity"
 msgstr ""
 
-#: components/views/Offset/index.tsx:563
-#: components/views/Offset/index.tsx:823
+#: components/views/Offset/index.tsx:567
+#: components/views/Offset/index.tsx:809
 msgid "offset.retire_carbon"
 msgstr ""
 
@@ -554,19 +550,19 @@ msgstr ""
 msgid "offset.retire_specific_tooltip"
 msgstr ""
 
-#: components/views/Offset/index.tsx:681
+#: components/views/Offset/index.tsx:667
 msgid "offset.retirement_credit"
 msgstr ""
 
-#: components/views/Offset/index.tsx:715
+#: components/views/Offset/index.tsx:701
 msgid "offset.retirement_message"
 msgstr ""
 
-#: components/views/Offset/index.tsx:724
+#: components/views/Offset/index.tsx:710
 msgid "offset.retirement_purpose"
 msgstr ""
 
-#: components/views/Offset/index.tsx:766
+#: components/views/Offset/index.tsx:752
 msgid "offset.retiring"
 msgstr ""
 
@@ -670,11 +666,11 @@ msgstr ""
 msgid "offset.you_have_retired"
 msgstr ""
 
-#: components/views/Offset/index.tsx:734
+#: components/views/Offset/index.tsx:720
 msgid "offset_cost"
 msgstr ""
 
-#: components/views/Offset/index.tsx:796
+#: components/views/Offset/index.tsx:782
 msgid "offset_disclaimer"
 msgstr ""
 
@@ -744,7 +740,7 @@ msgstr ""
 
 #: components/TransactionModal/Approve.tsx:97
 #: components/views/Bond/index.tsx:454
-#: components/views/Offset/index.tsx:450
+#: components/views/Offset/index.tsx:455
 #: components/views/Stake/index.tsx:253
 #: components/views/Wrap/index.tsx:230
 msgid "shared.approve"
@@ -777,18 +773,18 @@ msgstr ""
 msgid "shared.enter_amount"
 msgstr ""
 
-#: components/views/Offset/index.tsx:394
+#: components/views/Offset/index.tsx:399
 msgid "shared.enter_beneficiary"
 msgstr ""
 
 #: components/views/Bond/index.tsx:417
-#: components/views/Offset/index.tsx:389
+#: components/views/Offset/index.tsx:394
 #: components/views/Stake/index.tsx:240
 #: components/views/Wrap/index.tsx:209
 msgid "shared.enter_quantity"
 msgstr ""
 
-#: components/views/Offset/index.tsx:402
+#: components/views/Offset/index.tsx:407
 msgid "shared.enter_retirement_message"
 msgstr ""
 
@@ -799,21 +795,21 @@ msgstr ""
 msgid "shared.error"
 msgstr ""
 
-#: components/views/Offset/index.tsx:442
+#: components/views/Offset/index.tsx:447
 #: components/views/Stake/index.tsx:245
 #: components/views/Wrap/index.tsx:222
 msgid "shared.insufficient_balance"
 msgstr ""
 
-#: components/views/Offset/index.tsx:410
+#: components/views/Offset/index.tsx:415
 msgid "shared.invalid_beneficiary_addr"
 msgstr ""
 
-#: components/views/Offset/index.tsx:434
+#: components/views/Offset/index.tsx:439
 msgid "shared.invalid_project_address"
 msgstr ""
 
-#: components/views/Offset/index.tsx:426
+#: components/views/Offset/index.tsx:431
 msgid "shared.invalid_quantity"
 msgstr ""
 
@@ -822,8 +818,8 @@ msgstr ""
 #: components/RebaseCard/index.tsx:69
 #: components/views/Bond/index.tsx:411
 #: components/views/Loading/index.tsx:11
-#: components/views/Offset/index.tsx:376
-#: components/views/Offset/index.tsx:521
+#: components/views/Offset/index.tsx:381
+#: components/views/Offset/index.tsx:525
 #: components/views/PKlima/index.tsx:158
 #: components/views/Stake/index.tsx:431
 #: components/views/Stake/index.tsx:438
@@ -835,7 +831,7 @@ msgstr ""
 #: components/views/Bond/index.tsx:397
 #: components/views/Buy/index.tsx:63
 #: components/views/Home/index.tsx:154
-#: components/views/Offset/index.tsx:368
+#: components/views/Offset/index.tsx:373
 #: components/views/PKlima/index.tsx:150
 #: components/views/Stake/index.tsx:227
 #: components/views/Wrap/index.tsx:196
@@ -849,11 +845,11 @@ msgstr ""
 msgid "shared.max"
 msgstr ""
 
-#: components/views/Offset/index.tsx:381
+#: components/views/Offset/index.tsx:386
 msgid "shared.redirecting_checkout"
 msgstr ""
 
-#: components/views/Offset/index.tsx:460
+#: components/views/Offset/index.tsx:465
 msgid "shared.retire"
 msgstr ""
 

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/views/Offset/index.tsx:669
+#: components/views/Offset/index.tsx:701
 msgid "Beneficiary 0x address (optional)"
 msgstr "Beneficiary 0x address (optional)"
 
-#: components/views/Offset/index.tsx:657
+#: components/views/Offset/index.tsx:689
 msgid "Beneficiary name"
 msgstr "Beneficiary name"
 
@@ -342,7 +342,7 @@ msgstr "Connection Error"
 msgid "connect_modal.sign_in"
 msgstr "Sign In / Connect"
 
-#: components/views/Offset/index.tsx:722
+#: components/views/Offset/index.tsx:754
 msgid "fiat.max_quantity"
 msgstr "${0} maximum for credit cards"
 
@@ -461,11 +461,11 @@ msgstr "CONFIRMATION"
 msgid "nav.back"
 msgstr "BACK"
 
-#: components/views/Offset/index.tsx:706
+#: components/views/Offset/index.tsx:738
 msgid "offset.aggregation_fee_tooltip"
 msgstr "This cost includes slippage and the aggregation fee of 1%."
 
-#: components/views/Offset/index.tsx:602
+#: components/views/Offset/index.tsx:612
 msgid "offset.amount_in_tonnes"
 msgstr "How many tonnes of carbon would you like to offset?"
 
@@ -473,19 +473,19 @@ msgstr "How many tonnes of carbon would you like to offset?"
 msgid "offset.breakdown"
 msgstr "Breakdown"
 
-#: components/views/Offset/index.tsx:448
+#: components/views/Offset/index.tsx:455
 msgid "offset.checkout"
 msgstr "Checkout"
 
-#: components/views/Offset/index.tsx:672
+#: components/views/Offset/index.tsx:704
 msgid "offset.default_retirement_address"
 msgstr "Defaults to the connected wallet address"
 
-#: components/views/Offset/index.tsx:744
+#: components/views/Offset/index.tsx:776
 msgid "offset.dropdown_payWith.label"
 msgstr "Pay with"
 
-#: components/views/Offset/index.tsx:575
+#: components/views/Offset/index.tsx:585
 msgid "offset.dropdown_retire.label"
 msgstr "Select carbon offset token to retire"
 
@@ -497,35 +497,39 @@ msgstr "This address has not completed any retirements."
 msgid "offset.enter_address"
 msgstr "Enter 0x address"
 
-#: components/views/Offset/index.tsx:556
+#: components/views/Offset/index.tsx:566
 msgid "offset.go_carbon_neutral"
 msgstr "Go carbon neutral by retiring carbon and claiming the underlying environmental benefit of the carbon offset. Learn more about carbon tokens in our <0>docs</0>."
 
-#: components/views/Offset/index.tsx:532
+#: components/views/Offset/index.tsx:542
 msgid "offset.incompatible"
 msgstr "INPUT TOKEN INCOMPATIBLE"
 
-#: components/views/Offset/index.tsx:411
+#: components/views/Offset/index.tsx:418
 msgid "offset.insufficient_project_tonnage"
 msgstr "Insufficient project tonnage"
 
-#: components/views/Offset/index.tsx:632
+#: components/views/Offset/index.tsx:653
+msgid "offset.invalid_fractional_quantity_fiat"
+msgstr "Cannot use a fractional quantity when paying with credit card!"
+
+#: components/views/Offset/index.tsx:664
 msgid "offset.invalid_project_tonnage"
 msgstr "Cannot exceed available tonnage of the project selected"
 
-#: components/views/Offset/index.tsx:564
+#: components/views/Offset/index.tsx:574
 msgid "offset.lifi"
 msgstr "Cross-chain offsetting is now available through <0>LI.FI and Etherspot</0>, with support for multiple chains and tokens."
 
-#: components/views/Offset/index.tsx:639
+#: components/views/Offset/index.tsx:671
 msgid "offset.min_quantity_fiat"
 msgstr "Minimum 1-tonne purchase for credit cards"
 
-#: components/views/Offset/index.tsx:748
+#: components/views/Offset/index.tsx:780
 msgid "offset.modal_payWith.title"
 msgstr "Select Token"
 
-#: components/views/Offset/index.tsx:579
+#: components/views/Offset/index.tsx:589
 msgid "offset.modal_retire.title"
 msgstr "Select Carbon Type"
 
@@ -533,12 +537,12 @@ msgstr "Select Carbon Type"
 msgid "offset.number_of_retirements"
 msgstr "Total retirements"
 
-#: components/views/Offset/index.tsx:620
+#: components/views/Offset/index.tsx:640
 msgid "offset.offset_quantity"
 msgstr "Enter quantity to offset"
 
-#: components/views/Offset/index.tsx:553
-#: components/views/Offset/index.tsx:791
+#: components/views/Offset/index.tsx:563
+#: components/views/Offset/index.tsx:823
 msgid "offset.retire_carbon"
 msgstr "Retire Carbon"
 
@@ -550,19 +554,19 @@ msgstr "Retire specific project tokens (optional)"
 msgid "offset.retire_specific_tooltip"
 msgstr "Subject to additional fee, determined by the selected pool and paid to the bridge provider."
 
-#: components/views/Offset/index.tsx:649
+#: components/views/Offset/index.tsx:681
 msgid "offset.retirement_credit"
 msgstr "Who will this retirement be credited to?"
 
-#: components/views/Offset/index.tsx:683
+#: components/views/Offset/index.tsx:715
 msgid "offset.retirement_message"
 msgstr "Retirement message"
 
-#: components/views/Offset/index.tsx:692
+#: components/views/Offset/index.tsx:724
 msgid "offset.retirement_purpose"
 msgstr "Describe the purpose of this retirement"
 
-#: components/views/Offset/index.tsx:734
+#: components/views/Offset/index.tsx:766
 msgid "offset.retiring"
 msgstr "Retiring"
 
@@ -666,11 +670,11 @@ msgstr "Tonnes of carbon"
 msgid "offset.you_have_retired"
 msgstr "You've Retired"
 
-#: components/views/Offset/index.tsx:702
+#: components/views/Offset/index.tsx:734
 msgid "offset_cost"
 msgstr "Cost"
 
-#: components/views/Offset/index.tsx:764
+#: components/views/Offset/index.tsx:796
 msgid "offset_disclaimer"
 msgstr "Be careful not to expose any sensitive personal information. Your message can not be edited and will permanently exist on a public blockchain."
 
@@ -740,7 +744,7 @@ msgstr "The updated contract now assumes pKLIMA holders have staked and earned r
 
 #: components/TransactionModal/Approve.tsx:97
 #: components/views/Bond/index.tsx:454
-#: components/views/Offset/index.tsx:443
+#: components/views/Offset/index.tsx:450
 #: components/views/Stake/index.tsx:253
 #: components/views/Wrap/index.tsx:230
 msgid "shared.approve"
@@ -773,18 +777,18 @@ msgstr "Loading..."
 msgid "shared.enter_amount"
 msgstr "Enter Amount"
 
-#: components/views/Offset/index.tsx:387
+#: components/views/Offset/index.tsx:394
 msgid "shared.enter_beneficiary"
 msgstr "Enter beneficiary name"
 
 #: components/views/Bond/index.tsx:417
-#: components/views/Offset/index.tsx:382
+#: components/views/Offset/index.tsx:389
 #: components/views/Stake/index.tsx:240
 #: components/views/Wrap/index.tsx:209
 msgid "shared.enter_quantity"
 msgstr "ENTER QUANTITY"
 
-#: components/views/Offset/index.tsx:395
+#: components/views/Offset/index.tsx:402
 msgid "shared.enter_retirement_message"
 msgstr "Enter retirement message"
 
@@ -795,21 +799,21 @@ msgstr "Enter retirement message"
 msgid "shared.error"
 msgstr "ERROR"
 
-#: components/views/Offset/index.tsx:435
+#: components/views/Offset/index.tsx:442
 #: components/views/Stake/index.tsx:245
 #: components/views/Wrap/index.tsx:222
 msgid "shared.insufficient_balance"
 msgstr "INSUFFICIENT BALANCE"
 
-#: components/views/Offset/index.tsx:403
+#: components/views/Offset/index.tsx:410
 msgid "shared.invalid_beneficiary_addr"
 msgstr "Invalid beneficiary address"
 
-#: components/views/Offset/index.tsx:427
+#: components/views/Offset/index.tsx:434
 msgid "shared.invalid_project_address"
 msgstr "Invalid project address"
 
-#: components/views/Offset/index.tsx:419
+#: components/views/Offset/index.tsx:426
 msgid "shared.invalid_quantity"
 msgstr "Invalid quantity"
 
@@ -818,8 +822,8 @@ msgstr "Invalid quantity"
 #: components/RebaseCard/index.tsx:69
 #: components/views/Bond/index.tsx:411
 #: components/views/Loading/index.tsx:11
-#: components/views/Offset/index.tsx:369
-#: components/views/Offset/index.tsx:511
+#: components/views/Offset/index.tsx:376
+#: components/views/Offset/index.tsx:521
 #: components/views/PKlima/index.tsx:158
 #: components/views/Stake/index.tsx:431
 #: components/views/Stake/index.tsx:438
@@ -831,7 +835,7 @@ msgstr "Loading..."
 #: components/views/Bond/index.tsx:397
 #: components/views/Buy/index.tsx:63
 #: components/views/Home/index.tsx:154
-#: components/views/Offset/index.tsx:361
+#: components/views/Offset/index.tsx:368
 #: components/views/PKlima/index.tsx:150
 #: components/views/Stake/index.tsx:227
 #: components/views/Wrap/index.tsx:196
@@ -845,11 +849,11 @@ msgstr "Login / Connect"
 msgid "shared.max"
 msgstr "Max"
 
-#: components/views/Offset/index.tsx:374
+#: components/views/Offset/index.tsx:381
 msgid "shared.redirecting_checkout"
 msgstr "Redirecting to checkout..."
 
-#: components/views/Offset/index.tsx:453
+#: components/views/Offset/index.tsx:460
 msgid "shared.retire"
 msgstr "Retire carbon"
 

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/views/Offset/index.tsx:701
+#: components/views/Offset/index.tsx:687
 msgid "Beneficiary 0x address (optional)"
 msgstr "Beneficiary 0x address (optional)"
 
-#: components/views/Offset/index.tsx:689
+#: components/views/Offset/index.tsx:675
 msgid "Beneficiary name"
 msgstr "Beneficiary name"
 
@@ -342,7 +342,7 @@ msgstr "Connection Error"
 msgid "connect_modal.sign_in"
 msgstr "Sign In / Connect"
 
-#: components/views/Offset/index.tsx:754
+#: components/views/Offset/index.tsx:740
 msgid "fiat.max_quantity"
 msgstr "${0} maximum for credit cards"
 
@@ -461,11 +461,11 @@ msgstr "CONFIRMATION"
 msgid "nav.back"
 msgstr "BACK"
 
-#: components/views/Offset/index.tsx:738
+#: components/views/Offset/index.tsx:724
 msgid "offset.aggregation_fee_tooltip"
 msgstr "This cost includes slippage and the aggregation fee of 1%."
 
-#: components/views/Offset/index.tsx:612
+#: components/views/Offset/index.tsx:616
 msgid "offset.amount_in_tonnes"
 msgstr "How many tonnes of carbon would you like to offset?"
 
@@ -473,19 +473,19 @@ msgstr "How many tonnes of carbon would you like to offset?"
 msgid "offset.breakdown"
 msgstr "Breakdown"
 
-#: components/views/Offset/index.tsx:455
+#: components/views/Offset/index.tsx:460
 msgid "offset.checkout"
 msgstr "Checkout"
 
-#: components/views/Offset/index.tsx:704
+#: components/views/Offset/index.tsx:690
 msgid "offset.default_retirement_address"
 msgstr "Defaults to the connected wallet address"
 
-#: components/views/Offset/index.tsx:776
+#: components/views/Offset/index.tsx:762
 msgid "offset.dropdown_payWith.label"
 msgstr "Pay with"
 
-#: components/views/Offset/index.tsx:585
+#: components/views/Offset/index.tsx:589
 msgid "offset.dropdown_retire.label"
 msgstr "Select carbon offset token to retire"
 
@@ -497,39 +497,35 @@ msgstr "This address has not completed any retirements."
 msgid "offset.enter_address"
 msgstr "Enter 0x address"
 
-#: components/views/Offset/index.tsx:566
+#: components/views/Offset/index.tsx:570
 msgid "offset.go_carbon_neutral"
 msgstr "Go carbon neutral by retiring carbon and claiming the underlying environmental benefit of the carbon offset. Learn more about carbon tokens in our <0>docs</0>."
 
-#: components/views/Offset/index.tsx:542
+#: components/views/Offset/index.tsx:546
 msgid "offset.incompatible"
 msgstr "INPUT TOKEN INCOMPATIBLE"
 
-#: components/views/Offset/index.tsx:418
+#: components/views/Offset/index.tsx:423
 msgid "offset.insufficient_project_tonnage"
 msgstr "Insufficient project tonnage"
 
-#: components/views/Offset/index.tsx:653
-msgid "offset.invalid_fractional_quantity_fiat"
-msgstr "Cannot use a fractional quantity when paying with credit card!"
-
-#: components/views/Offset/index.tsx:664
+#: components/views/Offset/index.tsx:650
 msgid "offset.invalid_project_tonnage"
 msgstr "Cannot exceed available tonnage of the project selected"
 
-#: components/views/Offset/index.tsx:574
+#: components/views/Offset/index.tsx:578
 msgid "offset.lifi"
 msgstr "Cross-chain offsetting is now available through <0>LI.FI and Etherspot</0>, with support for multiple chains and tokens."
 
-#: components/views/Offset/index.tsx:671
+#: components/views/Offset/index.tsx:657
 msgid "offset.min_quantity_fiat"
-msgstr "Minimum 1-tonne purchase for credit cards"
+msgstr "Minimum 1-tonne purchase. Whole integers only."
 
-#: components/views/Offset/index.tsx:780
+#: components/views/Offset/index.tsx:766
 msgid "offset.modal_payWith.title"
 msgstr "Select Token"
 
-#: components/views/Offset/index.tsx:589
+#: components/views/Offset/index.tsx:593
 msgid "offset.modal_retire.title"
 msgstr "Select Carbon Type"
 
@@ -537,12 +533,12 @@ msgstr "Select Carbon Type"
 msgid "offset.number_of_retirements"
 msgstr "Total retirements"
 
-#: components/views/Offset/index.tsx:640
+#: components/views/Offset/index.tsx:638
 msgid "offset.offset_quantity"
 msgstr "Enter quantity to offset"
 
-#: components/views/Offset/index.tsx:563
-#: components/views/Offset/index.tsx:823
+#: components/views/Offset/index.tsx:567
+#: components/views/Offset/index.tsx:809
 msgid "offset.retire_carbon"
 msgstr "Retire Carbon"
 
@@ -554,19 +550,19 @@ msgstr "Retire specific project tokens (optional)"
 msgid "offset.retire_specific_tooltip"
 msgstr "Subject to additional fee, determined by the selected pool and paid to the bridge provider."
 
-#: components/views/Offset/index.tsx:681
+#: components/views/Offset/index.tsx:667
 msgid "offset.retirement_credit"
 msgstr "Who will this retirement be credited to?"
 
-#: components/views/Offset/index.tsx:715
+#: components/views/Offset/index.tsx:701
 msgid "offset.retirement_message"
 msgstr "Retirement message"
 
-#: components/views/Offset/index.tsx:724
+#: components/views/Offset/index.tsx:710
 msgid "offset.retirement_purpose"
 msgstr "Describe the purpose of this retirement"
 
-#: components/views/Offset/index.tsx:766
+#: components/views/Offset/index.tsx:752
 msgid "offset.retiring"
 msgstr "Retiring"
 
@@ -670,11 +666,11 @@ msgstr "Tonnes of carbon"
 msgid "offset.you_have_retired"
 msgstr "You've Retired"
 
-#: components/views/Offset/index.tsx:734
+#: components/views/Offset/index.tsx:720
 msgid "offset_cost"
 msgstr "Cost"
 
-#: components/views/Offset/index.tsx:796
+#: components/views/Offset/index.tsx:782
 msgid "offset_disclaimer"
 msgstr "Be careful not to expose any sensitive personal information. Your message can not be edited and will permanently exist on a public blockchain."
 
@@ -744,7 +740,7 @@ msgstr "The updated contract now assumes pKLIMA holders have staked and earned r
 
 #: components/TransactionModal/Approve.tsx:97
 #: components/views/Bond/index.tsx:454
-#: components/views/Offset/index.tsx:450
+#: components/views/Offset/index.tsx:455
 #: components/views/Stake/index.tsx:253
 #: components/views/Wrap/index.tsx:230
 msgid "shared.approve"
@@ -777,18 +773,18 @@ msgstr "Loading..."
 msgid "shared.enter_amount"
 msgstr "Enter Amount"
 
-#: components/views/Offset/index.tsx:394
+#: components/views/Offset/index.tsx:399
 msgid "shared.enter_beneficiary"
 msgstr "Enter beneficiary name"
 
 #: components/views/Bond/index.tsx:417
-#: components/views/Offset/index.tsx:389
+#: components/views/Offset/index.tsx:394
 #: components/views/Stake/index.tsx:240
 #: components/views/Wrap/index.tsx:209
 msgid "shared.enter_quantity"
 msgstr "ENTER QUANTITY"
 
-#: components/views/Offset/index.tsx:402
+#: components/views/Offset/index.tsx:407
 msgid "shared.enter_retirement_message"
 msgstr "Enter retirement message"
 
@@ -799,21 +795,21 @@ msgstr "Enter retirement message"
 msgid "shared.error"
 msgstr "ERROR"
 
-#: components/views/Offset/index.tsx:442
+#: components/views/Offset/index.tsx:447
 #: components/views/Stake/index.tsx:245
 #: components/views/Wrap/index.tsx:222
 msgid "shared.insufficient_balance"
 msgstr "INSUFFICIENT BALANCE"
 
-#: components/views/Offset/index.tsx:410
+#: components/views/Offset/index.tsx:415
 msgid "shared.invalid_beneficiary_addr"
 msgstr "Invalid beneficiary address"
 
-#: components/views/Offset/index.tsx:434
+#: components/views/Offset/index.tsx:439
 msgid "shared.invalid_project_address"
 msgstr "Invalid project address"
 
-#: components/views/Offset/index.tsx:426
+#: components/views/Offset/index.tsx:431
 msgid "shared.invalid_quantity"
 msgstr "Invalid quantity"
 
@@ -822,8 +818,8 @@ msgstr "Invalid quantity"
 #: components/RebaseCard/index.tsx:69
 #: components/views/Bond/index.tsx:411
 #: components/views/Loading/index.tsx:11
-#: components/views/Offset/index.tsx:376
-#: components/views/Offset/index.tsx:521
+#: components/views/Offset/index.tsx:381
+#: components/views/Offset/index.tsx:525
 #: components/views/PKlima/index.tsx:158
 #: components/views/Stake/index.tsx:431
 #: components/views/Stake/index.tsx:438
@@ -835,7 +831,7 @@ msgstr "Loading..."
 #: components/views/Bond/index.tsx:397
 #: components/views/Buy/index.tsx:63
 #: components/views/Home/index.tsx:154
-#: components/views/Offset/index.tsx:368
+#: components/views/Offset/index.tsx:373
 #: components/views/PKlima/index.tsx:150
 #: components/views/Stake/index.tsx:227
 #: components/views/Wrap/index.tsx:196
@@ -849,11 +845,11 @@ msgstr "Login / Connect"
 msgid "shared.max"
 msgstr "Max"
 
-#: components/views/Offset/index.tsx:381
+#: components/views/Offset/index.tsx:386
 msgid "shared.redirecting_checkout"
 msgstr "Redirecting to checkout..."
 
-#: components/views/Offset/index.tsx:460
+#: components/views/Offset/index.tsx:465
 msgid "shared.retire"
 msgstr "Retire carbon"
 

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"


### PR DESCRIPTION
## Description

This PR fixes an issue where a user can enter a fractional quantity when inputting the tonnes of carbon to offset (when the "Credit Card" option is selected as the payment method.

## Related Ticket

Resolves #818

## Changes

| Before  | After  |
|---------|--------|
|<img width="600" alt="Screenshot 2023-01-13 at 23 11 21" src="https://user-images.githubusercontent.com/92357475/212435519-ec4a2ae8-d830-4e0d-a774-aac89c894059.png"> | <img width="600" alt="Screenshot 2023-01-13 at 23 11 56" src="https://user-images.githubusercontent.com/92357475/212435585-1d9e34eb-24ae-4e0c-947d-9afe5f1c7ec9.png">|

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
