### PR TITLE
add rss id to podcast schema

### DIFF
--- a/cms/schemas/podcast.js
+++ b/cms/schemas/podcast.js
@@ -22,6 +22,8 @@ export default {
     {
       name: "rssId",
       title: "RSS Id",
+      description:
+        "6-digit ID used to construct the URL to this podcast episode on rss.com",
       type: "string",
     },
     {

--- a/cms/schemas/podcast.js
+++ b/cms/schemas/podcast.js
@@ -20,6 +20,11 @@ export default {
       validation: (Rule) => Rule.required(),
     },
     {
+      name: "rssId",
+      title: "RSS Id",
+      type: "string",
+    },
+    {
       name: "embedCode",
       title: "Embed code",
       type: "string",


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

This PR adds a new field to the podcast schema called `rssId`. This is the first PR of 3 as suggested in #908 and will need to be deployed to sanity studio.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #908 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
