### PR TITLE
Links and key added to Portfolio page

### DIFF
--- a/carbonmark/components/Activities/Activity.tsx
+++ b/carbonmark/components/Activities/Activity.tsx
@@ -98,7 +98,13 @@ export const Activity = (props: Props) => {
 
   return (
     <div key={props.activity.id} className={styles.activity}>
-      {project && <Text t="h5">{project.name}</Text>}
+      {project && (
+        <Link href={`/projects/${project.key}-${project.vintage}`}>
+          <Text t="h5" className={styles.link}>
+            {project.name}
+          </Text>
+        </Link>
+      )}
       <Text t="body1" color="lighter">
         <i>
           {getElapsedTime({

--- a/carbonmark/components/Activities/styles.ts
+++ b/carbonmark/components/Activities/styles.ts
@@ -16,3 +16,12 @@ export const activity = css`
     margin-right: 0.4rem;
   }
 `;
+
+export const link = css`
+  color: black;
+  text-decoration: none;
+
+  &:hover {
+    color: blue;
+  }
+`;

--- a/carbonmark/components/ProjectKey/index.tsx
+++ b/carbonmark/components/ProjectKey/index.tsx
@@ -1,0 +1,16 @@
+import { Text } from "components/Text";
+import { FC } from "react";
+
+import * as styles from "./styles";
+
+type Props = {
+  projectKey: string;
+};
+
+export const ProjectKey: FC<Props> = (props) => {
+  return (
+    <Text t="body2" className={styles.projectKey}>
+      {props.projectKey}
+    </Text>
+  );
+};

--- a/carbonmark/components/ProjectKey/styles.ts
+++ b/carbonmark/components/ProjectKey/styles.ts
@@ -1,0 +1,11 @@
+import { css } from "@emotion/css";
+
+export const projectKey = css`
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--border-radius);
+  flex-direction: row;
+  align-items: center;
+  align-self: flex-start;
+  height: 2.6rem;
+`;

--- a/carbonmark/components/pages/Portfolio/AssetProject/index.tsx
+++ b/carbonmark/components/pages/Portfolio/AssetProject/index.tsx
@@ -5,15 +5,16 @@ import { CarbonmarkButton } from "components/CarbonmarkButton";
 import { Card } from "components/Card";
 import { Category } from "components/Category";
 import { ProjectImage } from "components/ProjectImage";
+import { ProjectKey } from "components/ProjectKey";
 import { Text } from "components/Text";
 import { Vintage } from "components/Vintage";
 import { createRetireLink } from "lib/createUrls";
 import { formatToTonnes } from "lib/formatNumbers";
 import { AssetForListing } from "lib/types/carbonmark";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { FC } from "react";
 import * as styles from "./styles";
-
 interface Props {
   asset: AssetForListing;
   onSell: () => void;
@@ -31,14 +32,25 @@ export const AssetProject: FC<Props> = (props) => {
         <div className={styles.tags}>
           <Category category={props.asset.project.category} />
           <Vintage vintage={props.asset.project.vintage} />
+          <ProjectKey projectKey={props.asset.project.key} />
         </div>
       )}
 
-      <Text t="h4">{props.asset.project?.name || props.asset.tokenName}</Text>
+      <Link
+        href={`/projects/${props.asset.project?.key}-${props.asset.project?.vintage}`}
+      >
+        <Text t="h4" className={styles.link}>
+          {props.asset.project?.name || props.asset.tokenName}
+        </Text>
+      </Link>
 
       {props.asset.project && (
         <div className={styles.image}>
-          <ProjectImage category={props.asset.project?.category} />
+          <Link
+            href={`/projects/${props.asset.project.key}-${props.asset.project.vintage}`}
+          >
+            <ProjectImage category={props.asset.project?.category} />
+          </Link>
         </div>
       )}
       <Text t="body1">

--- a/carbonmark/components/pages/Portfolio/AssetProject/styles.ts
+++ b/carbonmark/components/pages/Portfolio/AssetProject/styles.ts
@@ -26,3 +26,12 @@ export const buttons = css`
     color: var(--white);
   }
 `;
+export const link = css`
+  color: black;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    color: blue;
+  }
+`;


### PR DESCRIPTION
## Description

On the portfolio page:
1) Added projectId-key
2) Image and project title link to project page
3) Hover styles applied to title

Activity feed:
1) Project title is links to project page and has hover styles applied
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Reviewers: @Atmosfearful @ShimonD-KlimaDAO 

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #997 


## Changes

| Before  | After  |
|---------|--------|
| <img width="1203" alt="portfolio before" src="https://user-images.githubusercontent.com/72105234/233521786-21f61782-dae6-457d-bb50-b8db33b26432.png"> | <img width="755" alt="portfolio after" src="https://user-images.githubusercontent.com/72105234/233521818-e0a9a1c1-0aa3-41bb-9234-06b834762d43.png"> |

| Before  | After  |
|---------|--------|
| <img width="369" alt="Screen Shot 2023-04-20 at 9 35 36 PM" src="https://user-images.githubusercontent.com/72105234/233521864-bfb341bd-208c-4304-a143-c90604e24fda.png"> | <img width="454" alt="Screen Shot 2023-04-20 at 9 35 33 PM" src="https://user-images.githubusercontent.com/72105234/233522284-90b455d4-abef-423b-b978-b16486b2dfc5.png">|

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
