### PR TITLE
Better pledge redirect UX

### DIFF
--- a/lib/components/Buttons/styles.ts
+++ b/lib/components/Buttons/styles.ts
@@ -65,17 +65,10 @@ export const buttonPrimary = css`
     color: white; /* same in darkmode */
   }
 
-  &:disabled {
-    background-color: var(--surface-03);
-    color: var(--font-03);
-    cursor: not-allowed;
-  }
-
   &.gray {
     background-color: var(--surface-01);
 
     &,
-    &:hover,
     &:hover:not(:disabled),
     &:visited {
       color: var(--font-02); /* same in darkmode */
@@ -86,7 +79,6 @@ export const buttonPrimary = css`
     background-color: var(--surface-01);
 
     &,
-    &:hover,
     &:hover:not(:disabled),
     &:visited {
       color: var(--font-02); /* same in darkmode */
@@ -100,11 +92,16 @@ export const buttonPrimary = css`
 
   &.blue {
     background-color: var(--klima-blue);
-    &:hover,
     &:hover:not(:disabled),
     &:visited {
       color: var(--surface-01); /* same in darkmode */
     }
+  }
+
+  &:disabled {
+    background-color: var(--surface-03);
+    color: var(--font-03);
+    cursor: not-allowed;
   }
 `;
 

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -30,6 +30,7 @@ export interface ConnectModalProps {
     error: string;
   };
   buttonClassName?: string;
+  /** Callback invoked when the modal is closed by X or click-off, NOT invoked on successful connection */
   onClose?: () => void;
   showModal: boolean;
 }
@@ -80,21 +81,28 @@ export const ConnectModal = (props: ConnectModalProps) => {
       }
       toggleModal();
       setStep("connect");
-      props.onClose?.();
     } catch (e: any) {
       console.error(e);
       setStep("error");
     }
   };
+
+  const handleClose = () => {
+    if (props.showModal) {
+      toggleModal();
+      props.onClose?.();
+    }
+  };
+
   if (!props.showModal) return null;
   return (
     <div aria-modal={true}>
-      <div className={styles.modalBackground} onClick={() => toggleModal()} />
+      <div className={styles.modalBackground} onClick={handleClose} />
       <div className={styles.modalContainer}>
         <div className={styles.modalContent} ref={focusTrapRef}>
           <span className="title">
             <Text t="h4">{getTitle(step)}</Text>
-            <button onClick={() => toggleModal()}>
+            <button onClick={handleClose}>
               <Close fontSize="large" />
             </button>
           </span>

--- a/site/components/pages/Pledge/index.tsx
+++ b/site/components/pages/Pledge/index.tsx
@@ -43,6 +43,15 @@ export const Pledge: NextPage = () => {
 
   const handleCreatePledge = async () => {
     setShouldRedirect(true);
+    if (!address) {
+      toggleModal();
+    } else {
+      router.push(`/pledge/${address}`);
+    }
+  };
+
+  const handleModalClose = () => {
+    setShouldRedirect(false);
   };
 
   useEffect(() => {
@@ -50,6 +59,25 @@ export const Pledge: NextPage = () => {
       router.push(`/pledge/${address}`);
     }
   }, [shouldRedirect, address]);
+
+  const getCTALabel = () => {
+    if (shouldRedirect) {
+      return t({
+        message: "Connecting...",
+        id: "pledges.home.hero.connecting",
+      });
+    }
+    if (address) {
+      return t({
+        message: "View your pledge",
+        id: "pledges.home.hero.view",
+      });
+    }
+    return t({
+      message: "Create a pledge",
+      id: "pledges.home.hero.create",
+    });
+  };
 
   return (
     <>
@@ -70,6 +98,7 @@ export const Pledge: NextPage = () => {
       />
       {renderModal &&
         renderModal({
+          onClose: handleModalClose,
           errorMessage: t({
             message: "We had some trouble connecting. Please try again.",
             id: "connect_modal.error_message",
@@ -122,28 +151,12 @@ export const Pledge: NextPage = () => {
               </Text>
 
               <div className="actions">
-                {address ? (
-                  <ButtonPrimary
-                    onClick={handleCreatePledge}
-                    variant="blue"
-                    label={t({
-                      message: "Create a pledge",
-                      id: "pledges.home.hero.create",
-                    })}
-                  />
-                ) : (
-                  <ButtonPrimary
-                    variant="blue"
-                    label={t({
-                      message: "Create a pledge",
-                      id: "pledges.home.hero.create",
-                    })}
-                    onClick={() => {
-                      handleCreatePledge();
-                      toggleModal();
-                    }}
-                  />
-                )}
+                <ButtonPrimary
+                  onClick={handleCreatePledge}
+                  variant="blue"
+                  disabled={shouldRedirect}
+                  label={getCTALabel()}
+                />
 
                 <ButtonPrimary
                   variant="gray"
@@ -320,28 +333,12 @@ export const Pledge: NextPage = () => {
               </li>
             </ol>
 
-            {address ? (
-              <ButtonPrimary
-                onClick={handleCreatePledge}
-                variant="blue"
-                label={t({
-                  message: "Create a pledge",
-                  id: "pledges.home.hero.create",
-                })}
-              />
-            ) : (
-              <ButtonPrimary
-                variant="blue"
-                label={t({
-                  message: "Create a pledge",
-                  id: "pledges.home.hero.create",
-                })}
-                onClick={() => {
-                  handleCreatePledge();
-                  toggleModal();
-                }}
-              />
-            )}
+            <ButtonPrimary
+              onClick={handleCreatePledge}
+              variant="blue"
+              disabled={shouldRedirect}
+              label={getCTALabel()}
+            />
           </section>
 
           <section className={styles.banner}>
@@ -355,28 +352,12 @@ export const Pledge: NextPage = () => {
                 Create your pledge and go climate positive
               </Text>
 
-              {address ? (
-                <ButtonPrimary
-                  onClick={handleCreatePledge}
-                  variant="blue"
-                  label={t({
-                    message: "Create a pledge",
-                    id: "pledges.home.hero.create",
-                  })}
-                />
-              ) : (
-                <ButtonPrimary
-                  variant="blue"
-                  label={t({
-                    message: "Create a pledge",
-                    id: "pledges.home.hero.create",
-                  })}
-                  onClick={() => {
-                    handleCreatePledge();
-                    toggleModal();
-                  }}
-                />
-              )}
+              <ButtonPrimary
+                onClick={handleCreatePledge}
+                variant="blue"
+                disabled={shouldRedirect}
+                label={getCTALabel()}
+              />
             </div>
           </section>
         </div>


### PR DESCRIPTION
## Description

This was bothering me for months so I had to jump on it.

- add "connecting" label and disabled state (when connection is still pending)
- add "view your pledge" instead of "create pledge" when the user is already connected
- only show "create pledge" when not connected
- use modal onClose callback to detect when the user cancels the connect modal (reset button state)
- Fix a css issue where disabled button styles were not working for blue buttons,
- Fix a css issue where disabled buttons had an incorrect hover state (text should stay gray and not turn white on hover)

## Changes

![Screenshot_20230116_034637](https://user-images.githubusercontent.com/88635679/212782259-17c1be83-09f3-4a3a-a1e1-10d9a9f52485.png)
![Screenshot_20230116_034608](https://user-images.githubusercontent.com/88635679/212782260-adcdd1c6-858f-4f87-a37f-80ca842bc621.png)
![Screenshot_20230116_034556](https://user-images.githubusercontent.com/88635679/212782262-54949dd9-31aa-4ea4-9a36-ace54af27125.png)

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
