### PR TITLE
[retirement_filters] add verra link to project details card

### DIFF
--- a/app/components/views/Offset/ProjectSearch/SelectProjectButton/index.tsx
+++ b/app/components/views/Offset/ProjectSearch/SelectProjectButton/index.tsx
@@ -58,7 +58,7 @@ export const SelectProjectButton: FC<Props> = (props) => {
         </div>
       </div>
 
-      <Text t="body4">{props.project.name || props.project.projectID} →</Text>
+      <Text t="body3">{props.project.name || props.project.projectID}</Text>
 
       <Text t="badge" className={styles.regionLabel}>
         {props.project.country || props.project.region}

--- a/app/components/views/Offset/ProjectSearch/SelectProjectButton/index.tsx
+++ b/app/components/views/Offset/ProjectSearch/SelectProjectButton/index.tsx
@@ -3,6 +3,7 @@ import { RetirementToken, verra } from "@klimadao/lib/constants";
 import { trimWithLocale } from "@klimadao/lib/utils";
 import { Trans } from "@lingui/macro";
 import CheckIcon from "@mui/icons-material/Check";
+import LaunchIcon from "@mui/icons-material/Launch";
 import { FC } from "react";
 
 import {
@@ -57,22 +58,27 @@ export const SelectProjectButton: FC<Props> = (props) => {
         </div>
       </div>
 
-      <Anchor href={linkToProjectDetails()}>
-        <Text t="body4">{props.project.name || props.project.projectID} →</Text>
-      </Anchor>
+      <Text t="body4">{props.project.name || props.project.projectID} →</Text>
 
       <Text t="badge" className={styles.regionLabel}>
         {props.project.country || props.project.region}
       </Text>
 
       {props.selectedRetirementToken !== "mco2" && (
-        <Text t="badge">
+        <Text t="badge" className={styles.tonnageLabel}>
           <Trans id="offset.selectiveRetirement.project.available_tonnes">
             Available tonnes:{" "}
             {trimWithLocale(availableTonnes.toString(), 2, "en")}
           </Trans>
         </Text>
       )}
+
+      <Anchor href={linkToProjectDetails()}>
+        <Text t="badge" color="lightest" className={styles.projectDetailsLink}>
+          Project details
+          <LaunchIcon />
+        </Text>
+      </Anchor>
     </button>
   );
 };

--- a/app/components/views/Offset/ProjectSearch/SelectProjectButton/styles.ts
+++ b/app/components/views/Offset/ProjectSearch/SelectProjectButton/styles.ts
@@ -55,4 +55,25 @@ export const checkedIcon = css`
 
 export const regionLabel = css`
   color: var(--klima-green);
+  font-size: 1.3rem;
+`;
+
+export const tonnageLabel = css`
+  font-size: 1.3rem;
+`;
+
+export const projectDetailsLink = css`
+  display: flex;
+  align-items: center;
+  font-size: 1.2rem;
+
+  &:hover {
+    color: var(--klima-green);
+    cursor: pointer;
+  }
+
+  svg {
+    padding: 0.4rem; // hacky way to make svg smaller
+    color: inherit;
+  }
 `;


### PR DESCRIPTION
## Description

@theprofessora, I've made these further changes:
- "View project details" looked too wordy, "Project details" as an outbound link can be inferred from the iconography
- Made the font colour lighter to lower its visual heirarchy

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #863 

## Changes

| Before  | After  |
|---------|--------|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/97446324/212527009-8762b041-fc34-4dfe-9ad0-97cdad319fc6.png">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/97446324/212526995-54ef7e90-dd22-4d9b-b236-4a042eafbea5.png">|


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
