### PR TITLE
remove web3wallet from local storage on refusal

### DIFF
--- a/lib/utils/useProvider/index.tsx
+++ b/lib/utils/useProvider/index.tsx
@@ -164,7 +164,7 @@ export const useProvider = (): Web3ModalState => {
       window.location.reload();
     };
     const handleDisconnect = () => {
-      localStorage.clear();
+      localStorage.removeItem("web3-wallet");
       window.location.reload();
     };
 

--- a/lib/utils/useProvider/index.tsx
+++ b/lib/utils/useProvider/index.tsx
@@ -123,7 +123,6 @@ export const useProvider = (): Web3ModalState => {
       };
       setWeb3State(newState);
     } catch (e: any) {
-      console.log(e);
       if (
         // TODO check message for coinbase when it is working again
         e.code === 4001 || // metamask

--- a/lib/utils/useProvider/index.tsx
+++ b/lib/utils/useProvider/index.tsx
@@ -123,12 +123,15 @@ export const useProvider = (): Web3ModalState => {
       };
       setWeb3State(newState);
     } catch (e: any) {
+      console.log(e);
       if (
         // TODO check message for coinbase when it is working again
-        e.code === 4001 ||
-        e.message === "User closed modal" ||
-        e.message === "User cancelled login"
+        e.code === 4001 || // metamask
+        e.message === "User closed modal" || // wallet connect
+        e.message === "User cancelled login" || // torus message
+        e.message === "User denied account authorization" // coinbase message
       ) {
+        localStorage.removeItem("web3-wallet");
         e.name = "rejected";
       }
       throw e;
@@ -161,7 +164,7 @@ export const useProvider = (): Web3ModalState => {
       window.location.reload();
     };
     const handleDisconnect = () => {
-      localStorage.removeItem("web3-wallet");
+      localStorage.clear();
       window.location.reload();
     };
 


### PR DESCRIPTION
## Description
If the users session expires on their wallet but the web3-wallet value is still in local storage then the app tries to reconnect them. This brings up the modal and when the user closes the rpc modal and triggers the refusal error the item is now cleared from storage.
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #902 
Resolves #868 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
