### PR TITLE
Create Listing Modal Content Changes #1059

### DIFF
--- a/carbonmark/components/CreateListing/index.tsx
+++ b/carbonmark/components/CreateListing/index.tsx
@@ -154,7 +154,7 @@ export const CreateListing: FC<Props> = (props) => {
           approvalText={t({
             id: "transaction.create_listing.approval_description",
             message:
-              "You are about to create a new listing.\n\nThe first step is to grant the approval to transfer this asset from your wallet to Carbonmark, the next step is to approve the actual transfer and make your listing live.\n\nYou can choose to remove your active listing at any time which will automatically transfer the listed asset back to your wallet.\n\nVerify all information is correct and click 'approve' to continue.",
+              "You are about to create a new listing. The first step is to grant the approval to transfer this asset from your wallet to Carbonmark, the next step is to approve the actual transfer and make your listing live. You can choose to remove your active listing at any time which will automatically transfer the listed asset back to your wallet. Verify all information is correct and click 'approve' to continue.",
           })}
           onApproval={handleApproval}
           onSubmit={onAddListing}

--- a/carbonmark/components/CreateListing/index.tsx
+++ b/carbonmark/components/CreateListing/index.tsx
@@ -154,7 +154,7 @@ export const CreateListing: FC<Props> = (props) => {
           approvalText={t({
             id: "transaction.create_listing.approval_description",
             message:
-              "You are about to transfer ownership of this asset from your wallet to Carbonmark.  You can remove your listing at any time until it has been sold.",
+              "You are about to create a new listing.\n\nThe first step is to grant the approval to transfer this asset from your wallet to Carbonmark, the next step is to approve the actual transfer and make your listing live.\n\nYou can choose to remove your active listing at any time which will automatically transfer the listed asset back to your wallet.\n\nVerify all information is correct and click 'approve' to continue.",
           })}
           onApproval={handleApproval}
           onSubmit={onAddListing}

--- a/carbonmark/components/CustomTrans/index.tsx
+++ b/carbonmark/components/CustomTrans/index.tsx
@@ -1,0 +1,21 @@
+import { i18n } from "@lingui/core";
+import React, { FC } from "react";
+
+interface CustomTransProps {
+  id: string;
+  style?: React.CSSProperties;
+}
+
+export const CustomTrans: FC<CustomTransProps> = ({ id, style }) => {
+  const translatedDescription = i18n._(id);
+
+  return (
+    <div>
+      {translatedDescription.split("\n").map((line, index) => (
+        <p key={index} style={style}>
+          {line}
+        </p>
+      ))}
+    </div>
+  );
+};

--- a/carbonmark/components/FormatTrans/index.tsx
+++ b/carbonmark/components/FormatTrans/index.tsx
@@ -1,19 +1,19 @@
 import { i18n } from "@lingui/core";
 import React, { FC } from "react";
 
-interface CustomTransProps {
+interface FormatTransProps {
   id: string;
   style?: React.CSSProperties;
 }
 
-export const CustomTrans: FC<CustomTransProps> = ({ id, style }) => {
+export const FormatTrans: FC<FormatTransProps> = ({ id, style }) => {
   const translatedDescription = i18n._(id);
 
   return (
     <div>
-      {translatedDescription.split("\n").map((line, index) => (
+      {translatedDescription.match(/[^\.!\?]+[\.!\?]+/g)?.map((line, index) => (
         <p key={index} style={style}>
-          {line}
+          {line.trim()}
         </p>
       ))}
     </div>

--- a/carbonmark/components/Transaction/Approve.tsx
+++ b/carbonmark/components/Transaction/Approve.tsx
@@ -42,15 +42,6 @@ export const Approve: FC<Props> = (props) => {
           success,
         })}
       >
-        {/* {!!props.description && (
-          <div>
-            {props.description.split("\n").map((line, index) => (
-              <Fragment key={index}>
-                <p style={{ marginBottom: "1.5em" }}>{line}</p>
-              </Fragment>
-            ))}
-          </div>
-        )} */}
         <div>
           {props.description && (
             <FormatTrans

--- a/carbonmark/components/Transaction/Approve.tsx
+++ b/carbonmark/components/Transaction/Approve.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "components/shared/Spinner";
 import { Text } from "components/Text";
 import { carbonmarkTokenInfoMap } from "lib/getTokenInfo";
 import { getStatusMessage, TransactionStatusMessage } from "lib/statusMessage";
-import { FC } from "react";
+import { FC, Fragment } from "react";
 import { HighlightValue } from "./HighlightValue";
 import * as styles from "./styles";
 import { Value } from "./types";
@@ -41,12 +41,15 @@ export const Approve: FC<Props> = (props) => {
           success,
         })}
       >
-        <Text>
-          <Trans id="transaction_modal.approve.title">
-            Please confirm the transaction
-          </Trans>
-        </Text>
-        {!!props.description && <Text t="body1">{props.description}</Text>}
+        {!!props.description && (
+          <div>
+            {props.description.split("\n").map((line, index) => (
+              <Fragment key={index}>
+                <p style={{ marginBottom: "1.5em" }}>{line}</p>
+              </Fragment>
+            ))}
+          </div>
+        )}
         <HighlightValue
           label={
             <Text t="body1" color="lighter">

--- a/carbonmark/components/Transaction/Approve.tsx
+++ b/carbonmark/components/Transaction/Approve.tsx
@@ -4,11 +4,12 @@ import { Trans } from "@lingui/macro";
 import CheckIcon from "@mui/icons-material/Check";
 import SendRounded from "@mui/icons-material/SendRounded";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
+import { FormatTrans } from "components/FormatTrans";
 import { Spinner } from "components/shared/Spinner";
 import { Text } from "components/Text";
 import { carbonmarkTokenInfoMap } from "lib/getTokenInfo";
 import { getStatusMessage, TransactionStatusMessage } from "lib/statusMessage";
-import { FC, Fragment } from "react";
+import { FC } from "react";
 import { HighlightValue } from "./HighlightValue";
 import * as styles from "./styles";
 import { Value } from "./types";
@@ -41,7 +42,7 @@ export const Approve: FC<Props> = (props) => {
           success,
         })}
       >
-        {!!props.description && (
+        {/* {!!props.description && (
           <div>
             {props.description.split("\n").map((line, index) => (
               <Fragment key={index}>
@@ -49,7 +50,15 @@ export const Approve: FC<Props> = (props) => {
               </Fragment>
             ))}
           </div>
-        )}
+        )} */}
+        <div>
+          {props.description && (
+            <FormatTrans
+              id={props.description}
+              style={{ marginBottom: "1.5em" }}
+            />
+          )}
+        </div>
         <HighlightValue
           label={
             <Text t="body1" color="lighter">

--- a/carbonmark/components/Transaction/Submit.tsx
+++ b/carbonmark/components/Transaction/Submit.tsx
@@ -4,7 +4,7 @@ import { Trans } from "@lingui/macro";
 import CheckIcon from "@mui/icons-material/Check";
 import SendRounded from "@mui/icons-material/SendRounded";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
-import { CustomTrans } from "components/CustomTrans";
+import { FormatTrans } from "components/FormatTrans";
 import { Spinner } from "components/shared/Spinner";
 import { Text } from "components/Text";
 import { carbonmarkTokenInfoMap } from "lib/getTokenInfo";
@@ -34,7 +34,7 @@ export const Submit: FC<Props> = (props) => {
 
   const showSubmitButton = !showButtonSpinner && !success;
   const showCloseButton = !showButtonSpinner && success;
-
+  console.log(props);
   return (
     <>
       <div
@@ -42,7 +42,7 @@ export const Submit: FC<Props> = (props) => {
           success,
         })}
       >
-        <CustomTrans
+        <FormatTrans
           id="transaction_modal.submit.title"
           style={{ marginBottom: "1.5em" }}
         />

--- a/carbonmark/components/Transaction/Submit.tsx
+++ b/carbonmark/components/Transaction/Submit.tsx
@@ -34,7 +34,6 @@ export const Submit: FC<Props> = (props) => {
 
   const showSubmitButton = !showButtonSpinner && !success;
   const showCloseButton = !showButtonSpinner && success;
-  console.log(props);
   return (
     <>
       <div

--- a/carbonmark/components/Transaction/Submit.tsx
+++ b/carbonmark/components/Transaction/Submit.tsx
@@ -1,5 +1,6 @@
 import { cx } from "@emotion/css";
 import { concatAddress } from "@klimadao/lib/utils";
+import { i18n } from "@lingui/core";
 import { Trans } from "@lingui/macro";
 import CheckIcon from "@mui/icons-material/Check";
 import SendRounded from "@mui/icons-material/SendRounded";
@@ -23,6 +24,25 @@ interface Props {
   description?: string;
 }
 
+interface CustomTransProps {
+  id: string;
+  style?: React.CSSProperties;
+}
+
+export const CustomTrans: FC<CustomTransProps> = ({ id, style }) => {
+  const translatedDescription = i18n._(id);
+
+  return (
+    <div>
+      {translatedDescription.split("\n").map((line, index) => (
+        <p key={index} style={style}>
+          {line}
+        </p>
+      ))}
+    </div>
+  );
+};
+
 export const Submit: FC<Props> = (props) => {
   const statusType = props.status?.statusType;
 
@@ -41,12 +61,10 @@ export const Submit: FC<Props> = (props) => {
           success,
         })}
       >
-        <Text>
-          <Trans id="transaction_modal.submit.title">
-            Please submit the transaction
-          </Trans>
-        </Text>
-        {!!props.description && <Text>{props.description}</Text>}
+        <CustomTrans
+          id="transaction_modal.submit.title"
+          style={{ marginBottom: "1.5em" }}
+        />
         <HighlightValue
           label={
             <Text t="body1" color="lighter">

--- a/carbonmark/components/Transaction/Submit.tsx
+++ b/carbonmark/components/Transaction/Submit.tsx
@@ -1,10 +1,10 @@
 import { cx } from "@emotion/css";
 import { concatAddress } from "@klimadao/lib/utils";
-import { i18n } from "@lingui/core";
 import { Trans } from "@lingui/macro";
 import CheckIcon from "@mui/icons-material/Check";
 import SendRounded from "@mui/icons-material/SendRounded";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
+import { CustomTrans } from "components/CustomTrans";
 import { Spinner } from "components/shared/Spinner";
 import { Text } from "components/Text";
 import { carbonmarkTokenInfoMap } from "lib/getTokenInfo";
@@ -23,25 +23,6 @@ interface Props {
   status: TransactionStatusMessage | null;
   description?: string;
 }
-
-interface CustomTransProps {
-  id: string;
-  style?: React.CSSProperties;
-}
-
-export const CustomTrans: FC<CustomTransProps> = ({ id, style }) => {
-  const translatedDescription = i18n._(id);
-
-  return (
-    <div>
-      {translatedDescription.split("\n").map((line, index) => (
-        <p key={index} style={style}>
-          {line}
-        </p>
-      ))}
-    </div>
-  );
-};
 
 export const Submit: FC<Props> = (props) => {
   const statusType = props.status?.statusType;

--- a/carbonmark/components/Transaction/index.tsx
+++ b/carbonmark/components/Transaction/index.tsx
@@ -2,13 +2,12 @@ import { Trans } from "@lingui/macro";
 import { FC, useState } from "react";
 
 import { CarbonmarkButton } from "components/CarbonmarkButton";
+import { getAddress } from "lib/networkAware/getAddress";
 import { TransactionStatusMessage } from "lib/statusMessage";
 import { Approve } from "./Approve";
+import * as styles from "./styles";
 import { Submit } from "./Submit";
 import { Value } from "./types";
-
-import { getAddress } from "lib/networkAware/getAddress";
-import * as styles from "./styles";
 
 interface Props {
   hasApproval: boolean;

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -899,11 +899,11 @@ msgstr "tonnes"
 
 #: components/CreateListing/index.tsx:154
 msgid "transaction.create_listing.approval_description"
-msgstr "You are about to transfer ownership of this asset from your wallet to Carbonmark.  You can remove your listing at any time until it has been sold."
+msgstr "You are about to create a new listing.\n\nThe first step is to grant the approval to transfer this asset from your wallet to Carbonmark, the next step is to approve the actual transfer and make your listing live.\n\nYou can choose to remove your active listing at any time which will automatically transfer the listed asset back to your wallet.\n\nVerify all information is correct and click 'approve' to continue."
 
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:238
 msgid "transaction.edit_listing.approval_description"
-msgstr "You are about to transfer ownership of this asset from your wallet to Carbonmark. You can remove your listing at any time until it has been sold."
+msgstr "You are about to edit your listing.\n\nThe first step is to grant the approval to transfer this asset from your wallet to Carbonmark, the next step is to approve the actual transfer and update your listing.\n\nYou can choose to remove your active listing at any time which will automatically transfer the listed asset back to your wallet.\n\nVerify all information is correct and click 'approve' to continue."
 
 #: lib/statusMessage.ts:31
 msgid "transaction.status.done"
@@ -971,7 +971,7 @@ msgstr "Submit price per tonne"
 
 #: components/Transaction/Submit.tsx:45
 msgid "transaction_modal.submit.title"
-msgstr "Please submit the transaction"
+msgstr "The previous step granted the approval to transfer this asset from your wallet to Carbonmark, your asset has not been transferred yet. \n To finalize the transfer of this asset to Carbonmark and make your listing live, verify all information is correct and then click submit below."
 
 #: components/Transaction/index.tsx:47
 msgid "transaction_modal.view.approve.title"

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -899,11 +899,11 @@ msgstr "tonnes"
 
 #: components/CreateListing/index.tsx:154
 msgid "transaction.create_listing.approval_description"
-msgstr "You are about to create a new listing.\n\nThe first step is to grant the approval to transfer this asset from your wallet to Carbonmark, the next step is to approve the actual transfer and make your listing live.\n\nYou can choose to remove your active listing at any time which will automatically transfer the listed asset back to your wallet.\n\nVerify all information is correct and click 'approve' to continue."
+msgstr "You are about to create a new listing. The first step is to grant the approval to transfer this asset from your wallet to Carbonmark, the next step is to approve the actual transfer and make your listing live. You can choose to remove your active listing at any time which will automatically transfer the listed asset back to your wallet. Verify all information is correct and click 'approve' to continue."
 
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:238
 msgid "transaction.edit_listing.approval_description"
-msgstr "You are about to edit your listing.\n\nThe first step is to grant the approval to transfer this asset from your wallet to Carbonmark, the next step is to approve the actual transfer and update your listing.\n\nYou can choose to remove your active listing at any time which will automatically transfer the listed asset back to your wallet.\n\nVerify all information is correct and click 'approve' to continue."
+msgstr "You are about to edit your listing. The first step is to grant the approval to transfer this asset from your wallet to Carbonmark, the next step is to approve the actual transfer and update your listing. You can choose to remove your active listing at any time which will automatically transfer the listed asset back to your wallet. Verify all information is correct and click 'approve' to continue."
 
 #: lib/statusMessage.ts:31
 msgid "transaction.status.done"
@@ -971,7 +971,7 @@ msgstr "Submit price per tonne"
 
 #: components/Transaction/Submit.tsx:45
 msgid "transaction_modal.submit.title"
-msgstr "The previous step granted the approval to transfer this asset from your wallet to Carbonmark, your asset has not been transferred yet. \n To finalize the transfer of this asset to Carbonmark and make your listing live, verify all information is correct and then click submit below."
+msgstr "The previous step granted the approval to transfer this asset from your wallet to Carbonmark, your asset has not been transferred yet. To finalize the transfer of this asset to Carbonmark and make your listing live, verify all information is correct and then click submit below."
 
 #: components/Transaction/index.tsx:47
 msgid "transaction_modal.view.approve.title"


### PR DESCRIPTION
## Description

Added more verbose and explanatory text to the Create and Edit Listing modal. 

This turned out to a more involved task as lingui created difficulties with formatting. This appears to be a new issue as current long text that is formatted, such as the main `About Carbonmark` blog section doesn't appear to be translated, while long text that is translated, such as the Disclaimer below it, is translated but not formatted.

I created a `CustomTrans` component that injects a line break after every sentence, which fulfilled this task re: the modal.  However, if there will be a substantial number of lengthy translations then it's probably worth the time to modify the component so that it accepts a param of which sentences to inject line breaks after. If not, then the current component has much less potential for user error.

Also just a note on a small UX glitch; the update button is disabled on page load even though the value is valid.

Reviewers:

@Atmosfearful @ShimonD-KlimaDAO 

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1059 

## Changes

### **Create Approve**
| Before  | After  |
|---------|--------|
| ![Screen Shot 2023-04-24 at 10 00 45 AM](https://user-images.githubusercontent.com/72105234/234019976-afcd80da-f80d-49b8-8dbb-59aa1273b466.png)|<img width="592" alt="Screen Shot 2023-04-21 at 1 59 32 PM" src="https://user-images.githubusercontent.com/72105234/234020013-fb219525-b593-41ad-b451-e012fff7740d.png">|

### **Edit Approve**
| Before  | After  |
|---------|--------|
| same as above |![Screen Shot 2023-04-24 at 9 45 37 AM](https://user-images.githubusercontent.com/72105234/234020432-bece474f-a785-4d6a-a1bf-bb6071b84438.png)|

### **Create Submit**

| Before  | After  |
|---------|--------|
|![submit2](https://user-images.githubusercontent.com/72105234/234020724-48c8781a-d6f1-4f63-b25d-e1d2feb062d6.png) | <img width="589" alt="Screen Shot 2023-04-22 at 3 08 01 PM" src="https://user-images.githubusercontent.com/72105234/234020792-d57e50ab-f825-4630-b66e-b6506945ef23.png"> |

### **Edit Submit*

| Before  | After  |
|---------|--------|
| same as above | ![Screen Shot 2023-04-24 at 10 07 22 AM](https://user-images.githubusercontent.com/72105234/234021425-254ab9b0-8afb-4a12-b00d-652bfdc8b379.png) |




## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
