### PR TITLE
add generic browser wallet button

### DIFF
--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -23,7 +23,8 @@ import * as styles from "./styles";
 const Close = (CloseDefault as any).default as any;
 const MailOutlineIcon = (MailOutlineIconDefault as any).default as any;
 const ExtensionIcon = (ExtensionIconDefault as any).default as any;
-export interface ConnectModalProps {
+
+interface ConnectModalProps {
   errorMessage: string;
   torusText: string;
   titles: {
@@ -54,10 +55,11 @@ export const ConnectModal = (props: ConnectModalProps) => {
 
   const showBrave = eth?.isBraveWallet;
   const showMetamask = eth?.isMetaMask;
-  const showCoinbaseWallet = eth?.isCoinbaseWallet;
+  const showBrowserWallet = eth && !showBrave && !showMetamask;
 
   const getTitle = (step: "connect" | "error" | "loading") =>
     !props.titles ? "loading" : props.titles[step];
+
   useEffect(() => {
     if (props.showModal) {
       setStep("connect");
@@ -66,6 +68,7 @@ export const ConnectModal = (props: ConnectModalProps) => {
       document.body.style.overflow = "";
     }
   }, [props.showModal]);
+
   const handleConnect = async (params: {
     wallet: "coinbase" | "torus" | "walletConnect" | "injected";
   }) => {
@@ -129,13 +132,13 @@ export const ConnectModal = (props: ConnectModalProps) => {
                     <Text t="button">Brave</Text>
                   </span>
                 )}
-                {!showBrave && !showMetamask && eth && (
+                {showBrowserWallet && (
                   <span
                     className={styles.walletButton}
                     onClick={() => handleConnect({ wallet: "injected" })}
                   >
                     <ExtensionIcon className={styles.browserWalletIcon} />
-                    <Text t="button">Browser</Text>
+                    <Text t="button">Browser Injected Wallet</Text>
                   </span>
                 )}
                 <span

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -142,7 +142,7 @@ export const ConnectModal = (props: ConnectModalProps) => {
                   className={styles.walletButton}
                   onClick={() =>
                     handleConnect({
-                      wallet: showCoinbaseWallet ? "injected" : "coinbase",
+                      wallet: eth?.isCoinbaseWallet ? "injected" : "coinbase",
                     })
                   }
                 >

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -134,7 +134,7 @@ export const ConnectModal = (props: ConnectModalProps) => {
                     className={styles.walletButton}
                     onClick={() => handleConnect({ wallet: "injected" })}
                   >
-                    <ExtensionIcon fontSize="large" />
+                    <ExtensionIcon className={styles.browserWalletIcon} />
                     <Text t="button">Browser</Text>
                   </span>
                 )}

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -1,4 +1,5 @@
 import CloseDefault from "@mui/icons-material/Close";
+import ExtensionIconDefault from "@mui/icons-material/Extension";
 import MailOutlineIconDefault from "@mui/icons-material/MailOutline";
 import { providers } from "ethers";
 import React, { useEffect, useState } from "react";
@@ -21,6 +22,7 @@ import * as styles from "./styles";
 // ems modules and javascript are strange so we import like this
 const Close = (CloseDefault as any).default as any;
 const MailOutlineIcon = (MailOutlineIconDefault as any).default as any;
+const ExtensionIcon = (ExtensionIconDefault as any).default as any;
 export interface ConnectModalProps {
   errorMessage: string;
   torusText: string;
@@ -125,6 +127,15 @@ export const ConnectModal = (props: ConnectModalProps) => {
                   >
                     <BraveIcon />
                     <Text t="button">Brave</Text>
+                  </span>
+                )}
+                {!showBrave && !showMetamask && eth && (
+                  <span
+                    className={styles.walletButton}
+                    onClick={() => handleConnect({ wallet: "injected" })}
+                  >
+                    <ExtensionIcon fontSize="large" />
+                    <Text t="button">Browser</Text>
                   </span>
                 )}
                 <span

--- a/lib/components/ConnectModal/styles.ts
+++ b/lib/components/ConnectModal/styles.ts
@@ -40,6 +40,11 @@ export const walletButton = css`
   }
 `;
 
+export const browserWalletIcon = css`
+  width: 3.6rem;
+  height: 3.6rem;
+`;
+
 export const buttonsContainer = css`
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description
If wallet is injected then that wallet is used. If this wallet is not metamask or brave then a generic wallet button is shown. If the wallet is coinbase then it will connect without using the sdk.
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->
@ShimonD-KlimaDAO do you mind testing this one? Adding expected behavior shortly.
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #881 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
