### PR TITLE
cleanup embed codes

### DIFF
--- a/cms/schemas/podcast.js
+++ b/cms/schemas/podcast.js
@@ -27,11 +27,6 @@ export default {
       type: "string",
     },
     {
-      name: "embedCode",
-      title: "Embed code",
-      type: "string",
-    },
-    {
       name: "publishedAt",
       title: "Published at",
       type: "datetime",

--- a/site/components/pages/Resources/lib/queries.ts
+++ b/site/components/pages/Resources/lib/queries.ts
@@ -24,7 +24,6 @@ const filterDocumentsByTags = (params: QueryParams) => /* groq */ `
       author->,
       "imageUrl": mainImage.asset->url,
       rssId,
-      "embed": embedCode,
       "tags": tags[]->label_en
     }
   `;
@@ -40,7 +39,6 @@ const filterDocumentsWithoutTags = (params: QueryParams) => /* groq */ `
     author->,
     "imageUrl": mainImage.asset->url,
     rssId,
-    "embed": embedCode,
     "tags": tags[]->label_en
   }
 `;
@@ -90,7 +88,6 @@ export const searchByText = (searchQuery: string) => /* groq */ `
       author->,
       "imageUrl": mainImage.asset->url,
       rssId,
-      "embed": embedCode,
       "tags": tags[]->label_en
     }
     [ _score > 0]

--- a/site/lib/queries.ts
+++ b/site/lib/queries.ts
@@ -121,7 +121,6 @@ export type PodcastDetails = {
   title: string;
   summary: string;
   rssId?: string;
-  embed?: string;
 };
 export type AllPodcasts = PodcastDetails[];
 export type LatestPost = { slug: string; title: string };
@@ -146,7 +145,6 @@ export type Document = {
   author: { name: string };
   imageUrl?: string;
   rssId?: string;
-  embed?: string;
 };
 
 export interface QueryContent {

--- a/site/lib/queries.ts
+++ b/site/lib/queries.ts
@@ -25,7 +25,6 @@ export const queries = {
       author->,
       "imageUrl": mainImage.asset->url,
       rssId,
-      "embed": embedCode,
       "tags": tags[]->label_en
     }
   `,
@@ -100,7 +99,6 @@ export const queries = {
     publishedAt, 
     host->, 
     rssId,
-    "embed": embedCode
   }
 `,
 };


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Clean up of embed codes on podcasts which were replaced by rss id's in #908.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #908 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
