### PR TITLE
import vars before globals in site

### DIFF
--- a/site/pages/_app.tsx
+++ b/site/pages/_app.tsx
@@ -1,5 +1,4 @@
 import { GridContainer, Web3ContextProvider } from "@klimadao/lib/components";
-import "@klimadao/lib/theme/globals.css";
 import "@klimadao/lib/theme/normalize.css";
 import "@klimadao/lib/theme/variables.css";
 import { useTabListener } from "@klimadao/lib/utils";
@@ -8,6 +7,8 @@ import { I18nProvider } from "@lingui/react";
 import type { AppProps } from "next/app";
 import Script from "next/script";
 import { useEffect, useRef } from "react";
+// keep globals on new line so that it is imported after variables.css
+import "@klimadao/lib/theme/globals.css";
 
 const loadFallbackOnServer = async () => {
   if (typeof window === "undefined") {


### PR DESCRIPTION
## Description
import vars before globals in site using a new line to tell auto sort to ignore it
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #943 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
