### PR TITLE
add view retirements button to carbon tonnes retired card

### DIFF
--- a/app/components/CarbonTonnesRetiredCard/index.tsx
+++ b/app/components/CarbonTonnesRetiredCard/index.tsx
@@ -1,16 +1,20 @@
+import { t, Trans } from "@lingui/macro";
 import { FC } from "react";
-
-import { Trans } from "@lingui/macro";
-import ForestOutlinedIcon from "@mui/icons-material/ForestOutlined";
-
 import { useSelector } from "react-redux";
+
+import ForestOutlinedIcon from "@mui/icons-material/ForestOutlined";
+import LaunchOutlinedIcon from "@mui/icons-material/LaunchOutlined";
+
+import { ButtonPrimary, Text } from "@klimadao/lib/components";
 import { selectCarbonRetired } from "state/selectors";
 
-import { Text } from "@klimadao/lib/components";
+import { urls } from "@klimadao/lib/constants";
+import { useWeb3 } from "@klimadao/lib/utils";
 
 import * as styles from "./styles";
 
 export const CarbonTonnesRetiredCard: FC = () => {
+  const { address } = useWeb3();
   const totalCarbonRetired = useSelector(selectCarbonRetired);
   return (
     <div className={styles.card}>
@@ -37,6 +41,19 @@ export const CarbonTonnesRetiredCard: FC = () => {
             <Trans id="offset.number_of_retirements">Total retirements</Trans>
           </Text>
         </div>
+        {Number(totalCarbonRetired?.totalRetirements) > 0 && (
+          <ButtonPrimary
+            target="_blank"
+            variant="transparent"
+            icon={<LaunchOutlinedIcon />}
+            href={`${urls.retirements}/${address}`}
+            className={styles.button}
+            label={t({
+              id: "offset.view_retirements",
+              message: "View Retirements",
+            })}
+          />
+        )}
       </div>
     </div>
   );

--- a/app/components/CarbonTonnesRetiredCard/styles.ts
+++ b/app/components/CarbonTonnesRetiredCard/styles.ts
@@ -56,3 +56,14 @@ export const card = css`
     }
   }
 `;
+
+export const button = css`
+  width: 22rem;
+  color: #fff !important;
+  border: 1px solid #fff;
+
+  svg {
+    width: 0.75em !important;
+    height: 0.75em !important;
+  }
+`;

--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/views/Offset/index.tsx:685
 msgid "Beneficiary 0x address (optional)"
@@ -527,7 +533,7 @@ msgstr ""
 msgid "offset.modal_retire.title"
 msgstr ""
 
-#: components/CarbonTonnesRetiredCard/index.tsx:37
+#: components/CarbonTonnesRetiredCard/index.tsx:41
 msgid "offset.number_of_retirements"
 msgstr ""
 
@@ -656,11 +662,15 @@ msgstr ""
 msgid "offset.successModal.title"
 msgstr ""
 
-#: components/CarbonTonnesRetiredCard/index.tsx:29
+#: components/CarbonTonnesRetiredCard/index.tsx:33
 msgid "offset.tonnes_of_carbon_retired"
 msgstr ""
 
-#: components/CarbonTonnesRetiredCard/index.tsx:20
+#: components/CarbonTonnesRetiredCard/index.tsx:51
+msgid "offset.view_retirements"
+msgstr ""
+
+#: components/CarbonTonnesRetiredCard/index.tsx:24
 msgid "offset.you_have_retired"
 msgstr ""
 

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -533,7 +533,7 @@ msgstr "Select Token"
 msgid "offset.modal_retire.title"
 msgstr "Select Carbon Type"
 
-#: components/CarbonTonnesRetiredCard/index.tsx:37
+#: components/CarbonTonnesRetiredCard/index.tsx:41
 msgid "offset.number_of_retirements"
 msgstr "Total retirements"
 
@@ -662,11 +662,15 @@ msgstr "VIEW RETIREMENT"
 msgid "offset.successModal.title"
 msgstr "Retirement Successful!"
 
-#: components/CarbonTonnesRetiredCard/index.tsx:29
+#: components/CarbonTonnesRetiredCard/index.tsx:33
 msgid "offset.tonnes_of_carbon_retired"
 msgstr "Tonnes of carbon"
 
-#: components/CarbonTonnesRetiredCard/index.tsx:20
+#: components/CarbonTonnesRetiredCard/index.tsx:51
+msgid "offset.view_retirements"
+msgstr "View Retirements"
+
+#: components/CarbonTonnesRetiredCard/index.tsx:24
 msgid "offset.you_have_retired"
 msgstr "You've Retired"
 

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Adds a "View Retirements" button to the Carbon Tonnes retirement card when a user has 1 or more retirements. The card remains as is if a user has 0 retirements.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #864 

<!-- If there are UI changes, please include a before and after screenshot in the following template: -->

## Changes

| Before  | After  |
|---------|--------|
|<img width="650" alt="Screenshot 2023-01-31 at 21 56 16" src="https://user-images.githubusercontent.com/92357475/215893062-904a0045-c5c9-4a6c-8fe9-e2c3431dfae0.png">|<img width="650" alt="Screenshot 2023-01-31 at 21 55 51" src="https://user-images.githubusercontent.com/92357475/215893098-660fb278-c137-4c87-88c3-7f89e40e1bbb.png">|

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
