### PR TITLE
dont hide dropdown on nav click

### DIFF
--- a/site/components/Navigation/DropdownItemDesktop.tsx
+++ b/site/components/Navigation/DropdownItemDesktop.tsx
@@ -1,6 +1,6 @@
 import { cx } from "@emotion/css";
 import Tippy from "@tippyjs/react";
-import { FC } from "react";
+import { FC, useRef } from "react";
 import * as styles from "./styles";
 
 interface Props {
@@ -10,6 +10,8 @@ interface Props {
 }
 
 export const DropdownItemDesktop: FC<Props> = (props) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const onClickHide = () => buttonRef.current?.blur(); // Tippy will keep the button focused (if clicked) after dropdown is hidden unless we blur it
   return (
     <div className={cx(styles.navMain_DesktopItemContainer)}>
       <Tippy
@@ -17,12 +19,15 @@ export const DropdownItemDesktop: FC<Props> = (props) => {
           <div className={styles.navMain_DesktopSubMenu}>{props.children}</div>
         }
         interactive={true}
+        hideOnClick={false}
+        onHide={onClickHide}
       >
         <button
           className={cx(styles.navMain_DesktopLink, {
             dropdown: true,
           })}
           data-active={props.active?.toString()}
+          ref={buttonRef}
         >
           {props.name}
         </button>


### PR DESCRIPTION
## Description
If the user clicks a nav button the dropdown will no longer be hidden. We have to manually blur/unfocus the element if the user clicks the nav button then hides the dropdown.
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #719 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
