### PR TITLE
Fix testnet project categories

### DIFF
--- a/carbonmark/lib/projectGetter.ts
+++ b/carbonmark/lib/projectGetter.ts
@@ -1,7 +1,7 @@
 import { Project } from "lib/types/carbonmark";
 
 export const getCategoryFromProject = (project: Project) =>
-  project.methodologies[0]?.category || "Other"; // fallback for Staging Testnet Data
+  project.methodologies?.[0]?.category || "Other"; // fallback for Staging Testnet Data
 
 export const getMethodologyFromProject = (project: Project) =>
-  project.methodologies[0]?.id || "Unknown";
+  project.methodologies?.[0]?.id || "Unknown";


### PR DESCRIPTION
## Description

When running carbonmark locally with testnet => a lot of projects are hardcoded!

These projects do not have the `methodologies` array from which the category data is retrieved.
=> Page generation fails with "can not read ... of undefined"

This PR fixes that.

## Related Ticket
Again the same as in https://github.com/KlimaDAO/klimadao/pull/1023


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
