### PR TITLE
(replaces #965) Tufnel/Decrement Allowance of Payment Token after retirement

### DIFF
--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -56,6 +56,7 @@ import {
   selectProjectTokens,
 } from "state/selectors";
 import {
+  decrementAllowance,
   decrementProjectToken,
   setAllowance,
   setProjectToken,
@@ -374,6 +375,13 @@ export const Offset = (props: Props) => {
             retirementToken: selectedRetirementToken,
             cost,
             quantity,
+          })
+        );
+        dispatch(
+          decrementAllowance({
+            token: paymentMethod,
+            spender: "retirementAggregatorV2",
+            value: cost,
           })
         );
       }


### PR DESCRIPTION
## Description

Reduces the spending allowance of `retirementAggregatorV2` by the `cost` of the `paymentMethod` token after retirement.

Given that the spender is the V2 contract, this branch is a branch of the PR #960 . The relevant change to `staging`, separate from #960 is here -> [decrementAllowance](https://github.com/KlimaDAO/klimadao/compare/tufnel/fix-decrement-allowance-post-retirement?expand=1#diff-b68c42fa04a583195c0f40a15e663dcebdd59c469a31bac00a34e1848e2a6c06R382-R387)

## Reviewers

@Atmosfearful

## Related Ticket

Resolves #964 


## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
