### PR TITLE
Use SWR for Single Project

### DIFF
--- a/carbonmark/hooks/useFetchProject.ts
+++ b/carbonmark/hooks/useFetchProject.ts
@@ -1,0 +1,17 @@
+import { fetcher } from "lib/fetcher";
+import type { SWRConfiguration } from "swr";
+import useSWR from "swr";
+import { Project } from "../lib/types/carbonmark";
+
+export const useFetchProject = (
+  projectID: string,
+  options?: SWRConfiguration
+) => {
+  const { data: project, ...rest } = useSWR<Project>(
+    `/api/projects/${projectID}`,
+    fetcher,
+    options
+  );
+
+  return { project, ...rest };
+};

--- a/carbonmark/pages/projects/[project_id]/index.tsx
+++ b/carbonmark/pages/projects/[project_id]/index.tsx
@@ -1,16 +1,11 @@
-import { Project } from "components/pages/Project";
+import { PageProps, Project } from "components/pages/Project";
 import { getCarbonmarkProject } from "lib/carbonmark";
 import { loadTranslation } from "lib/i18n";
-import { Project as ProjectType } from "lib/types/carbonmark";
 import { GetStaticProps } from "next";
 import { ParsedUrlQuery } from "querystring";
 
 interface Params extends ParsedUrlQuery {
   project_id: string;
-}
-
-interface PageProps {
-  project: ProjectType;
 }
 
 export const getStaticProps: GetStaticProps<PageProps, Params> = async (
@@ -33,6 +28,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
     return {
       props: {
         project,
+        projectID: params.project_id,
         translation,
         fixedThemeName: "theme-light",
       },


### PR DESCRIPTION
## Description

Please test that the following works:

- Go to a Single Project page of the [preview link](https://carbonmark-git-lady-swr-for-cache-klimadao.vercel.app/projects)
- Click on "Buy" of a listing
- Purchase this Listing
- On the Purchase Receipt page => click on the link above "back to project details"
- The same former Single Project Page is rendered
- => The **activity** should contain your just bought listing purchase ✔️ 
- => The **listing** you bought should be gone on that Project page ✔️ 

Please keep in mind that the backend can still be slow !
We might want to integrate a refresh interval if a user is logged in for these pages.

## Related Ticket

Part of https://github.com/KlimaDAO/klimadao/issues/1019


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
