### PR TITLE
Goats/modal error handling

### DIFF
--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -31,6 +31,7 @@ import { ChangeLanguageButton } from "components/ChangeLanguageButton";
 import { IsomorphicRoutes } from "components/IsomorphicRoutes";
 import { NavMenu } from "components/NavMenu";
 import { setAppState } from "state/app";
+import { connectErrorStrings } from "../../../lib/constants";
 import { Buy } from "../Buy";
 import * as styles from "./styles";
 
@@ -168,6 +169,7 @@ export const Home: FC = () => {
                 message: "We had some trouble connecting. Please try again.",
                 id: "connect_modal.error_message",
               }),
+              errors: connectErrorStrings,
               torusText: t({
                 message: "or continue with",
                 id: "connectModal.continue",

--- a/app/components/views/Home/index.tsx
+++ b/app/components/views/Home/index.tsx
@@ -165,10 +165,6 @@ export const Home: FC = () => {
               />
             )}
             {renderModal({
-              errorMessage: t({
-                message: "We had some trouble connecting. Please try again.",
-                id: "connect_modal.error_message",
-              }),
               errors: connectErrorStrings,
               torusText: t({
                 message: "or continue with",

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -1,4 +1,5 @@
 import { urls } from "@klimadao/lib/constants";
+import { t } from "@lingui/macro";
 
 /** True if actually deployed on the production domain (not a preview/staging domain, not local dev) */
 export const IS_PRODUCTION =
@@ -23,3 +24,14 @@ export const IS_STATIC_EXPORT = process.env.IS_STATIC_EXPORT;
 export const FIAT_RETIREMENT_API_URL = IS_PRODUCTION
   ? "https://checkout.offsetra.com/api/checkout"
   : "https://staging-checkout.offsetra.com/api/checkout";
+
+export const connectErrorStrings = {
+  default: t({
+    message: "We had some trouble connecting. Please try again.",
+    id: "connect_modal.error_message_default",
+  }),
+  rejected: t({
+    message: "User refused connection. Dont do that. Bad user.",
+    id: "connect_modal.error_message_refused",
+  }),
+};

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -31,7 +31,7 @@ export const connectErrorStrings = {
     id: "connect_modal.error_message_default",
   }),
   rejected: t({
-    message: "User refused connection. Dont do that. Bad user.",
+    message: "User refused connection.",
     id: "connect_modal.error_message_refused",
   }),
 };

--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:685
 msgid "Beneficiary 0x address (optional)"
@@ -316,23 +322,27 @@ msgstr ""
 msgid "choose_bond.ubo.description"
 msgstr ""
 
-#: components/views/Home/index.tsx:171
+#: components/views/Home/index.tsx:169
 msgid "connectModal.continue"
 msgstr ""
 
-#: components/views/Home/index.tsx:180
+#: components/views/Home/index.tsx:178
 msgid "connect_modal.connecting"
 msgstr ""
 
-#: components/views/Home/index.tsx:167
-msgid "connect_modal.error_message"
+#: lib/constants.ts:29
+msgid "connect_modal.error_message_default"
 msgstr ""
 
-#: components/views/Home/index.tsx:184
+#: lib/constants.ts:33
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#: components/views/Home/index.tsx:182
 msgid "connect_modal.error_title"
 msgstr ""
 
-#: components/views/Home/index.tsx:176
+#: components/views/Home/index.tsx:174
 msgid "connect_modal.sign_in"
 msgstr ""
 
@@ -824,7 +834,7 @@ msgstr ""
 
 #: components/views/Bond/index.tsx:396
 #: components/views/Buy/index.tsx:63
-#: components/views/Home/index.tsx:153
+#: components/views/Home/index.tsx:154
 #: components/views/Offset/index.tsx:371
 #: components/views/PKlima/index.tsx:149
 #: components/views/Stake/index.tsx:227

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -322,23 +322,27 @@ msgstr "Treasury Balance"
 msgid "choose_bond.ubo.description"
 msgstr "C3 Universal Basic Offset"
 
-#: components/views/Home/index.tsx:171
+#: components/views/Home/index.tsx:169
 msgid "connectModal.continue"
 msgstr "or continue with"
 
-#: components/views/Home/index.tsx:180
+#: components/views/Home/index.tsx:178
 msgid "connect_modal.connecting"
 msgstr "Connecting..."
 
-#: components/views/Home/index.tsx:167
-msgid "connect_modal.error_message"
+#: lib/constants.ts:29
+msgid "connect_modal.error_message_default"
 msgstr "We had some trouble connecting. Please try again."
 
-#: components/views/Home/index.tsx:184
+#: lib/constants.ts:33
+msgid "connect_modal.error_message_refused"
+msgstr "User refused connection."
+
+#: components/views/Home/index.tsx:182
 msgid "connect_modal.error_title"
 msgstr "Connection Error"
 
-#: components/views/Home/index.tsx:176
+#: components/views/Home/index.tsx:174
 msgid "connect_modal.sign_in"
 msgstr "Sign In / Connect"
 
@@ -830,7 +834,7 @@ msgstr "Loading..."
 
 #: components/views/Bond/index.tsx:396
 #: components/views/Buy/index.tsx:63
-#: components/views/Home/index.tsx:153
+#: components/views/Home/index.tsx:154
 #: components/views/Offset/index.tsx:371
 #: components/views/PKlima/index.tsx:149
 #: components/views/Stake/index.tsx:227

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -25,7 +25,6 @@ const MailOutlineIcon = (MailOutlineIconDefault as any).default as any;
 const ExtensionIcon = (ExtensionIconDefault as any).default as any;
 
 export interface ConnectModalProps {
-  errorMessage: string;
   torusText: string;
   titles: {
     connect: string;

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -24,7 +24,7 @@ const Close = (CloseDefault as any).default as any;
 const MailOutlineIcon = (MailOutlineIconDefault as any).default as any;
 const ExtensionIcon = (ExtensionIconDefault as any).default as any;
 
-interface ConnectModalProps {
+export interface ConnectModalProps {
   errorMessage: string;
   torusText: string;
   titles: {

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -33,6 +33,10 @@ interface ConnectModalProps {
     error: string;
   };
   buttonClassName?: string;
+  errors: {
+    default: string;
+    rejected: string;
+  };
   /** Callback invoked when the modal is closed by X or click-off, NOT invoked on successful connection */
   onClose?: () => void;
   showModal: boolean;
@@ -48,6 +52,9 @@ export const ConnectModal = (props: ConnectModalProps) => {
   const { connect, toggleModal } = useWeb3();
   const focusTrapRef = useFocusTrap();
   const [eth, setEth] = useState<WindowEthereum | undefined>(undefined);
+  const [errorName, setErrorName] = useState<
+    "default" | "rejected" | undefined
+  >();
 
   useEffect(() => {
     if (window) setEth((window as any).ethereum as WindowEthereum);
@@ -88,6 +95,11 @@ export const ConnectModal = (props: ConnectModalProps) => {
       setStep("connect");
     } catch (e: any) {
       console.error(e);
+      if (e.name === "rejected") {
+        setErrorName(e.name);
+      } else {
+        setErrorName("default");
+      }
       setStep("error");
     }
   };
@@ -196,7 +208,7 @@ export const ConnectModal = (props: ConnectModalProps) => {
           )}
           {step === "error" && (
             <div className={styles.errorContent}>
-              <Text t="body2">{props.errorMessage}</Text>
+              <Text t="body2">{props.errors[errorName ?? "default"]}</Text>
               <ButtonPrimary label="OK" onClick={() => setStep("connect")} />
             </div>
           )}

--- a/lib/components/Web3Context/types.ts
+++ b/lib/components/Web3Context/types.ts
@@ -65,7 +65,6 @@ export interface DisconnectedWeb3State {
   network: undefined;
 }
 export interface RenderModalProps {
-  errorMessage: string;
   torusText: string;
   titles: {
     connect: string;

--- a/lib/components/Web3Context/types.ts
+++ b/lib/components/Web3Context/types.ts
@@ -72,6 +72,10 @@ export interface RenderModalProps {
     loading: string;
     error: string;
   };
+  errors: {
+    default: string;
+    rejected: string;
+  };
   buttonClassName?: string;
   onClose?: () => void;
 }

--- a/lib/utils/useProvider/index.tsx
+++ b/lib/utils/useProvider/index.tsx
@@ -123,7 +123,15 @@ export const useProvider = (): Web3ModalState => {
       };
       setWeb3State(newState);
     } catch (e: any) {
-      throw new Error(e);
+      if (
+        // TODO check message for coinbase when it is working again
+        e.code === 4001 ||
+        e.message === "User closed modal" ||
+        e.message === "User cancelled login"
+      ) {
+        e.name = "rejected";
+      }
+      throw e;
     }
   };
 

--- a/site/components/pages/Pledge/HeaderDesktop/index.tsx
+++ b/site/components/pages/Pledge/HeaderDesktop/index.tsx
@@ -1,5 +1,13 @@
+<<<<<<< HEAD
 import { ButtonPrimary, KlimaInfinityLogo } from "@klimadao/lib/components";
 import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
+=======
+import {
+  ButtonPrimary,
+  ConnectModal,
+  KlimaInfinityLogo
+} from "@klimadao/lib/components";
+>>>>>>> 6ddadb1a (errors)
 import { t } from "@lingui/macro";
 import dynamic from "next/dynamic";
 import Link from "next/link";

--- a/site/components/pages/Pledge/HeaderDesktop/index.tsx
+++ b/site/components/pages/Pledge/HeaderDesktop/index.tsx
@@ -1,13 +1,5 @@
-<<<<<<< HEAD
 import { ButtonPrimary, KlimaInfinityLogo } from "@klimadao/lib/components";
 import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
-=======
-import {
-  ButtonPrimary,
-  ConnectModal,
-  KlimaInfinityLogo
-} from "@klimadao/lib/components";
->>>>>>> 6ddadb1a (errors)
 import { t } from "@lingui/macro";
 import dynamic from "next/dynamic";
 import Link from "next/link";

--- a/site/components/pages/Pledge/PledgeDashboard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/index.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import { Modal } from "components/Modal";
 import { PageHead } from "components/PageHead";
 
+import { connectErrorStrings } from "lib/constants";
 import { AcceptModal, RemoveModal } from "../InvitationModals";
 import { PledgeForm } from "../PledgeForm";
 import { PledgeLayout } from "../PledgeLayout";
@@ -161,6 +162,7 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
             message: "We had some trouble connecting. Please try again.",
             id: "connect_modal.error_message",
           }),
+          errors: connectErrorStrings,
           torusText: t({
             message: "or continue with",
             id: "connectModal.continue",

--- a/site/components/pages/Pledge/PledgeDashboard/index.tsx
+++ b/site/components/pages/Pledge/PledgeDashboard/index.tsx
@@ -158,10 +158,6 @@ export const PledgeDashboard: NextPage<Props> = (props) => {
       />
       {renderModal &&
         renderModal({
-          errorMessage: t({
-            message: "We had some trouble connecting. Please try again.",
-            id: "connect_modal.error_message",
-          }),
           errors: connectErrorStrings,
           torusText: t({
             message: "or continue with",

--- a/site/components/pages/Pledge/index.tsx
+++ b/site/components/pages/Pledge/index.tsx
@@ -14,6 +14,7 @@ import * as styles from "./styles";
 import { useWeb3 } from "@klimadao/lib/utils";
 import { Footer } from "components/Footer";
 import { Navigation } from "components/Navigation";
+import { connectErrorStrings } from "lib/constants";
 
 export const Pledge: NextPage = () => {
   const router = useRouter();
@@ -99,6 +100,7 @@ export const Pledge: NextPage = () => {
       {renderModal &&
         renderModal({
           onClose: handleModalClose,
+          errors: connectErrorStrings,
           errorMessage: t({
             message: "We had some trouble connecting. Please try again.",
             id: "connect_modal.error_message",

--- a/site/components/pages/Pledge/index.tsx
+++ b/site/components/pages/Pledge/index.tsx
@@ -101,10 +101,6 @@ export const Pledge: NextPage = () => {
         renderModal({
           onClose: handleModalClose,
           errors: connectErrorStrings,
-          errorMessage: t({
-            message: "We had some trouble connecting. Please try again.",
-            id: "connect_modal.error_message",
-          }),
           torusText: t({
             message: "or continue with",
             id: "connectModal.continue",

--- a/site/lib/constants.ts
+++ b/site/lib/constants.ts
@@ -20,7 +20,7 @@ export const connectErrorStrings = {
     id: "connect_modal.error_message_default",
   }),
   rejected: t({
-    message: "User refused connection. Dont do that. Bad user.",
+    message: "User refused connection.",
     id: "connect_modal.error_message_refused",
   }),
 };

--- a/site/lib/constants.ts
+++ b/site/lib/constants.ts
@@ -1,4 +1,5 @@
 import { urls } from "@klimadao/lib/constants";
+import { t } from "@lingui/macro";
 
 /** True if actually deployed on the production domain (not a preview/staging domain, not local dev) */
 export const IS_PRODUCTION =
@@ -12,3 +13,14 @@ export const MONTH_IN_SECONDS = 2592000;
 export const API_BASE_URL = IS_LOCAL_DEVELOPMENT
   ? "http://localhost:3000"
   : urls.home;
+
+export const connectErrorStrings = {
+  default: t({
+    message: "We had some trouble connecting. Please try again.",
+    id: "connect_modal.error_message_default",
+  }),
+  rejected: t({
+    message: "User refused connection. Dont do that. Bad user.",
+    id: "connect_modal.error_message_refused",
+  }),
+};

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"
@@ -403,28 +409,31 @@ msgstr ""
 msgid "concat.careers"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:164
-#: components/pages/Pledge/index.tsx:106
+#: components/pages/Pledge/PledgeDashboard/index.tsx:162
+#: components/pages/Pledge/index.tsx:104
 msgid "connectModal.continue"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:173
-#: components/pages/Pledge/index.tsx:115
+#: components/pages/Pledge/PledgeDashboard/index.tsx:171
+#: components/pages/Pledge/index.tsx:113
 msgid "connect_modal.connecting"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:160
-#: components/pages/Pledge/index.tsx:102
-msgid "connect_modal.error_message"
+#: lib/constants.ts:18
+msgid "connect_modal.error_message_default"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:177
-#: components/pages/Pledge/index.tsx:119
+#: lib/constants.ts:22
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:175
+#: components/pages/Pledge/index.tsx:117
 msgid "connect_modal.error_title"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:169
-#: components/pages/Pledge/index.tsx:111
+#: components/pages/Pledge/PledgeDashboard/index.tsx:167
+#: components/pages/Pledge/index.tsx:109
 msgid "connect_modal.sign_in"
 msgstr ""
 
@@ -1114,15 +1123,15 @@ msgstr ""
 msgid "pledges.dashboard.footprint.tooltip.quantity"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:136
+#: components/pages/Pledge/PledgeDashboard/index.tsx:137
 msgid "pledges.dashboard.head.metaDescription"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:132
+#: components/pages/Pledge/PledgeDashboard/index.tsx:133
 msgid "pledges.dashboard.head.metaTitle"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:128
+#: components/pages/Pledge/PledgeDashboard/index.tsx:129
 msgid "pledges.dashboard.head.title"
 msgstr ""
 
@@ -1182,7 +1191,7 @@ msgstr ""
 msgid "pledges.form.awaiting_signature"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:191
+#: components/pages/Pledge/PledgeDashboard/index.tsx:189
 msgid "pledges.form.confirm_delete"
 msgstr ""
 
@@ -1194,7 +1203,7 @@ msgstr ""
 msgid "pledges.form.confirm_remove_cancel"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:206
+#: components/pages/Pledge/index.tsx:204
 msgid "pledges.form.error"
 msgstr ""
 
@@ -1334,7 +1343,7 @@ msgstr ""
 msgid "pledges.form.submit_button"
 msgstr ""
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:187
+#: components/pages/Pledge/PledgeDashboard/index.tsx:185
 msgid "pledges.form.title"
 msgstr ""
 
@@ -1350,43 +1359,43 @@ msgstr ""
 msgid "pledges.form.wallets.label"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:93
+#: components/pages/Pledge/index.tsx:94
 msgid "pledges.head.metaDescription"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:89
+#: components/pages/Pledge/index.tsx:90
 msgid "pledges.head.metaTitle"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:85
+#: components/pages/Pledge/index.tsx:86
 msgid "pledges.head.title"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:65
+#: components/pages/Pledge/index.tsx:66
 msgid "pledges.home.hero.connecting"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:76
+#: components/pages/Pledge/index.tsx:77
 msgid "pledges.home.hero.create"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:164
+#: components/pages/Pledge/index.tsx:162
 msgid "pledges.home.hero.learn_more"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:71
+#: components/pages/Pledge/index.tsx:72
 msgid "pledges.home.hero.view"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:200
+#: components/pages/Pledge/index.tsx:198
 msgid "pledges.home.search.label"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:194
+#: components/pages/Pledge/index.tsx:192
 msgid "pledges.home.search.placeholder"
 msgstr ""
 
-#: components/pages/Pledge/index.tsx:220
+#: components/pages/Pledge/index.tsx:218
 msgid "pledges.home.search.submit"
 msgstr ""
 

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -409,28 +409,31 @@ msgstr "We work with traditional carbon market players, crypto platforms, corpor
 msgid "concat.careers"
 msgstr "Careers"
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:164
-#: components/pages/Pledge/index.tsx:106
+#: components/pages/Pledge/PledgeDashboard/index.tsx:162
+#: components/pages/Pledge/index.tsx:104
 msgid "connectModal.continue"
 msgstr "or continue with"
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:173
-#: components/pages/Pledge/index.tsx:115
+#: components/pages/Pledge/PledgeDashboard/index.tsx:171
+#: components/pages/Pledge/index.tsx:113
 msgid "connect_modal.connecting"
 msgstr "Connecting..."
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:160
-#: components/pages/Pledge/index.tsx:102
-msgid "connect_modal.error_message"
+#: lib/constants.ts:18
+msgid "connect_modal.error_message_default"
 msgstr "We had some trouble connecting. Please try again."
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:177
-#: components/pages/Pledge/index.tsx:119
+#: lib/constants.ts:22
+msgid "connect_modal.error_message_refused"
+msgstr "User refused connection."
+
+#: components/pages/Pledge/PledgeDashboard/index.tsx:175
+#: components/pages/Pledge/index.tsx:117
 msgid "connect_modal.error_title"
 msgstr "Connection Error"
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:169
-#: components/pages/Pledge/index.tsx:111
+#: components/pages/Pledge/PledgeDashboard/index.tsx:167
+#: components/pages/Pledge/index.tsx:109
 msgid "connect_modal.sign_in"
 msgstr "Sign In / Connect"
 
@@ -1120,15 +1123,15 @@ msgstr "{0}% of footprint"
 msgid "pledges.dashboard.footprint.tooltip.quantity"
 msgstr "{0} Carbon Tonne(s)"
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:136
+#: components/pages/Pledge/PledgeDashboard/index.tsx:137
 msgid "pledges.dashboard.head.metaDescription"
 msgstr "{pledgeOwnerTitle} pledges to Offset {currentTotalFootprint} Carbon Tonnes. View their carbon offset history and read more about their commitment."
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:132
+#: components/pages/Pledge/PledgeDashboard/index.tsx:133
 msgid "pledges.dashboard.head.metaTitle"
 msgstr "{pledgeOwnerTitle}'s Pledge"
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:128
+#: components/pages/Pledge/PledgeDashboard/index.tsx:129
 msgid "pledges.dashboard.head.title"
 msgstr "{pledgeOwnerTitle}'s Pledge | KlimaDAO"
 
@@ -1188,7 +1191,7 @@ msgstr "Add wallet"
 msgid "pledges.form.awaiting_signature"
 msgstr "Awaiting signature..."
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:191
+#: components/pages/Pledge/PledgeDashboard/index.tsx:189
 msgid "pledges.form.confirm_delete"
 msgstr "confirm removal"
 
@@ -1200,7 +1203,7 @@ msgstr "remove"
 msgid "pledges.form.confirm_remove_cancel"
 msgstr "cancel"
 
-#: components/pages/Pledge/index.tsx:206
+#: components/pages/Pledge/index.tsx:204
 msgid "pledges.form.error"
 msgstr "Enter a wallet address, .klima or .eth domain"
 
@@ -1340,7 +1343,7 @@ msgstr "0x..."
 msgid "pledges.form.submit_button"
 msgstr "Save pledge"
 
-#: components/pages/Pledge/PledgeDashboard/index.tsx:187
+#: components/pages/Pledge/PledgeDashboard/index.tsx:185
 msgid "pledges.form.title"
 msgstr "Your pledge"
 
@@ -1356,43 +1359,43 @@ msgstr "Use your wallet to sign and confirm this edit."
 msgid "pledges.form.wallets.label"
 msgstr "Secondary Wallet(s)"
 
-#: components/pages/Pledge/index.tsx:93
+#: components/pages/Pledge/index.tsx:94
 msgid "pledges.head.metaDescription"
 msgstr "Demonstrate your commitment to climate positivity by claiming your pledge dashboard to highlight all of your carbon offsetting activity"
 
-#: components/pages/Pledge/index.tsx:89
+#: components/pages/Pledge/index.tsx:90
 msgid "pledges.head.metaTitle"
 msgstr "Create a carbon pledge and showcase your impact"
 
-#: components/pages/Pledge/index.tsx:85
+#: components/pages/Pledge/index.tsx:86
 msgid "pledges.head.title"
 msgstr "KlimaDAO | Pledges"
 
-#: components/pages/Pledge/index.tsx:65
+#: components/pages/Pledge/index.tsx:66
 msgid "pledges.home.hero.connecting"
 msgstr "Connecting..."
 
-#: components/pages/Pledge/index.tsx:76
+#: components/pages/Pledge/index.tsx:77
 msgid "pledges.home.hero.create"
 msgstr "Create a pledge"
 
-#: components/pages/Pledge/index.tsx:164
+#: components/pages/Pledge/index.tsx:162
 msgid "pledges.home.hero.learn_more"
 msgstr "Learn more"
 
-#: components/pages/Pledge/index.tsx:71
+#: components/pages/Pledge/index.tsx:72
 msgid "pledges.home.hero.view"
 msgstr "View your pledge"
 
-#: components/pages/Pledge/index.tsx:200
+#: components/pages/Pledge/index.tsx:198
 msgid "pledges.home.search.label"
 msgstr "ENS or 0x address"
 
-#: components/pages/Pledge/index.tsx:194
+#: components/pages/Pledge/index.tsx:192
 msgid "pledges.home.search.placeholder"
 msgstr "Enter ENS, KNS or 0x address"
 
-#: components/pages/Pledge/index.tsx:220
+#: components/pages/Pledge/index.tsx:218
 msgid "pledges.home.search.submit"
 msgstr "Search"
 


### PR DESCRIPTION
## Description
The modal now expects an errors object with "default" and "refused" keys. We can add more errors but the message from the provider will now be logged to the console correctly so people can send us helpful console logs if they have errors connecting
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #841 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
