### PR TITLE
#988 Show handle names

### DIFF
--- a/carbonmark/components/Activities/Activity.tsx
+++ b/carbonmark/components/Activities/Activity.tsx
@@ -119,7 +119,7 @@ export const Activity = (props: Props) => {
       <Text t="body1">
         {!!addressA && (
           <Link className="account" href={`/users/${addressA}`}>
-            {formatWalletAddress(addressA, connectedAddress)}{" "}
+            {addressA.length >= 11 ? formatWalletAddress(addressA, connectedAddress) : addressA}{" "}
           </Link>
         )}
 
@@ -128,7 +128,7 @@ export const Activity = (props: Props) => {
         {addressB && (
           <Link className="account" href={`/users/${addressB}`}>
             {" "}
-            {formatWalletAddress(addressB, connectedAddress)}
+            {addressB.length >= 11 ? formatWalletAddress(addressB, connectedAddress) : addressB}
           </Link>
         )}
       </Text>

--- a/carbonmark/components/Activities/Activity.tsx
+++ b/carbonmark/components/Activities/Activity.tsx
@@ -119,7 +119,9 @@ export const Activity = (props: Props) => {
       <Text t="body1">
         {!!addressA && (
           <Link className="account" href={`/users/${addressA}`}>
-            {addressA.length >= 11 ? formatWalletAddress(addressA, connectedAddress) : addressA}{" "}
+            {addressA.length >= 11
+              ? formatWalletAddress(addressA, connectedAddress)
+              : addressA}{" "}
           </Link>
         )}
 
@@ -128,7 +130,9 @@ export const Activity = (props: Props) => {
         {addressB && (
           <Link className="account" href={`/users/${addressB}`}>
             {" "}
-            {addressB.length >= 11 ? formatWalletAddress(addressB, connectedAddress) : addressB}
+            {addressB.length >= 11
+              ? formatWalletAddress(addressB, connectedAddress)
+              : addressB}
           </Link>
         )}
       </Text>

--- a/carbonmark/components/Activities/Activity.tsx
+++ b/carbonmark/components/Activities/Activity.tsx
@@ -38,8 +38,11 @@ export const Activity = (props: Props) => {
   const isUpdateQuantity = props.activity.activityType === "UpdatedQuantity";
   const isUpdatePrice = props.activity.activityType === "UpdatedPrice";
 
-  const sellerID = props.activity.seller.id;
-  const buyerId = props.activity.buyer?.id;
+  const seller = props.activity.seller;
+  const buyer = props.activity.buyer;
+
+  const sellerID = "handle" in seller ? seller.handle : seller.id;
+  const buyerId = buyer && "handle" in buyer ? buyer.handle : buyer?.id;
 
   // type guard
   const project = isUserActivity(props.activity)

--- a/carbonmark/components/pages/Project/BuyOptions/SellerListing.tsx
+++ b/carbonmark/components/pages/Project/BuyOptions/SellerListing.tsx
@@ -6,7 +6,10 @@ import { Card } from "components/Card";
 import { Text } from "components/Text";
 import { createProjectPurchaseLink, createSellerLink } from "lib/createUrls";
 import { formatBigToTonnes, formatToPrice } from "lib/formatNumbers";
-import { isConnectedAddress } from "lib/formatWalletAddress";
+import {
+  formatWalletAddress,
+  isConnectedAddress,
+} from "lib/formatWalletAddress";
 import { Listing, Project } from "lib/types/carbonmark";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -26,6 +29,16 @@ const getFormattedDate = (timestamp: string, locale = "en") => {
   }).format(date);
 };
 
+function getSellerId(seller: Listing["seller"]): string | undefined {
+  if (!seller) {
+    return undefined;
+  }
+
+  return seller.handle !== undefined
+    ? seller.handle
+    : formatWalletAddress(seller.id);
+}
+
 export const SellerListing: FC<Props> = (props) => {
   const { locale } = useRouter();
   const { address, isConnected, toggleModal } = useWeb3();
@@ -33,6 +46,8 @@ export const SellerListing: FC<Props> = (props) => {
   const isConnectedSeller =
     !!props.listing.seller &&
     isConnectedAddress(props.listing.seller.id, address);
+
+  const sellerId = getSellerId(props.listing.seller);
 
   return (
     <Card>
@@ -48,8 +63,12 @@ export const SellerListing: FC<Props> = (props) => {
             </div>
           )}
           <Text t="body1">
-            <Link href={createSellerLink(props.listing.seller.handle)}>
-              {isConnectedSeller ? "You" : "@" + props.listing.seller.handle}
+            <Link
+              href={createSellerLink(
+                props.listing.seller.handle ?? props.listing.seller.id
+              )}
+            >
+              {isConnectedSeller ? "You" : "@" + sellerId}
             </Link>
           </Text>
         </div>

--- a/carbonmark/lib/projectGetter.ts
+++ b/carbonmark/lib/projectGetter.ts
@@ -1,7 +1,7 @@
 import { Project } from "lib/types/carbonmark";
 
 export const getCategoryFromProject = (project: Project) =>
-  project.methodologies?.[0]?.category || "Other"; // fallback for Staging Testnet Data
+  project.methodologies?.[0]?.category ?? "Other"; // fallback for Staging Testnet Data
 
 export const getMethodologyFromProject = (project: Project) =>
-  project.methodologies?.[0]?.id || "Unknown";
+  project.methodologies?.[0]?.id ?? "Unknown";

--- a/carbonmark/lib/projectGetter.ts
+++ b/carbonmark/lib/projectGetter.ts
@@ -1,7 +1,7 @@
 import { Project } from "lib/types/carbonmark";
 
 export const getCategoryFromProject = (project: Project) =>
-  project.methodologies?.[0]?.category ?? "Other"; // fallback for Staging Testnet Data
+  project.methodologies?.[0]?.category || "Other"; // fallback for Staging Testnet Data
 
 export const getMethodologyFromProject = (project: Project) =>
-  project.methodologies?.[0]?.id ?? "Unknown";
+  project.methodologies?.[0]?.id || "Unknown";

--- a/carbonmark/pages/api/categories/index.ts
+++ b/carbonmark/pages/api/categories/index.ts
@@ -18,7 +18,8 @@ const getCategories: NextApiHandler<Category[] | APIDefaultResponse> = async (
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }

--- a/carbonmark/pages/api/countries/index.ts
+++ b/carbonmark/pages/api/countries/index.ts
@@ -18,7 +18,8 @@ const getCountries: NextApiHandler<Country[] | APIDefaultResponse> = async (
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }

--- a/carbonmark/pages/api/projects/[project_id].ts
+++ b/carbonmark/pages/api/projects/[project_id].ts
@@ -24,7 +24,8 @@ const singleProject: NextApiHandler<User | APIDefaultResponse> = async (
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }

--- a/carbonmark/pages/api/projects/index.ts
+++ b/carbonmark/pages/api/projects/index.ts
@@ -19,7 +19,8 @@ const getProjects: NextApiHandler<Project[] | APIDefaultResponse> = async (
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }

--- a/carbonmark/pages/api/users/[user].ts
+++ b/carbonmark/pages/api/users/[user].ts
@@ -26,7 +26,8 @@ const singleUser: NextApiHandler<User | APIDefaultResponse> = async (
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }
@@ -57,7 +58,8 @@ const singleUser: NextApiHandler<User | APIDefaultResponse> = async (
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }

--- a/carbonmark/pages/api/users/index.ts
+++ b/carbonmark/pages/api/users/index.ts
@@ -37,7 +37,8 @@ const createUser: NextApiHandler<User | APIDefaultResponse> = async (
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }

--- a/carbonmark/pages/api/users/login/index.ts
+++ b/carbonmark/pages/api/users/login/index.ts
@@ -26,7 +26,8 @@ const loginUser: NextApiHandler<
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }

--- a/carbonmark/pages/api/users/login/verify/index.ts
+++ b/carbonmark/pages/api/users/login/verify/index.ts
@@ -28,7 +28,8 @@ const verifyUser: NextApiHandler<
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }

--- a/carbonmark/pages/api/vintages/index.ts
+++ b/carbonmark/pages/api/vintages/index.ts
@@ -17,7 +17,8 @@ const getVintages: NextApiHandler<string[] | APIDefaultResponse> = async (
         const json = await result.json();
 
         return res.status(200).json(json);
-      } catch ({ message }) {
+      } catch (error) {
+        const { message } = error as Error;
         console.error("Request failed:", message);
         res.status(500).json({ message: "Internal server error" });
       }


### PR DESCRIPTION
## Description

Shows user handle name where possible instead of the wallet address.

The only place this is currently not possible is where the type is UserActivity, which looks to be on the user page. There is a note from two days ago that this is being added to the api response, so sounds like this will be a quick fix to add once that is done. 

Also in this PR:

1) small chaining issue in Project Getter

2) fixed some error types so the linter is satisfied.

Reviewers:
@Atmosfearful 
@ShimonD-KlimaDAO 

## Related Ticket

Resolves #988 

## Changes

| Before  | After  |
|---------|--------|
|<img width="596" alt="before1" src="https://user-images.githubusercontent.com/72105234/233407421-6a0dc793-0f5e-4fc1-a2f5-5adbcdaa272a.png"> |<img width="636" alt="after1" src="https://user-images.githubusercontent.com/72105234/233407522-40b0943c-d044-40e9-b70c-52323349a96a.png">|


| Before  | After  |
|---------|--------|
| <img width="605" alt="before" src="https://user-images.githubusercontent.com/72105234/233408101-d81db17a-e14f-42cd-8ad7-1b7a5163e8fe.png"> |<img width="605" alt="after" src="https://user-images.githubusercontent.com/72105234/233407857-50977899-1b18-42bd-b6cc-ec2dfa7e6019.png">|


## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
