### PR TITLE
Use SWR for updating user profile data

### DIFF
--- a/carbonmark/components/pages/Users/ProfileButton/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileButton/index.tsx
@@ -1,14 +1,17 @@
-import { t } from "@lingui/macro";
 import ModeEditOutlinedIcon from "@mui/icons-material/ModeEditOutlined";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { FC } from "react";
 import * as styles from "./styles";
 
-/** A responsive button to allow the user to edit their profile */
-export const ProfileButton: FC<{ onClick: () => void }> = (props) => {
+type Props = {
+  label: string;
+  onClick: () => void;
+};
+
+export const ProfileButton: FC<Props> = (props) => {
   return (
     <ButtonPrimary
-      label={t`Edit Profile`}
+      label={props.label}
       className={styles.profileButtonStyle}
       variant="gray"
       icon={<ModeEditOutlinedIcon />}

--- a/carbonmark/components/pages/Users/ProfileHeader/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileHeader/index.tsx
@@ -1,34 +1,34 @@
 import { Trans } from "@lingui/macro";
 import { ProfileLogo } from "components/pages/Users/ProfileLogo";
 import { Text } from "components/Text";
+import { User } from "lib/types/carbonmark";
 import { FC } from "react";
 import * as styles from "./styles";
 
 type Props = {
+  carbonmarkUser: User | null;
   userName: string;
-  description?: string;
-  isCarbonmarkUser: boolean;
-  profileImgUrl?: string;
-  handle?: string;
 };
 
 export const ProfileHeader: FC<Props> = (props) => {
+  const isCarbonmarkUser = !!props.carbonmarkUser;
+
   return (
     <div className={styles.profileHeader}>
       <ProfileLogo
-        isCarbonmarkUser={props.isCarbonmarkUser}
-        profileImgUrl={props.profileImgUrl}
+        isCarbonmarkUser={isCarbonmarkUser}
+        profileImgUrl={props.carbonmarkUser?.profileImgUrl}
       />
       <div className={styles.profileText}>
         <div className={styles.titles}>
-          <Text t="h4">{props.userName}</Text>
-          {props.handle && (
+          <Text t="h4">{props.carbonmarkUser?.username || props.userName}</Text>
+          {props.carbonmarkUser?.handle && (
             <Text t="h4" className="handle">
-              @{props.handle}
+              @{props.carbonmarkUser.handle}
             </Text>
           )}
         </div>
-        {!props.isCarbonmarkUser && (
+        {!isCarbonmarkUser && (
           <Text t="body1">
             <Trans id="profile.create_your_profile">
               Create your profile on Carbonmark and start selling
@@ -36,7 +36,7 @@ export const ProfileHeader: FC<Props> = (props) => {
           </Text>
         )}
 
-        {props.isCarbonmarkUser && !props.description && (
+        {isCarbonmarkUser && !props.carbonmarkUser?.description && (
           <Text t="body1">
             <Trans id="profile.edit_your_profile">
               Edit your profile to add a description
@@ -44,8 +44,8 @@ export const ProfileHeader: FC<Props> = (props) => {
           </Text>
         )}
 
-        {props.isCarbonmarkUser && props.description && (
-          <Text t="body1">{props.description}</Text>
+        {isCarbonmarkUser && props.carbonmarkUser?.description && (
+          <Text t="body1">{props.carbonmarkUser.description}</Text>
         )}
       </div>
     </div>

--- a/carbonmark/components/pages/Users/ProfileSidebar/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileSidebar/index.tsx
@@ -1,0 +1,30 @@
+import { Activities } from "components/Activities";
+import { Stats } from "components/Stats";
+import { getActiveListings, getAllListings } from "lib/listingsGetter";
+import { User } from "lib/types/carbonmark";
+import { FC } from "react";
+
+type Props = {
+  user: User | null;
+  isPending?: boolean;
+  title: string;
+};
+
+export const ProfileSidebar: FC<Props> = (props) => {
+  const allListings = props.user && getAllListings(props.user.listings);
+  const activeListings = props.user && getActiveListings(props.user.listings);
+
+  return (
+    <>
+      <Stats
+        allListings={allListings || []}
+        activeListings={activeListings || []}
+        description={props.title}
+      />
+      <Activities
+        activities={props.user?.activities || []}
+        isLoading={props.isPending}
+      />
+    </>
+  );
+};

--- a/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
@@ -25,6 +25,7 @@ type Props = {
   listings: ListingWithProject[];
   assets: AssetForListing[];
   onFinishEditing: () => void;
+  isUpdatingData: boolean;
 };
 
 const getBalanceForListing = (
@@ -169,13 +170,18 @@ export const ListingEditable: FC<Props> = (props) => {
   return (
     <>
       {props.listings.map((listing) => (
-        <Listing key={listing.id} listing={listing}>
-          <CarbonmarkButton
-            label={<Trans id="profile.listing.edit">Edit</Trans>}
-            className={styles.editListingButton}
-            onClick={() => setListingToEdit(listing)}
-          />
-        </Listing>
+        <div
+          className={props.isUpdatingData ? styles.loadingOverlay : ""}
+          key={listing.id}
+        >
+          <Listing listing={listing}>
+            <CarbonmarkButton
+              label={<Trans id="profile.listing.edit">Edit</Trans>}
+              className={styles.editListingButton}
+              onClick={() => setListingToEdit(listing)}
+            />
+          </Listing>
+        </div>
       ))}
 
       <Modal

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -175,31 +175,33 @@ export const SellerConnected: FC<Props> = (props) => {
             </Text>
           )}
         </div>
-        <CarbonmarkButton
-          label={
-            isLoadingAssets ? (
-              <Spinner />
-            ) : (
-              <>
-                <span className={styles.addListingButtonText}>
-                  <Trans id="profile.create_new_listing">
-                    Create New Listing
-                  </Trans>
-                </span>
-                <span className={styles.addListingButtonIcon}>
-                  <AddIcon />
-                </span>
-              </>
-            )
-          }
-          disabled={
-            isLoadingAssets ||
-            !hasAssets ||
-            isUpdatingUser ||
-            !assetsData?.length
-          }
-          onClick={() => setShowCreateListingModal(true)}
-        />
+        {isCarbonmarkUser && (
+          <CarbonmarkButton
+            label={
+              isLoadingAssets ? (
+                <Spinner />
+              ) : (
+                <>
+                  <span className={styles.addListingButtonText}>
+                    <Trans id="profile.create_new_listing">
+                      Create New Listing
+                    </Trans>
+                  </span>
+                  <span className={styles.addListingButtonIcon}>
+                    <AddIcon />
+                  </span>
+                </>
+              )
+            }
+            disabled={
+              isLoadingAssets ||
+              !hasAssets ||
+              isUpdatingUser ||
+              !assetsData?.length
+            }
+            onClick={() => setShowCreateListingModal(true)}
+          />
+        )}
       </div>
 
       <TwoColLayout>

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -31,7 +31,7 @@ type Props = {
 
 export const SellerConnected: FC<Props> = (props) => {
   const scrollToRef = useRef<null | HTMLDivElement>(null);
-  const { carbonmarkUser } = useFetchUser(props.userAddress);
+  const { carbonmarkUser, isLoading } = useFetchUser(props.userAddress);
   const [assetsData, setAssetsData] = useState<AssetForListing[] | null>(null);
   const [showEditProfileModal, setShowEditProfileModal] = useState(false);
   const [isLoadingAssets, setIsLoadingAssets] = useState(false);
@@ -39,11 +39,13 @@ export const SellerConnected: FC<Props> = (props) => {
   const [showCreateListingModal, setShowCreateListingModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
-  const isCarbonmarkUser = !!carbonmarkUser;
   const hasAssets = !!carbonmarkUser?.assets?.length;
   const activeListings = getActiveListings(carbonmarkUser?.listings ?? []);
   const sortedListings = getSortByUpdateListings(activeListings);
   const hasListings = !!activeListings.length;
+
+  const isCarbonmarkUser = !isLoading && !!carbonmarkUser;
+  const isUnregistered = !isLoading && carbonmarkUser === null;
 
   const scrollToTop = () =>
     scrollToRef.current &&
@@ -146,7 +148,10 @@ export const SellerConnected: FC<Props> = (props) => {
   return (
     <div ref={scrollToRef} className={styles.container}>
       <div className={styles.userControlsRow}>
-        <ProfileButton onClick={() => setShowEditProfileModal(true)} />
+        <ProfileButton
+          label={isUnregistered ? t`Create Profile` : t`Edit Profile`}
+          onClick={() => setShowEditProfileModal(true)}
+        />
         <LoginButton className="loginButton" />
       </div>
       <div className={styles.fullWidth}>

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -225,6 +225,7 @@ export const SellerConnected: FC<Props> = (props) => {
               listings={sortedListings}
               onFinishEditing={onUpdateUser}
               assets={assetsData || []}
+              isUpdatingData={isPending}
             />
           )}
         </Col>

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -1,6 +1,5 @@
 import { t, Trans } from "@lingui/macro";
 import AddIcon from "@mui/icons-material/Add";
-import { Activities } from "components/Activities";
 import { CarbonmarkButton } from "components/CarbonmarkButton";
 import { Card } from "components/Card";
 import { CreateListing } from "components/CreateListing";
@@ -8,22 +7,18 @@ import { LoginButton } from "components/LoginButton";
 import { Modal } from "components/shared/Modal";
 import { Spinner } from "components/shared/Spinner";
 import { SpinnerWithLabel } from "components/SpinnerWithLabel";
-import { Stats } from "components/Stats";
 import { Text } from "components/Text";
 import { Col, TwoColLayout } from "components/TwoColLayout";
 import { addProjectsToAssets } from "lib/actions";
 import { getUser } from "lib/api";
 import { getAssetsWithProjectTokens } from "lib/getAssetsData";
-import {
-  getActiveListings,
-  getAllListings,
-  getSortByUpdateListings,
-} from "lib/listingsGetter";
+import { getActiveListings, getSortByUpdateListings } from "lib/listingsGetter";
 import { pollUntil } from "lib/pollUntil";
 import { AssetForListing, User } from "lib/types/carbonmark";
 import { FC, useEffect, useRef, useState } from "react";
 import { ProfileButton } from "../ProfileButton";
 import { ProfileHeader } from "../ProfileHeader";
+import { ProfileSidebar } from "../ProfileSidebar";
 import { EditProfile } from "./Forms/EditProfile";
 import { ListingEditable } from "./ListingEditable";
 import * as styles from "./styles";
@@ -46,7 +41,6 @@ export const SellerConnected: FC<Props> = (props) => {
 
   const isCarbonmarkUser = !!user;
   const hasAssets = !!user?.assets?.length;
-  const allListings = getAllListings(user?.listings ?? []);
   const activeListings = getActiveListings(user?.listings ?? []);
   const sortedListings = getSortByUpdateListings(activeListings);
   const hasListings = !!activeListings.length;
@@ -237,14 +231,10 @@ export const SellerConnected: FC<Props> = (props) => {
         </Col>
 
         <Col>
-          <Stats
-            allListings={allListings || []}
-            activeListings={activeListings || []}
-            description={t`Your seller data`}
-          />
-          <Activities
-            activities={user?.activities || []}
-            isLoading={isUpdatingUser}
+          <ProfileSidebar
+            user={user}
+            isPending={isUpdatingUser}
+            title={t`Your seller data`}
           />
         </Col>
       </TwoColLayout>

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -156,11 +156,8 @@ export const SellerConnected: FC<Props> = (props) => {
       </div>
       <div className={styles.fullWidth}>
         <ProfileHeader
-          handle={carbonmarkUser?.handle}
-          userName={carbonmarkUser?.username || props.userName}
-          isCarbonmarkUser={isCarbonmarkUser}
-          description={carbonmarkUser?.description}
-          profileImgUrl={carbonmarkUser?.profileImgUrl}
+          carbonmarkUser={carbonmarkUser}
+          userName={props.userName}
         />
       </div>
       <div className={styles.listings}>

--- a/carbonmark/components/pages/Users/SellerConnected/styles.ts
+++ b/carbonmark/components/pages/Users/SellerConnected/styles.ts
@@ -94,3 +94,8 @@ export const deleteListingButton = css`
   width: 100%;
   margin-top: 1.6rem;
 `;
+
+export const loadingOverlay = css`
+  pointer-events: none;
+  opacity: 0.5;
+`;

--- a/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
@@ -4,9 +4,9 @@ import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { LoginButton } from "components/LoginButton";
 import { Text } from "components/Text";
 import { Col, TwoColLayout } from "components/TwoColLayout";
+import { useFetchUser } from "hooks/useFetchUser";
 import { createProjectPurchaseLink } from "lib/createUrls";
 import { getActiveListings, getSortByUpdateListings } from "lib/listingsGetter";
-import { User } from "lib/types/carbonmark";
 import { FC } from "react";
 import { Listing } from "../Listing";
 import { ProfileHeader } from "../ProfileHeader";
@@ -14,15 +14,15 @@ import { ProfileSidebar } from "../ProfileSidebar";
 import * as styles from "./styles";
 
 type Props = {
-  carbonmarkUser: User | null;
   userName: string;
+  userAddress: string;
 };
 
 export const SellerUnconnected: FC<Props> = (props) => {
   const { address, isConnected, toggleModal } = useWeb3();
-  const userData = props.carbonmarkUser;
+  const { carbonmarkUser } = useFetchUser(props.userAddress);
 
-  const activeListings = getActiveListings(userData?.listings ?? []);
+  const activeListings = getActiveListings(carbonmarkUser?.listings ?? []);
   const hasListings = !!activeListings.length;
 
   const sortedListings =
@@ -37,11 +37,11 @@ export const SellerUnconnected: FC<Props> = (props) => {
       </div>
       <div className={styles.fullWidth}>
         <ProfileHeader
-          userName={userData?.username || props.userName}
-          handle={props.carbonmarkUser?.handle}
-          isCarbonmarkUser={!!userData}
-          description={userData?.description}
-          profileImgUrl={userData?.profileImgUrl}
+          userName={carbonmarkUser?.username || props.userName}
+          handle={carbonmarkUser?.handle}
+          isCarbonmarkUser={!!carbonmarkUser}
+          description={carbonmarkUser?.description}
+          profileImgUrl={carbonmarkUser?.profileImgUrl}
         />
       </div>
       <div className={styles.listings}>
@@ -89,7 +89,10 @@ export const SellerUnconnected: FC<Props> = (props) => {
           )}
         </Col>
         <Col>
-          <ProfileSidebar user={userData} title={t`Data for this seller`} />
+          <ProfileSidebar
+            user={carbonmarkUser}
+            title={t`Data for this seller`}
+          />
         </Col>
       </TwoColLayout>
     </div>

--- a/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
@@ -37,11 +37,8 @@ export const SellerUnconnected: FC<Props> = (props) => {
       </div>
       <div className={styles.fullWidth}>
         <ProfileHeader
-          userName={carbonmarkUser?.username || props.userName}
-          handle={carbonmarkUser?.handle}
-          isCarbonmarkUser={!!carbonmarkUser}
-          description={carbonmarkUser?.description}
-          profileImgUrl={carbonmarkUser?.profileImgUrl}
+          carbonmarkUser={carbonmarkUser}
+          userName={props.userName}
         />
       </div>
       <div className={styles.listings}>

--- a/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
@@ -1,21 +1,16 @@
 import { useWeb3 } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
-import { Activities } from "components/Activities";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { LoginButton } from "components/LoginButton";
-import { Stats } from "components/Stats";
 import { Text } from "components/Text";
 import { Col, TwoColLayout } from "components/TwoColLayout";
 import { createProjectPurchaseLink } from "lib/createUrls";
-import {
-  getActiveListings,
-  getAllListings,
-  getSortByUpdateListings,
-} from "lib/listingsGetter";
+import { getActiveListings, getSortByUpdateListings } from "lib/listingsGetter";
 import { User } from "lib/types/carbonmark";
 import { FC } from "react";
 import { Listing } from "../Listing";
 import { ProfileHeader } from "../ProfileHeader";
+import { ProfileSidebar } from "../ProfileSidebar";
 import * as styles from "./styles";
 
 type Props = {
@@ -27,7 +22,6 @@ export const SellerUnconnected: FC<Props> = (props) => {
   const { address, isConnected, toggleModal } = useWeb3();
   const userData = props.carbonmarkUser;
 
-  const allListings = getAllListings(userData?.listings ?? []);
   const activeListings = getActiveListings(userData?.listings ?? []);
   const hasListings = !!activeListings.length;
 
@@ -95,12 +89,7 @@ export const SellerUnconnected: FC<Props> = (props) => {
           )}
         </Col>
         <Col>
-          <Stats
-            description={t`Data for this seller`}
-            allListings={allListings || []}
-            activeListings={activeListings || []}
-          />
-          <Activities activities={userData?.activities || []} />
+          <ProfileSidebar user={userData} title={t`Data for this seller`} />
         </Col>
       </TwoColLayout>
     </div>

--- a/carbonmark/components/pages/Users/index.tsx
+++ b/carbonmark/components/pages/Users/index.tsx
@@ -4,26 +4,31 @@ import { Layout } from "components/Layout";
 import { PageHead } from "components/PageHead";
 import { Spinner } from "components/shared/Spinner";
 import { useConnectedUser } from "hooks/useConnectedUser";
+import { useFetchUser } from "hooks/useFetchUser";
+import { fetcher } from "lib/fetcher";
 import { User } from "lib/types/carbonmark";
 import { NextPage } from "next";
 import { useEffect, useState } from "react";
+import { SWRConfig } from "swr";
 import { SellerConnected } from "./SellerConnected";
 import { SellerUnconnected } from "./SellerUnconnected";
 
-type Props = {
+export type PageProps = {
   userAddress: string;
   userDomain: string | null;
   carbonmarkUser: User | null;
 };
 
-export const Users: NextPage<Props> = (props) => {
+const Page: NextPage<PageProps> = (props) => {
+  const { carbonmarkUser } = useFetchUser(props.userAddress);
+
   const { isConnectedUser, isUnconnectedUser } = useConnectedUser(
     props.userAddress
   );
   const [isLoading, setIsLoading] = useState(false);
 
   const userName =
-    props.userDomain || props.carbonmarkUser?.handle || props.userAddress;
+    props.userDomain || carbonmarkUser?.handle || props.userAddress;
 
   // Wait until web3 is ready
   useEffect(() => {
@@ -36,10 +41,10 @@ export const Users: NextPage<Props> = (props) => {
     <>
       <PageHead
         title={t`${
-          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+          carbonmarkUser?.handle || concatAddress(props.userAddress)
         } | Profile | Carbonmark`}
         mediaTitle={`${
-          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+          carbonmarkUser?.handle || concatAddress(props.userAddress)
         }'s Profile on Carbonmark`}
         metaDescription={t`Create and edit listings, and track your activity with your Carbonmark profile.`}
       />
@@ -51,13 +56,13 @@ export const Users: NextPage<Props> = (props) => {
           <SellerConnected
             userAddress={props.userAddress}
             userName={userName}
-            carbonmarkUser={props.carbonmarkUser}
+            carbonmarkUser={carbonmarkUser}
           />
         )}
 
         {isUnconnectedUser && (
           <SellerUnconnected
-            carbonmarkUser={props.carbonmarkUser}
+            carbonmarkUser={carbonmarkUser}
             userName={userName}
           />
         )}
@@ -65,3 +70,16 @@ export const Users: NextPage<Props> = (props) => {
     </>
   );
 };
+
+export const Users: NextPage<PageProps> = (props) => (
+  <SWRConfig
+    value={{
+      fetcher,
+      fallback: {
+        [`/api/users/${props.userAddress}?type=wallet`]: props.carbonmarkUser,
+      },
+    }}
+  >
+    <Page {...props} />
+  </SWRConfig>
+);

--- a/carbonmark/components/pages/Users/index.tsx
+++ b/carbonmark/components/pages/Users/index.tsx
@@ -62,7 +62,7 @@ const Page: NextPage<PageProps> = (props) => {
 
         {isUnconnectedUser && (
           <SellerUnconnected
-            carbonmarkUser={carbonmarkUser}
+            userAddress={props.userAddress}
             userName={userName}
           />
         )}

--- a/carbonmark/components/pages/Users/index.tsx
+++ b/carbonmark/components/pages/Users/index.tsx
@@ -2,12 +2,10 @@ import { concatAddress } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
 import { Layout } from "components/Layout";
 import { PageHead } from "components/PageHead";
-import { Spinner } from "components/shared/Spinner";
 import { useConnectedUser } from "hooks/useConnectedUser";
 import { fetcher } from "lib/fetcher";
 import { User } from "lib/types/carbonmark";
 import { NextPage } from "next";
-import { useEffect, useState } from "react";
 import { SWRConfig } from "swr";
 import { SellerConnected } from "./SellerConnected";
 import { SellerUnconnected } from "./SellerUnconnected";
@@ -22,17 +20,9 @@ const Page: NextPage<PageProps> = (props) => {
   const { isConnectedUser, isUnconnectedUser } = useConnectedUser(
     props.userAddress
   );
-  const [isLoading, setIsLoading] = useState(false);
 
   const userName =
     props.userDomain || props.carbonmarkUser?.handle || props.userAddress;
-
-  // Wait until web3 is ready
-  useEffect(() => {
-    if (isConnectedUser || isUnconnectedUser) {
-      setIsLoading(false);
-    }
-  }, [isConnectedUser, isUnconnectedUser]);
 
   return (
     <>
@@ -47,8 +37,6 @@ const Page: NextPage<PageProps> = (props) => {
       />
 
       <Layout userAddress={props.userAddress}>
-        {isLoading && <Spinner />}
-
         {isConnectedUser && (
           <SellerConnected
             userAddress={props.userAddress}

--- a/carbonmark/components/pages/Users/index.tsx
+++ b/carbonmark/components/pages/Users/index.tsx
@@ -4,7 +4,6 @@ import { Layout } from "components/Layout";
 import { PageHead } from "components/PageHead";
 import { Spinner } from "components/shared/Spinner";
 import { useConnectedUser } from "hooks/useConnectedUser";
-import { useFetchUser } from "hooks/useFetchUser";
 import { fetcher } from "lib/fetcher";
 import { User } from "lib/types/carbonmark";
 import { NextPage } from "next";
@@ -20,15 +19,13 @@ export type PageProps = {
 };
 
 const Page: NextPage<PageProps> = (props) => {
-  const { carbonmarkUser } = useFetchUser(props.userAddress);
-
   const { isConnectedUser, isUnconnectedUser } = useConnectedUser(
     props.userAddress
   );
   const [isLoading, setIsLoading] = useState(false);
 
   const userName =
-    props.userDomain || carbonmarkUser?.handle || props.userAddress;
+    props.userDomain || props.carbonmarkUser?.handle || props.userAddress;
 
   // Wait until web3 is ready
   useEffect(() => {
@@ -41,10 +38,10 @@ const Page: NextPage<PageProps> = (props) => {
     <>
       <PageHead
         title={t`${
-          carbonmarkUser?.handle || concatAddress(props.userAddress)
+          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
         } | Profile | Carbonmark`}
         mediaTitle={`${
-          carbonmarkUser?.handle || concatAddress(props.userAddress)
+          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
         }'s Profile on Carbonmark`}
         metaDescription={t`Create and edit listings, and track your activity with your Carbonmark profile.`}
       />
@@ -56,7 +53,6 @@ const Page: NextPage<PageProps> = (props) => {
           <SellerConnected
             userAddress={props.userAddress}
             userName={userName}
-            carbonmarkUser={carbonmarkUser}
           />
         )}
 

--- a/carbonmark/pages/users/[user].tsx
+++ b/carbonmark/pages/users/[user].tsx
@@ -2,7 +2,7 @@ import { ethers } from "ethers";
 import { GetStaticProps } from "next";
 import { ParsedUrlQuery } from "querystring";
 
-import { Users } from "components/pages/Users";
+import { PageProps, Users } from "components/pages/Users";
 import { loadTranslation } from "lib/i18n";
 import { getAddressByDomain } from "lib/shared/getAddressByDomain";
 import { getIsDomainInURL } from "lib/shared/getIsDomainInURL";
@@ -12,12 +12,6 @@ import { User } from "lib/types/carbonmark";
 
 interface Params extends ParsedUrlQuery {
   user: string;
-}
-
-interface PageProps {
-  userAddress: string;
-  userDomain: string | null;
-  carbonmarkUser: User | null;
 }
 
 export const getStaticProps: GetStaticProps<PageProps, Params> = async (


### PR DESCRIPTION
## Description

This is the final PR for improving the page cache.

### How to test:

**Edit Profile**
- Change your profile data
- The changes should be visible immediately 
-  Note: When you refresh the page now, it might be that the data is not updated! This is because the backend might be slow. But in normal cases a user would not refresh now.

**Create, Change a Listing**
- Create or edit a Listing
- Loadings spinner should appear with "Updating your data" (see screenshot)
- Meanwhile, the backend is polled to wait for an updated user's activity
- Until then all listings are disabled to prevent the user from further editing
- When the backend needs to long, an error message is shown "please refresh the page"
- On Success, the listing is updated ✔️ 
- On Success, the activity is updated ✔️ 
- On Success, the corresponding project is updated  ✔️ (different page URL) 
- On Success, the portfolio activity is updated ✔️ (different page URL) 


**Additional Changes:**

- When a user has not yet been registered on Carbonmark => the Profile button is "Create Profile"

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1019

## Screenshots

### PENDING
![Bildschirmfoto 2023-04-27 um 16 01 11](https://user-images.githubusercontent.com/95881624/234886600-792e4061-1459-4001-8161-99956d97017c.png)

### New USER with "create profile" button label
![Bildschirmfoto 2023-04-26 um 12 40 58](https://user-images.githubusercontent.com/95881624/234886649-7ce336f2-aa89-4963-8fdb-9c268e9fcb38.png)


## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
