### PR TITLE
Fix null check on projectGetter.ts

### DIFF
--- a/carbonmark/lib/projectGetter.ts
+++ b/carbonmark/lib/projectGetter.ts
@@ -1,7 +1,7 @@
 import { Project } from "lib/types/carbonmark";
 
 export const getCategoryFromProject = (project: Project) =>
-  project.methodologies?.[0]?.category || "Other"; // fallback for Staging Testnet Data
+  project.methodologies?.[0]?.category ?? "Other"; // fallback for Staging Testnet Data
 
 export const getMethodologyFromProject = (project: Project) =>
-  project.methodologies?.[0]?.id || "Unknown";
+  project.methodologies?.[0]?.id ?? "Unknown";


### PR DESCRIPTION
## Description

Null checks on projectGetter functions were failing on empty project arrays

## Changes

| Before  | After  |
|---------|--------|
|<img width="834" alt="image" src="https://user-images.githubusercontent.com/7104689/233520049-4a9e9c00-be1a-437e-9fe9-19bda8a58524.png">|<img width="834" alt="image" src="https://user-images.githubusercontent.com/7104689/233520217-8ff5194d-92a6-4f7b-93a1-f10d42450820.png">|


