### PR TITLE
fix focus trap for connect and enter key listeners

### DIFF
--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -105,15 +105,14 @@ export const ConnectModal = (props: ConnectModalProps) => {
       <div className={styles.modalBackground} onClick={handleClose} />
       <div className={styles.modalContainer}>
         <div className={styles.modalContent} ref={focusTrapRef}>
-          <div className="title">
+          <span className="title">
             <div>
-              <Text t="h4" tabIndex={1}>
-                {getTitle(step)}
-              </Text>
+              <Text t="h4">{getTitle(step)}</Text>
             </div>
-            <button onClick={handleClose} tabIndex={2}>
+            <button onClick={handleClose}>
               <Close fontSize="large" />
             </button>
+<<<<<<< HEAD
           </div>
           {step === "connect" && (
             <div>
@@ -169,67 +168,86 @@ export const ConnectModal = (props: ConnectModalProps) => {
                     })
                   }
                   tabIndex={5}
-                >
-                  <CoinbaseWalletIcon />
-                  <Text t="button">Coinbase</Text>
-                </span>
-                <span
+=======
+          </span>
+          <div
+            className={styles.connectContent}
+            data-display={step === "connect"}
+          >
+            <div className={styles.buttonsContainer}>
+              {showMetamask && (
+                <button
                   className={styles.walletButton}
-                  onClick={() => handleConnect({ wallet: "walletConnect" })}
-                  tabIndex={6}
-                  onKeyDown={(e) =>
-                    e.code === "Enter" &&
-                    handleConnect({ wallet: "walletConnect" })
-                  }
+                  onClick={() => handleConnect({ wallet: "injected" })}
+>>>>>>> c7c12cb6 (use button element and hide with css)
                 >
-                  <WalletConnectIcon />
-                  <Text t="button">walletconnect</Text>
-                </span>
-              </div>
-              <span className={styles.continueBox}>
-                <div className={styles.leftLine} />
-                <Text className={styles.continueText} t="badge">
-                  {props.torusText}
-                </Text>
-                <div className={styles.rightLine} />
-              </span>
-              <div
-                className={styles.torusButtons}
-                onClick={() => handleConnect({ wallet: "torus" })}
-                onKeyDown={(e) =>
-                  e.code === "Enter" && handleConnect({ wallet: "torus" })
+                  <MetaMaskFoxIcon />
+                  <Text t="button">Metamask</Text>
+                </button>
+              )}
+              {showBrave && (
+                <button
+                  className={styles.walletButton}
+                  onClick={() => handleConnect({ wallet: "injected" })}
+                >
+                  <BraveIcon />
+                  <Text t="button">Brave</Text>
+                </button>
+              )}
+              <button
+                className={styles.walletButton}
+                onClick={() =>
+                  handleConnect({
+                    wallet: showCoinbaseWallet ? "injected" : "coinbase",
+                  })
                 }
-                tabIndex={7}
               >
-                <span className={styles.buttonBackground}>
-                  <TwitterIcon className={styles.twitter} />
-                </span>
-                <span className={styles.buttonBackground}>
-                  <FacebookColorIcon />
-                </span>
-                <span className={styles.buttonBackground}>
-                  <GoogleIcon />
-                </span>
-                <span className={styles.buttonBackground}>
-                  <DiscordColorIcon className={styles.discord} />
-                </span>
-                <span className={styles.buttonBackground}>
-                  <MailOutlineIcon fontSize="large" />
-                </span>
-              </div>
+                <CoinbaseWalletIcon />
+                <Text t="button">Coinbase</Text>
+              </button>
+              <button
+                className={styles.walletButton}
+                onClick={() => handleConnect({ wallet: "walletConnect" })}
+              >
+                <WalletConnectIcon />
+                <Text t="button">walletconnect</Text>
+              </button>
             </div>
-          )}
-          {step === "loading" && (
-            <div className={styles.spinner}>
-              <Spinner />
-            </div>
-          )}
-          {step === "error" && (
-            <div className={styles.errorContent}>
-              <Text t="body2">{props.errorMessage}</Text>
-              <ButtonPrimary label="OK" onClick={() => setStep("connect")} />
-            </div>
-          )}
+            <span className={styles.continueBox}>
+              <div className={styles.leftLine} />
+              <Text className={styles.continueText} t="badge">
+                {props.torusText}
+              </Text>
+              <div className={styles.rightLine} />
+            </span>
+            <button
+              className={styles.torusButtons}
+              onClick={() => handleConnect({ wallet: "torus" })}
+            >
+              <span className={styles.buttonBackground}>
+                <TwitterIcon className={styles.twitter} />
+              </span>
+              <span className={styles.buttonBackground}>
+                <FacebookColorIcon />
+              </span>
+              <span className={styles.buttonBackground}>
+                <GoogleIcon />
+              </span>
+              <span className={styles.buttonBackground}>
+                <DiscordColorIcon className={styles.discord} />
+              </span>
+              <span className={styles.buttonBackground}>
+                <MailOutlineIcon fontSize="large" />
+              </span>
+            </button>
+          </div>
+          <div className={styles.spinner} data-display={step === "loading"}>
+            <Spinner />
+          </div>
+          <div className={styles.errorContent} data-display={step === "error"}>
+            <Text t="body2">{props.errorMessage}</Text>
+            <ButtonPrimary label="OK" onClick={() => setStep("connect")} />
+          </div>
         </div>
       </div>
     </div>

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -55,7 +55,7 @@ export const ConnectModal = (props: ConnectModalProps) => {
 
   const showBrave = eth?.isBraveWallet;
   const showMetamask = eth?.isMetaMask;
-  const shouldUseCoinbaseSDK = eth?.isCoinbaseWallet;
+  const isInjectedCoinbase = eth?.isCoinbaseWallet;
   const showBrowserWallet = eth && !showBrave && !showMetamask;
 
   const getTitle = (step: "connect" | "error" | "loading") =>
@@ -138,19 +138,19 @@ export const ConnectModal = (props: ConnectModalProps) => {
                 </button>
               )}
               {showBrowserWallet && (
-                <span
+                <button
                   className={styles.walletButton}
                   onClick={() => handleConnect({ wallet: "injected" })}
                 >
                   <ExtensionIcon className={styles.browserWalletIcon} />
                   <Text t="button">Browser Injected Wallet</Text>
-                </span>
+                </button>
               )}
               <button
                 className={styles.walletButton}
                 onClick={() =>
                   handleConnect({
-                    wallet: shouldUseCoinbaseSDK ? "injected" : "coinbase",
+                    wallet: isInjectedCoinbase ? "injected" : "coinbase",
                   })
                 }
               >

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -112,63 +112,6 @@ export const ConnectModal = (props: ConnectModalProps) => {
             <button onClick={handleClose}>
               <Close fontSize="large" />
             </button>
-<<<<<<< HEAD
-          </div>
-          {step === "connect" && (
-            <div>
-              <div className={styles.buttonsContainer}>
-                {showMetamask && (
-                  <div
-                    className={styles.walletButton}
-                    onClick={() => handleConnect({ wallet: "injected" })}
-                    tabIndex={3}
-                    onKeyDown={(e) =>
-                      e.code === "Enter" &&
-                      handleConnect({ wallet: "injected" })
-                    }
-                  >
-                    <MetaMaskFoxIcon />
-                    <Text t="button">Metamask</Text>
-                  </div>
-                )}
-                {showBrave && (
-                  <span
-                    className={styles.walletButton}
-                    onClick={() => handleConnect({ wallet: "injected" })}
-                    onKeyDown={(e) =>
-                      e.code === "Enter" &&
-                      handleConnect({ wallet: "injected" })
-                    }
-                    tabIndex={4}
-                  >
-                    <BraveIcon />
-                    <Text t="button">Brave</Text>
-                  </span>
-                )}
-                {showBrowserWallet && (
-                  <span
-                    className={styles.walletButton}
-                    onClick={() => handleConnect({ wallet: "injected" })}
-                  >
-                    <ExtensionIcon className={styles.browserWalletIcon} />
-                    <Text t="button">Browser Injected Wallet</Text>
-                  </span>
-                )}
-                <span
-                  className={styles.walletButton}
-                  onClick={() =>
-                    handleConnect({
-                      wallet: eth?.isCoinbaseWallet ? "injected" : "coinbase",
-                    })
-                  }
-                  onKeyDown={(e) =>
-                    e.code === "Enter" &&
-                    handleConnect({
-                      wallet: showCoinbaseWallet ? "injected" : "coinbase",
-                    })
-                  }
-                  tabIndex={5}
-=======
           </span>
           <div
             className={styles.connectContent}
@@ -179,7 +122,6 @@ export const ConnectModal = (props: ConnectModalProps) => {
                 <button
                   className={styles.walletButton}
                   onClick={() => handleConnect({ wallet: "injected" })}
->>>>>>> c7c12cb6 (use button element and hide with css)
                 >
                   <MetaMaskFoxIcon />
                   <Text t="button">Metamask</Text>

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -55,7 +55,7 @@ export const ConnectModal = (props: ConnectModalProps) => {
 
   const showBrave = eth?.isBraveWallet;
   const showMetamask = eth?.isMetaMask;
-  const showCoinbase = eth?.isCoinbaseWallet;
+  const shouldUseCoinbaseSDK = eth?.isCoinbaseWallet;
   const showBrowserWallet = eth && !showBrave && !showMetamask;
 
   const getTitle = (step: "connect" | "error" | "loading") =>
@@ -150,7 +150,7 @@ export const ConnectModal = (props: ConnectModalProps) => {
                 className={styles.walletButton}
                 onClick={() =>
                   handleConnect({
-                    wallet: showCoinbase ? "injected" : "coinbase",
+                    wallet: shouldUseCoinbaseSDK ? "injected" : "coinbase",
                   })
                 }
               >

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -105,28 +105,42 @@ export const ConnectModal = (props: ConnectModalProps) => {
       <div className={styles.modalBackground} onClick={handleClose} />
       <div className={styles.modalContainer}>
         <div className={styles.modalContent} ref={focusTrapRef}>
-          <span className="title">
-            <Text t="h4">{getTitle(step)}</Text>
-            <button onClick={handleClose}>
+          <div className="title">
+            <div>
+              <Text t="h4" tabIndex={1}>
+                {getTitle(step)}
+              </Text>
+            </div>
+            <button onClick={handleClose} tabIndex={2}>
               <Close fontSize="large" />
             </button>
-          </span>
+          </div>
           {step === "connect" && (
-            <>
+            <div>
               <div className={styles.buttonsContainer}>
                 {showMetamask && (
-                  <span
+                  <div
                     className={styles.walletButton}
                     onClick={() => handleConnect({ wallet: "injected" })}
+                    tabIndex={3}
+                    onKeyDown={(e) =>
+                      e.code === "Enter" &&
+                      handleConnect({ wallet: "injected" })
+                    }
                   >
                     <MetaMaskFoxIcon />
                     <Text t="button">Metamask</Text>
-                  </span>
+                  </div>
                 )}
                 {showBrave && (
                   <span
                     className={styles.walletButton}
                     onClick={() => handleConnect({ wallet: "injected" })}
+                    onKeyDown={(e) =>
+                      e.code === "Enter" &&
+                      handleConnect({ wallet: "injected" })
+                    }
+                    tabIndex={4}
                   >
                     <BraveIcon />
                     <Text t="button">Brave</Text>
@@ -148,6 +162,13 @@ export const ConnectModal = (props: ConnectModalProps) => {
                       wallet: eth?.isCoinbaseWallet ? "injected" : "coinbase",
                     })
                   }
+                  onKeyDown={(e) =>
+                    e.code === "Enter" &&
+                    handleConnect({
+                      wallet: showCoinbaseWallet ? "injected" : "coinbase",
+                    })
+                  }
+                  tabIndex={5}
                 >
                   <CoinbaseWalletIcon />
                   <Text t="button">Coinbase</Text>
@@ -155,6 +176,11 @@ export const ConnectModal = (props: ConnectModalProps) => {
                 <span
                   className={styles.walletButton}
                   onClick={() => handleConnect({ wallet: "walletConnect" })}
+                  tabIndex={6}
+                  onKeyDown={(e) =>
+                    e.code === "Enter" &&
+                    handleConnect({ wallet: "walletConnect" })
+                  }
                 >
                   <WalletConnectIcon />
                   <Text t="button">walletconnect</Text>
@@ -170,6 +196,10 @@ export const ConnectModal = (props: ConnectModalProps) => {
               <div
                 className={styles.torusButtons}
                 onClick={() => handleConnect({ wallet: "torus" })}
+                onKeyDown={(e) =>
+                  e.code === "Enter" && handleConnect({ wallet: "torus" })
+                }
+                tabIndex={7}
               >
                 <span className={styles.buttonBackground}>
                   <TwitterIcon className={styles.twitter} />
@@ -187,7 +217,7 @@ export const ConnectModal = (props: ConnectModalProps) => {
                   <MailOutlineIcon fontSize="large" />
                 </span>
               </div>
-            </>
+            </div>
           )}
           {step === "loading" && (
             <div className={styles.spinner}>

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -55,6 +55,7 @@ export const ConnectModal = (props: ConnectModalProps) => {
 
   const showBrave = eth?.isBraveWallet;
   const showMetamask = eth?.isMetaMask;
+  const showCoinbase = eth?.isCoinbaseWallet;
   const showBrowserWallet = eth && !showBrave && !showMetamask;
 
   const getTitle = (step: "connect" | "error" | "loading") =>
@@ -136,11 +137,20 @@ export const ConnectModal = (props: ConnectModalProps) => {
                   <Text t="button">Brave</Text>
                 </button>
               )}
+              {showBrowserWallet && (
+                <span
+                  className={styles.walletButton}
+                  onClick={() => handleConnect({ wallet: "injected" })}
+                >
+                  <ExtensionIcon className={styles.browserWalletIcon} />
+                  <Text t="button">Browser Injected Wallet</Text>
+                </span>
+              )}
               <button
                 className={styles.walletButton}
                 onClick={() =>
                   handleConnect({
-                    wallet: showCoinbaseWallet ? "injected" : "coinbase",
+                    wallet: showCoinbase ? "injected" : "coinbase",
                   })
                 }
               >

--- a/lib/components/ConnectModal/index.tsx
+++ b/lib/components/ConnectModal/index.tsx
@@ -114,92 +114,95 @@ export const ConnectModal = (props: ConnectModalProps) => {
               <Close fontSize="large" />
             </button>
           </span>
-          <div
-            className={styles.connectContent}
-            data-display={step === "connect"}
-          >
-            <div className={styles.buttonsContainer}>
-              {showMetamask && (
+          {step === "connect" && (
+            <div className={styles.connectContent}>
+              <div className={styles.buttonsContainer}>
+                {showMetamask && (
+                  <button
+                    className={styles.walletButton}
+                    onClick={() => handleConnect({ wallet: "injected" })}
+                  >
+                    <MetaMaskFoxIcon />
+                    <Text t="button">Metamask</Text>
+                  </button>
+                )}
+                {showBrave && (
+                  <button
+                    className={styles.walletButton}
+                    onClick={() => handleConnect({ wallet: "injected" })}
+                  >
+                    <BraveIcon />
+                    <Text t="button">Brave</Text>
+                  </button>
+                )}
+                {showBrowserWallet && (
+                  <button
+                    className={styles.walletButton}
+                    onClick={() => handleConnect({ wallet: "injected" })}
+                  >
+                    <ExtensionIcon className={styles.browserWalletIcon} />
+                    <Text t="button">Browser Injected Wallet</Text>
+                  </button>
+                )}
                 <button
                   className={styles.walletButton}
-                  onClick={() => handleConnect({ wallet: "injected" })}
+                  onClick={() =>
+                    handleConnect({
+                      wallet: isInjectedCoinbase ? "injected" : "coinbase",
+                    })
+                  }
                 >
-                  <MetaMaskFoxIcon />
-                  <Text t="button">Metamask</Text>
+                  <CoinbaseWalletIcon />
+                  <Text t="button">Coinbase</Text>
                 </button>
-              )}
-              {showBrave && (
                 <button
                   className={styles.walletButton}
-                  onClick={() => handleConnect({ wallet: "injected" })}
+                  onClick={() => handleConnect({ wallet: "walletConnect" })}
                 >
-                  <BraveIcon />
-                  <Text t="button">Brave</Text>
+                  <WalletConnectIcon />
+                  <Text t="button">walletconnect</Text>
                 </button>
-              )}
-              {showBrowserWallet && (
-                <button
-                  className={styles.walletButton}
-                  onClick={() => handleConnect({ wallet: "injected" })}
-                >
-                  <ExtensionIcon className={styles.browserWalletIcon} />
-                  <Text t="button">Browser Injected Wallet</Text>
-                </button>
-              )}
+              </div>
+              <span className={styles.continueBox}>
+                <div className={styles.leftLine} />
+                <Text className={styles.continueText} t="badge">
+                  {props.torusText}
+                </Text>
+                <div className={styles.rightLine} />
+              </span>
               <button
-                className={styles.walletButton}
-                onClick={() =>
-                  handleConnect({
-                    wallet: isInjectedCoinbase ? "injected" : "coinbase",
-                  })
-                }
+                className={styles.torusButtons}
+                onClick={() => handleConnect({ wallet: "torus" })}
               >
-                <CoinbaseWalletIcon />
-                <Text t="button">Coinbase</Text>
-              </button>
-              <button
-                className={styles.walletButton}
-                onClick={() => handleConnect({ wallet: "walletConnect" })}
-              >
-                <WalletConnectIcon />
-                <Text t="button">walletconnect</Text>
+                <span className={styles.buttonBackground}>
+                  <TwitterIcon className={styles.twitter} />
+                </span>
+                <span className={styles.buttonBackground}>
+                  <FacebookColorIcon />
+                </span>
+                <span className={styles.buttonBackground}>
+                  <GoogleIcon />
+                </span>
+                <span className={styles.buttonBackground}>
+                  <DiscordColorIcon className={styles.discord} />
+                </span>
+                <span className={styles.buttonBackground}>
+                  <MailOutlineIcon fontSize="large" />
+                </span>
               </button>
             </div>
-            <span className={styles.continueBox}>
-              <div className={styles.leftLine} />
-              <Text className={styles.continueText} t="badge">
-                {props.torusText}
-              </Text>
-              <div className={styles.rightLine} />
-            </span>
-            <button
-              className={styles.torusButtons}
-              onClick={() => handleConnect({ wallet: "torus" })}
-            >
-              <span className={styles.buttonBackground}>
-                <TwitterIcon className={styles.twitter} />
-              </span>
-              <span className={styles.buttonBackground}>
-                <FacebookColorIcon />
-              </span>
-              <span className={styles.buttonBackground}>
-                <GoogleIcon />
-              </span>
-              <span className={styles.buttonBackground}>
-                <DiscordColorIcon className={styles.discord} />
-              </span>
-              <span className={styles.buttonBackground}>
-                <MailOutlineIcon fontSize="large" />
-              </span>
-            </button>
-          </div>
-          <div className={styles.spinner} data-display={step === "loading"}>
-            <Spinner />
-          </div>
-          <div className={styles.errorContent} data-display={step === "error"}>
-            <Text t="body2">{props.errorMessage}</Text>
-            <ButtonPrimary label="OK" onClick={() => setStep("connect")} />
-          </div>
+          )}
+          {step === "loading" && (
+            <div className={styles.spinner}>
+              <Spinner />
+            </div>
+          )}
+          {step === "error" && (
+            <div className={styles.errorContent}>
+              <Text t="body2">{props.errorMessage}</Text>
+              <ButtonPrimary label="OK" onClick={() => setStep("connect")} />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/lib/components/ConnectModal/styles.ts
+++ b/lib/components/ConnectModal/styles.ts
@@ -25,6 +25,14 @@ export const modalContainer = css`
   overflow: hidden;
 `;
 
+export const connectContent = css`
+  &[data-display="true"] {
+    display: flex;
+    flex-direction: column;
+  }
+  display: none;
+`;
+
 export const walletButton = css`
   background: var(--white);
   display: flex;
@@ -96,10 +104,16 @@ export const spinner = css`
   justify-content: center;
   align-items: center;
   padding: 6rem;
+  &[data-display="false"] {
+    display: none;
+  }
 `;
 
 export const errorContent = css`
   display: flex;
+  &[data-display="false"] {
+    display: none;
+  }
   flex-direction: column;
   align-items: center;
   gap: 2.4rem;

--- a/lib/components/ConnectModal/styles.ts
+++ b/lib/components/ConnectModal/styles.ts
@@ -26,11 +26,8 @@ export const modalContainer = css`
 `;
 
 export const connectContent = css`
-  &[data-display="true"] {
-    display: flex;
-    flex-direction: column;
-  }
-  display: none;
+  display: flex;
+  flex-direction: column;
 `;
 
 export const walletButton = css`
@@ -104,16 +101,10 @@ export const spinner = css`
   justify-content: center;
   align-items: center;
   padding: 6rem;
-  &[data-display="false"] {
-    display: none;
-  }
 `;
 
 export const errorContent = css`
   display: flex;
-  &[data-display="false"] {
-    display: none;
-  }
   flex-direction: column;
   align-items: center;
   gap: 2.4rem;


### PR DESCRIPTION
## Description
I added tab indexes to the modal content because the focus trap wasn't working. The tabbing is off on the error step and I cant figure out why the tab indexes are getting messed up. I also added a handler for enter button press when buttons are focused.
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #830 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
