### PR TITLE
Resolve type discrepancies

### DIFF
--- a/carbonmark/components/Activities/Activity.tsx
+++ b/carbonmark/components/Activities/Activity.tsx
@@ -98,9 +98,7 @@ export const Activity = (props: Props) => {
 
   return (
     <div key={props.activity.id} className={styles.activity}>
-      {props.showTitle && (
-        <Text t="h5">{props.activity.project?.name || "unknown"}</Text>
-      )}
+      {project && <Text t="h5">{project.name}</Text>}
       <Text t="body1" color="lighter">
         <i>
           {getElapsedTime({

--- a/carbonmark/components/Activities/Activity.tsx
+++ b/carbonmark/components/Activities/Activity.tsx
@@ -4,15 +4,23 @@ import { Text } from "components/Text";
 import { formatBigToPrice, formatBigToTonnes } from "lib/formatNumbers";
 import { formatWalletAddress } from "lib/formatWalletAddress";
 import { getElapsedTime } from "lib/getElapsedTime";
-import { ActivityType as ActivityT } from "lib/types/carbonmark";
+import { ProjectActivity, UserActivity } from "lib/types/carbonmark";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { getActivityActions } from "./Activities.constants";
 import * as styles from "./styles";
-type Props = {
-  activity: ActivityT;
-  showTitle?: boolean;
+
+interface Props {
+  activity: UserActivity | ProjectActivity;
+}
+
+const isUserActivity = (
+  activity: UserActivity | ProjectActivity
+): activity is UserActivity => {
+  // only user activity objects have the project entry
+  return !!(activity as UserActivity).project;
 };
+
 /** Represents a single activity of a user  */
 export const Activity = (props: Props) => {
   const { address: connectedAddress } = useWeb3();
@@ -32,6 +40,11 @@ export const Activity = (props: Props) => {
 
   const sellerID = props.activity.seller.id;
   const buyerId = props.activity.buyer?.id;
+
+  // type guard
+  const project = isUserActivity(props.activity)
+    ? props.activity.project
+    : null;
 
   /** By default the seller is the "source" of all actions */
   addressA = sellerID;

--- a/carbonmark/components/Activities/index.tsx
+++ b/carbonmark/components/Activities/index.tsx
@@ -2,33 +2,28 @@ import { Trans } from "@lingui/macro";
 import { Card } from "components/Card";
 import { Spinner } from "components/shared/Spinner";
 import { Text } from "components/Text";
-import { ActivityType } from "lib/types/carbonmark";
+import { ProjectActivity, UserActivity } from "lib/types/carbonmark";
 import { FC } from "react";
 import { Activity } from "./Activity";
 import * as styles from "./styles";
 
 interface Props {
-  activities: ActivityType[];
+  activities: ProjectActivity[] | UserActivity[];
   isLoading?: boolean;
-  showTitles?: boolean;
 }
 
 export const Activities: FC<Props> = (props) => {
-  const showTitle = props.showTitles ?? true;
-  const hasActivities = !!props.activities?.length;
-  const sortedActivities =
-    (hasActivities &&
-      props.activities
-        .sort((a, b) => Number(b.timeStamp) - Number(a.timeStamp))
-        .slice(0, 5)) ||
-    [];
+  const activities = props.activities || [];
+  const sortedActivities = activities
+    .sort((a, b) => Number(b.timeStamp) - Number(a.timeStamp))
+    .slice(0, 5);
 
   return (
     <Card>
       <Text t="h4" color="lighter">
         <Trans>Activity</Trans>
       </Text>
-      {!hasActivities && (
+      {!sortedActivities.length && (
         <Text t="body1" color="lighter">
           <i>
             <Trans id="user.activities.empty_state">No activity to show</Trans>
@@ -40,14 +35,9 @@ export const Activities: FC<Props> = (props) => {
           <Spinner />
         </div>
       )}
-      {!!sortedActivities.length &&
-        sortedActivities.map((activity) => (
-          <Activity
-            key={activity.id}
-            activity={activity}
-            showTitle={showTitle}
-          />
-        ))}
+      {sortedActivities.map((activity) => (
+        <Activity key={activity.id} activity={activity} />
+      ))}
     </Card>
   );
 };

--- a/carbonmark/components/pages/Home/index.tsx
+++ b/carbonmark/components/pages/Home/index.tsx
@@ -31,6 +31,7 @@ import { useResponsive } from "hooks/useResponsive";
 import { urls as carbonmarkUrls } from "lib/constants";
 import { createProjectLink } from "lib/createUrls";
 import { formatBigToPrice } from "lib/formatNumbers";
+import { getCategoryFromProject } from "lib/projectGetter";
 import { Project } from "lib/types/carbonmark";
 import { NextPage } from "next";
 import Image from "next/image";
@@ -126,11 +127,9 @@ export const Home: NextPage<Props> = (props) => {
                 >
                   <div className={cx(styles.card, "card")}>
                     <div className={styles.cardImage}>
-                      {!!project.methodologies[0]?.category && (
-                        <ProjectImage
-                          category={project.methodologies[0]?.category}
-                        />
-                      )}
+                      <ProjectImage
+                        category={getCategoryFromProject(project)}
+                      />
                     </div>
                     <div className={styles.cardContent}>
                       <Text t="body3" as="h4">
@@ -140,11 +139,7 @@ export const Home: NextPage<Props> = (props) => {
                       <Text as="h5">{project?.name}</Text>
                       <Text t="body1">{project?.description}</Text>
                       <div className={styles.tags}>
-                        {!!project.methodologies[0]?.category && (
-                          <Category
-                            category={project.methodologies[0]?.category}
-                          />
-                        )}
+                        <Category category={getCategoryFromProject(project)} />
                         <Vintage vintage={project.vintage} />
                       </div>
                     </div>

--- a/carbonmark/components/pages/Project/BuyOptions/SellerListing.tsx
+++ b/carbonmark/components/pages/Project/BuyOptions/SellerListing.tsx
@@ -7,14 +7,14 @@ import { Text } from "components/Text";
 import { createProjectPurchaseLink, createSellerLink } from "lib/createUrls";
 import { formatBigToTonnes, formatToPrice } from "lib/formatNumbers";
 import { isConnectedAddress } from "lib/formatWalletAddress";
-import { ListingFormatted, Project } from "lib/types/carbonmark";
+import { Listing, Project } from "lib/types/carbonmark";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { FC } from "react";
 import * as styles from "./styles";
 
 type Props = {
-  listing: ListingFormatted;
+  listing: Listing;
   project: Project;
   isBestPrice: boolean;
 };

--- a/carbonmark/components/pages/Project/Purchase/PurchaseForm.tsx
+++ b/carbonmark/components/pages/Project/Purchase/PurchaseForm.tsx
@@ -60,7 +60,7 @@ export type FormValues = {
 
 type Props = {
   onSubmit: (values: FormValues) => void;
-  listing: Omit<Listing, "project">;
+  listing: Listing;
   values: null | FormValues;
   isLoading: boolean;
 };

--- a/carbonmark/components/pages/Project/Purchase/PurchaseForm.tsx
+++ b/carbonmark/components/pages/Project/Purchase/PurchaseForm.tsx
@@ -60,7 +60,7 @@ export type FormValues = {
 
 type Props = {
   onSubmit: (values: FormValues) => void;
-  listing: Listing;
+  listing: Omit<Listing, "project">;
   values: null | FormValues;
   isLoading: boolean;
 };

--- a/carbonmark/components/pages/Project/Purchase/index.tsx
+++ b/carbonmark/components/pages/Project/Purchase/index.tsx
@@ -27,12 +27,12 @@ import { useState } from "react";
 import { FormValues, PurchaseForm } from "./PurchaseForm";
 import * as styles from "./styles";
 
-type Props = {
+export interface ProjectPurchasePageProps {
   project: Project;
-  listing: Listing;
-};
+  listing: Omit<Listing, "project">;
+}
 
-export const ProjectPurchase: NextPage<Props> = (props) => {
+export const ProjectPurchase: NextPage<ProjectPurchasePageProps> = (props) => {
   const { locale, push } = useRouter();
   const { address, provider } = useWeb3();
   const [isLoadingAllowance, setIsLoadingAllowance] = useState(false);

--- a/carbonmark/components/pages/Project/Purchase/index.tsx
+++ b/carbonmark/components/pages/Project/Purchase/index.tsx
@@ -29,7 +29,7 @@ import * as styles from "./styles";
 
 export interface ProjectPurchasePageProps {
   project: Project;
-  listing: Omit<Listing, "project">;
+  listing: Listing;
 }
 
 export const ProjectPurchase: NextPage<ProjectPurchasePageProps> = (props) => {

--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -22,7 +22,6 @@ import {
 } from "lib/listingsGetter";
 import { getCategoryFromProject } from "lib/projectGetter";
 import {
-  Listing,
   PriceFlagged,
   Project as ProjectType,
   ProjectBuyOption,
@@ -51,11 +50,9 @@ const Page: NextPage<PageProps> = (props) => {
   }
 
   const allListings =
-    Array.isArray(project.listings) &&
-    getAllListings(project.listings as Listing[]);
+    Array.isArray(project.listings) && getAllListings(project.listings);
   const activeListings =
-    (Array.isArray(project.listings) &&
-      getActiveListings(project.listings as Listing[])) ||
+    (Array.isArray(project.listings) && getActiveListings(project.listings)) ||
     [];
 
   const category = getCategoryFromProject(project);
@@ -71,7 +68,7 @@ const Page: NextPage<PageProps> = (props) => {
 
   const sortedListingsAndPrices = sortPricesAndListingsByBestPrice(
     poolPrices,
-    activeListings as Listing[]
+    activeListings
   );
 
   const bestPrice =

--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -22,6 +22,7 @@ import {
 } from "lib/listingsGetter";
 import { getCategoryFromProject } from "lib/projectGetter";
 import {
+  Listing,
   PriceFlagged,
   Project as ProjectType,
   ProjectBuyOption,
@@ -50,9 +51,11 @@ const Page: NextPage<PageProps> = (props) => {
   }
 
   const allListings =
-    Array.isArray(project.listings) && getAllListings(project.listings);
+    Array.isArray(project.listings) &&
+    getAllListings(project.listings as Listing[]);
   const activeListings =
-    (Array.isArray(project.listings) && getActiveListings(project.listings)) ||
+    (Array.isArray(project.listings) &&
+      getActiveListings(project.listings as Listing[])) ||
     [];
 
   const category = getCategoryFromProject(project);
@@ -68,7 +71,7 @@ const Page: NextPage<PageProps> = (props) => {
 
   const sortedListingsAndPrices = sortPricesAndListingsByBestPrice(
     poolPrices,
-    activeListings
+    activeListings as Listing[]
   );
 
   const bestPrice =
@@ -207,10 +210,7 @@ const Page: NextPage<PageProps> = (props) => {
               allListings={allListings || []}
               activeListings={activeListings || []}
             />
-            <Activities
-              activities={project.activities || []}
-              showTitles={false}
-            />
+            <Activities activities={project.activities || []} />
           </div>
         </div>
       </Layout>

--- a/carbonmark/components/pages/Purchases/index.tsx
+++ b/carbonmark/components/pages/Purchases/index.tsx
@@ -120,7 +120,7 @@ export const PurchaseReceipt: NextPage<Props> = (props) => {
                         {props.purchase.listing.project.name}
                       </Text>
                       <Text t="body3" className="country">
-                        {props.purchase.listing.project.country.id}
+                        {props.purchase.listing.project.country?.id}
                       </Text>
                     </div>
                     <CarbonmarkButton

--- a/carbonmark/components/pages/Users/Listing/index.tsx
+++ b/carbonmark/components/pages/Users/Listing/index.tsx
@@ -5,14 +5,14 @@ import { ProjectImage } from "components/ProjectImage";
 import { Text } from "components/Text";
 import { Vintage } from "components/Vintage";
 import { formatBigToPrice, formatBigToTonnes } from "lib/formatNumbers";
-import { Listing as ListingType } from "lib/types/carbonmark";
+import { ListingWithProject } from "lib/types/carbonmark";
 import { useRouter } from "next/router";
 import { FC, ReactNode } from "react";
 
 import * as styles from "./styles";
 
 type Props = {
-  listing: ListingType;
+  listing: ListingWithProject;
   children: ReactNode;
 };
 

--- a/carbonmark/components/pages/Users/SellerConnected/Forms/EditListing.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/Forms/EditListing.tsx
@@ -5,7 +5,7 @@ import { InputField } from "components/shared/Form/InputField";
 import { Text } from "components/Text";
 import { MINIMUM_TONNE_PRICE } from "lib/constants";
 import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
-import { Listing } from "lib/types/carbonmark";
+import { ListingWithProject } from "lib/types/carbonmark";
 import { useRouter } from "next/router";
 import { FC } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -22,7 +22,7 @@ export type FormValues = {
 type Props = {
   onSubmit: (values: FormValues) => void;
   onCancel: () => void;
-  listing: Listing;
+  listing: ListingWithProject;
   values: null | FormValues;
   assetBalance: string;
 };

--- a/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
@@ -15,20 +15,20 @@ import {
 } from "lib/actions";
 import { formatToTonnes } from "lib/formatNumbers";
 import { TransactionStatusMessage, TxnStatus } from "lib/statusMessage";
-import { AssetForListing, Listing as ListingType } from "lib/types/carbonmark";
+import { AssetForListing, ListingWithProject } from "lib/types/carbonmark";
 import { FC, useState } from "react";
 import { Listing } from "../Listing";
 import { EditListing, FormValues } from "./Forms/EditListing";
 import * as styles from "./styles";
 
 type Props = {
-  listings: ListingType[];
+  listings: ListingWithProject[];
   assets: AssetForListing[];
   onFinishEditing: () => void;
 };
 
 const getBalanceForListing = (
-  listing: ListingType,
+  listing: ListingWithProject,
   assets: AssetForListing[]
 ): number => {
   const matchingBalance = assets.find(
@@ -39,7 +39,9 @@ const getBalanceForListing = (
 
 export const ListingEditable: FC<Props> = (props) => {
   const { provider, address } = useWeb3();
-  const [listingToEdit, setListingToEdit] = useState<ListingType | null>(null);
+  const [listingToEdit, setListingToEdit] = useState<ListingWithProject | null>(
+    null
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [inputValues, setInputValues] = useState<FormValues | null>(null);
   const [status, setStatus] = useState<TransactionStatusMessage | null>(null);

--- a/carbonmark/hooks/useFetchProjects.ts
+++ b/carbonmark/hooks/useFetchProjects.ts
@@ -4,7 +4,7 @@ import { isNil } from "lodash";
 import { negate } from "lodash/fp";
 import { useRouter } from "next/router";
 import useSWR from "swr";
-import { Category, CategoryName, Project } from "../lib/types/carbonmark";
+import { Project } from "../lib/types/carbonmark";
 
 /** SWR hook that listens to the router for query param changes */
 export const useFetchProjects = () => {
@@ -14,17 +14,6 @@ export const useFetchProjects = () => {
     revalidateOnMount: false,
   });
   /** Remove any null or undefined projects */
-  const projects = data?.filter(negate(isNil)).map(sanitizeProject) ?? [];
+  const projects = data?.filter(negate(isNil)) ?? [];
   return { projects, ...rest };
 };
-
-/** Remove trailing spaces from Category  */
-export const sanitizeCategory = (cat: Category): Category => ({
-  ...cat,
-  id: cat?.id.trim() as CategoryName,
-});
-
-export const sanitizeProject = (project: Project): Project => ({
-  ...project,
-  category: project.category ? sanitizeCategory(project.category) : null,
-});

--- a/carbonmark/lib/actions.ts
+++ b/carbonmark/lib/actions.ts
@@ -294,9 +294,9 @@ export const getProjectInfoFromApi = async (
       key: project.key,
       projectID: project.projectID,
       name: project.name,
-      methodology: project.methodology,
+      methodology: project.methodologies[0].id,
       vintage: project.vintage,
-      category: project.category?.id || "Other",
+      category: project.methodologies[0].category || "Other",
     };
   } catch (e: any) {
     console.error("getProjectInfoFromApi Error for projectId", projectId, e);

--- a/carbonmark/lib/actions.ts
+++ b/carbonmark/lib/actions.ts
@@ -19,6 +19,10 @@ import { getStaticProvider } from "lib/networkAware/getStaticProvider";
 import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
 import { OnStatusHandler } from "lib/statusMessage";
 import { Asset, AssetForListing } from "lib/types/carbonmark";
+import {
+  getCategoryFromProject,
+  getMethodologyFromProject,
+} from "./projectGetter";
 
 /** Get allowance for carbonmark contract, spending an 18 decimal token. Don't use this for USDC */
 export const getCarbonmarkAllowance = async (params: {
@@ -294,9 +298,9 @@ export const getProjectInfoFromApi = async (
       key: project.key,
       projectID: project.projectID,
       name: project.name,
-      methodology: project.methodologies[0].id,
+      methodology: getMethodologyFromProject(project),
       vintage: project.vintage,
-      category: project.methodologies[0].category || "Other",
+      category: getCategoryFromProject(project),
     };
   } catch (e: any) {
     console.error("getProjectInfoFromApi Error for projectId", projectId, e);

--- a/carbonmark/lib/getTokenInfo.ts
+++ b/carbonmark/lib/getTokenInfo.ts
@@ -1,7 +1,7 @@
 import { CarbonmarkToken } from "lib/types/carbonmark";
 import { StaticImageData } from "next/legacy/image";
 import C3 from "public/icons/c3_token.png";
-import TC02 from "public/icons/toucan_token.png";
+import TCO2 from "public/icons/toucan_token.png";
 import USDC from "public/icons/USDC.png";
 
 type CarbonmarkTokenMap = {
@@ -15,5 +15,5 @@ type CarbonmarkTokenMap = {
 export const carbonmarkTokenInfoMap: CarbonmarkTokenMap = {
   usdc: { key: "usdc", icon: USDC, label: "USDC" },
   c3: { key: "c3", icon: C3, label: "C3" },
-  tc02: { key: "tc02", icon: TC02, label: "TC02" },
+  tco2: { key: "tco2", icon: TCO2, label: "TCO2" },
 };

--- a/carbonmark/lib/listingsGetter.ts
+++ b/carbonmark/lib/listingsGetter.ts
@@ -2,46 +2,57 @@ import { formatUnits } from "@klimadao/lib/utils";
 import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
 import {
   Listing,
-  ListingFormatted,
+  ListingWithProject,
   Price,
   PriceFlagged,
   ProjectBuyOption,
 } from "lib/types/carbonmark";
 
-export const getAmountLeftToSell = (listings: Listing[]) =>
+export const getAmountLeftToSell = <T extends Listing | ListingWithProject>(
+  listings: T[]
+) =>
   listings.reduce((acc, curr) => {
     const leftToSellTotal = acc + Number(formatUnits(curr.leftToSell));
     return leftToSellTotal;
   }, 0);
 
-export const getTotalAmountToSell = (listings: Listing[]) =>
+export const getTotalAmountToSell = <T extends Listing | ListingWithProject>(
+  listings: T[]
+) =>
   listings.reduce((acc, curr) => {
     const totalAmountTo = acc + Number(formatUnits(curr.totalAmountToSell));
     return totalAmountTo;
   }, 0);
 
-export const getTotalAmountSold = (listings: Listing[]) => {
+export const getTotalAmountSold = <T extends Listing | ListingWithProject>(
+  listings: T[]
+) => {
   const totalAmount = getTotalAmountToSell(listings);
   const leftToSell = getAmountLeftToSell(listings);
   return totalAmount - leftToSell;
 };
 
-export const getActiveListings = (listings: Listing[]) =>
-  listings.filter((l) => l.active && l.deleted === false);
+export const getActiveListings = <T extends Listing | ListingWithProject>(
+  listings: T[]
+) => listings.filter((l) => l.active && l.deleted === false);
 
-export const getAllListings = (listings: Listing[]) =>
-  listings.filter((l) => l.deleted === false);
+export const getAllListings = <T extends Listing | ListingWithProject>(
+  listings: T[]
+) => listings.filter((l) => l.deleted === false);
 
-export const getSortByUpdateListings = (listings: Listing[]) =>
-  listings.sort((a, b) => Number(b.updatedAt) - Number(a.updatedAt));
+export const getSortByUpdateListings = <T extends Listing | ListingWithProject>(
+  listings: T[]
+) => listings.sort((a, b) => Number(b.updatedAt) - Number(a.updatedAt));
 
 export const getLowestPriceFromBuyOptions = (options: ProjectBuyOption[]) => {
   return options[0].singleUnitPrice;
 };
 
-export const sortPricesAndListingsByBestPrice = (
+export const sortPricesAndListingsByBestPrice = <
+  T extends Listing | ListingWithProject
+>(
   prices: Price[],
-  listings: Listing[]
+  listings: T[]
 ): ProjectBuyOption[] => {
   const flaggedPrices = !!prices?.length && flagPrices(prices);
   const formattedListings = !!listings?.length && formatListings(listings);
@@ -54,7 +65,9 @@ export const sortPricesAndListingsByBestPrice = (
   );
 };
 
-export const formatListings = (listings: Listing[]): ListingFormatted[] =>
+export const formatListings = <T extends Listing | ListingWithProject>(
+  listings: T[]
+) =>
   listings.map((listing) => ({
     ...listing,
     singleUnitPrice: formatUnits(

--- a/carbonmark/lib/projectGetter.ts
+++ b/carbonmark/lib/projectGetter.ts
@@ -1,5 +1,7 @@
 import { Project } from "lib/types/carbonmark";
 
 export const getCategoryFromProject = (project: Project) =>
-  (project?.methodologies?.length && project.methodologies[0].category) ||
-  "Other"; // fallback for Staging Testnet Data
+  project.methodologies[0]?.category || "Other"; // fallback for Staging Testnet Data
+
+export const getMethodologyFromProject = (project: Project) =>
+  project.methodologies[0]?.id || "Unknown";

--- a/carbonmark/lib/types/carbonmark.ts
+++ b/carbonmark/lib/types/carbonmark.ts
@@ -15,7 +15,7 @@ export interface Project {
   vintage: string;
   projectAddress: string;
   registry: string;
-  listings: Omit<Listing, "project">[] | null;
+  listings: Listing[] | null;
   price: BigNumber;
   country: Country | null;
   activities: ProjectActivity[] | null;
@@ -49,12 +49,12 @@ export interface User {
   description: string;
   profileImgUrl?: string;
   wallet: string;
-  listings: Listing[];
+  listings: ListingWithProject[];
   activities: UserActivity[];
   assets: Asset[];
 }
 
-export type Listing = {
+export interface Listing {
   id: string;
   /** Plain integer, not a bignumber */
   totalAmountToSell: string;
@@ -76,6 +76,10 @@ export type Listing = {
     profileImgUrl: string;
     id: string;
   };
+}
+
+/** Some endpoints do not include this `project` property. */
+export interface ListingWithProject extends Listing {
   /** careful, project is not present on Project["listings"] entries */
   project: {
     id: string;
@@ -90,19 +94,13 @@ export type Listing = {
     registry: string;
     vintage: string;
   };
-};
+}
 
 export type PriceFlagged = Price & {
   isPoolProject: true;
 };
 
-// makes sense to convert more BigNumbers !
-// see https://github.com/Atmosfearful/bezos-frontend/issues/50
-export type ListingFormatted = Omit<Listing, "singleUnitPrice"> & {
-  singleUnitPrice: string; // USDCs
-};
-
-export type ProjectBuyOption = ListingFormatted | PriceFlagged;
+export type ProjectBuyOption = Listing | PriceFlagged;
 
 export type ActivityActionT =
   | "UpdatedQuantity"
@@ -253,7 +251,7 @@ export type Purchase = {
   /** Stringified 18 decimal BigNumber */
   amount: BigNumber;
   /** The purchased listing info */
-  listing: Listing;
+  listing: ListingWithProject;
   /** Stringified 6 decimal BigNumber */
   price: string;
   /** Unix seconds timestamp */

--- a/carbonmark/pages/projects/[project_id]/purchase/[listing_id].ts
+++ b/carbonmark/pages/projects/[project_id]/purchase/[listing_id].ts
@@ -1,7 +1,9 @@
-import { ProjectPurchase } from "components/pages/Project/Purchase";
+import {
+  ProjectPurchase,
+  ProjectPurchasePageProps,
+} from "components/pages/Project/Purchase";
 import { getCarbonmarkProject } from "lib/carbonmark";
 import { loadTranslation } from "lib/i18n";
-import { Listing, Project } from "lib/types/carbonmark";
 import { GetStaticProps } from "next";
 import { ParsedUrlQuery } from "querystring";
 
@@ -9,14 +11,10 @@ interface Params extends ParsedUrlQuery {
   project_id: string;
 }
 
-interface PageProps {
-  project: Project;
-  listing: Listing;
-}
-
-export const getStaticProps: GetStaticProps<PageProps, Params> = async (
-  ctx
-) => {
+export const getStaticProps: GetStaticProps<
+  ProjectPurchasePageProps,
+  Params
+> = async (ctx) => {
   const { params, locale } = ctx;
 
   if (!params || !params?.project_id) {
@@ -29,9 +27,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
     // check if listing ID is correct here on server? Or rather on client with nicer error state?
     const listing =
       !!project.listings?.length &&
-      project.listings.find(
-        (listing: Listing) => listing.id === params?.listing_id
-      );
+      project.listings.find((listing) => listing.id === params?.listing_id);
 
     if (!listing) {
       throw new Error("No matching listing found");

--- a/carbonmark/pages/projects/index.tsx
+++ b/carbonmark/pages/projects/index.tsx
@@ -1,9 +1,14 @@
 import { Projects } from "components/pages/Projects";
-import { sanitizeCategory } from "hooks/useFetchProjects";
 import { urls } from "lib/constants";
 import { fetcher } from "lib/fetcher";
 import { loadTranslation } from "lib/i18n";
-import { Category, Country, Project, Vintage } from "lib/types/carbonmark";
+import {
+  Category,
+  CategoryName,
+  Country,
+  Project,
+  Vintage,
+} from "lib/types/carbonmark";
 import { GetStaticProps } from "next";
 
 export interface ProjectsPageStaticProps {
@@ -21,7 +26,9 @@ export const getStaticProps: GetStaticProps<ProjectsPageStaticProps> = async (
     const vintages = await fetcher<string[]>(urls.api.vintages);
     let categories = await fetcher<Category[]>(urls.api.categories);
     /** @note because the API is returning trailing empty spaces on some categories, trim them here */
-    categories = categories.map(sanitizeCategory);
+    categories = categories.map((category) => ({
+      id: category.id.trim() as CategoryName,
+    }));
     const countries = await fetcher<Country[]>(urls.api.countries);
     const translation = await loadTranslation(ctx.locale);
 


### PR DESCRIPTION
## Description

I looked at the real JSON data on prod and aligned the types.
I separated the activity types into UserActivity and ProjectActivity because they differ between these endpoints
I should have separated the Listing types as well, but it was faster to just use `Omit<Listing, "project">` where needed.
Then I addressed all the downstream issues that were exposed.

Some TODOs on the backend still, which I marked in the carbonmark types file, and will direct najadas attention to.

## Related Ticket
Closes #1007 
