### PR TITLE
Add translated blog posts

### DIFF
--- a/cms/schemas/post.js
+++ b/cms/schemas/post.js
@@ -27,6 +27,18 @@ export default {
       validation: (Rule) => Rule.required(),
     },
     {
+      title: "Locale",
+      name: "locale",
+      type: "string",
+      description: "Leaving this empty defaults the locale to 'en'",
+      options: {
+        list: [
+          { title: "en", value: "en" },
+          { title: "zh-CN", value: "zh-CN" },
+        ],
+      },
+    },
+    {
       title: "Domain",
       name: "domain",
       type: "string",

--- a/site/components/pages/Resources/ResourcesList/index.tsx
+++ b/site/components/pages/Resources/ResourcesList/index.tsx
@@ -27,6 +27,7 @@ import {
 import { queryFilteredDocuments, searchDocumentsByText } from "../lib/queries";
 
 import { Document } from "lib/queries";
+import { useRouter } from "next/router";
 import * as styles from "./styles";
 
 export interface Props {
@@ -48,6 +49,7 @@ const defaultValues: FormValues = {
 };
 
 export const ResourcesList: FC<Props> = (props) => {
+  const { locale } = useRouter();
   const [visibleDocuments, setVisibleDocuments] = useState<Document[] | null>(
     props.documents
   );
@@ -85,7 +87,10 @@ export const ResourcesList: FC<Props> = (props) => {
     try {
       setIsLoading(true);
 
-      const searchResult = await searchDocumentsByText(values.search);
+      const searchResult = await searchDocumentsByText(
+        values.search,
+        locale || "en"
+      );
 
       // remove all filters and sortBy as search results do not take filters into account and are sorted by relevance
       // but don't delete current search term in input field
@@ -124,7 +129,10 @@ export const ResourcesList: FC<Props> = (props) => {
 
     // query with input values
     try {
-      const filteredDocuments = await queryFilteredDocuments(values);
+      const filteredDocuments = await queryFilteredDocuments(
+        values,
+        locale || "en"
+      );
       if (filteredDocuments.length) {
         setVisibleDocuments(filteredDocuments);
       } else {

--- a/site/lib/queries.ts
+++ b/site/lib/queries.ts
@@ -7,16 +7,22 @@ wants to publish their posts but dont want it to appear in the production enviro
 NOTE: When constructing a new query for posts, please add the hideFromProduction filter to the prodQuery
 so the query wont reveal any hidden posts in the production environment */
 
-export const hideFromProduction = IS_PRODUCTION
+const hideFromProduction = IS_PRODUCTION
   ? "hideFromProduction != true"
   : "true";
 
-export const isDomainKlimadao = '(domain == "klimadao" || !defined(domain))';
+const isDomainKlimadao = '(domain == "klimadao" || !defined(domain))';
+
+const localeFilter =
+  '(locale == $locale || (!defined(locale) && $locale == "en"))';
+
+/** these filters are typicaly used for all queries, filters the documents for locale, domain and production environment */
+export const baseFilters = `${localeFilter} && ${hideFromProduction} && ${isDomainKlimadao}`;
 
 export const queries = {
   /** fetch all blog posts and podcasts, sorted by publishedAt, limit to 20 */
   allDocuments: /* groq */ `
-    *[_type in ["post", "podcast"] && ${hideFromProduction} && ${isDomainKlimadao}][0...20] | order(publishedAt desc) {
+    *[_type in ["post", "podcast"] && ${baseFilters}][0...20] | order(publishedAt desc) {
       "type": _type,
       publishedAt, 
       title, 
@@ -31,7 +37,7 @@ export const queries = {
 
   /** fetch all blog posts, sorted by publishedAt */
   allPosts: /* groq */ `
-    *[_type == "post" && ${hideFromProduction} && ${isDomainKlimadao}] | order(publishedAt desc) {
+    *[_type == "post" && ${baseFilters}] | order(publishedAt desc) {
       summary, 
       "slug": slug.current, 
       title, 
@@ -43,7 +49,7 @@ export const queries = {
 
   /** fetch all blog posts with isFeaturedArticle == true, limit to 20, sorted by publishedAt */
   allFeaturedPosts: /* groq */ `
-    *[_type == "post"  && isFeaturedArticle == true && ${hideFromProduction} && ${isDomainKlimadao}][0...20] | order(publishedAt desc) {
+    *[_type == "post"  && isFeaturedArticle == true && ${baseFilters}][0...20] | order(publishedAt desc) {
       summary, 
       "slug": slug.current, 
       title, 
@@ -56,14 +62,14 @@ export const queries = {
 
   /** fetch the last published post slug and title */
   latestPost: /* groq */ `
-    *[_type == "post" && ${hideFromProduction} && ${isDomainKlimadao}] | order(publishedAt desc) {
+    *[_type == "post" && ${baseFilters}] | order(publishedAt desc) {
       "slug": slug.current, 
       title
     }[0]
   `,
   /** fetch a blog post based on slug */
   post: /* groq */ `
-    *[_type == "post" && slug.current == $slug && ${hideFromProduction} && ${isDomainKlimadao}][0] {
+    *[_type == "post" && slug.current == $slug && ${baseFilters}][0] {
       body[] {
         ...,
         markDefs[]{
@@ -92,7 +98,7 @@ export const queries = {
   `,
 
   allPodcasts: /* groq */ `
-  *[_type == "podcast"  && ${hideFromProduction} && ${isDomainKlimadao}] | order(publishedAt desc) {
+  *[_type == "podcast"  && ${baseFilters}] | order(publishedAt desc) {
     summary, 
     "slug": slug.current, 
     title, 

--- a/site/pages/blog/[pid].tsx
+++ b/site/pages/blog/[pid].tsx
@@ -8,6 +8,7 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
   try {
     const post = await fetchCMSContent("post", {
       slug: ctx.params?.pid,
+      locale: ctx.locale,
     });
     const translation = await loadTranslation(ctx.locale);
     if (!post) {

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -11,7 +11,9 @@ import { GetStaticProps } from "next";
 
 export const getStaticProps: GetStaticProps<Props> = async (ctx) => {
   const treasuryBalance = await getTreasuryBalance({ infuraId: INFURA_ID });
-  const latestPost = await fetchCMSContent("latestPost");
+  const latestPost = await fetchCMSContent("latestPost", {
+    locale: ctx.locale,
+  });
   const translation = await loadTranslation(ctx.locale);
   const blockRate = await fetchBlockRate();
   const monthlyStakingRewards = await getStakingRewards({

--- a/site/pages/resources/index.tsx
+++ b/site/pages/resources/index.tsx
@@ -5,10 +5,13 @@ import { GetStaticPropsContext } from "next";
 
 export async function getStaticProps(ctx: GetStaticPropsContext) {
   try {
-    const documents = await fetchCMSContent("allDocuments");
-    const featuredArticles = await fetchCMSContent("allFeaturedPosts");
+    const { locale } = ctx;
+    const documents = await fetchCMSContent("allDocuments", { locale });
+    const featuredArticles = await fetchCMSContent("allFeaturedPosts", {
+      locale,
+    });
 
-    const translation = await loadTranslation(ctx.locale);
+    const translation = await loadTranslation(locale);
     if (!documents) {
       throw new Error("No documents found");
     }


### PR DESCRIPTION
## Description
 - [x] To the schema, add an optional Locale dropdown with pre-known locales. For now only en and zh-CN (mandarin chinese)
 - [x] If zh-CN is selected, query for posts with zh-CN locale. No English posts.
 - [x] Otherwise, only query for English posts (for en, no locale, and all other locales)

Resolves #968 

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
