### PR TITLE
Use JsonRpcBatchProvider by default

### DIFF
--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -13,7 +13,7 @@ import {
 
 export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
   return async (dispatch) => {
-    const provider = getStaticProvider({ batchRequests: true });
+    const provider = getStaticProvider();
     try {
       const currentBlock = await provider.getBlockNumber();
 

--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -13,7 +13,7 @@ import {
 
 export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
   return async (dispatch) => {
-    const provider = getStaticProvider();
+    const provider = getStaticProvider({ batchRequests: true });
     try {
       const currentBlock = await provider.getBlockNumber();
 

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -180,7 +180,7 @@ export const calcBondDetails = (params: {
   value?: string;
 }): Thunk => {
   return async (dispatch) => {
-    const provider = getStaticProvider({ batchRequests: true });
+    const provider = getStaticProvider();
     let amountInWei;
     if (!params.value || params.value === "") {
       amountInWei = utils.parseEther("0");
@@ -318,7 +318,7 @@ export const calculateUserBondDetails = (params: {
 }): Thunk => {
   return async (dispatch) => {
     if (!params.address) return;
-    const provider = getStaticProvider({ batchRequests: true });
+    const provider = getStaticProvider();
     // inverse bonds dont have user details
     if (getIsInverse(params.bond)) {
       const klimaContract = getContract({

--- a/app/actions/bonds.ts
+++ b/app/actions/bonds.ts
@@ -180,7 +180,7 @@ export const calcBondDetails = (params: {
   value?: string;
 }): Thunk => {
   return async (dispatch) => {
-    const provider = getStaticProvider();
+    const provider = getStaticProvider({ batchRequests: true });
     let amountInWei;
     if (!params.value || params.value === "") {
       amountInWei = utils.parseEther("0");
@@ -315,15 +315,15 @@ export const calcBondDetails = (params: {
 export const calculateUserBondDetails = (params: {
   address: string;
   bond: Bond;
-  provider: providers.JsonRpcProvider;
 }): Thunk => {
   return async (dispatch) => {
     if (!params.address) return;
+    const provider = getStaticProvider({ batchRequests: true });
     // inverse bonds dont have user details
     if (getIsInverse(params.bond)) {
       const klimaContract = getContract({
         contractName: "klima",
-        provider: params.provider,
+        provider,
       });
 
       const inverseAllowance = await klimaContract.allowance(
@@ -341,12 +341,12 @@ export const calculateUserBondDetails = (params: {
     // Calculate bond details.
     const bondContract = contractForBond({
       bond: params.bond,
-      provider: params.provider,
+      provider,
     });
 
     const reserveContract = contractForReserve({
       bond: params.bond,
-      providerOrSigner: params.provider,
+      providerOrSigner: provider,
     });
 
     const bondDetails = await bondContract.bondInfo(params.address);

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -53,7 +53,7 @@ export const getRetirementAllowances = (params: {
       const promises = offsetInputTokens.reduce((arr, val) => {
         const contract = getContract({
           contractName: val,
-          provider: getStaticProvider({ batchRequests: true }),
+          provider: getStaticProvider(),
         });
         arr.push(
           getAllowance({

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -53,7 +53,7 @@ export const getRetirementAllowances = (params: {
       const promises = offsetInputTokens.reduce((arr, val) => {
         const contract = getContract({
           contractName: val,
-          provider: getStaticProvider(),
+          provider: getStaticProvider({ batchRequests: true }),
         });
         arr.push(
           getAllowance({

--- a/app/actions/offset.ts
+++ b/app/actions/offset.ts
@@ -27,7 +27,6 @@ import {
 import { AllowancesFormatted } from "@klimadao/lib/types/allowances";
 
 export const getRetiredOffsetBalances = (params: {
-  provider: providers.JsonRpcProvider;
   address: string;
   onRPCError: () => void;
 }): Thunk => {
@@ -45,7 +44,6 @@ export const getRetiredOffsetBalances = (params: {
 };
 
 export const getRetirementAllowances = (params: {
-  provider: providers.JsonRpcProvider;
   address: string;
   onRPCError: () => void;
 }): Thunk => {
@@ -55,7 +53,7 @@ export const getRetirementAllowances = (params: {
       const promises = offsetInputTokens.reduce((arr, val) => {
         const contract = getContract({
           contractName: val,
-          provider: params.provider,
+          provider: getStaticProvider(),
         });
         arr.push(
           getAllowance({

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -1,4 +1,4 @@
-import { Contract, providers } from "ethers";
+import { Contract } from "ethers";
 import { Thunk } from "state";
 
 import { AllowancesFormatted } from "@klimadao/lib/types/allowances";
@@ -8,6 +8,7 @@ import {
   getContract,
   getENSProfile,
   getKNSProfile,
+  getStaticProvider,
   getTokenDecimals,
   getTokensFromSpender,
 } from "@klimadao/lib/utils";
@@ -58,17 +59,17 @@ type ContractsObject = {
 };
 
 export const loadAccountDetails = (params: {
-  provider: providers.JsonRpcProvider;
   address: string;
   onRPCError: () => void;
 }): Thunk => {
   return async (dispatch) => {
     try {
+      const provider = getStaticProvider({ batchRequests: true });
       // all assets
       const assetsContracts = assets.reduce((obj, asset) => {
         const contract = getContract({
           contractName: asset,
-          provider: params.provider,
+          provider,
         });
         return { ...obj, [asset]: contract };
       }, {} as ContractsObject);

--- a/app/actions/user.ts
+++ b/app/actions/user.ts
@@ -64,7 +64,7 @@ export const loadAccountDetails = (params: {
 }): Thunk => {
   return async (dispatch) => {
     try {
-      const provider = getStaticProvider({ batchRequests: true });
+      const provider = getStaticProvider();
       // all assets
       const assetsContracts = assets.reduce((obj, asset) => {
         const contract = getContract({

--- a/app/components/views/Bond/index.tsx
+++ b/app/components/views/Bond/index.tsx
@@ -242,7 +242,6 @@ export const Bond: FC<Props> = (props) => {
           calculateUserBondDetails({
             address: props.address,
             bond: props.bond,
-            provider: props.provider,
           })
         );
       }

--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -24,7 +24,7 @@ import { Wrap } from "components/views/Wrap";
 import { initLocale } from "lib/i18n";
 
 import { ButtonPrimary } from "@klimadao/lib/components";
-import { concatAddress, getStaticProvider, useWeb3 } from "@klimadao/lib/utils";
+import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
 import Menu from "@mui/icons-material/Menu";
 import { ChangeLanguageButton } from "components/ChangeLanguageButton";
@@ -89,7 +89,6 @@ export const Home: FC = () => {
       dispatch(
         loadAccountDetails({
           address: address,
-          provider: getStaticProvider(),
           onRPCError: handleRPCError,
         })
       );

--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -89,7 +89,7 @@ export const Home: FC = () => {
       dispatch(
         loadAccountDetails({
           address: address,
-          provider: getStaticProvider(),
+          provider: getStaticProvider({ batchRequests: true }),
           onRPCError: handleRPCError,
         })
       );

--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -89,7 +89,7 @@ export const Home: FC = () => {
       dispatch(
         loadAccountDetails({
           address: address,
-          provider: getStaticProvider({ batchRequests: true }),
+          provider: getStaticProvider(),
           onRPCError: handleRPCError,
         })
       );

--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -13,7 +13,7 @@ import {
   retirementTokens,
   urls,
 } from "@klimadao/lib/constants";
-import { getStaticProvider, getTokenDecimals } from "@klimadao/lib/utils";
+import { getTokenDecimals } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import { providers, utils } from "ethers";
 import { ChangeEvent, useEffect, useRef, useState } from "react";
@@ -150,23 +150,21 @@ export const Offset = (props: Props) => {
   }, [params]);
 
   useEffect(() => {
-    if (props.isConnected && props.address && props.provider) {
+    if (props.isConnected && props.address) {
       dispatch(
         getRetiredOffsetBalances({
           address: props.address,
-          provider: props.provider,
           onRPCError: props.onRPCError,
         })
       );
       dispatch(
         getRetirementAllowances({
           address: props.address,
-          provider: getStaticProvider(),
           onRPCError: props.onRPCError,
         })
       );
     }
-  }, [props.isConnected, props.address, props.provider]);
+  }, [props.isConnected, props.address]);
 
   // effects
   useEffect(() => {

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -72,7 +72,6 @@ export const getRetirementTotalsAndBalances = async (params: {
   try {
     const provider = getStaticProvider({
       infuraId: params.infuraId,
-      batchRequests: true,
     });
     const retirementStorageContract = createRetirementStorageContract(provider);
 

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -28,7 +28,6 @@ export const getRetirementIndexInfo = async (params: {
   try {
     const provider = getStaticProvider({
       infuraId: params.infuraId,
-      batchRequests: true,
     });
     const storageContract = createRetirementStorageContract(provider);
 

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -28,6 +28,7 @@ export const getRetirementIndexInfo = async (params: {
   try {
     const provider = getStaticProvider({
       infuraId: params.infuraId,
+      batchRequests: true,
     });
     const storageContract = createRetirementStorageContract(provider);
 
@@ -72,6 +73,7 @@ export const getRetirementTotalsAndBalances = async (params: {
   try {
     const provider = getStaticProvider({
       infuraId: params.infuraId,
+      batchRequests: true,
     });
     const retirementStorageContract = createRetirementStorageContract(provider);
 

--- a/lib/utils/getRetirement/index.ts
+++ b/lib/utils/getRetirement/index.ts
@@ -26,7 +26,9 @@ export const getRetirementIndexInfo = async (params: {
   infuraId?: string;
 }): Promise<RetirementIndexInfoResult> => {
   try {
-    const provider = getStaticProvider({ infuraId: params.infuraId });
+    const provider = getStaticProvider({
+      infuraId: params.infuraId,
+    });
     const storageContract = createRetirementStorageContract(provider);
 
     const [
@@ -68,7 +70,9 @@ export const getRetirementTotalsAndBalances = async (params: {
   infuraId?: string;
 }): Promise<RetirementsTotalsAndBalances> => {
   try {
-    const provider = getStaticProvider({ infuraId: params.infuraId });
+    const provider = getStaticProvider({
+      infuraId: params.infuraId,
+    });
     const retirementStorageContract = createRetirementStorageContract(provider);
 
     const promises: [

--- a/lib/utils/getStaticProvider/index.ts
+++ b/lib/utils/getStaticProvider/index.ts
@@ -2,7 +2,7 @@ import { providers } from "ethers";
 import { urls } from "../../constants";
 import { getInfuraUrl } from "../getInfuraUrl";
 
-const { JsonRpcProvider } = providers;
+const { JsonRpcProvider, JsonRpcBatchProvider } = providers;
 
 interface RuntimeProviders {
   eth: {
@@ -19,7 +19,7 @@ interface RuntimeProviders {
   };
 }
 
-const runtimeProviders: RuntimeProviders = {
+const staticProviders: RuntimeProviders = {
   eth: {
     infura: undefined,
     default: new JsonRpcProvider(urls.defaultEthRpc),
@@ -34,6 +34,23 @@ const runtimeProviders: RuntimeProviders = {
     default: new JsonRpcProvider(urls.polygonTestnetRpc),
   },
 };
+
+const batchProviders: RuntimeProviders = {
+  eth: {
+    infura: undefined,
+    default: new JsonRpcBatchProvider(urls.defaultEthRpc),
+  },
+  polygon: {
+    infura: undefined,
+    // TEMP use infura id until polygon-rpc stops being flaky
+    default: new JsonRpcBatchProvider(urls.infuraPolygonRpcClient),
+  },
+  mumbai: {
+    infura: undefined,
+    default: new JsonRpcBatchProvider(urls.polygonTestnetRpc),
+  },
+};
+
 /**
  * Returns a provider for making RPC calls to the given chain.
  * 'static' because the RPC is chosen by us, can't be changed by the user, and can't be used for signing txns.
@@ -42,22 +59,26 @@ const runtimeProviders: RuntimeProviders = {
  */
 export const getStaticProvider = (params?: {
   chain?: "polygon" | "eth" | "mumbai";
+  batchRequests?: boolean;
   infuraId?: string;
 }): providers.JsonRpcProvider => {
-  const chain = params?.chain || "polygon";
+  const { chain = "polygon", batchRequests = false } = params || {};
+  const providers = batchRequests ? batchProviders : staticProviders;
 
   if (!params?.infuraId) {
-    return runtimeProviders[chain].default;
+    return providers[chain].default;
   }
 
-  const existingInfura = runtimeProviders[chain].infura; // satisfy ts null check
+  const existingInfura = providers[chain].infura; // satisfy ts null check
   if (existingInfura) return existingInfura;
 
   const infuraUrl = getInfuraUrl({
     chain,
     infuraId: params.infuraId,
   });
-  const newInfura = new JsonRpcProvider(infuraUrl);
-  runtimeProviders[chain].infura = newInfura;
+  const newInfura = batchProviders
+    ? new JsonRpcBatchProvider(infuraUrl)
+    : new JsonRpcProvider(infuraUrl);
+  providers[chain].infura = newInfura;
   return newInfura;
 };

--- a/lib/utils/getStaticProvider/index.ts
+++ b/lib/utils/getStaticProvider/index.ts
@@ -69,7 +69,9 @@ export const getStaticProvider = (params?: {
   batchRequests?: boolean;
   infuraId?: string;
 }): providers.JsonRpcProvider => {
-  const { chain = "polygon", batchRequests = false } = params || {};
+  // const { chain = "polygon", batchRequests = false } = params || {};
+  const { chain = "polygon" } = params || {};
+  const batchRequests = false;
   const providerMap = batchRequests ? batchProviders : staticProviders;
   const ProviderClass = batchRequests ? JsonRpcBatchProvider : JsonRpcProvider;
 

--- a/lib/utils/getStaticProvider/index.ts
+++ b/lib/utils/getStaticProvider/index.ts
@@ -6,21 +6,22 @@ const { JsonRpcProvider, JsonRpcBatchProvider } = providers;
 
 const defaultUrls = {
   eth: urls.defaultEthRpc,
+  // TEMP use infura id until polygon-rpc stops being flaky
   polygon: urls.infuraPolygonRpcClient,
   mumbai: urls.polygonTestnetRpc,
 };
 
 interface RuntimeProviders {
   eth: {
-    default: providers.JsonRpcProvider;
+    default?: providers.JsonRpcProvider;
     infura?: providers.JsonRpcProvider;
   };
   polygon: {
-    default: providers.JsonRpcProvider;
+    default?: providers.JsonRpcProvider;
     infura?: providers.JsonRpcProvider;
   };
   mumbai: {
-    default: providers.JsonRpcProvider;
+    default?: providers.JsonRpcProvider;
     infura?: providers.JsonRpcProvider;
   };
 }
@@ -28,32 +29,30 @@ interface RuntimeProviders {
 const staticProviders: RuntimeProviders = {
   eth: {
     infura: undefined,
-    default: new JsonRpcProvider(urls.defaultEthRpc),
+    default: undefined,
   },
   polygon: {
     infura: undefined,
-    // TEMP use infura id until polygon-rpc stops being flaky
-    default: new JsonRpcProvider(urls.infuraPolygonRpcClient),
+    default: undefined,
   },
   mumbai: {
     infura: undefined,
-    default: new JsonRpcProvider(urls.polygonTestnetRpc),
+    default: undefined,
   },
 };
 
 const batchProviders: RuntimeProviders = {
   eth: {
     infura: undefined,
-    default: new JsonRpcBatchProvider(urls.defaultEthRpc),
+    default: undefined,
   },
   polygon: {
     infura: undefined,
-    // TEMP use infura id until polygon-rpc stops being flaky
-    default: new JsonRpcBatchProvider(urls.infuraPolygonRpcClient),
+    default: undefined,
   },
   mumbai: {
     infura: undefined,
-    default: new JsonRpcBatchProvider(urls.polygonTestnetRpc),
+    default: undefined,
   },
 };
 
@@ -64,30 +63,32 @@ const batchProviders: RuntimeProviders = {
  * If no infura id is provided, a default public rpc is used.
  */
 export const getStaticProvider = (params?: {
+  /** Default "polygon" */
   chain?: "polygon" | "eth" | "mumbai";
+  /** Use JsonRpcBatchProvider instead. Default "true". Set to false if batching causes problems. */
   batchRequests?: boolean;
   infuraId?: string;
 }): providers.JsonRpcProvider => {
-  const { chain = "polygon", batchRequests = false } = params || {};
+  const { chain = "polygon", batchRequests = true } = params || {};
   const providerMap = batchRequests ? batchProviders : staticProviders;
   const ProviderClass = batchRequests ? JsonRpcBatchProvider : JsonRpcProvider;
 
-  // no infuraId provided, use defaults
-  if (!params?.infuraId) {
+  // infuraId provided
+  if (params?.infuraId) {
     // instantiate if needed
-    if (!providerMap[chain].default) {
-      providerMap[chain].default = new ProviderClass(defaultUrls[chain]);
+    if (!providerMap[chain].infura) {
+      const infuraUrl = getInfuraUrl({
+        chain,
+        infuraId: params.infuraId,
+      });
+      providerMap[chain].infura = new ProviderClass(infuraUrl);
     }
-    return providerMap[chain].default;
+    return providerMap[chain].infura;
   }
-
-  const existingInfura = providerMap[chain].infura; // satisfy ts null check
-  if (existingInfura) return existingInfura;
-
-  const infuraUrl = getInfuraUrl({
-    chain,
-    infuraId: params.infuraId,
-  });
-  providerMap[chain].infura = new ProviderClass(infuraUrl);
-  return providerMap[chain].infura;
+  // otherwise use defaults
+  // instantiate if needed
+  if (!providerMap[chain].default) {
+    providerMap[chain].default = new ProviderClass(defaultUrls[chain]);
+  }
+  return providerMap[chain].default;
 };

--- a/lib/utils/getStaticProvider/index.ts
+++ b/lib/utils/getStaticProvider/index.ts
@@ -69,9 +69,7 @@ export const getStaticProvider = (params?: {
   batchRequests?: boolean;
   infuraId?: string;
 }): providers.JsonRpcProvider => {
-  // const { chain = "polygon", batchRequests = false } = params || {};
-  const { chain = "polygon" } = params || {};
-  const batchRequests = false;
+  const { chain = "polygon", batchRequests = true } = params || {};
   const providerMap = batchRequests ? batchProviders : staticProviders;
   const ProviderClass = batchRequests ? JsonRpcBatchProvider : JsonRpcProvider;
 

--- a/lib/utils/getStaticProvider/index.ts
+++ b/lib/utils/getStaticProvider/index.ts
@@ -69,7 +69,7 @@ export const getStaticProvider = (params?: {
   batchRequests?: boolean;
   infuraId?: string;
 }): providers.JsonRpcProvider => {
-  const { chain = "polygon", batchRequests = true } = params || {};
+  const { chain = "polygon", batchRequests = false } = params || {};
   const providerMap = batchRequests ? batchProviders : staticProviders;
   const ProviderClass = batchRequests ? JsonRpcBatchProvider : JsonRpcProvider;
 

--- a/lib/utils/getTreasuryBalance/index.ts
+++ b/lib/utils/getTreasuryBalance/index.ts
@@ -6,7 +6,7 @@ import { getStaticProvider } from "../getStaticProvider";
 const getOwnedBCTFromSLP = async (params: { adr: "klimaBctLp" }) => {
   const contract = getContract({
     contractName: params.adr,
-    provider: getStaticProvider({ batchRequests: true }),
+    provider: getStaticProvider(),
   });
   const [token0, token1, [reserve0, reserve1], treasurySLP, totalSLP] =
     await Promise.all([

--- a/lib/utils/getTreasuryBalance/index.ts
+++ b/lib/utils/getTreasuryBalance/index.ts
@@ -1,16 +1,12 @@
-import { providers } from "ethers";
 import { addresses } from "../../constants";
 import { getContract } from "../getContract";
 import { getInteger } from "../getInteger";
 import { getStaticProvider } from "../getStaticProvider";
 
-const getOwnedBCTFromSLP = async (params: {
-  adr: "klimaBctLp";
-  provider: providers.JsonRpcProvider;
-}) => {
+const getOwnedBCTFromSLP = async (params: { adr: "klimaBctLp" }) => {
   const contract = getContract({
     contractName: params.adr,
-    provider: params.provider,
+    provider: getStaticProvider({ batchRequests: true }),
   });
   const [token0, token1, [reserve0, reserve1], treasurySLP, totalSLP] =
     await Promise.all([
@@ -43,15 +39,17 @@ export const getTreasuryBalance = async (params?: {
   infuraId?: string;
 }): Promise<number> => {
   try {
-    const provider = getStaticProvider({
-      infuraId: params?.infuraId,
+    const bctContract = getContract({
+      contractName: "bct",
+      provider: getStaticProvider({
+        infuraId: params?.infuraId,
+      }),
     });
-    const bctContract = getContract({ contractName: "bct", provider });
 
     const nakedBCT = getInteger(
       await bctContract.balanceOf(addresses.mainnet.treasury)
     );
-    const bctKLIMA = await getOwnedBCTFromSLP({ adr: "klimaBctLp", provider });
+    const bctKLIMA = await getOwnedBCTFromSLP({ adr: "klimaBctLp" });
     const sum = nakedBCT + bctKLIMA;
     return sum;
   } catch (e) {

--- a/site/lib/getBalances.ts
+++ b/site/lib/getBalances.ts
@@ -24,7 +24,7 @@ export type Balances = {
 };
 
 export const getBalances = async (params: Params): Promise<Balances> => {
-  const provider = getStaticProvider({ batchRequests: true });
+  const provider = getStaticProvider();
 
   const klimaContract = getContract({ contractName: "klima", provider });
   const sklimaContract = getContract({ contractName: "sklima", provider });
@@ -34,21 +34,23 @@ export const getBalances = async (params: Params): Promise<Balances> => {
   const nboContract = getContract({ contractName: "nbo", provider });
   const uboContract = getContract({ contractName: "ubo", provider });
 
-  const klimaBalance = await klimaContract.balanceOf(params.address);
-  const sklimaBalance = await sklimaContract.balanceOf(params.address);
-  const bctBalance = await bctContract.balanceOf(params.address);
-  const nctBalance = await nctContract.balanceOf(params.address);
-  const mco2Balance = await mco2Contract.balanceOf(params.address);
-  const nboBalance = await nboContract.balanceOf(params.address);
-  const uboBalance = await uboContract.balanceOf(params.address);
+  const [klima, sklima, bct, nct, mco2, nbo, ubo] = await Promise.all([
+    klimaContract.balanceOf(params.address),
+    sklimaContract.balanceOf(params.address),
+    bctContract.balanceOf(params.address),
+    nctContract.balanceOf(params.address),
+    mco2Contract.balanceOf(params.address),
+    nboContract.balanceOf(params.address),
+    uboContract.balanceOf(params.address),
+  ]);
 
   return {
-    klima: formatUnits(klimaBalance, 9),
-    sklima: formatUnits(sklimaBalance, 9),
-    bct: formatUnits(bctBalance),
-    nct: formatUnits(nctBalance),
-    mco2: formatUnits(mco2Balance),
-    nbo: formatUnits(nboBalance),
-    ubo: formatUnits(uboBalance),
+    klima: formatUnits(klima, 9),
+    sklima: formatUnits(sklima, 9),
+    bct: formatUnits(bct),
+    nct: formatUnits(nct),
+    mco2: formatUnits(mco2),
+    nbo: formatUnits(nbo),
+    ubo: formatUnits(ubo),
   };
 };

--- a/site/lib/getBalances.ts
+++ b/site/lib/getBalances.ts
@@ -24,7 +24,7 @@ export type Balances = {
 };
 
 export const getBalances = async (params: Params): Promise<Balances> => {
-  const provider = getStaticProvider();
+  const provider = getStaticProvider({ batchRequests: true });
 
   const klimaContract = getContract({ contractName: "klima", provider });
   const sklimaContract = getContract({ contractName: "sklima", provider });


### PR DESCRIPTION
## Description
This PR enhances `getStaticProvider` to support a `batchRequests` parameter which is `true` by default.
When `batchRequests` is `true`, we use `JsonRpcBatchProvider` instead of the normal `JsonRpcProvider`.

The BatchProvider does a single https request for multiple calls. Magic!

This pr also changes how default providers are instantiated to avoid unnecessary calls to mumbai and ethereum rpcs.

## Experiments
Based on these experiments I decided it is worth it to use `batchRequests: true` as the default setting, simply to reduce the number of requests (cost savings) with minimal change to actual page performance.

### batching disabled
/#/offset page, while connected, full page refresh with cache disabled:
```
143 requests
522 kB transferred
1.5 MB resources
Finish: 2.04 s
DOMContentLoaded: 364 ms
Load: 592 ms
```

### batch specific requests
As an experiment I tried only batching a few locations where we use Promise.all
```
77 requests
514 kB transferred
1.5 MB resources
Finish: 1.87 s
DOMContentLoaded: 350 ms
Load: 631 ms
```

### batching enabled for all requests
when batchRequests is true by default:
```
59 requests
513 kB transferred
1.5 MB resources
Finish: 2.05 s
DOMContentLoaded: 361 ms
Load: 684 ms
```

## Related Ticket

#892

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
