### PR TITLE
Fix methodologies missing on Staging Testnet

### DIFF
--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -19,7 +19,6 @@ import {
   sortPricesAndListingsByBestPrice,
 } from "lib/listingsGetter";
 import {
-  CategoryName,
   PriceFlagged,
   Project as ProjectType,
   ProjectBuyOption,
@@ -46,7 +45,10 @@ export const Project: NextPage<Props> = (props) => {
       getActiveListings(props.project.listings)) ||
     [];
 
-  const category = props.project.methodologies[0].category as CategoryName;
+  const category =
+    (props.project?.methodologies?.length &&
+      props.project.methodologies[0].category) ||
+    "Other"; // fallback for Staging Testnet Data
   const allMethodologyIds =
     props.project?.methodologies?.map(({ id }) => id) || [];
   const allMethodologyNames =

--- a/carbonmark/lib/types/carbonmark.ts
+++ b/carbonmark/lib/types/carbonmark.ts
@@ -9,7 +9,7 @@ export interface Project {
     {
       id: string;
       name: string;
-      category: string;
+      category: CategoryName;
     }
   ];
   methodology: string;


### PR DESCRIPTION
## Description

Tiny follow-up on https://github.com/KlimaDAO/klimadao/issues/986

=> when running on testnet, the dummy projects do not contain a "methodologies" array
which results in an error while rendering the page

Please note that the ticket is still open as the /projects view is still not changed.


## Related Ticket

related to #986

## Changes

| Before  | After  |
|---------|--------|
|![Bildschirm­foto 2023-04-12 um 14 10 08](https://user-images.githubusercontent.com/95881624/231454637-10ca147b-9488-45dd-8562-895faad4ce0b.png) |![Bildschirm­foto 2023-04-12 um 14 17 40](https://user-images.githubusercontent.com/95881624/231454676-cc0e5e5e-2ee7-49f8-8f00-346577b497c5.png)|



## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
