### PR TITLE
format-all for carbon-projects CMS

### DIFF
--- a/carbon-projects/sanity.cli.ts
+++ b/carbon-projects/sanity.cli.ts
@@ -1,8 +1,8 @@
-import {defineCliConfig} from 'sanity/cli'
+import { defineCliConfig } from "sanity/cli";
 
 export default defineCliConfig({
   api: {
-    projectId: 'l6of5nwi',
-    dataset: 'production'
-  }
-})
+    projectId: "l6of5nwi",
+    dataset: "production",
+  },
+});

--- a/carbon-projects/sanity.config.ts
+++ b/carbon-projects/sanity.config.ts
@@ -1,18 +1,18 @@
-import {defineConfig} from 'sanity'
-import {deskTool} from 'sanity/desk'
-import {visionTool} from '@sanity/vision'
-import {schemaTypes} from './schemas'
+import { visionTool } from "@sanity/vision";
+import { defineConfig } from "sanity";
+import { deskTool } from "sanity/desk";
+import { schemaTypes } from "./schemas";
 
 export default defineConfig({
-  name: 'default',
-  title: 'project-data',
+  name: "default",
+  title: "project-data",
 
-  projectId: 'l6of5nwi',
-  dataset: 'production',
+  projectId: "l6of5nwi",
+  dataset: "production",
 
   plugins: [deskTool(), visionTool()],
 
   schema: {
     types: schemaTypes,
   },
-})
+});

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -156,7 +156,8 @@ export default defineType({
     },
     {
       name: "country",
-      description: "ISO-3166 English Short Name of the country where the project was implemented",
+      description:
+        "ISO-3166 English Short Name of the country where the project was implemented",
       type: "string",
       group: "location",
       validation: (r) => r.required(),
@@ -166,7 +167,8 @@ export default defineType({
     },
     {
       name: "state",
-      description: "(optional) state or territory where the project was implemented",
+      description:
+        "(optional) state or territory where the project was implemented",
       type: "string",
       group: "location",
     },


### PR DESCRIPTION

- [x] I have formatted JS and TS files with `npm run format-all`
