### PR TITLE
Update Portfolio data and cache with SWR

### DIFF
--- a/carbonmark/components/pages/Portfolio/CarbonmarkAssets.tsx
+++ b/carbonmark/components/pages/Portfolio/CarbonmarkAssets.tsx
@@ -1,0 +1,99 @@
+import { Trans } from "@lingui/macro";
+import { CreateListing } from "components/CreateListing";
+import { SpinnerWithLabel } from "components/SpinnerWithLabel";
+import { Text } from "components/Text";
+import { addProjectsToAssets } from "lib/actions";
+import { getAssetsWithProjectTokens } from "lib/getAssetsData";
+import { AssetForListing, User } from "lib/types/carbonmark";
+import Link from "next/link";
+import { FC, useEffect, useState } from "react";
+import { AssetProject } from "./AssetProject";
+import * as styles from "./styles";
+
+type Props = {
+  address: string;
+  user: User | null;
+  isLoadingUser: boolean;
+};
+
+export const CarbonmarkAssets: FC<Props> = (props) => {
+  const [isLoadingAssets, setIsLoadingAssets] = useState(false);
+  const [assetsData, setAssetsData] = useState<AssetForListing[] | null>(null);
+  const [assetToSell, setAssetToSell] = useState<AssetForListing | null>(null);
+
+  const assetWithProjectTokens =
+    !!props.user?.assets?.length &&
+    getAssetsWithProjectTokens(props.user.assets);
+
+  const hasAssets = !isLoadingAssets && !!assetWithProjectTokens;
+
+  // load Assets every time user changed
+  useEffect(() => {
+    if (hasAssets) {
+      const getAssetsData = async () => {
+        try {
+          setIsLoadingAssets(true);
+
+          if (assetWithProjectTokens) {
+            const assetsWithProject = await addProjectsToAssets({
+              assets: assetWithProjectTokens,
+            });
+            // TODO: filter assets with balance > 0
+            // this will be unnecessary as soon as bezos switched to mainnet
+
+            const assetsWithBalance = assetsWithProject.filter(
+              (a) => Number(a.balance) > 0
+            );
+
+            setAssetsData(assetsWithBalance);
+          }
+        } catch (e) {
+          console.error(e);
+        } finally {
+          setIsLoadingAssets(false);
+        }
+      };
+
+      getAssetsData();
+    }
+  }, [props.user]);
+
+  const onUpdateUser = () => {
+    console.log("UPDATE");
+  };
+
+  return (
+    <>
+      {props.isLoadingUser && <SpinnerWithLabel />}
+
+      <div className={props.isLoadingUser ? styles.loadingOverlay : ""}>
+        {!!assetsData &&
+          assetsData.map((a) => (
+            <AssetProject
+              key={a.tokenAddress}
+              asset={a}
+              onSell={() => setAssetToSell(a)}
+            />
+          ))}
+
+        {!!assetToSell && (
+          <CreateListing
+            onModalClose={() => setAssetToSell(null)}
+            onSubmit={onUpdateUser}
+            assets={[assetToSell]}
+            showModal={!!assetToSell}
+            successScreen={
+              <Text>
+                <Trans>
+                  Success. Go to your{" "}
+                  <Link href={`/users/${props.address}`}>Profile page</Link> to
+                  see your new listing.
+                </Trans>
+              </Text>
+            }
+          />
+        )}
+      </div>
+    </>
+  );
+};

--- a/carbonmark/components/pages/Portfolio/CarbonmarkAssets.tsx
+++ b/carbonmark/components/pages/Portfolio/CarbonmarkAssets.tsx
@@ -65,16 +65,15 @@ export const CarbonmarkAssets: FC<Props> = (props) => {
     <>
       {isUpdatingUser && <SpinnerWithLabel label={t`Loading your assets`} />}
 
-      <div className={isUpdatingUser ? styles.loadingOverlay : ""}>
-        {!!assetsData &&
-          assetsData.map((a) => (
-            <AssetProject
-              key={a.tokenAddress}
-              asset={a}
-              onSell={() => setAssetToSell(a)}
-            />
-          ))}
-      </div>
+      {!!assetsData &&
+        assetsData.map((a) => (
+          <div
+            className={isUpdatingUser ? styles.loadingOverlay : ""}
+            key={a.tokenAddress}
+          >
+            <AssetProject asset={a} onSell={() => setAssetToSell(a)} />
+          </div>
+        ))}
 
       {!!assetToSell && (
         <CreateListing

--- a/carbonmark/components/pages/Portfolio/PortfolioSidebar.tsx
+++ b/carbonmark/components/pages/Portfolio/PortfolioSidebar.tsx
@@ -1,0 +1,28 @@
+import { t } from "@lingui/macro";
+import { Activities } from "components/Activities";
+import { Stats } from "components/Stats";
+import { getActiveListings, getAllListings } from "lib/listingsGetter";
+import { User } from "lib/types/carbonmark";
+import { FC } from "react";
+import { Balances } from "./Balances";
+
+type Props = {
+  user: User | null;
+};
+
+export const PortfolioSidebar: FC<Props> = (props) => {
+  const allListings = props.user && getAllListings(props.user.listings);
+  const activeListings = props.user && getActiveListings(props.user.listings);
+
+  return (
+    <>
+      <Balances />
+      <Stats
+        allListings={allListings || []}
+        activeListings={activeListings || []}
+        description={t`Your seller data`}
+      />
+      <Activities activities={props.user?.activities || []} />
+    </>
+  );
+};

--- a/carbonmark/components/pages/Portfolio/PortfolioSidebar.tsx
+++ b/carbonmark/components/pages/Portfolio/PortfolioSidebar.tsx
@@ -8,6 +8,7 @@ import { Balances } from "./Balances";
 
 type Props = {
   user: User | null;
+  isPending: boolean;
 };
 
 export const PortfolioSidebar: FC<Props> = (props) => {
@@ -22,7 +23,10 @@ export const PortfolioSidebar: FC<Props> = (props) => {
         activeListings={activeListings || []}
         description={t`Your seller data`}
       />
-      <Activities activities={props.user?.activities || []} />
+      <Activities
+        activities={props.user?.activities || []}
+        isLoading={props.isPending}
+      />
     </>
   );
 };

--- a/carbonmark/components/pages/Portfolio/index.tsx
+++ b/carbonmark/components/pages/Portfolio/index.tsx
@@ -7,12 +7,12 @@ import { LoginCard } from "components/LoginCard";
 import { PageHead } from "components/PageHead";
 import { SpinnerWithLabel } from "components/SpinnerWithLabel";
 import { Text } from "components/Text";
-import { Col } from "components/TwoColLayout";
 import { addProjectsToAssets } from "lib/actions";
 import { getUser } from "lib/api";
 import { getAssetsWithProjectTokens } from "lib/getAssetsData";
 import { pollUntil } from "lib/pollUntil";
 import { AssetForListing, User } from "lib/types/carbonmark";
+import { Col, TwoColLayout } from "components/TwoColLayout";
 import { NextPage } from "next";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -136,11 +136,6 @@ export const Portfolio: NextPage = () => {
       />
 
       <Layout>
-        <div className={styles.portfolioControls}>
-          <LoginButton />
-        </div>
-        <div className={styles.portfolioContent}>
-          <Col>
             {!isConnectedUser && (
               <LoginCard isLoading={isLoadingUser} onLogin={toggleModal} />
             )}
@@ -161,6 +156,12 @@ export const Portfolio: NextPage = () => {
                   key={a.tokenAddress}
                   asset={a}
                   onSell={() => setAssetToSell(a)}
+        <div className={styles.container}>
+          <div className={styles.portfolioControls}>
+            <LoginButton />
+          </div>
+          <TwoColLayout>
+            <Col>
                 />
               ))}
 
@@ -197,11 +198,12 @@ export const Portfolio: NextPage = () => {
                 </Trans>
               </Text>
             )}
-          </Col>
+            </Col>
 
             <Col>
               <PortfolioSidebar user={carbonmarkUser} />
             </Col>
+          </TwoColLayout>
         </div>
       </Layout>
     </>

--- a/carbonmark/components/pages/Portfolio/index.tsx
+++ b/carbonmark/components/pages/Portfolio/index.tsx
@@ -1,26 +1,23 @@
 import { useWeb3 } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
-import { Activities } from "components/Activities";
 import { CreateListing } from "components/CreateListing";
 import { Layout } from "components/Layout";
 import { LoginButton } from "components/LoginButton";
 import { LoginCard } from "components/LoginCard";
 import { PageHead } from "components/PageHead";
 import { SpinnerWithLabel } from "components/SpinnerWithLabel";
-import { Stats } from "components/Stats";
 import { Text } from "components/Text";
 import { Col } from "components/TwoColLayout";
 import { addProjectsToAssets } from "lib/actions";
 import { getUser } from "lib/api";
 import { getAssetsWithProjectTokens } from "lib/getAssetsData";
-import { getActiveListings, getAllListings } from "lib/listingsGetter";
 import { pollUntil } from "lib/pollUntil";
 import { AssetForListing, User } from "lib/types/carbonmark";
 import { NextPage } from "next";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { AssetProject } from "./AssetProject";
-import { Balances } from "./Balances";
+import { PortfolioSidebar } from "./PortfolioSidebar";
 import * as styles from "./styles";
 
 export const Portfolio: NextPage = () => {
@@ -34,9 +31,6 @@ export const Portfolio: NextPage = () => {
 
   const assetWithProjectTokens =
     !!user?.assets?.length && getAssetsWithProjectTokens(user.assets);
-  const hasListings = !isLoadingUser && !!user?.listings?.length;
-  const allListings = hasListings && getAllListings(user.listings);
-  const activeListings = hasListings && getActiveListings(user.listings);
 
   const isConnectedUser = isConnected && address;
   const isLoading = isLoadingUser || isLoadingAssets;
@@ -205,15 +199,9 @@ export const Portfolio: NextPage = () => {
             )}
           </Col>
 
-          <Col className="statsColumn">
-            <Balances />
-            <Stats
-              allListings={allListings || []}
-              activeListings={activeListings || []}
-              description={t`Your seller data`}
-            />
-            <Activities activities={user?.activities || []} />
-          </Col>
+            <Col>
+              <PortfolioSidebar user={carbonmarkUser} />
+            </Col>
         </div>
       </Layout>
     </>

--- a/carbonmark/components/pages/Portfolio/styles.ts
+++ b/carbonmark/components/pages/Portfolio/styles.ts
@@ -1,6 +1,13 @@
 import { css } from "@emotion/css";
 import breakpoints from "@klimadao/lib/theme/breakpoints";
 
+export const container = css`
+  grid-column: main;
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 2.4rem;
+`;
+
 export const portfolioControls = css`
   grid-column: main;
   flex-direction: row-reverse;
@@ -8,15 +15,6 @@ export const portfolioControls = css`
 
   ${breakpoints.desktop} {
     display: flex;
-  }
-`;
-
-export const portfolioContent = css`
-  grid-column: main;
-  display: grid;
-  gap: 2.4rem;
-  ${breakpoints.desktop} {
-    grid-template-columns: 2fr 1fr;
   }
 `;
 

--- a/carbonmark/components/pages/Portfolio/styles.ts
+++ b/carbonmark/components/pages/Portfolio/styles.ts
@@ -23,3 +23,8 @@ export const errorMessage = css`
   margin-bottom: 0.2rem;
   word-break: break-word;
 `;
+
+export const loadingOverlay = css`
+  pointer-events: none;
+  opacity: 0.5;
+`;

--- a/carbonmark/hooks/useFetchUser.ts
+++ b/carbonmark/hooks/useFetchUser.ts
@@ -1,0 +1,17 @@
+import { urls } from "lib/constants";
+import { fetcher } from "lib/fetcher";
+import { User } from "lib/types/carbonmark";
+import type { SWRConfiguration } from "swr";
+import useSWR from "swr";
+
+export const useFetchUser = (address?: string, options?: SWRConfiguration) => {
+  const { data, ...rest } = useSWR<User>(
+    address ? `${urls.baseUrl}/api/users/${address}?type=wallet` : null,
+    fetcher,
+    options
+  );
+
+  const carbonmarkUser = !!data?.handle ? data : null;
+
+  return { carbonmarkUser, ...rest };
+};

--- a/carbonmark/hooks/useFetchUser.ts
+++ b/carbonmark/hooks/useFetchUser.ts
@@ -1,4 +1,3 @@
-import { urls } from "lib/constants";
 import { fetcher } from "lib/fetcher";
 import { User } from "lib/types/carbonmark";
 import type { SWRConfiguration } from "swr";
@@ -6,7 +5,7 @@ import useSWR from "swr";
 
 export const useFetchUser = (address?: string, options?: SWRConfiguration) => {
   const { data, ...rest } = useSWR<User>(
-    address ? `${urls.baseUrl}/api/users/${address}?type=wallet` : null,
+    address ? `/api/users/${address}?type=wallet` : null,
     fetcher,
     options
   );

--- a/carbonmark/lib/api.ts
+++ b/carbonmark/lib/api.ts
@@ -1,3 +1,4 @@
+import { pollUntil } from "lib/pollUntil";
 import {
   Category,
   CategoryName,
@@ -164,4 +165,26 @@ export const getVintages = async (): Promise<string[]> => {
     throw new Error(data.message);
   }
   return data;
+};
+
+export const getUserUntil = async (params: {
+  address: string;
+  retryUntil: (u: User) => boolean;
+  maxAttempts?: number;
+  retryInterval?: number;
+}): Promise<User> => {
+  const fetchUser = () =>
+    getUser({
+      user: params.address,
+      type: "wallet",
+    });
+
+  const updatedUser = await pollUntil({
+    fn: fetchUser,
+    validate: params.retryUntil,
+    ms: params.retryInterval || 1000,
+    maxAttempts: params.maxAttempts || 50,
+  });
+
+  return updatedUser;
 };


### PR DESCRIPTION
## Description

Please test that the following works:

**Connect**
- Go to your Portfolio on the [preview link](https://carbonmark-git-lady-swr-portfolio-klimadao.vercel.app/portfolio)
- You should see the LoginCard ✔️ 
- When you connect your wallet, you should see a loading spinner ✔️ 
- When your wallet is connected, you see your assets correctly displayed ✔️ 
- If you do not have any assets, you should see an empty state message ✔️ 

**Create a Listing**
- Click on "Sell" of one your assets
- Create a Listing with one of your assets
- Wait until the success modal appears **=> CLOSE THIS MODAL !** (Going to the Profile is not in scope of this PR)
- You should see now two loadings spinners with "Loading your assets" ✔️ 
- The frontend polls the API to wait until the backend updated your user data with the newly created listing (interval: 1 second, max attempts: 50)
- When the max attempts have been reached, an error message appears "please refresh the page" ✔️ 
- When the polling succeeded with the updated data, your **assets** should be updated correctly ✔️ 
- When the polling succeeded with the updated data, your **activity** data should show your new listing ✔️ 

## Related Ticket

Part of https://github.com/KlimaDAO/klimadao/issues/1019

## Changes

This PR contains  additional refactorings:
- Extract the Assets components from the main index page
- Put an overlay above all assets when the polling starts to ensure that the user is not changing anything while pending

![Bildschirm­foto 2023-04-18 um 15 53 51](https://user-images.githubusercontent.com/95881624/232802890-910649a6-3fa2-4b3a-815c-f41b0f2cfc68.png)



## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
