### PR TITLE
Revert "Extract translation strings"

### DIFF
--- a/site/locale/de/messages.po
+++ b/site/locale/de/messages.po
@@ -13,15 +13,15 @@ msgstr "Sprache wechseln"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:33
 msgid "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
-msgstr ""
+msgstr "Jeder CO2-Ausgleich durch KlimaDAO erfolgt durch verifizierte CO2-Projekte. Klicken Sie hier, um mehr über das Projekt zu erfahren."
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:68
 msgid "Explore MCO2 on carbon.klimadao.finance"
-msgstr ""
+msgstr "MCO2 auf carbon.klimadao.finance entdecken"
 
 #: components/pages/Infinity/index.tsx:530
 msgid "Frequently Asked Questions"
-msgstr ""
+msgstr "Häufig gestellte Fragen"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:47
 msgid "Location: {0}"
@@ -29,11 +29,11 @@ msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:50
 msgid "MCO2 Token"
-msgstr ""
+msgstr "MCO2-Token"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:52
 msgid "Methodology: {0}"
-msgstr ""
+msgstr "Methodik: {0}"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:23
 msgid "No retirement message provided."
@@ -41,7 +41,7 @@ msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:146
 msgid "Processing data..."
-msgstr ""
+msgstr "Daten werden verarbeitet..."
 
 #: components/InvalidNetworkModal/index.tsx:80
 msgid "Switch to Polygon"
@@ -53,11 +53,11 @@ msgstr "Die App funktioniert nur im Polygon-Mainnet."
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:74
 msgid "View on Polygonscan"
-msgstr ""
+msgstr "Auf Polygonscan ansehen"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:150
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
-msgstr ""
+msgstr "Wir haben die Verarbeitung der Blockchaindaten für diesen Ausgleich noch nicht abgeschlossen. Dies dauert etwas länger, wenn das Netzwerk überlastet ist."
 
 #: components/InvalidNetworkModal/index.tsx:65
 msgid "Wrong Network"
@@ -74,370 +74,370 @@ msgstr "Haftungsausschluss:"
 
 #: components/pages/Buy/index.tsx:433
 msgid "buy.answer_exchange"
-msgstr ""
+msgstr "Fortgeschrittene Nutzer können die <0>Polygon Bridge</0> verwenden, um digitale Assets von Etherum nach Polygon zu transferieren. Über <1>Polygon Gas Swap</1> tauschen Sie digitale Assets wie USDC oder MATIC."
 
 #: components/pages/Buy/index.tsx:390
 msgid "buy.bond_answer_cedit_card"
-msgstr ""
+msgstr "Einige Anbieter wie <0>Transak</0> erlauben es Ihnen, KLIMA gegen eine kleine Gebühr mit einer Kreditkarte zu kaufen. Sollte Ihre Wallet keine MATIC-Tokens beinhalten, können Sie jedoch keinerlei Aktionen ausführen (wie Überweisungen). Um Gebühren und das genannte Problem zu umgehen, empfehlen wir daher, MATIC direkt zu kaufen und die Tokens gegen KLIMA auf Sushi.com zu tauschen."
 
 #: components/pages/Buy/index.tsx:408
 msgid "buy.bond_answer_cex1"
-msgstr ""
+msgstr "KLIMA steht auf zentralisierten Börsen wie Coinbase, BInance oder Crypto.com nicht zur Verfügung, da diese in der Regel sehr hohe Notierungsgebühren verlangen und von teuren Market Makern finanziert werden müssen."
 
 #: components/pages/Buy/index.tsx:416
 msgid "buy.bond_answer_cex2"
-msgstr ""
+msgstr "KLIMA-Tokens stehen stattdessen auf einer dezentralisierten Börse (DEX) zur Verfügung, wo Smart Contracts und die Blockchain für einen reibungslosen Ablauf sorgen. DEXs bringen einige große Vorteile mit. So ermöglichen sie es der DAO, den Großteil der eigenen Liquidität zu behalten. Dadurch bleibt die DAO autonom und erwirtschaftet Gewinn, um die Mitarbeiter zu bezahlen. Wir haben uns für Sushis DEX entschieden, da diese Börse bereits Dutzende Millionen Transaktionsvolumen jeden Tag bearbeitet."
 
 #: components/pages/Buy/index.tsx:371
 msgid "buy.bond_description1"
-msgstr ""
+msgstr "Erfahrene Kryptonutzer können durch Bonds KLIMA direkt vom Protokoll kaufen. Um KLIMA über Bonds zu erhalten, stellen Sie ein CO2-Token oder ein Liquiditätstoken bereit und erhalten im Gegenzug vergünstigtes KLIMA. Durch diesen Mechanismus wird die Schatzkammer der DAO langsam mit digitalem CO2 gefüllt."
 
 #: components/pages/Buy/index.tsx:380
 msgid "buy.bond_description_capacity"
-msgstr ""
+msgstr "Bond-Kapazitäten sind limitiert und Bonds sind nicht immer verfügbar."
 
 #: components/pages/Buy/index.tsx:401
 msgid "buy.bond_question_cex"
-msgstr ""
+msgstr "Warum kann ich KLIMA nicht bei Coinbase oder anderen zentralisierten Börsen finden? Warum muss ich <0>Sushi.com</0> nutzen?"
 
 #: components/pages/Buy/index.tsx:385
 msgid "buy.bond_question_credit_card"
-msgstr ""
+msgstr "Kann ich KLIMA direkt mit einer Kreditkarte kaufen?"
 
 #: components/pages/Buy/index.tsx:190
 msgid "buy.connect_advanced"
-msgstr ""
+msgstr "Achtung: Diese Anweisungen gelten nur für Torus Wallet-Nutzer. Sushi unterstützt zahlreiche verschiedene Wallets."
 
 #: components/pages/Buy/index.tsx:185
 msgid "buy.connect_torus_sushi"
-msgstr ""
+msgstr "3A. Torus mit Sushi.com über WalletConnect verbinden"
 
 #: components/pages/Buy/index.tsx:212
 msgid "buy.connect_torus_sushi_description2"
-msgstr ""
+msgstr "Rufen Sie <0>Sushi.com</0> in einem neuen Browser-Tab auf und klicken Sie oben rechts auf \"Verbinden\" (oder \"Connect\"). Einige Walletoptionen werden eingeblendet. Klicken SIe auf WalletConnect. Anschließend werden Sie einen QR-Code sehen. Klicken Sie auf \"In die Zwischenablage kopieren\" (oder \"Copy to Clipboard\")."
 
 #: components/pages/Buy/index.tsx:229
 msgid "buy.connect_torus_sushi_description3"
-msgstr ""
+msgstr "Kehren Sie zur Torus Wallet-App zurück und fügen Sie diesen Code in das WalletConnect-Widget ein. Dadurch wird eine vorrübergehende Verbindung zwischen Ihrer Wallet und <0>Sushi.com</0> hergestellt."
 
 #: components/pages/Buy/index.tsx:237
 msgid "buy.connect_torus_sushi_description4"
-msgstr ""
+msgstr "Wenn Sie den Sushi-Tab in Ihrem Browser aufrufen, sollten Sie Ihre Torus-Adresse in der Ecke oben rechts sehen."
 
 #: components/pages/Buy/index.tsx:243
 msgid "buy.connect_torus_sushi_description5"
-msgstr ""
+msgstr "Nutzen Sie abschließend das Drop-Down-Menü auf <0>Sushi.com</0>, um auf das Polygon-Netzwerk zu wechseln."
 
 #: components/pages/Buy/index.tsx:72
 msgid "buy.create_wallet_description"
-msgstr ""
+msgstr "<0>Erstellen Sie eine Wallet.</0> Wir empfehlen Torus, aber unsere App unterstützt die meisten Web3-Wallets (wie Metamask, Coinbase Wallet, Brave, MyEtherWallet und viele weitere)."
 
 #: components/pages/Buy/index.tsx:114
 msgid "buy.create_wallet_description1"
-msgstr ""
+msgstr "Gehen Sie auf <0>app.klimadao.finance</0> und klicken Sie oben rechts auf \"Verbinden\"."
 
 #: components/pages/Buy/index.tsx:120
 msgid "buy.create_wallet_description2"
-msgstr ""
+msgstr "Wählen Sie die Anmeldeoption \"E-Mail oder Social-Media\", die Sie zum Login mit Torus auffordern wird. Torus ist eine Software, die eine sichere Wallet für Sie erstellt und dabei existierende E-Mail- oder Social-Media-Logins verwendet. Ihre neue Torus-Wallet können Sie für Hunderte Apps in Web3 und DeFi verwenden."
 
 #: components/pages/Buy/index.tsx:129
 msgid "buy.create_wallet_description3"
-msgstr ""
+msgstr "Sobald Sie verbunden sind, sollten Sie Ihre neue Wallet-Adresse oben links in der App sehen."
 
 #: components/pages/Buy/index.tsx:135
 msgid "buy.create_wallet_description4"
-msgstr ""
+msgstr "Möchten Sie Torus nicht verwenden, können Sie jede Polygon-kompatible Web3-Wallet nutzen."
 
 #: components/pages/Buy/index.tsx:111
 msgid "buy.create_wallet_item"
-msgstr ""
+msgstr "1. Wallet erstellen"
 
 #: components/pages/Buy/index.tsx:319
 msgid "buy.faq_title"
-msgstr ""
+msgstr "FAQ"
 
 #: components/pages/Buy/index.tsx:27
 #: components/pages/Buy/index.tsx:28
 msgid "buy.head.title"
-msgstr ""
+msgstr "So kaufst du KLIMA"
 
 #: components/pages/Buy/index.tsx:41
 msgid "buy.how_to_buy"
-msgstr ""
+msgstr "So kaufst du KLIMA"
 
 #: components/pages/Buy/index.tsx:44
 msgid "buy.how_to_paragraph_part_1"
-msgstr ""
+msgstr "KLIMA ist eine durch CO2-Zertifikate gedeckte digitale Währung, mit der Sie Ihren CO2-Fußabdruck digital ausgleichen und/oder Belohnungen erhalten können. KLIMA zu besitzen, berechtigt Sie dazu, am Wahlprozess teilzunehmen und die Ausrichtung des Digitalen CO2-Marktes zu steuern."
 
 #: components/pages/Buy/index.tsx:51
 msgid "buy.how_to_paragraph_part_2"
-msgstr ""
+msgstr "Dieses kurze Tutorial richtet sich an Personen ohne Erfahrung mit Web3 und DeFi."
 
 #: components/pages/Buy/index.tsx:143
 msgid "buy.load_wallet"
-msgstr ""
+msgstr "2. MATIC-Tokens in deine Wallet überweisen"
 
 #: components/pages/Buy/index.tsx:85
 msgid "buy.load_wallet_description"
-msgstr ""
+msgstr "<0>Überweisen Sie MATIC-Tokens an Ihre neue Wallet.</0> MATIC ist der \"Treibstoff\" des Polygon-Netzwerks. Um Transaktionen über Polygon zu bezahlen, müssen Sie immer einen Centbruchteil in MATIC bezahlen."
 
 #: components/pages/Buy/index.tsx:148
 msgid "buy.load_wallet_description1"
-msgstr ""
+msgstr "Verwenden Sie einen Service wie <0>MoonPay</0> oder <1>Transak</1> oder eine zentralisierte Börse wie <2>Coinbase</2>, um MATIC zu kaufen und zu Ihrer neuerstellten Wallet zu senden."
 
 #: components/pages/Buy/index.tsx:158
 msgid "buy.load_wallet_description2"
-msgstr ""
+msgstr "<0>Stellen Sie sicher, dass die MATIC-Tokens an Ihre neue Wallet-Adresse gesendet werden!</0> Sie önnen die Adresse kopieren, indem Sie sich mit unserer App verbinden und die Adresse im Navigationsmenü anklicken."
 
 #: components/pages/Buy/index.tsx:168
 msgid "buy.load_wallet_description3"
-msgstr ""
+msgstr "<0>Stellen Sie sicher, die MATIC-Tokens über das Polygon-Netzwerk zu senden!</0> Börsen wie Coinbase werden Sie Fragen, an welches Netzwerk Sie die MATIC-Tokens senden möchten. Wählen Sie immer Polygon aus."
 
 #: components/pages/Buy/index.tsx:427
 msgid "buy.question_exchange"
-msgstr ""
+msgstr "Ich möchte eine andere Börse nutzen, aber diese verkauft kein MATIC"
 
 #: components/pages/Buy/index.tsx:322
 msgid "buy.question_why_matic"
-msgstr ""
+msgstr "Warum muss ich zuerst MATIC kaufen?"
 
 #: components/pages/Buy/index.tsx:327
 msgid "buy.question_why_matic_answer"
-msgstr ""
+msgstr "KLIMAs Token und das Protokoll verwenden die Polygon-Blockchain. MATIC ist der \"Treibstoff\", der jede Transaktion über Polygon befeuert. Eine Transaktion kann nicht ausgeführt werden, ohne die Transaktionsgebühr zu bezahlen. Das heißt, dass du MATIC im Wert von Centbruchteilen entrichten musst, um die folgenden Aktionen auszuführen:"
 
 #: components/pages/Buy/index.tsx:338
 msgid "buy.question_why_matic_answer_bullet1"
-msgstr ""
+msgstr "KLIMA für sKLIMA staken"
 
 #: components/pages/Buy/index.tsx:345
 msgid "buy.question_why_matic_answer_bullet2"
-msgstr ""
+msgstr "Unterschiedliche Tokens tauschen"
 
 #: components/pages/Buy/index.tsx:352
 msgid "buy.question_why_matic_answer_bullet3"
-msgstr ""
+msgstr "Tokens an eine andere Wallet senden"
 
 #: components/pages/Buy/index.tsx:359
 msgid "buy.question_why_matic_answer_bullet4"
-msgstr ""
+msgstr "KLIMA oder andere Tokens nutzen, um CO2 auszugleichen"
 
 #: components/pages/Buy/index.tsx:292
 msgid "buy.staking_cta"
-msgstr ""
+msgstr "Staken, verdienen, abstimmen und ausgleichen!"
 
 #: components/pages/Buy/index.tsx:295
 msgid "buy.staking_description1"
-msgstr ""
+msgstr "Herzlichen Glückwunsch! Sie haben nun KLIMA in Ihrer Wallet, das Sie unbedingt im Austausch für sKLIMA <0>staken</0> sollten. Dadurch erhöht sich Ihr KLIMA-Guthaben langsam, während das Protokoll ebenfalls wächst."
 
 #: components/pages/Buy/index.tsx:303
 msgid "buy.staking_description2"
-msgstr ""
+msgstr "Sie können die App auch verwenden, um KLIMA auszugeben und Ihren CO2-Fußabdruck über die Blockchain mit <0>digitalen CO2-Zertifikaten ausgleichen</0>."
 
 #: components/pages/Buy/index.tsx:310
 msgid "buy.staking_description3"
-msgstr ""
+msgstr "Achten Sie abschließend auf <0>laufende Abstimmungen</0>, um das Protokoll in die richtige Richtung zu lenken."
 
 #: components/pages/Buy/index.tsx:69
 msgid "buy.step_1"
-msgstr ""
+msgstr "1."
 
 #: components/pages/Buy/index.tsx:82
 msgid "buy.step_2"
-msgstr ""
+msgstr "2."
 
 #: components/pages/Buy/index.tsx:97
 msgid "buy.step_3"
-msgstr ""
+msgstr "3."
 
 #: components/pages/Buy/index.tsx:62
 msgid "buy.summary_steps_title"
-msgstr ""
+msgstr "Am einfachsten können Sie KLIMA über die folgenden drei Schritte beziehen:"
 
 #: components/pages/Buy/index.tsx:59
 msgid "buy.summary_title"
-msgstr ""
+msgstr "Zusammenfassung"
 
 #: components/pages/Buy/index.tsx:253
 msgid "buy.swap_description1"
-msgstr ""
+msgstr "Haben Sie Ihre Wallet verbunden und auf Polygon umgestellt, sollten Sie jetzt MATIC gegen KLIMA tauschen können."
 
 #: components/pages/Buy/index.tsx:259
 msgid "buy.swap_description2"
-msgstr ""
+msgstr "<0>Wichtig: Tauschen Sie nicht alle MATIC-Tokens gegen KLIMA ein!</0> Bewahren Sie mindestens 0,5 MATIC auf, um zukünftige Transaktionen zu bezahlen."
 
 #: components/pages/Buy/index.tsx:275
 msgid "buy.swap_description3"
-msgstr ""
+msgstr "Sollten Sie Torus verwenden, lassen Sie den Browser-Tab mit der Torus-App geöffnet. Sie werden Ihre Wallet noch einmal aufrufen müssen, um die Transaktionne zu genehmigen und zu autorisieren."
 
 #: components/pages/Buy/index.tsx:282
 msgid "buy.swap_description4"
-msgstr ""
+msgstr "Optional: Möchten Sie Ihre Transaktionen über Sushi klimapositiv machen, sollten Sie die von KlimaDAO eingeführte \"Green Fee\" in den Optionen von Sushi.com aktivieren. Damit werden bei jeder Transaktion automatisch 0,02 MATIC ausgegeben, um digital CO2 auszugleichen!"
 
 #: components/pages/Buy/index.tsx:100
 msgid "buy.swap_for_klima_description"
-msgstr ""
+msgstr "<0>Gegen KLIMA tauschen.</0> Sushi ist eine dezentralisierte Börse, an der Sie Ihre MATIC-Tokens so günstig wie möglich gegen KLIMA eintauschen können."
 
 #: components/pages/Buy/index.tsx:250
 msgid "buy.swap_subtitle"
-msgstr ""
+msgstr "3B. MATIC für KLIMA tauschen."
 
 #: components/pages/Buy/index.tsx:179
 msgid "buy.swap_wallet"
-msgstr ""
+msgstr "3. Gegen KLIMA auf <0>Sushi.com</0> tauschen"
 
 #: components/pages/Buy/index.tsx:196
 msgid "buy.torus_login_description"
-msgstr ""
+msgstr "Gehen Sie in einem neuen Browser-Tab zur <0>Torus Polygon Webapp</0> und loggen Sie sich mit Ihrem neuen Torus-Account ein. Sobald Sie sich einloggen, sollten Sie ein WalletConnect-Widget sehen."
 
 #: components/pages/Buy/index.tsx:205
 msgid "buy.wallet_connect_example"
-msgstr ""
+msgstr "wallet connect eingabebeispiel"
 
 #: components/pages/Buy/index.tsx:222
 #: components/pages/Buy/index.tsx:268
 msgid "buy.wallet_connect_example_qr_code"
-msgstr ""
+msgstr "wallet connect qr code beispiel"
 
 #: components/pages/Buy/index.tsx:366
 msgid "buy.what_are_bonds"
-msgstr ""
+msgstr "Gibt es andere Möglichkeiten, KLIMA zu bekommen? Was sind Bonds?"
 
 #: components/pages/About/Community/index.tsx:116
 msgid "community.become_a_partner"
-msgstr ""
+msgstr "PARTNER WERDEN"
 
 #: components/pages/About/Community/index.tsx:180
 msgid "community.bigcowg_logo"
-msgstr ""
+msgstr "BICOWG-Logo"
 
 #: components/pages/About/Community/index.tsx:172
 msgid "community.blockchainforclimatefondation_logo"
-msgstr ""
+msgstr "Blockchain for Climate Foundation-Logo"
 
 #: components/pages/About/Community/index.tsx:314
 msgid "community.come_on_in"
-msgstr ""
+msgstr "Betreten"
 
 #: components/pages/About/Community/index.tsx:228
 msgid "community.deltawave_logo"
-msgstr ""
+msgstr "Delta Wave-Logo"
 
 #: components/pages/About/Community/index.tsx:265
 msgid "community.digitalcharityart_logo"
-msgstr ""
+msgstr "Digital Charity Art-Logo"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:329
 msgid "community.discord_is_where_we_share"
-msgstr ""
+msgstr "Wir nutzen Discord, um wichtige Ankündigungen mitzuteilen, Fragen zu beantworten, wöchentliche Voice-Meetings abzuhalten - und Memes zu tauschen. Auf unserem permanent moderierten Discord-Server ist immer etwas los. Wir haben separate Kanäle für alles: vom Tokenhandel über Nachhaltigkeit bis zu CO2-Märkten."
 
 #: components/pages/About/Community/index.tsx:244
 msgid "community.dovu_logo"
-msgstr ""
+msgstr "Dovu-Logo"
 
 #: components/pages/About/Community/index.tsx:249
 msgid "community.eco_logo"
-msgstr ""
+msgstr "Eco-Logo"
 
 #: components/pages/About/Community/index.tsx:236
 msgid "community.etcgroup_logo"
-msgstr ""
+msgstr "ETC Group-Logo"
 
 #: components/pages/About/Community/index.tsx:361
 msgid "community.get_in_touch"
-msgstr ""
+msgstr "Willst du uns etwas mitteilen?"
 
 #: components/pages/About/Community/index.tsx:204
 msgid "community.gitcoin_logo"
-msgstr ""
+msgstr "Gitcoin-Logo"
 
 #: components/pages/About/Community/index.tsx:95
 msgid "community.head.headline"
-msgstr ""
+msgstr "Community"
 
 #: components/pages/About/Community/index.tsx:102
 msgid "community.head.metadescription"
-msgstr ""
+msgstr "Erfahre mehr über unsere Community leidenschaftlicher Klimates"
 
 #: components/pages/About/Community/index.tsx:96
 msgid "community.head.subline"
-msgstr ""
+msgstr "KlimaDAO ist eine dezentralisierte, autonome Organisation für positiven Wandel. Wir werden von einer leidenschaftlichen Community aus Klimates aufgebaut und verwaltet."
 
 #: components/pages/About/Community/index.tsx:94
 #: components/pages/About/Community/index.tsx:101
 msgid "community.head.title"
-msgstr ""
+msgstr "KlimaDAO-Community"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:364
 msgid "community.if_you_ve_got_questions"
-msgstr ""
+msgstr "Falls du Fragen, Ideen oder Anregungen hast: Wir helfen dir dabei, den richtigen Ansprechpartner zu finden."
 
 #: components/pages/About/Community/index.tsx:317
 msgid "community.join_our_discord"
-msgstr ""
+msgstr "Unserem Discord beitreten"
 
 #: components/pages/About/Community/index.tsx:304
 msgid "community.join_the_klima_community"
-msgstr ""
+msgstr "Tritt der Klima-Community bei"
 
 #: components/pages/About/Community/index.tsx:281
 msgid "community.landx_logo"
-msgstr ""
+msgstr "LandX-Logo"
 
 #: components/pages/About/Community/index.tsx:113
 #: components/pages/About/Community/index.tsx:358
 msgid "community.lets_work_together"
-msgstr ""
+msgstr "Lass uns zusammenarbeiten!"
 
 #: components/pages/About/Community/index.tsx:156
 msgid "community.moss_logo"
-msgstr ""
+msgstr "Moss-Logo"
 
 #: components/pages/About/Community/index.tsx:196
 msgid "community.oceandrop_logo"
-msgstr ""
+msgstr "Oceandrop-Logo"
 
 #: components/pages/About/Community/index.tsx:257
 msgid "community.offsetra_logo"
-msgstr ""
+msgstr "Offsetra-Logo"
 
 #: components/pages/About/Community/index.tsx:212
 msgid "community.olympusdao_logo"
-msgstr ""
+msgstr "OlympusDAO-Logo"
 
 #: components/pages/About/Community/index.tsx:220
 msgid "community.openearth_logo"
-msgstr ""
+msgstr "Open Earth-Logo"
 
 #: components/pages/About/Community/index.tsx:151
 msgid "community.our_partners"
-msgstr ""
+msgstr "UNSERE PARTNER"
 
 #: components/pages/About/Community/index.tsx:188
 msgid "community.polygon_logo"
-msgstr ""
+msgstr "Polygon-Logo"
 
 #: components/pages/About/Community/index.tsx:164
 msgid "community.toucan_logo"
-msgstr ""
+msgstr "Toucan-Logo"
 
 #: components/pages/About/Community/index.tsx:273
 msgid "community.toughtforfood_logo"
-msgstr ""
+msgstr "Thought for Food-Logo"
 
 #: components/pages/About/Community/index.tsx:132
 msgid "community.tree_grove"
-msgstr ""
+msgstr "Baumgruppe"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:119
 msgid "community.we_work_with_traditionnal"
-msgstr ""
+msgstr "Wir arbeiten eng mit traditionellen Akteuren auf dem CO2-Markt, Kryptoplattformen und Unternehmen zusammen - und allem dazwischen."
 
 #: components/pages/About/Contact/index.tsx:63
 msgid "concat.careers"
-msgstr ""
+msgstr "Karriere"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:170
 #: components/pages/Pledge/index.tsx:112
@@ -478,21 +478,21 @@ msgstr "Verbindungsfehler"
 
 #: components/pages/About/Contact/index.tsx:140
 msgid "contact.bug_reports"
-msgstr ""
+msgstr "Fehlermitteilungen"
 
 #. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
 #: components/pages/About/Contact/index.tsx:143
 msgid "contact.bug_reports.to_file_a_bug_report"
-msgstr ""
+msgstr "Trete unserem Discord-Communityserver bei, um im #bug-reports-Kanal Fehler zu melden oder Fragen zu stellen. Jemand aus unserer <0>Community</0> wird dir gerne helfen und eine Lösung für dich finden."
 
 #. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
 #: components/pages/About/Contact/index.tsx:66
 msgid "contact.careers.we_re_hiring"
-msgstr ""
+msgstr "Unser Team arbeitet global verteilt in allen Zeitzonen. Wir geben regelmäßig neue Rollen und Bountys auf unserem <0>Discordserver</0> bekannt. Wenn du dich gut selbst organisieren kannst und einer zielorientierten DAO beitreten möchtest, würden wir uns freuen, wenn du dich bei uns meldest!"
 
 #: components/pages/About/Contact/index.tsx:25
 msgid "contact.head.description"
-msgstr ""
+msgstr "Kontaktiere jemanden von KlimaDAO."
 
 #: components/pages/About/Contact/index.tsx:18
 msgid "contact.head.headline"
@@ -500,494 +500,496 @@ msgstr "Kontakt"
 
 #: components/pages/About/Contact/index.tsx:19
 msgid "contact.head.subline"
-msgstr ""
+msgstr "Fragen, Sorgen, Ideen? Über diese Kanäle kannst du mit uns in Kontakt treten. Wir freuen uns auf Organisationen ebenso wie auf Privatpersonen."
 
 #: components/pages/About/Contact/index.tsx:17
 #: components/pages/About/Contact/index.tsx:24
 msgid "contact.head.title"
-msgstr ""
+msgstr "KlimaDAO kontaktieren"
 
 #: components/pages/About/Contact/index.tsx:105
 msgid "contact.media"
-msgstr ""
+msgstr "Medien"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:108
 msgid "contact.media.if_you_are_a_journalist"
-msgstr ""
+msgstr "Journalist/in oder Contentcreator? Unser Marketingteam würde dich gerne kennenlernen!"
 
 #. Use this <0>Media Request Form</0>.
 #: components/pages/About/Contact/index.tsx:117
 msgid "contact.media.use_this_media_request_form"
-msgstr ""
+msgstr "Nutze dieses <0>Medienanfrageformular</0> oder sende eine E-Mail an <1>press@klimadao.finance</1>"
 
 #: components/pages/About/Contact/index.tsx:85
 msgid "contact.partnerships"
-msgstr ""
+msgstr "Partnerschaften"
 
 #. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
 #: components/pages/About/Contact/index.tsx:88
 msgid "contact.partnerships.until_we_finish_building"
-msgstr ""
+msgstr "Bis der Aufbau der Partnerschaftenseite abgeschlossen ist, leiten wir potenzielle Partner und Kooperationsanfragen an <0>dieses Kontaktformular</0> weiter."
 
 #: components/pages/About/Contact/index.tsx:35
 msgid "contact.quest_and_support"
-msgstr ""
+msgstr "Fragen & Support"
 
 #. Join our <0>community</0>
 #: components/pages/About/Contact/index.tsx:38
 msgid "contact.quest_and_support.join_our_community"
-msgstr ""
+msgstr "Unserer <0>Community</0> beitreten"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:46
 msgid "contact.quest_and_support.join_our_discord_server"
-msgstr ""
+msgstr "Trete unserem Discord-Server bei und stelle Fragen im #questions-Kanal. Bei uns findest du tausende freundliche, sachkundige Communitymitglieder, die dir gerne helfen werden."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:64
 msgid "disclaimer.1_an_offer_or_sollicitation"
-msgstr ""
+msgstr "1. Ein Angebot oder die Aufforderung zur Abgabe eines Angebots, um Wertpapiere, andere Vermögenswerte oder Dienstleistungen zu halten oder zu kontrollieren, die mit immateriellen Vorteilen verbunden sind;"
 
 #: components/pages/About/Disclaimer/index.tsx:111
 msgid "disclaimer.1_meet_your_requirements"
-msgstr ""
+msgstr "1. Ihren Anforderungen entspricht;"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:116
 msgid "disclaimer.2_be_available_on_an_uninterrupted"
-msgstr ""
+msgstr "2. Rund um die Uhr, fehlerfrei und zu 100 % sicher ist;"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:74
 msgid "disclaimer.2_financial_investment_or_trading_advice"
-msgstr ""
+msgstr "2. Finanz-, Anlage- oder Handelsberatung oder ein Angebot zur Erbringung einer solchen Beratung und/oder Dienstleistung."
 
 #: components/pages/About/Disclaimer/index.tsx:125
 msgid "disclaimer.3_be_reliable_complete_legal_or_safe"
-msgstr ""
+msgstr "3. Zuverlässig, vollständig und rechtssicher ist."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:32
 msgid "disclaimer.all_information_on_this_website"
-msgstr ""
+msgstr "Alle Informationen auf dieser Website werden nach bestem Wissen und Gewissen und nur zu allgemeinen Informationszwecken veröffentlicht."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:159
 msgid "disclaimer.any_action_you_take_upon_the_information"
-msgstr ""
+msgstr "Alle Maßnahmen, die Sie aufgrund der Informationen auf dieser Website ergreifen, erfolgen ausschließlich auf Ihr eigenes Risiko. Entscheidungen auf der Grundlage der auf dieser Website enthaltenen Informationen liegen in der alleinigen Verantwortung des Besuchers. KlimaDAO haftet nicht für Verluste und/oder Schäden im Zusammenhang mit der Nutzung der Website, dem Verlust Ihres Passworts/Ihrer Seed-Phrase, einem schlechten Handelsgeschäft, dem Senden eines Vermögenswertes an die falsche Adresse, dem Verlust Ihres Vermögens und durch Betrüger verursachte Schäden. KlimaDAO kann keine Verantwortung oder Haftung im Zusammenhang mit Marktveränderungen und deren Volatilität übernehmen. Sie müssen Ihre eigene Recherche durchführen und sich Ihrer eigenen Situation, Vertrautheit und Kenntnis der von dieser Plattform bereitgestellten Informationen oder Dienstleistungen gewiss sein."
 
 #: components/pages/About/Disclaimer/index.tsx:19
 msgid "disclaimer.disclaimer"
-msgstr ""
+msgstr "Haftungsausschluss"
 
 #: components/pages/About/Disclaimer/index.tsx:21
 msgid "disclaimer.head.description"
-msgstr ""
+msgstr "Wichtiger Haftungsausschluss von KlimaDAOs Rechtsabteilung."
 
 #: components/pages/About/Disclaimer/index.tsx:15
 #: components/pages/About/Disclaimer/index.tsx:25
 msgid "disclaimer.head.title"
-msgstr ""
+msgstr "KlimaDAO-Haftungsausschluss"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:102
 msgid "disclaimer.klimadao_and_its_suppliers"
-msgstr ""
+msgstr "KlimaDAO und seine Lieferanten geben keine Garantie ab, dass die Plattform:"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:43
 msgid "disclaimer.klimadao_is_a_platform"
-msgstr ""
+msgstr "KlimaDAO ist eine Plattform. Wir sind kein Makler, Finanzinstitut oder Kreditgeber. Die Dienstleistungen auf dieser Webseite beinhalten keine Angebote, die Ihre Wertpapiere, Optionen, Vermögenswerte, Terminkontrakte oder andere Derivate im Zusammenhang mit Wertpapieren in jeglichem rechtlichem Zuständigkeitsbereich halten oder kontrollieren. Der Webseiteninhalt ist nicht durch Wertpapiergesetze vorgeschrieben."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:130
 msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
-msgstr ""
+msgstr "Weder KlimaDAO noch seine Vertreter haften für Verluste jeglicher Art aus Handlungen, die im Vertrauen auf Materialien oder Informationen, die in dem Dienst enthalten sind, unternommen werden oder wurden. KlimaDAO macht die Nutzung des Dienstes und der Inhalte sicher, erklärt oder garantiert jedoch nicht, dass der Dienst und die Inhalte auf unserer Plattform frei von Viren oder anderen schädlichen Komponenten sind."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:178
 msgid "disclaimer.nothing_in_this_disclaimer"
-msgstr ""
+msgstr "Nichts in diesem Haftungsausschluss, Informationsinhalt oder Material soll oder soll so konstruiert werden, dass es eine Rechtsbeziehung zwischen uns und Ihnen herstellt oder einem von uns Rechte oder Pflichten gewährt."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:56
 msgid "disclaimer.nothing_in_this_platform"
-msgstr ""
+msgstr "Nichts auf dieser Plattform stellt Folgendes dar oder wird so ausgelegt:"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:83
 msgid "disclaimer.the_service_available"
-msgstr ""
+msgstr "Der im Dienst verfügbare oder über den Dienst zugängliche Dienst wird „wie besehen“ und im größtmöglichen Umfang gemäß geltendem Recht bereitgestellt. KlimaDAO und seine Vertreter, Berater, Direktoren, leitenden Angestellten, Mitarbeiter und Anteilseigner lehnen alle ausdrücklichen oder stillschweigenden Garantien ab, einschließlich, aber nicht beschränkt auf stillschweigende Garantien der Marktgängigkeit, Eignung für einen bestimmten Zweck und Nichtverletzung von Rechten sowie Garantien, die sich aus einem Kurs ergeben. KlimaDAO übernimmt keine Gewährleistung für die Vollständigkeit, Zuverlässigkeit und Richtigkeit dieser Informationen, Gewährleistung der Marktgängigkeit oder Eignung für einen bestimmten Zweck. Diese Plattform übernimmt keine Gewährleistung für die Vollständigkeit und Richtigkeit dieser Informationen."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:189
 msgid "disclaimer.we_recommend_that_you_visit"
-msgstr ""
+msgstr "Aus Sicherheitsgründen empfehlen wir dir, unsere allgemeine Krypto-Sicherheitsseite zu besuchen. Denke bitte immer daran: Teile nie deine Private Keys oder deine Seed Phrase mit anderen. Weder unsere Teammitglieder noch unsere App wird jemals nach diesen Daten fragen."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:144
 msgid "disclaimer.you_bear_full_responsibility"
-msgstr ""
+msgstr "Du trägst die volle Verantwortung für die Bereitstellung privater Daten, die Verifizierung der Identität und die Legimität."
 
 #: components/pages/errors/Custom404.tsx:41
 msgid "error.404.page.text"
-msgstr ""
+msgstr "Sorry, wir haben dich wohl in eine Sackgasse geschickt. <0/>Zurück zur Startseite geht es hier lang:"
 
 #: components/pages/errors/Custom500.tsx:39
 msgid "error.500.page.text"
-msgstr ""
+msgstr "Tut uns Leid, irgendwas ist schiefgelaufen.<0/> Kehre hier zur Startseite zurück:"
 
 #: components/pages/errors/Custom500.tsx:34
 msgid "error.500.page.title"
-msgstr ""
+msgstr "500 - Serverseitiger Fehler aufgetreten"
 
 #: components/pages/errors/Custom500.tsx:19
 msgid "error.page.500.head.title"
-msgstr ""
+msgstr "500 - Seite nicht gefunden"
 
 #: components/pages/errors/Custom500.tsx:15
 msgid "error.page.500.title"
-msgstr ""
+msgstr "500 - Seite nicht gefunden"
 
 #: components/pages/Home/index.tsx:236
 msgid "home.backed_by_carbon"
-msgstr ""
+msgstr "Gedeckt durch CO2."
 
 #: components/pages/Home/index.tsx:327
 msgid "home.cars_annual"
-msgstr ""
+msgstr "Autos (jährlich)"
 
 #: components/pages/Home/index.tsx:296
 msgid "home.equivalent_to"
-msgstr ""
+msgstr "ENTSPRICHT"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:411
 msgid "home.every_klima_token_is_backed"
-msgstr ""
+msgstr "Jedes KLIMA-Token ist von einem echten CO2-Zertifikat gedeckt. Diese Tokens werden genutzt, um CO2-Emissionen auszugleichen, mit DeFi-Applikationen zu interagieren und Zugang zum rasant wachsenden weltweiten CO2-Markt zu erhalten."
 
 #: components/SocialProof/index.tsx:19
 msgid "home.featured_on"
-msgstr ""
+msgstr "KlimaDAO in den Medien"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:107
 msgid "home.fight_climate_change"
-msgstr ""
+msgstr "Bekämpfe den Klimawandel und erhalte Belohnungen durch KLIMA: eine digitale, durch reale CO2-Zertifikate gedeckte Währung."
 
 #: components/pages/Home/index.tsx:462
 msgid "home.get_exposure_to_the_growing_carbon_economy"
-msgstr ""
+msgstr "Steige jetzt in die wachsende CO2-Wirtschaft ein. Kaufe, stake, und werde belohnt. Finanzieller Aktivismus für unseren Planeten."
 
 #: components/pages/Home/index.tsx:459
 msgid "home.get_klima"
-msgstr ""
+msgstr "KLIMA KAUFEN"
 
 #: components/pages/Home/index.tsx:310
 msgid "home.hectares_of_forest"
-msgstr ""
+msgstr "Hektar Wald"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:154
 msgid "home.klima_defies_climate_change"
-msgstr ""
+msgstr "KlimaDAO ist DeFi gegen den Klimawandel"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:164
 msgid "home.klima_is_the_center"
-msgstr ""
+msgstr "KlimaDAO ist das Zentrum einer neuen grünen Wirtschaft. Dafür nutzen wir das energieeffiziente Polygon-Netzwerk und viele neue Technologien, um Marktfragmentierung zu verringern und Nachhaltigkeitsprojekten schneller finanzielle Mittel bereitzustellen - weltweit."
 
 #. Long sentence
 #: components/pages/Home/index.tsx:440
 msgid "home.klima_tokens_are_minted"
-msgstr ""
+msgstr "KLIMA-Tokens werden ungefähr alle sieben Stunden neu generiert und an aktuelle sKLIMA-Besitzer verteilt. Gemeinsam errichten wir eine neue, nachhaltige Zukunft, während dein KLIMA-Vorrat wächst."
 
 #: components/pages/Home/index.tsx:83
 msgid "home.latest_news"
-msgstr ""
+msgstr "📰 Aktuelle Blog-Posts (Englisch):"
 
 #: components/pages/Home/index.tsx:139
 msgid "home.learn_more"
-msgstr ""
+msgstr "MEHR ERFAHREN"
 
 #: components/pages/Home/index.tsx:342
 msgid "home.liters_if_gasoline"
-msgstr ""
+msgstr "Liter Benzin"
 
 #: components/pages/Home/index.tsx:272
 msgid "home.massive impact"
-msgstr ""
+msgstr "Massive Auswirkung."
 
 #: components/pages/Home/index.tsx:210
 msgid "home.mechanics"
-msgstr ""
+msgstr "MECHANISMUS"
 
 #. <0>{0}% MONTHLY REWARDS</0><1>FOR TOKEN HOLDERS</1>
 #: components/pages/Home/index.tsx:428
 msgid "home.monthly_rewards_for_token_holders"
-msgstr ""
+msgstr "<0>{0} % MONATLICHE BELOHNUNGEN</0><1>FÜR TOKEN-BESITZER</1>"
 
 #: components/pages/Home/index.tsx:491
 msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
-msgstr ""
+msgstr "Alle Neuigkeiten, direkt in deinen Posteingang"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:499
 msgid "home.newletter.get_the_latest_updates"
-msgstr ""
+msgstr "Hole dir die neuesten Updates über KlimaDAO, während wir gemeinsam die Zukunft der CO2-Wirtschaft aufbauen."
 
 #: components/pages/Home/index.tsx:516
 msgid "home.newletter.never_shared_never_spammed"
-msgstr ""
+msgstr "Garantiert spamfrei."
 
 #: components/pages/Home/index.tsx:510
 msgid "home.newletter.sign_up"
-msgstr ""
+msgstr "Anmelden"
 
 #: components/pages/Home/index.tsx:496
 msgid "home.newsletter"
-msgstr ""
+msgstr "Newsletter"
 
 #. <0>Reserve Asset</0><1>Of the carbon economy</1>
 #: components/pages/Home/index.tsx:399
 msgid "home.reserve_asset_of_the_carbon_economy"
-msgstr ""
+msgstr "<0>Die Reservewährung</0><1>der CO2-Wirtschaft</1>"
 
 #: components/pages/Home/index.tsx:469
 msgid "home.see_tutorial"
-msgstr ""
+msgstr "Tutorial ansehen"
 
 #: components/pages/Home/index.tsx:357
 msgid "home.source"
-msgstr ""
+msgstr "Quelle"
 
 #: components/pages/Home/index.tsx:254
 msgid "home.strong_incentives"
-msgstr ""
+msgstr "Überzeugende Anreize."
 
 #. Long sentence
 #: components/pages/Home/index.tsx:213
 msgid "home.the_dao_sell_bonds"
-msgstr ""
+msgstr "Die DAO verkauft Anleihen und verteilt den Gewinn an KLIMA-Besitzer. Jede verkaufte Anleihe wird unserer Schatzkammer hinzugefügt oder verbessert die Liquidität grüner Schlüsselassets. Eine Win-Win-Situation für Mensch und Planet."
 
 #. TONS OF <0>CARBON ABSORBED</0> BY KLIMADAO
 #: components/pages/Home/index.tsx:283
 msgid "home.tons_of_carbon_absorbed_by_klimadao"
-msgstr ""
+msgstr "<0>CO2-TONNEN IM BESITZ</0> VON KLIMADAO"
 
 #. <0>WELCOME TO</0><1>KlimaDAO</1>
 #: components/pages/Home/index.tsx:94
 msgid "home.welcome_to_klimadao"
 msgstr ""
+"<0>WILLKOMMEN BEI</0><1>KlimaDAO</1>\n"
+""
 
 #: components/pages/Infinity/index.tsx:162
 msgid "infinity.affordable_subtitle"
-msgstr ""
+msgstr "Kostengünstig"
 
 #: components/pages/Infinity/index.tsx:157
 msgid "infinity.affordable_title"
-msgstr ""
+msgstr "Echtzeitpreisermittlung, niedrige Transaktionskosten"
 
 #: components/pages/Infinity/index.tsx:418
 msgid "infinity.box_amount_104k"
-msgstr ""
+msgstr "104k"
 
 #: components/pages/Infinity/index.tsx:404
 msgid "infinity.box_amount_11k"
-msgstr ""
+msgstr "11k"
 
 #: components/pages/Infinity/index.tsx:400
 msgid "infinity.box_title"
-msgstr ""
+msgstr "Zuletzt ausgeglichene CO2-Menge"
 
 #: components/pages/Infinity/index.tsx:414
 msgid "infinity.box_title2"
-msgstr ""
+msgstr "CO2-Tonnen insgesamt ausgeglichen"
 
 #: components/pages/Infinity/index.tsx:665
 msgid "infinity.button.read_blog_faq"
-msgstr ""
+msgstr "Ausführliche FAQs für KI-Kunden"
 
 #: components/pages/Infinity/index.tsx:368
 msgid "infinity.button.read_blog_polygon"
-msgstr ""
+msgstr "Mehr zu Polygons Kompensation"
 
 #: components/pages/Infinity/Cards/CardsSlider.tsx:89
 msgid "infinity.cards_slider.title"
-msgstr ""
+msgstr "Dutzende Organisationen haben mit Klima Infinity über 150.000 Tonnen CO2 ausgeglichen"
 
 #: components/pages/Infinity/index.tsx:331
 msgid "infinity.carousel_image_description"
-msgstr ""
+msgstr "Windkraftprojekt in Jaibhim, Indien"
 
 #: components/pages/Infinity/index.tsx:343
 msgid "infinity.carousel_info_subtitle"
-msgstr ""
+msgstr "Fördern Sie die Finanzierung von Projekten, die den Klimaschutz vorantreiben"
 
 #: components/pages/Infinity/index.tsx:338
 msgid "infinity.carousel_info_title"
-msgstr ""
+msgstr "Qualitativ hochwertige Projekte unterstützen"
 
 #: components/pages/Infinity/index.tsx:685
 msgid "infinity.cta_title"
-msgstr ""
+msgstr "Das CO2-Toolkit der nächsten Generation für Ihr Unternehmen."
 
 #: components/pages/Infinity/index.tsx:557
 msgid "infinity.faq_answer1"
-msgstr ""
+msgstr "Ein CO2-Offset repräsentiert die Entfernung des Äquivalents von einer Tonne CO2 (tCO2e) aus der Atmosphäre oder die Vermeidung von einer Tonne Emissionen."
 
 #: components/pages/Infinity/index.tsx:593
 msgid "infinity.faq_answer2_paragraph1"
-msgstr ""
+msgstr "CO2-Credits sind ein Schlüsselmechanismus der CO2-Finanzwirtschaft, um Gelder von Umweltverschmutzern zu Projekten zu leiten, die weltweit dazu beitragen, CO2 in der Atmosphäre zu reduzieren oder zu entfernen. Sie sind ein wichtiges Werkzeug, um aktuell schwer zu vermeidende Emissionen zu bekämpfen, deren Beseitigung noch zu teuer oder technisch zu komplex ist."
 
 #: components/pages/Infinity/index.tsx:603
 msgid "infinity.faq_answer2_paragraph2"
-msgstr ""
+msgstr "Sobald Sie CO2-Credits kaufen, können Sie diese mit Klima Infinity stilllegen und damit für immer aus dem Verkehr ziehen. Durch diese Stilllegung beanspruchen Sie den Umweltvorteil der CO2-Kompensation für sich."
 
 #: components/pages/Infinity/index.tsx:611
 msgid "infinity.faq_answer2_paragraph3"
-msgstr ""
+msgstr "Gekaufte CO2-Credits führen zu messbaren und nachvollziehbaren Emissionsreduktionen an anderer Stelle der Wirtschaft und können dazu genutzt werden, unvermeidbare CO2-Emissionen \"auszugleichen\". Durch den Handel und die Kompensation von CO2-Credits entstehen Marktmechanismen, die ein zuverlässiges Preisschild an CO2 hängen."
 
 #: components/pages/Infinity/index.tsx:648
 msgid "infinity.faq_answer3"
-msgstr ""
+msgstr "Das Ziel der Kohlenstoffmärkte ist die kosteneffiziente Reduktion von Treibhausgasemissionen (\"THG\" oder \"CO2\"), indem Grenzwerte für Emissionen festgelegt und Emissionseinheiten für den Handel freigegeben werden. Dadurch entstehen Finanzinstrumente, die Emissionsreduktionen repräsentieren. Aktiver Handel erlaubt es Projekten, die Emissionen günstig reduzieren können, für diese Arbeit von teureren Emittenten bezahlt zu werden. Dies senkt die wirtschaftlichen Kosten der Emissionsreduzierung."
 
 #: components/pages/Infinity/index.tsx:543
 msgid "infinity.faq_question1"
-msgstr ""
+msgstr "1. Was ist ein CO2-Offset?"
 
 #: components/pages/Infinity/index.tsx:577
 msgid "infinity.faq_question2"
-msgstr ""
+msgstr "2. Wie helfen Offsets dabei, den Klimawandel zu bekämpfen?"
 
 #: components/pages/Infinity/index.tsx:634
 msgid "infinity.faq_question3"
-msgstr ""
+msgstr "3. Was sind Kohlenstoffmärkte?"
 
 #: components/pages/Infinity/index.tsx:137
 msgid "infinity.fast_subtitle"
-msgstr ""
+msgstr "CO2-Ausgleich in Sekunden - ohne Papierkram"
 
 #: components/pages/Infinity/index.tsx:142
 msgid "infinity.fast_title"
-msgstr ""
+msgstr "Schnell"
 
 #: components/pages/Infinity/GetStartedModal.tsx:47
 msgid "infinity.getStartedModal_business"
-msgstr ""
+msgstr "Ich bin ein <0/>Unternehmen."
 
 #: components/pages/Infinity/GetStartedModal.tsx:70
 msgid "infinity.getStartedModal_individual"
-msgstr ""
+msgstr "Ich bin eine <0/>Privatperson."
 
 #: components/pages/Infinity/GetStartedModal.tsx:104
 msgid "infinity.getStartedModal_needAssistance"
-msgstr ""
+msgstr "Ich benötige Unterstützung, um den CO2-Fußabdruck meines Unternehmens zu berechnen."
 
 #: components/pages/Infinity/GetStartedModal.tsx:94
 msgid "infinity.getStartedModal_offsetCrypto"
-msgstr ""
+msgstr "Ich will<0/>Kryptoaktivitäten kompensieren."
 
 #: components/pages/Infinity/index.tsx:258
 msgid "infinity.getStarted_1"
-msgstr ""
+msgstr "1"
 
 #: components/pages/Infinity/index.tsx:272
 msgid "infinity.getStarted_2"
-msgstr ""
+msgstr "2"
 
 #: components/pages/Infinity/index.tsx:261
 msgid "infinity.getStarted_calculate"
-msgstr ""
+msgstr "Berechnen"
 
 #: components/pages/Infinity/index.tsx:264
 msgid "infinity.getStarted_calculate_subtitle"
-msgstr ""
+msgstr "Berechnen Sie den CO2-Fußabdruck Ihres Unternehmens und definieren Sie den Scope Ihrer Kompensation mit Klima Infinity."
 
 #: components/pages/Infinity/index.tsx:301
 msgid "infinity.getStarted_cta"
-msgstr ""
+msgstr "Beschleunigen Sie Ihren Weg zur CO2-Neutralität - und darüber hinaus"
 
 #: components/pages/Infinity/index.tsx:278
 msgid "infinity.getStarted_second_subtitle"
-msgstr ""
+msgstr "Implementieren Sie Ihre Kompensation mit nur wenigen Klicks und fast in Echtzeit."
 
 #: components/pages/Infinity/index.tsx:275
 msgid "infinity.getStarted_second_title"
-msgstr ""
+msgstr "Umsetzen"
 
 #: components/pages/Infinity/index.tsx:286
 msgid "infinity.getStarted_third"
-msgstr ""
+msgstr "3"
 
 #: components/pages/Infinity/index.tsx:292
 msgid "infinity.getStarted_third_subtitle"
-msgstr ""
+msgstr "Behalten Sie Ihr Engagement im Blick und machen Sie Ihr klimapositives Handeln besser sichtbar."
 
 #: components/pages/Infinity/index.tsx:289
 msgid "infinity.getStarted_third_title"
-msgstr ""
+msgstr "Sichtbar machen"
 
 #: components/pages/Infinity/index.tsx:67
 msgid "infinity.head.metaDescription"
-msgstr ""
+msgstr "Das CO2-Toolkit der nächsten Generation für Ihr Unternehmen."
 
 #: components/pages/Infinity/index.tsx:63
 msgid "infinity.head.metaTitle"
-msgstr ""
+msgstr "Klima Infinity - Werden Sie CO2-neutral"
 
 #: components/pages/Infinity/index.tsx:59
 msgid "infinity.head.title"
-msgstr ""
+msgstr "KlimaDAO | Klima Infinity"
 
 #: components/pages/Infinity/index.tsx:178
 msgid "infinity.info_subtitle1"
-msgstr ""
+msgstr "Für die fortschrittlichsten Organisationen der Welt"
 
 #: components/pages/Infinity/index.tsx:183
 msgid "infinity.info_subtitle2"
-msgstr ""
+msgstr "Die weltweit einfachste und leistungsstärkste Lösung für CO2-Kompensation"
 
 #: components/pages/Infinity/index.tsx:450
 msgid "infinity.mission_card1_subtitle"
-msgstr ""
+msgstr "CO2-Tonnen im Besitz von KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:447
 msgid "infinity.mission_card1_title"
-msgstr ""
+msgstr "18,1 Mio."
 
 #: components/pages/Infinity/index.tsx:472
 msgid "infinity.mission_card2_description"
-msgstr ""
+msgstr "CO2-Liquidität im Besitz von KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:469
 msgid "infinity.mission_card2_number"
-msgstr ""
+msgstr "10 Mio.+ USD"
 
 #: components/pages/Infinity/index.tsx:494
 msgid "infinity.mission_card3_description"
-msgstr ""
+msgstr "CO2-Tonnen ausgeglichen via KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:491
 msgid "infinity.mission_card3_number"
-msgstr ""
+msgstr "150.000+"
 
 #: components/pages/Infinity/index.tsx:387
 msgid "infinity.polygon_manifesto_description"
-msgstr ""
+msgstr "Indem Polygon ihre gesamten historischen Emissionen kompensierten, glich das Netzwerk ausnahmslos jede Interaktion aus - von der NFT-Erstellung bis zu DeFi-Transaktionen. Dies ist einer der Hauptgründe, weshalb Meta sich für die Herausgabe ihrer NFTs für Polygon entschieden hat."
 
 #: components/pages/Infinity/index.tsx:381
 msgid "infinity.polygon_manifesto_title"
-msgstr ""
+msgstr "Dieser Ausgleich ist Teil von Polygons Grünem Manifest"
 
 #: components/pages/Infinity/index.tsx:361
 msgid "infinity.polygon_story_description"
-msgstr ""
+msgstr "Polygon hat alle CO2-Emissionen seit Gründung des Netzwerkes kompensiert - etwa 90.000 Tonnen - und sich dazu verpflichtet, alle zukünftigen Transaktionen des Netzwerkes klimapositiv zu gestalten."
 
 #: components/pages/Infinity/index.tsx:356
 msgid "infinity.polygon_story_title"
-msgstr ""
+msgstr "Polygon nutzt Klima Infinity, um ihre Blockchain CO2-neutral zu machen"
 
 #: components/pages/Infinity/Cards/Card.tsx:66
 #: components/pages/Infinity/index.tsx:407
@@ -997,158 +999,158 @@ msgstr "Tonnen"
 
 #: components/pages/Infinity/index.tsx:196
 msgid "infinity.transparent_subtitle"
-msgstr ""
+msgstr "Transparent"
 
 #: components/pages/Infinity/index.tsx:191
 msgid "infinity.transparent_title"
-msgstr ""
+msgstr "Für immer in die Blockchain eingetragen"
 
 #: components/pages/Infinity/index.tsx:98
 msgid "infinity.welcome_subtitle"
-msgstr ""
+msgstr "Klima Infinity ist ein CO2-Toolkit der nächsten Generation für Ihr Unternehmen."
 
 #: components/pages/Infinity/index.tsx:93
 msgid "infinity.welcome_title"
-msgstr ""
+msgstr "Der einfachste Weg, CO2-neutral zu werden"
 
 #: components/pages/Infinity/index.tsx:224
 msgid "infinity.why_description"
-msgstr ""
+msgstr "KlimaDAO nutzt wegweisende DeFi-Technologien, um Marktfragmentierung zu reduzieren und die Bereitstellung eines klimazentrierten Finanzwesens für Nachhaltigkeitsprojekte weltweit zu beschleunigen."
 
 #: components/pages/Infinity/index.tsx:219
 msgid "infinity.why_subtitle"
-msgstr ""
+msgstr "DeFi gegen den Klimawandel"
 
 #: components/pages/Infinity/index.tsx:216
 msgid "infinity.why_title"
-msgstr ""
+msgstr "Warum KlimaDAO?"
 
 #: components/pages/Home/index.tsx:384
 msgid "invest_in_the_future"
-msgstr ""
+msgstr "Investiere in die Zukunft."
 
 #: components/pages/Infinity/index.tsx:439
 msgid "mission.header"
-msgstr ""
+msgstr "KlimaDAOs Mission ist die Demokratisierung des Klimaschutzes"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:79
 #: components/pages/Pledge/PledgeForm/index.tsx:83
 #: components/pages/Pledge/PledgeForm/index.tsx:99
 msgid "pledge.errors.default"
-msgstr ""
+msgstr "Ein Fehler ist aufgetreten"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:91
 msgid "pledge.errors.method_not_allowed"
-msgstr ""
+msgstr "Methode nicht erlaubt."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:75
 msgid "pledge.errors.pledge_not_found"
-msgstr ""
+msgstr "Unter dieser Adresse konnte kein Pledge gefunden werden."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:87
 msgid "pledge.errors.unknown_error"
-msgstr ""
+msgstr "Ein unbekannter Fehler ist aufgetreten."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:191
 msgid "pledge.form.error.cannot_add_yourself"
-msgstr ""
+msgstr "Sie können Ihre eigene Wallet nicht als sekundäre Wallet hinzufügen"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:227
 msgid "pledge.form.error.default_error_message"
-msgstr ""
+msgstr "Etwas ist schiefgelaufen. Bitte versuche es erneut."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:175
 msgid "pledge.form.error.duplicate_wallets"
-msgstr ""
+msgstr "Bitte entfernen Sie die doppelte(n) Wallet(s)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:616
 msgid "pledge.form.wallets.confirm_remove_wallet"
-msgstr ""
+msgstr "Sind Sie sicher, dass Sie {0} von Ihrem Pledge entfernen möchten?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:340
 msgid "pledge.form.wallets.tooltip"
-msgstr ""
+msgstr "Andere Wallets zu Ihrem Pledge hinzufügen. Falls der Besitzer der Wallet Ihre Einladung annimmt, wird deren Wallet auf Ihrem Pledge Dashboard erscheinen. Alle durch diese sekundäre Wallet getätigten CO2-Ausgleiche werden zu Ihrem Pledge beitragen. Sie bleiben Eigentümer und behalten Bearbeitungszugriff für diesen Pledge."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:41
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:111
 msgid "pledge.invitation.accept"
-msgstr ""
+msgstr "Einladung annehmen"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:70
 msgid "pledge.invitation.error.wallet_already_pinned"
-msgstr ""
+msgstr "Diese Wallet ist bereits mit einem anderen Pledge verknüpft. Entfernen Sie die Verknüpfung und versuchen Sie es noch einmal."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:49
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:44
 msgid "pledge.invitation.error_title"
-msgstr ""
+msgstr "Serverfehler"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:102
 msgid "pledge.invitation.join_message"
-msgstr ""
+msgstr "{shortenedAddress} hat Sie eingeladen, Ihre Wallet zu diesem Pledge hinzuzufügen. Ihre zukünftigen CO2-Ausgleiche werden zum Pledge von {shortenedAddress} hinzugefügt, falls Sie annehmen. Sie können Ihre Wallet jederzeit von diesem Pledge lösen."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:130
 msgid "pledge.invitation.later"
-msgstr ""
+msgstr "Erinnere mich später"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:118
 msgid "pledge.invitation.reject"
-msgstr ""
+msgstr "Einladung ablehnen"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:57
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:52
 msgid "pledge.invitation.signing"
-msgstr ""
+msgstr "Unterschreibe"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:193
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:179
 msgid "pledge.invitations.awaiting_signature"
-msgstr ""
+msgstr "Warte auf Unterschrift..."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:199
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:185
 msgid "pledge.invitations.signature_instructions"
-msgstr ""
+msgstr "Nutzen Sie Ihre Wallet, um diese Änderung zu unterschreiben und zu bestätigen."
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:129
 msgid "pledge.modal.are_you_sure"
-msgstr ""
+msgstr "Sind Sie sicher, dass Sie Ihre Wallet von diesem Pledge lösen möchten?"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:153
 msgid "pledge.modal.confirm"
-msgstr ""
+msgstr "Bestätigen"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:40
 msgid "pledge.modal.confirm_remove"
-msgstr ""
+msgstr "Entfernen bestätigen"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:39
 msgid "pledge.modal.edit_pledge"
-msgstr ""
+msgstr "Pledge bearbeiten"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:101
 msgid "pledge.modal.unable_to_edit"
-msgstr ""
+msgstr "Diese Wallet hat keine Berechtigung, diesen Pledge zu bearbeiten. Zur Bearbeitung müssen Sie sich mit der originalen Wallet ({0}) verbinden."
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:110
 msgid "pledge.modal.unpin_wallet"
-msgstr ""
+msgstr "meine wallet lösen"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:144
 msgid "pledge.modal.wallet_add_confirm"
-msgstr ""
+msgstr "Sie können nur eine Pledge-Seite pro Walletadresse haben. Sollten Sie bereits einen Pledge mit dieser Wallet erstellt haben, werden Besucher stattdessen zu dieser Pledge-Seite weitergeleitet. Sie können diese Wallet jederzeit entfernen."
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:110
 msgid "pledges.dashboard.assets.emptyBalance"
-msgstr ""
+msgstr "Keine CO2-Assets zum Anzeigen."
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:87
 msgid "pledges.dashboard.assets.title"
-msgstr ""
+msgstr "CO2-Assets"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
 msgid "pledges.dashboard.footprint.title"
-msgstr ""
+msgstr "Fußabdruck"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
 msgid "pledges.dashboard.footprint.tonnes"
@@ -1156,27 +1158,29 @@ msgstr "Tonnen"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:104
 msgid "pledges.dashboard.footprint.tooltip.category_percent"
-msgstr ""
+msgstr "{0}% des Fußabdrucks"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:110
 msgid "pledges.dashboard.footprint.tooltip.quantity"
-msgstr ""
+msgstr "{0} Tonnen CO2"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:137
 msgid "pledges.dashboard.head.metaDescription"
-msgstr ""
+msgstr "{pledgeOwnerTitle} verspricht, {currentTotalFootprint} Tonnen CO2 auszugleichen. Sehen Sie sich ihren Ausgleichsverlauf an und lesen Sie mehr über ihr Engagement."
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:133
 msgid "pledges.dashboard.head.metaTitle"
-msgstr ""
+msgstr "{pledgeOwnerTitle}'s Pledge"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:129
 msgid "pledges.dashboard.head.title"
 msgstr ""
+"{pledgeOwnerTitle}s Pledge | KlimaDAO\n"
+""
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:14
 msgid "pledges.dashboard.metholodogy.default_text"
-msgstr ""
+msgstr "Wie werden Sie Ihr Versprechen einlösen?"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:21
 msgid "pledges.dashboard.metholodogy.title"
@@ -1184,139 +1188,139 @@ msgstr "Methodik"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:14
 msgid "pledges.dashboard.pledge.default_text"
-msgstr ""
+msgstr "Schreiben Sie heute Ihr eigenes Versprechen!"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:21
 msgid "pledges.dashboard.pledge.title"
-msgstr ""
+msgstr "Versprechen"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:64
 msgid "pledges.dashboard.profile.pledge_met"
-msgstr ""
+msgstr "≥ 100 % des Versprechens erfüllt"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:73
 msgid "pledges.dashboard.profile.pledge_progress"
-msgstr ""
+msgstr "{0}% des Versprechens erfüllt"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:106
 msgid "pledges.dashboard.profile.pledged_to_offset"
-msgstr ""
+msgstr "Ausgleich von <0>{0}</0> Tonnen CO2 zugesichert"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:104
 msgid "pledges.dashboard.retirements.title"
-msgstr ""
+msgstr "CO2-Ausgleiche"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
 msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
-msgstr ""
+msgstr "{0} Tonnen CO2 ausgeglichen"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:123
 msgid "pledges.dashboard.retirements.total_tonnes_retired"
-msgstr ""
+msgstr "CO2-Tonnen insgesamt ausgeglichen"
 
 #: components/pages/Pledge/HeaderDesktop/index.tsx:37
 msgid "pledges.edit_pledge"
-msgstr ""
+msgstr "Versprechen bearbeiten"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:562
 msgid "pledges.form.add_footprint_category_button"
-msgstr ""
+msgstr "Kategorie hinzufügen"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:446
 msgid "pledges.form.add_wallet_button"
-msgstr ""
+msgstr "Wallet hinzufügen"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:242
 msgid "pledges.form.awaiting_signature"
-msgstr ""
+msgstr "Warte auf Unterschrift..."
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:197
 msgid "pledges.form.confirm_delete"
-msgstr ""
+msgstr "entfernen bestätigen"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:622
 msgid "pledges.form.confirm_remove"
-msgstr ""
+msgstr "entfernen"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:635
 msgid "pledges.form.confirm_remove_cancel"
-msgstr ""
+msgstr "abbrechen"
 
 #: components/pages/Pledge/index.tsx:212
 msgid "pledges.form.error"
-msgstr ""
+msgstr "Gib eine Walletaddresse oder eine .klima- oder .eth-Domain ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:74
 msgid "pledges.form.errors.categoryName.max"
-msgstr ""
+msgstr "Geben Sie weniger als 32 Zeichen ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:70
 msgid "pledges.form.errors.categoryName.required"
-msgstr ""
+msgstr "Geben Sie eine Kategorie an"
 
 #: components/pages/Pledge/lib/formSchema.ts:78
 msgid "pledges.form.errors.categoryQuantity.min"
-msgstr ""
+msgstr "Geben Sie einen Wert größer als 0 ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:50
 msgid "pledges.form.errors.description.max"
-msgstr ""
+msgstr "Geben Sie weniger als 500 Zeichen ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:46
 msgid "pledges.form.errors.description.required"
-msgstr ""
+msgstr "Geben Sie ein Versprechen an"
 
 #: components/pages/Pledge/lib/formSchema.ts:62
 msgid "pledges.form.errors.footprint.generic_error"
-msgstr ""
+msgstr "Geben Sie eine Schätzung an (in CO2-Tonnen)"
 
 #: components/pages/Pledge/lib/formSchema.ts:66
 msgid "pledges.form.errors.footprint.min"
-msgstr ""
+msgstr "Geben Sie einen Wert größer als 0 ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:58
 msgid "pledges.form.errors.methodology.max"
-msgstr ""
+msgstr "Geben Sie weniger als 1.000 Zeichen ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:54
 msgid "pledges.form.errors.methodology.required"
-msgstr ""
+msgstr "Geben Sie eine Methodik an"
 
 #: components/pages/Pledge/lib/formSchema.ts:34
 msgid "pledges.form.errors.name.required"
-msgstr ""
+msgstr "Geben Sie einen Namen ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:38
 msgid "pledges.form.errors.profileImageUrl.url"
-msgstr ""
+msgstr "Geben Sie eine gültige URL ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:42
 msgid "pledges.form.errors.profileWebsiteUrl.url"
-msgstr ""
+msgstr "Geben Sie eine gültige URL ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:86
 msgid "pledges.form.errors.walletAddress.isAddress"
-msgstr ""
+msgstr "Bitte geben Sie eine gültige Adresse ein"
 
 #: components/pages/Pledge/lib/formSchema.ts:90
 msgid "pledges.form.errors.walletAddress.isOwner"
-msgstr ""
+msgstr "Sie können den Eigentümer des Pledges nicht hinzufügen"
 
 #: components/pages/Pledge/lib/formSchema.ts:82
 msgid "pledges.form.errors.walletAddress.required"
-msgstr ""
+msgstr "Adresse erforderlich"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:489
 msgid "pledges.form.footprint.label"
-msgstr ""
+msgstr "Fußabdruck"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:497
 msgid "pledges.form.footprint.prompt"
-msgstr ""
+msgstr "Fügen Sie eine Kategorie hinzu und berechnen Sie Ihren CO2-Fußabdruck"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:260
 msgid "pledges.form.generic_error"
-msgstr ""
+msgstr "Etwas ist schiefgelaufen. Bitte versuche es erneut."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:518
 msgid "pledges.form.input.categoryName.label"
@@ -1324,23 +1328,23 @@ msgstr "Kategorie"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:510
 msgid "pledges.form.input.categoryName.placeholder"
-msgstr ""
+msgstr "Kategoriename"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:538
 msgid "pledges.form.input.categoryQuantity.label"
-msgstr ""
+msgstr "Menge"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:530
 msgid "pledges.form.input.categoryQuantity.placeholder"
-msgstr ""
+msgstr "CO2-Tonnen"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:323
 msgid "pledges.form.input.description.label"
-msgstr ""
+msgstr "Versprechen"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:316
 msgid "pledges.form.input.description.placeholder"
-msgstr ""
+msgstr "Was ist Ihr Versprechen?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:476
 msgid "pledges.form.input.methodology.label"
@@ -1348,67 +1352,67 @@ msgstr "Methodik"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:468
 msgid "pledges.form.input.methodology.placeholder"
-msgstr ""
+msgstr "Mit welchen Tools oder Methoden haben Sie Ihren CO2-Fußabdruck berechnet?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:280
 msgid "pledges.form.input.name.label"
-msgstr ""
+msgstr "Name"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:273
 msgid "pledges.form.input.name.placeholder"
-msgstr ""
+msgstr "Name oder Firmenname"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:291
 msgid "pledges.form.input.profileImageUrl.label"
-msgstr ""
+msgstr "Profilbild-URL (optional)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:305
 msgid "pledges.form.input.profileWebsiteUrl.label"
-msgstr ""
+msgstr "Webseite (optional)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:579
 msgid "pledges.form.input.totalFootprint.label"
-msgstr ""
+msgstr "Gesamtfußabdruck"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:380
 msgid "pledges.form.input.walletAddress.label"
-msgstr ""
+msgstr "Adresse"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:372
 msgid "pledges.form.input.walletAddress.placeholder"
-msgstr ""
+msgstr "0x..."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:595
 msgid "pledges.form.submit_button"
-msgstr ""
+msgstr "Versprechen speichern"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:193
 msgid "pledges.form.title"
-msgstr ""
+msgstr "Dein Pledge"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:52
 msgid "pledges.form.total_footprint_summary"
-msgstr ""
+msgstr "Gesamtfußabdruck: {0} Tonnen CO2"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:607
 msgid "pledges.form.use_your_wallet"
-msgstr ""
+msgstr "Nutzen Sie Ihre Wallet, um diese Änderung zu unterschreiben und zu bestätigen."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:332
 msgid "pledges.form.wallets.label"
-msgstr ""
+msgstr "Sekundäre Wallet(s)"
 
 #: components/pages/Pledge/index.tsx:94
 msgid "pledges.head.metaDescription"
-msgstr ""
+msgstr "Zeigen Sie, dass Sie Klimapositivität ernst meinen, indem Sie Ihr Pledge Dashboard nutzen, um Ihren CO2-Ausgleich sichtbar zu machen"
 
 #: components/pages/Pledge/index.tsx:90
 msgid "pledges.head.metaTitle"
-msgstr ""
+msgstr "Geben Sie eine CO2-Ausgleichszusicherung ab und zeigen Sie deren Wirkung"
 
 #: components/pages/Pledge/index.tsx:86
 msgid "pledges.head.title"
-msgstr ""
+msgstr "KlimaDAO | Versprechen"
 
 #: components/pages/Pledge/index.tsx:66
 msgid "pledges.home.hero.connecting"
@@ -1416,23 +1420,23 @@ msgstr "Verbinde..."
 
 #: components/pages/Pledge/index.tsx:77
 msgid "pledges.home.hero.create"
-msgstr ""
+msgstr "Zusicherung erstellen"
 
 #: components/pages/Pledge/index.tsx:170
 msgid "pledges.home.hero.learn_more"
-msgstr ""
+msgstr "Mehr erfahren"
 
 #: components/pages/Pledge/index.tsx:72
 msgid "pledges.home.hero.view"
-msgstr ""
+msgstr "Ihren Pledge ansehen"
 
 #: components/pages/Pledge/index.tsx:206
 msgid "pledges.home.search.label"
-msgstr ""
+msgstr "ENS- oder 0x-Adresse"
 
 #: components/pages/Pledge/index.tsx:200
 msgid "pledges.home.search.placeholder"
-msgstr ""
+msgstr "ENS-, KNS- oder 0x-Adresse eingeben"
 
 #: components/pages/Pledge/index.tsx:226
 msgid "pledges.home.search.submit"
@@ -1468,51 +1472,51 @@ msgstr "Auswählen"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:53
 msgid "resources.form.medium.header"
-msgstr ""
+msgstr "Medium"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:41
 msgid "resources.form.sub_topics.header"
-msgstr ""
+msgstr "Unterthemen"
 
 #: components/pages/Resources/index.tsx:31
 msgid "resources.head.metaDescription"
-msgstr ""
+msgstr "Updates und Thought Leadership von den Gründern, DAO-Mitarbeitern, Beratern und der Community."
 
 #: components/pages/Resources/index.tsx:27
 msgid "resources.head.metaTitle"
-msgstr ""
+msgstr "KlimaDAO-Ressourcen - mehr als nur CO2-neutral"
 
 #: components/pages/Resources/index.tsx:23
 msgid "resources.head.title"
-msgstr ""
+msgstr "KlimaDAO | Ressourcen"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:71
 msgid "resources.list.filter.tag.basics"
-msgstr ""
+msgstr "Grundlagen"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:111
 msgid "resources.list.filter.tag.carbon_footprint"
-msgstr ""
+msgstr "CO2-Fußabdruck"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:79
 msgid "resources.list.filter.tag.deep_dives"
-msgstr ""
+msgstr "Vertiefendes Wissen"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:52
 msgid "resources.list.filter.tag.klima_infinity"
-msgstr ""
+msgstr "Klima Infinity"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:44
 msgid "resources.list.filter.tag.klima_overview"
-msgstr ""
+msgstr "Klima-Übersicht"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:60
 msgid "resources.list.filter.tag.partnerships"
-msgstr ""
+msgstr "Partnerschaften"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:103
 msgid "resources.list.filter.tag.policy"
-msgstr ""
+msgstr "Regelwerk"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:95
 msgid "resources.list.filter.tag.press_releases"
@@ -1524,11 +1528,11 @@ msgstr "Nutzerguides"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:121
 msgid "resources.list.filter.type.blog"
-msgstr ""
+msgstr "Blog"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:129
 msgid "resources.list.filter.type.podcast"
-msgstr ""
+msgstr "Podcast"
 
 #: components/pages/Resources/SortyByDropDown/index.tsx:62
 msgid "resources.list.select.sort_by.toggle"
@@ -1560,15 +1564,15 @@ msgstr "Sortieren nach"
 
 #: components/pages/Resources/index.tsx:46
 msgid "resources.page.header.subline"
-msgstr ""
+msgstr "Updates und Thought Leadership von den Gründern, DAO-Mitarbeitern, Beratern und der Community."
 
 #: components/pages/Resources/index.tsx:43
 msgid "resources.page.header.title"
-msgstr ""
+msgstr "Ausgewählte Artikel"
 
 #: components/pages/Resources/ResourcesList/index.tsx:167
 msgid "resources.page.list.header"
-msgstr ""
+msgstr "Alles erkunden"
 
 #: components/pages/Resources/ResourcesList/index.tsx:249
 msgid "resources.page.list.no_search_results.title"
@@ -1588,15 +1592,15 @@ msgstr "Überprüfe deine Suche auf Tippfehler oder versuche es mit einem andere
 
 #: components/pages/Retirements/Footer/index.tsx:18
 msgid "retirement.footer.aboutKlima.left"
-msgstr ""
+msgstr "KlimaDAO fördert Nachhaltigkeit und ist der Initiator für einen transparenteren, liquideren CO2-Markt. Durch unsere Tools können Privatpersonen und Unternehmen jeder Anzahl oder Größe hochwertige CO2-Zertifikate über die Blockchain handeln und ausgleichen."
 
 #: components/pages/Retirements/Footer/index.tsx:28
 msgid "retirement.footer.aboutKlima.right"
-msgstr ""
+msgstr "KLIMA-Tokens stehen im Mittelpunkt der aufkeimenden, blockchainbasierten CO2-Wirtschaft. Mehr über KLIMA, CO2-Offsets und -Märkte und die zugrundeliegenden CO-Zertifikate erfährst du in unserer <0>Wissensdatenbank</0>."
 
 #: components/pages/Retirements/Footer/index.tsx:13
 msgid "retirement.footer.aboutKlima.title"
-msgstr ""
+msgstr "Über Klima"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:37
 msgid "retirement.footer.buy_klima.button.buy"
@@ -1608,135 +1612,135 @@ msgstr "Ausgleichen"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:30
 msgid "retirement.footer.buy_klima.text"
-msgstr ""
+msgstr "Mit CO2-gedeckten KLIMA-Tokens kannst du handeln, Staking-Belohnungen erhalten und mitmachen - und deine Belohnungen nutzen, um deine Emissionen auszugleichen!"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:25
 msgid "retirement.footer.buy_klima.title"
-msgstr ""
+msgstr "Kaufen, staken und belohnt werden."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:122
 msgid "retirement.head.metaDescription"
-msgstr ""
+msgstr "Transparente CO2-Offsets auf der Blockchain durch KlimaDAO."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:118
 msgid "retirement.head.metaTitle"
-msgstr ""
+msgstr "{retiree} hat {formattedAmount} Tonnen CO2 ausgeglichen"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:114
 msgid "retirement.head.title"
-msgstr ""
+msgstr "KlimaDAO | CO2-Ausgleichsquittung"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:266
 msgid "retirement.share.title"
-msgstr ""
+msgstr "Zeigen Sie Ihre Wirkung"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:176
 msgid "retirement.single.beneficiary.placeholder"
-msgstr ""
+msgstr "Keinen Empfängername angegeben"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:170
 msgid "retirement.single.beneficiary.title"
-msgstr ""
+msgstr "Empfänger"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:184
 msgid "retirement.single.beneficiaryAddress.title"
-msgstr ""
+msgstr "Empfängeradresse"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:245
 msgid "retirement.single.create_a_pledge"
-msgstr ""
+msgstr "Jetzt Pledge erstellen."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:231
 msgid "retirement.single.disclaimer"
-msgstr ""
+msgstr "Hier siehst du den bisherigen, permanenten Emissionsausgleich durch tokenisierte CO2-Zertifikate auf der Polygon-Blockchain. Jeder Emissionsausgleich und die damit verbundenen Daten sind unveränderlich und öffentlich einsehbar."
 
 #: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:30
 msgid "retirement.single.download_certificate_button"
-msgstr ""
+msgstr "PFD herunterladen"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:134
 msgid "retirement.single.header.subline"
-msgstr ""
+msgstr "CO2-äquivalente Emissionen ausgeglichen (in Tonnen)"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:241
 msgid "retirement.single.is_this_your_retirement"
-msgstr ""
+msgstr "Ist dies Ihr CO2-Ausgleich?"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
 msgid "retirement.single.message.title"
-msgstr ""
+msgstr "Ausgleichsnachricht"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:30
 msgid "retirement.single.no_pledge"
-msgstr ""
+msgstr "Dieser Nutzen hat keinen Pledge erstellt"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
 msgid "retirement.single.project_details.title"
-msgstr ""
+msgstr "Projektinformationen"
 
 #: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
 msgid "retirement.single.quantity"
-msgstr ""
+msgstr "AUSGEGLICHENE MENGE"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:205
 msgid "retirement.single.retirementCertificate.title"
-msgstr ""
+msgstr "Zertifikat"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:21
 msgid "retirement.single.retirementDate.title"
-msgstr ""
+msgstr "Datum"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:24
 msgid "retirement.single.timestamp.placeholder"
-msgstr ""
+msgstr "Kein Ausgleichszeitpunkt angegeben"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:302
 msgid "retirement.single.view_on_polygon_scan"
-msgstr ""
+msgstr "Auf Polygonscan ansehen"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:18
 msgid "retirement.single.view_pledge"
-msgstr ""
+msgstr "Pledge ansehen"
 
 #: components/pages/Retirements/List/index.tsx:40
 msgid "retirement.totals.all_retirements_list.empty"
-msgstr ""
+msgstr "Keine CO2-Ausgleiche gefunden"
 
 #: components/pages/Retirements/List/index.tsx:24
 msgid "retirement.totals.all_retirements_list.headline"
-msgstr ""
+msgstr "Alle CO2-Ausgleiche"
 
 #: components/pages/Retirements/index.tsx:46
 msgid "retirement.totals.head.metaTitle"
-msgstr ""
+msgstr "KlimaDAO - CO2-Ausgleich für {0}"
 
 #: components/pages/Retirements/index.tsx:40
 msgid "retirement.totals.head.title"
-msgstr ""
+msgstr "KlimaDAO - CO2-Ausgleich für {0}"
 
 #: components/pages/Retirements/index.tsx:65
 msgid "retirement.totals.page_headline"
-msgstr ""
+msgstr "CO2-Ausgleiche"
 
 #: components/pages/Retirements/index.tsx:71
 msgid "retirement.totals.page_subline"
-msgstr ""
+msgstr "für Empfänger"
 
 #: components/pages/Retirements/index.tsx:95
 msgid "retirement.totals.retired_assets"
-msgstr ""
+msgstr "Ausgeglichene Assets"
 
 #: components/pages/Retirements/index.tsx:111
 msgid "retirement.totals.retirements"
-msgstr ""
+msgstr "CO2-Ausgleiche"
 
 #: components/pages/Retirements/index.tsx:103
 msgid "retirement.totals.total_carbon_tonnes"
-msgstr ""
+msgstr "CO2-Tonnen insgesamt ausgeglichen"
 
 #: components/pages/Retirements/index.tsx:117
 msgid "retirement.totals.total_retirement_transactions"
-msgstr ""
+msgstr "Summe der Ausgleichstransaktionen"
 
 #: components/pages/errors/Custom404.tsx:20
 #: components/pages/errors/Custom404.tsx:24
@@ -1753,23 +1757,23 @@ msgstr "Über Klima"
 #: components/Navigation/index.tsx:115
 #: components/Navigation/index.tsx:261
 msgid "shared.app"
-msgstr ""
+msgstr "App"
 
 #: components/Footer/index.tsx:49
 msgid "shared.blog"
-msgstr ""
+msgstr "Blog"
 
 #: components/Footer/index.tsx:43
 #: components/Navigation/index.tsx:133
 #: components/Navigation/index.tsx:278
 msgid "shared.bond"
-msgstr ""
+msgstr "KLIMA bonden"
 
 #: components/Footer/index.tsx:37
 #: components/Navigation/index.tsx:117
 #: components/Navigation/index.tsx:265
 msgid "shared.buy"
-msgstr ""
+msgstr "KLIMA kaufen"
 
 #: components/Navigation/index.tsx:157
 #: components/Navigation/index.tsx:302
@@ -1780,15 +1784,15 @@ msgstr "CO2 kaufen"
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:118
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:147
 msgid "shared.cancel"
-msgstr ""
+msgstr "Abbrechen"
 
 #: components/Navigation/index.tsx:352
 msgid "shared.carbon_dashboard"
-msgstr ""
+msgstr "CO2-Dashboard"
 
 #: components/Navigation/index.tsx:203
 msgid "shared.carbon_dashboards"
-msgstr ""
+msgstr "CO2-Dashboards"
 
 #: components/Navigation/index.tsx:174
 #: components/Navigation/index.tsx:321
@@ -1800,11 +1804,11 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:31
 #: components/pages/About/AboutHeader/index.tsx:61
 msgid "shared.community"
-msgstr ""
+msgstr "Community"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:45
 msgid "shared.confirm"
-msgstr ""
+msgstr "Bestätigen"
 
 #: components/Footer/index.tsx:52
 #: components/Navigation/index.tsx:241
@@ -1816,14 +1820,14 @@ msgstr "Kontakt"
 #: components/pages/Infinity/index.tsx:117
 #: components/pages/Infinity/index.tsx:701
 msgid "shared.contact_sales"
-msgstr ""
+msgstr "Vertrieb kontaktieren"
 
 #: components/Navigation/index.tsx:96
 #: components/pages/About/AboutHeader/index.tsx:40
 #: components/pages/About/Community/index.tsx:129
 #: components/pages/About/Community/index.tsx:374
 msgid "shared.contact_us"
-msgstr ""
+msgstr "Kontaktiere uns"
 
 #: components/Footer/index.tsx:55
 #: components/Navigation/index.tsx:105
@@ -1831,52 +1835,52 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:49
 #: components/pages/About/AboutHeader/index.tsx:73
 msgid "shared.disclaimer"
-msgstr ""
+msgstr "Haftungsausschluss"
 
 #: components/Footer/index.tsx:46
 #: components/Navigation/index.tsx:211
 #: components/Navigation/index.tsx:360
 msgid "shared.docs"
-msgstr ""
+msgstr "Offizielle Dokumentation"
 
 #: components/Navigation/index.tsx:63
 #: components/pages/Home/index.tsx:115
 msgid "shared.enter_app"
-msgstr ""
+msgstr "App öffnen"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:157
 msgid "shared.error"
-msgstr ""
+msgstr "Fehler"
 
 #: components/pages/Infinity/GetStartedModal.tsx:25
 msgid "shared.get_started"
-msgstr ""
+msgstr "Jetzt starten"
 
 #: components/pages/Buy/index.tsx:29
 #: components/pages/Home/index.tsx:69
 #: components/pages/Retirements/index.tsx:52
 #: components/pages/errors/Custom500.tsx:23
 msgid "shared.head.description"
-msgstr ""
+msgstr "Fördere Klimaschutzmaßnahmen und erhalte Belohnungen durch eine CO2-gedeckte, digitale Währung."
 
 #: components/Footer/index.tsx:34
 msgid "shared.home"
-msgstr ""
+msgstr "Home"
 
 #: components/Navigation/index.tsx:194
 #: components/Navigation/index.tsx:343
 msgid "shared.how_to_buy"
-msgstr ""
+msgstr "KLIMA kaufen"
 
 #: components/pages/Infinity/index.tsx:108
 #: components/pages/Infinity/index.tsx:309
 #: components/pages/Infinity/index.tsx:692
 msgid "shared.infinity.get_started"
-msgstr ""
+msgstr "Jetzt starten"
 
 #: components/pages/Home/index.tsx:186
 msgid "shared.infinity_cta"
-msgstr ""
+msgstr "DEFI FÜR ORGANISATIONEN"
 
 #: components/Navigation/index.tsx:165
 #: components/Navigation/index.tsx:310
@@ -1903,12 +1907,12 @@ msgstr "Anmelden / Verbinden"
 
 #: components/pages/Home/index.tsx:193
 msgid "shared.loveletter_cta"
-msgstr ""
+msgstr "DEFI FÜR PRIVATPERSONEN"
 
 #: components/Navigation/index.tsx:179
 #: components/Navigation/index.tsx:325
 msgid "shared.loveletters"
-msgstr ""
+msgstr "Love Letters"
 
 #: components/Navigation/index.tsx:149
 #: components/Navigation/index.tsx:294
@@ -1918,15 +1922,15 @@ msgstr "Ausgleichen"
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:175
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:161
 msgid "shared.okay"
-msgstr ""
+msgstr "Okay"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:421
 msgid "shared.pending"
-msgstr ""
+msgstr "Ausstehend"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:135
 msgid "shared.remove"
-msgstr ""
+msgstr "entfernen"
 
 #: components/Navigation/index.tsx:185
 #: components/Navigation/index.tsx:334
@@ -1947,16 +1951,16 @@ msgstr "Sortieren nach:"
 #: components/Navigation/index.tsx:125
 #: components/Navigation/index.tsx:270
 msgid "shared.stake"
-msgstr ""
+msgstr "Klima staken"
 
 #: components/pages/Infinity/index.tsx:512
 msgid "shared.visit_klimadao_blog"
-msgstr ""
+msgstr "Besuche KlimaDAOs Blog"
 
 #: components/Navigation/index.tsx:141
 #: components/Navigation/index.tsx:286
 msgid "shared.wrap"
-msgstr ""
+msgstr "sKLIMA wrappen"
 
 #: lib/getWeb3ModalStrings.ts:13
 msgid "web3modal.injected.des"
@@ -1980,8 +1984,8 @@ msgstr "Mit Coinbase scannen, um dich zu verbinden"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:62
 msgid "{trimCurrentSupply} Tonnes remaining"
-msgstr ""
+msgstr "{trimCurrentSupply} Verbleibende Tonnen"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:57
 msgid "{trimTotalRetired} Tonnes retired in total"
-msgstr ""
+msgstr "{trimTotalRetired} Tonnen insgesamt ausgeglichen"

--- a/site/locale/es/messages.po
+++ b/site/locale/es/messages.po
@@ -13,35 +13,35 @@ msgstr "Cambiar idioma"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:33
 msgid "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
-msgstr ""
+msgstr "Cada retiro de KlimaDAO está vinculado a un proyecto de compensación verificado. Haga clic para obtener más información sobre el proyecto."
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:68
 msgid "Explore MCO2 on carbon.klimadao.finance"
-msgstr ""
+msgstr "Explore MCO2 en carbon.klimadao.finance"
 
 #: components/pages/Infinity/index.tsx:530
 msgid "Frequently Asked Questions"
-msgstr ""
+msgstr "Preguntas frecuentes"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:47
 msgid "Location: {0}"
-msgstr ""
+msgstr "Ubicación: {0}"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:50
 msgid "MCO2 Token"
-msgstr ""
+msgstr "Token MCO2"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:52
 msgid "Methodology: {0}"
-msgstr ""
+msgstr "Metodología: {0}"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:23
 msgid "No retirement message provided."
-msgstr ""
+msgstr "No se proporcionó ningún mensaje de retiro."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:146
 msgid "Processing data..."
-msgstr ""
+msgstr "Procesando datos..."
 
 #: components/InvalidNetworkModal/index.tsx:80
 msgid "Switch to Polygon"
@@ -53,11 +53,11 @@ msgstr "Esta aplicación sólo funciona en Polygon Mainnet."
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:74
 msgid "View on Polygonscan"
-msgstr ""
+msgstr "Ver en Polygonscan"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:150
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
-msgstr ""
+msgstr "No hemos terminado de procesar los datos de la blockchain para esta retirada. Esto suele tardar unos segundos, pero podría tardar más si la red está congestionada."
 
 #: components/InvalidNetworkModal/index.tsx:65
 msgid "Wrong Network"
@@ -76,39 +76,42 @@ msgstr "Aviso legal:"
 
 #: components/pages/Buy/index.tsx:433
 msgid "buy.answer_exchange"
-msgstr ""
+msgstr "Los usuarios avanzados pueden utilizar el <0>Polygon Bridge</0> para mover cualquier activo de Ethereum a Polygon, y/o el <1>Polygon Gas Swap</1> para intercambiar activos como USDC por MATIC."
 
 #: components/pages/Buy/index.tsx:390
 msgid "buy.bond_answer_cedit_card"
-msgstr ""
+msgstr "Sí, algunos proveedores de servicios on-ramp como <0>Transak</0> te permiten comprar KLIMA directamente con tarjeta de crédito, previo pago de una comisión. Sin embargo, si su monedero no tiene MATIC, no podrá transferir ni realizar otras acciones. Por esta razón, y para garantizar la mejor tasa del mercado, recomendamos comprar MATIC directamente en su lugar, y cambiar su MATIC por KLIMA en Sushi.com."
 
 #: components/pages/Buy/index.tsx:408
 msgid "buy.bond_answer_cex1"
-msgstr ""
+msgstr "KLIMA no se negocia en una bolsa centralizada como Coinbase, Binance o Crypto.com, ya que estas bolsas suelen cobrar comisiones de cotización muy elevadas y requieren la financiación de costosos creadores de mercado."
 
 #: components/pages/Buy/index.tsx:416
 msgid "buy.bond_answer_cex2"
 msgstr ""
+"En su lugar, los tokens KLIMA se negocian en una \"bolsa descentralizada\" (DEX) que funciona con contratos inteligentes y se ejecuta directamente en el blockchain. Los DEX tienen algunas ventajas importantes. Los DEX hacen posible que la DAO posea la mayor parte de la liquidez, por lo que puede mantener plena autonomía y generar ingresos para pagar a los contribuyentes. Elegimos utilizar la tecnología DEX de Sushi porque ya facilita decenas de millones de dólares en transacciones al día.\n"
+"\n"
+"Traducción realizada con la versión gratuita del traductor www.DeepL.com/Translator"
 
 #: components/pages/Buy/index.tsx:371
 msgid "buy.bond_description1"
-msgstr ""
+msgstr "Los criptousuarios experimentados pueden comprar KLIMA directamente desde el protocolo a través de bonos. Para adquirir KLIMA a través de bonos, usted proporciona un token de carbono o un token de liquidez y obtiene a cambio tokens de KLIMA con descuento. Este es el mecanismo que utiliza la DAO para hacer crecer su tesorería de carbono digital."
 
 #: components/pages/Buy/index.tsx:380
 msgid "buy.bond_description_capacity"
-msgstr ""
+msgstr "La capacidad de los bonos es limitada y no siempre están disponibles."
 
 #: components/pages/Buy/index.tsx:401
 msgid "buy.bond_question_cex"
-msgstr ""
+msgstr "¿Por qué no puedo encontrar KLIMA en Coinbase u otras bolsas centralizadas? ¿Por qué tengo que usar <0>Sushi.com</0>?"
 
 #: components/pages/Buy/index.tsx:385
 msgid "buy.bond_question_credit_card"
-msgstr ""
+msgstr "¿Puedo comprar KLIMA directamente con tarjeta de crédito?"
 
 #: components/pages/Buy/index.tsx:190
 msgid "buy.connect_advanced"
-msgstr ""
+msgstr "Nota: estas instrucciones son sólo para usuarios del monedero Torus. Sushi soporta una gran variedad de monederos diferentes."
 
 #: components/pages/Buy/index.tsx:185
 msgid "buy.connect_torus_sushi"
@@ -116,39 +119,39 @@ msgstr "3A. Conectar Torus a Sushi.com usando WalletConnect"
 
 #: components/pages/Buy/index.tsx:212
 msgid "buy.connect_torus_sushi_description2"
-msgstr ""
+msgstr "En otra pestaña del navegador, visita <0>Sushi.com</0> y haz clic en \"Conectar\" en la esquina superior derecha. Aparecerán varias opciones de monedero. Elija WalletConnect. Después de elegir WalletConnect, verá un código QR: haga clic en \"Copiar al portapapeles\"."
 
 #: components/pages/Buy/index.tsx:229
 msgid "buy.connect_torus_sushi_description3"
-msgstr ""
+msgstr "Vuelva a la aplicación del monedero Torus y pegue este código en el widget WalletConnect. Esto creará una conexión temporal entre su monedero y <0>Sushi.com</0>."
 
 #: components/pages/Buy/index.tsx:237
 msgid "buy.connect_torus_sushi_description4"
-msgstr ""
+msgstr "Cuando vuelva a la pestaña Sushi en su navegador, debería ver que su dirección Torus es ahora visible en la esquina superior derecha."
 
 #: components/pages/Buy/index.tsx:243
 msgid "buy.connect_torus_sushi_description5"
-msgstr ""
+msgstr "Por último, utilice el menú desplegable de <0>Sushi.com</0> para cambiar a la red Polygon."
 
 #: components/pages/Buy/index.tsx:72
 msgid "buy.create_wallet_description"
-msgstr ""
+msgstr "<0>Crea un monedero.</0> Recomendamos Torus Wallet, pero nuestra aplicación soporta la mayoría de monederos Web3 (Metamask, Coinbase Wallet, Brave, MyEtherWallet, y muchos más)."
 
 #: components/pages/Buy/index.tsx:114
 msgid "buy.create_wallet_description1"
-msgstr ""
+msgstr "Dirígete a <0>app.klimadao.finance</0> y haz clic en \"Conectar\" en la esquina superior derecha."
 
 #: components/pages/Buy/index.tsx:120
 msgid "buy.create_wallet_description2"
-msgstr ""
+msgstr "Elija la opción de inicio de sesión \"Email o Social\", que le dirigirá a iniciar sesión con Torus. Torus es una tecnología que genera un monedero seguro utilizando su correo electrónico existente o login de su perfil social. Podrá utilizar este nuevo monedero Torus en cientos de otras aplicaciones Web3 y DeFi."
 
 #: components/pages/Buy/index.tsx:129
 msgid "buy.create_wallet_description3"
-msgstr ""
+msgstr "Cuando estés conectado, deberías ver la dirección de tu nuevo monedero en la esquina superior izquierda de la aplicación."
 
 #: components/pages/Buy/index.tsx:135
 msgid "buy.create_wallet_description4"
-msgstr ""
+msgstr "Avanzado: si no desea utilizar Torus, puede utilizar cualquier monedero Web3 compatible con Polygon."
 
 #: components/pages/Buy/index.tsx:111
 msgid "buy.create_wallet_item"
@@ -156,24 +159,24 @@ msgstr "1. Crea un monedero"
 
 #: components/pages/Buy/index.tsx:319
 msgid "buy.faq_title"
-msgstr ""
+msgstr "Preguntas más frecuentes"
 
 #: components/pages/Buy/index.tsx:27
 #: components/pages/Buy/index.tsx:28
 msgid "buy.head.title"
-msgstr ""
+msgstr "Cómo comprar KLIMA"
 
 #: components/pages/Buy/index.tsx:41
 msgid "buy.how_to_buy"
-msgstr ""
+msgstr "Cómo comprar KLIMA"
 
 #: components/pages/Buy/index.tsx:44
 msgid "buy.how_to_paragraph_part_1"
-msgstr ""
+msgstr "KLIMA es un activo digital respaldado por carbono y puede apostarse para obtener recompensas o utilizarse para compensar carbono digital. Poseer KLIMA también te permite votar y ayudar a gobernar el Mercado Digital de Carbono."
 
 #: components/pages/Buy/index.tsx:51
 msgid "buy.how_to_paragraph_part_2"
-msgstr ""
+msgstr "Este es un breve tutorial para principiantes que son nuevos en Web3 y DeFi"
 
 #: components/pages/Buy/index.tsx:143
 msgid "buy.load_wallet"
@@ -181,63 +184,63 @@ msgstr "2. Cargue su monedero con tokens MATIC"
 
 #: components/pages/Buy/index.tsx:85
 msgid "buy.load_wallet_description"
-msgstr ""
+msgstr "<0>Carga tu nuevo monedero con tokens MATIC.</0> MATIC es el gas que alimenta la red Polygon. Cada transacción que ejecute en Polygon requerirá unos céntimos de MATIC para pagar la tarifa de red."
 
 #: components/pages/Buy/index.tsx:148
 msgid "buy.load_wallet_description1"
-msgstr ""
+msgstr "Utiliza un servicio como <0>MoonPay</0> o <1>Transak</1> o un exchange centralizado como <2>Coinbase</2> para comprar Polygon MATIC y enviarlo a tu monedero recién creado."
 
 #: components/pages/Buy/index.tsx:158
 msgid "buy.load_wallet_description2"
-msgstr ""
+msgstr "<0>¡Asegúrate de que los tokens MATIC se envían a la dirección de tu nuevo monedero!</0> Puedes copiar la dirección a tu portapapeles conectándote a nuestra app y haciendo clic en la dirección en el menú de navegación."
 
 #: components/pages/Buy/index.tsx:168
 msgid "buy.load_wallet_description3"
-msgstr ""
+msgstr "<0>¡Asegúrese de comprar y enviar los MATIC a través de la red Polygon!</0> Algunos exchanges como Coinbase le preguntarán a través de qué red enviar los tokens MATIC. Asegúrese de elegir siempre Polygon."
 
 #: components/pages/Buy/index.tsx:427
 msgid "buy.question_exchange"
-msgstr ""
+msgstr "¿Qué pasa si quiero usar un exchange diferente, pero no venden Polygon MATIC?"
 
 #: components/pages/Buy/index.tsx:322
 msgid "buy.question_why_matic"
-msgstr ""
+msgstr "¿Por qué tengo que comprar MATIC primero?"
 
 #: components/pages/Buy/index.tsx:327
 msgid "buy.question_why_matic_answer"
-msgstr ""
+msgstr "El token y el protocolo KLIMA viven en la blockchain de Polygon. MATIC es el \"gas\" que impulsa cada transacción en Polygon. No es posible ejecutar una transacción sin pagar la tasa de transacción. Esto significa que tendrá que pagar unos céntimos de MATIC por las siguientes acciones:"
 
 #: components/pages/Buy/index.tsx:338
 msgid "buy.question_why_matic_answer_bullet1"
-msgstr ""
+msgstr "Staking KLIMA para sKLIMA"
 
 #: components/pages/Buy/index.tsx:345
 msgid "buy.question_why_matic_answer_bullet2"
-msgstr ""
+msgstr "Intercambio entre diferentes tokens"
 
 #: components/pages/Buy/index.tsx:352
 msgid "buy.question_why_matic_answer_bullet3"
-msgstr ""
+msgstr "Envío de fichas a otro monedero"
 
 #: components/pages/Buy/index.tsx:359
 msgid "buy.question_why_matic_answer_bullet4"
-msgstr ""
+msgstr "Usar KLIMA u otros tokens para compensar carbono"
 
 #: components/pages/Buy/index.tsx:292
 msgid "buy.staking_cta"
-msgstr ""
+msgstr "¡Stake, gana, vota y compensa!"
 
 #: components/pages/Buy/index.tsx:295
 msgid "buy.staking_description1"
-msgstr ""
+msgstr "¡Enhorabuena! Ahora que tienes algo de KLIMA en tu cartera, te recomendamos fervientemente <0>staking</0> ese KLIMA por sKLIMA, que acumula recompensas con el tiempo a medida que crece el protocolo."
 
 #: components/pages/Buy/index.tsx:303
 msgid "buy.staking_description2"
-msgstr ""
+msgstr "También puedes utilizar la app para gastar KLIMA y <0>retirar carbono digital</0> en la blockchain."
 
 #: components/pages/Buy/index.tsx:310
 msgid "buy.staking_description3"
-msgstr ""
+msgstr "Por último, mantente atento a las <0>votaciones en curso</0> y ayuda a guiar el protocolo en la dirección correcta."
 
 #: components/pages/Buy/index.tsx:69
 msgid "buy.step_1"
@@ -253,31 +256,31 @@ msgstr "3."
 
 #: components/pages/Buy/index.tsx:62
 msgid "buy.summary_steps_title"
-msgstr ""
+msgstr "La mejor y más fácil manera de conseguir KLIMA es seguir estos tres pasos:"
 
 #: components/pages/Buy/index.tsx:59
 msgid "buy.summary_title"
-msgstr ""
+msgstr "Resumen"
 
 #: components/pages/Buy/index.tsx:253
 msgid "buy.swap_description1"
-msgstr ""
+msgstr "Después de conectar su monedero y cambiar a la red Polygon, ahora debería poder cambiar de MATIC a KLIMA."
 
 #: components/pages/Buy/index.tsx:259
 msgid "buy.swap_description2"
-msgstr ""
+msgstr "<0>Nota importante: ¡no cambies todo tu MATIC por KLIMA!</0> Guarda al menos 0,5 MATIC para pagar futuras tasas de transacción."
 
 #: components/pages/Buy/index.tsx:275
 msgid "buy.swap_description3"
-msgstr ""
+msgstr "Si está utilizando Torus, mantenga abierta la pestaña del navegador con la aplicación Torus. Tendrá que volver a su monedero para aprobar y autorizar las transacciones."
 
 #: components/pages/Buy/index.tsx:282
 msgid "buy.swap_description4"
-msgstr ""
+msgstr "Optional: If you'd like your Sushi transactions themselves to be climate positive, you should enable the Sushi 'Green Fee', powered by KlimaDAO. This will spend 0.02 MATIC per transaction to purchase and retire digital carbon automatically!"
 
 #: components/pages/Buy/index.tsx:100
 msgid "buy.swap_for_klima_description"
-msgstr ""
+msgstr "<0>Swap por KLIMA.</0> Sushi es un Exchange descentralizado donde puedes intercambiar instantáneamente algunos de tus tokens MATIC por tokens KLIMA al precio más bajo posible."
 
 #: components/pages/Buy/index.tsx:250
 msgid "buy.swap_subtitle"
@@ -289,157 +292,157 @@ msgstr "3. Cambiar por KLIMA en <0>Sushi.com</0>"
 
 #: components/pages/Buy/index.tsx:196
 msgid "buy.torus_login_description"
-msgstr ""
+msgstr "En una nueva pestaña del navegador, vaya a la aplicación web <0>Torus Polygon</0> e inicie sesión con su nueva cuenta Torus. Cuando inicie sesión, debería ver un widget WalletConnect."
 
 #: components/pages/Buy/index.tsx:205
 msgid "buy.wallet_connect_example"
-msgstr ""
+msgstr "ejemplo de entrada wallet connect"
 
 #: components/pages/Buy/index.tsx:222
 #: components/pages/Buy/index.tsx:268
 msgid "buy.wallet_connect_example_qr_code"
-msgstr ""
+msgstr "ejemplo de código qr de wallet connect"
 
 #: components/pages/Buy/index.tsx:366
 msgid "buy.what_are_bonds"
-msgstr ""
+msgstr "¿Hay otras formas de conseguir KLIMA? ¿Qué son los bonos?"
 
 #: components/pages/About/Community/index.tsx:116
 msgid "community.become_a_partner"
-msgstr ""
+msgstr "CONVERTIRSE EN UN SOCIO"
 
 #: components/pages/About/Community/index.tsx:180
 msgid "community.bigcowg_logo"
-msgstr ""
+msgstr "logotipo de BICOWG"
 
 #: components/pages/About/Community/index.tsx:172
 msgid "community.blockchainforclimatefondation_logo"
-msgstr ""
+msgstr "Logotipo de la Fundación Blockchain for Climate"
 
 #: components/pages/About/Community/index.tsx:314
 msgid "community.come_on_in"
-msgstr ""
+msgstr "Entra"
 
 #: components/pages/About/Community/index.tsx:228
 msgid "community.deltawave_logo"
-msgstr ""
+msgstr "Logo de Delta Wave"
 
 #: components/pages/About/Community/index.tsx:265
 msgid "community.digitalcharityart_logo"
-msgstr ""
+msgstr "Logo de Digital Charity Art"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:329
 msgid "community.discord_is_where_we_share"
-msgstr ""
+msgstr "En Discord compartimos anuncios importantes, hacemos el office-hours, respondemos preguntas e intercambiamos memes. Nuestro servidor de Discord es muy activo y está moderado las 24 horas del día. Tenemos canales para todo, desde trading hasta sostenibilidad y los mercados de carbono."
 
 #: components/pages/About/Community/index.tsx:244
 msgid "community.dovu_logo"
-msgstr ""
+msgstr "Logo de Dovu"
 
 #: components/pages/About/Community/index.tsx:249
 msgid "community.eco_logo"
-msgstr ""
+msgstr "Logo de Eco"
 
 #: components/pages/About/Community/index.tsx:236
 msgid "community.etcgroup_logo"
-msgstr ""
+msgstr "Logo de Etc Group"
 
 #: components/pages/About/Community/index.tsx:361
 msgid "community.get_in_touch"
-msgstr ""
+msgstr "Contactanos?"
 
 #: components/pages/About/Community/index.tsx:204
 msgid "community.gitcoin_logo"
-msgstr ""
+msgstr "Logo de Gitcoin"
 
 #: components/pages/About/Community/index.tsx:95
 msgid "community.head.headline"
-msgstr ""
+msgstr "Comunidad"
 
 #: components/pages/About/Community/index.tsx:102
 msgid "community.head.metadescription"
-msgstr ""
+msgstr "Aprende sobre nuestra comunidad de apasionados Klimates"
 
 #: components/pages/About/Community/index.tsx:96
 msgid "community.head.subline"
-msgstr ""
+msgstr "KlimaDAO es una Organización Autónoma Descentralizada para el Cambio. Estamos gobernados y construidos por una comunidad de apasionados Klimates."
 
 #: components/pages/About/Community/index.tsx:94
 #: components/pages/About/Community/index.tsx:101
 msgid "community.head.title"
-msgstr ""
+msgstr "Comunidad KlimaDAO"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:364
 msgid "community.if_you_ve_got_questions"
-msgstr ""
+msgstr "Si tiene preguntas, ideas, consejos o cualquier otra cosa: podemos ayudarle a encontrar la persona adecuada con la que hablar."
 
 #: components/pages/About/Community/index.tsx:317
 msgid "community.join_our_discord"
-msgstr ""
+msgstr "Únete a nuestro Discord"
 
 #: components/pages/About/Community/index.tsx:304
 msgid "community.join_the_klima_community"
-msgstr ""
+msgstr "Únete a la comunidad Klima"
 
 #: components/pages/About/Community/index.tsx:281
 msgid "community.landx_logo"
-msgstr ""
+msgstr "Logotipo de LandX"
 
 #: components/pages/About/Community/index.tsx:113
 #: components/pages/About/Community/index.tsx:358
 msgid "community.lets_work_together"
-msgstr ""
+msgstr "Trabajemos juntos"
 
 #: components/pages/About/Community/index.tsx:156
 msgid "community.moss_logo"
-msgstr ""
+msgstr "Logo de Moss"
 
 #: components/pages/About/Community/index.tsx:196
 msgid "community.oceandrop_logo"
-msgstr ""
+msgstr "Logo de Oceandrop"
 
 #: components/pages/About/Community/index.tsx:257
 msgid "community.offsetra_logo"
-msgstr ""
+msgstr "Logo de Offsetra"
 
 #: components/pages/About/Community/index.tsx:212
 msgid "community.olympusdao_logo"
-msgstr ""
+msgstr "Logo de OlympusDAO"
 
 #: components/pages/About/Community/index.tsx:220
 msgid "community.openearth_logo"
-msgstr ""
+msgstr "Logo de Open Earth"
 
 #: components/pages/About/Community/index.tsx:151
 msgid "community.our_partners"
-msgstr ""
+msgstr "NUESTROS SOCIOS"
 
 #: components/pages/About/Community/index.tsx:188
 msgid "community.polygon_logo"
-msgstr ""
+msgstr "Logo de Polygon"
 
 #: components/pages/About/Community/index.tsx:164
 msgid "community.toucan_logo"
-msgstr ""
+msgstr "logotipo de Toucan"
 
 #: components/pages/About/Community/index.tsx:273
 msgid "community.toughtforfood_logo"
-msgstr ""
+msgstr "Logotipo de Thought for Food"
 
 #: components/pages/About/Community/index.tsx:132
 msgid "community.tree_grove"
-msgstr ""
+msgstr "arboleda"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:119
 msgid "community.we_work_with_traditionnal"
-msgstr ""
+msgstr "Trabajamos con los actores del mercado tradicional de carbono, las plataformas de criptomonedas, las empresas y todos los que están en el medio."
 
 #: components/pages/About/Contact/index.tsx:63
 msgid "concat.careers"
-msgstr ""
+msgstr "Carreras profesionales"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:170
 #: components/pages/Pledge/index.tsx:112
@@ -480,21 +483,21 @@ msgstr "Error de conexión"
 
 #: components/pages/About/Contact/index.tsx:140
 msgid "contact.bug_reports"
-msgstr ""
+msgstr "Informes de errores"
 
 #. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
 #: components/pages/About/Contact/index.tsx:143
 msgid "contact.bug_reports.to_file_a_bug_report"
-msgstr ""
+msgstr "Para presentar un informe de error, únete a nuestro servidor de Discord de la comunidad y haz tu pregunta en el canal #bug-reports. Alguien de nuestra <0>comunidad</0> estará encantado de investigar y encontrar una solución para ti."
 
 #. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
 #: components/pages/About/Contact/index.tsx:66
 msgid "contact.careers.we_re_hiring"
-msgstr ""
+msgstr "Somos un equipo totalmente remoto que contrata en todas las zonas horarias. Publicamos regularmente funciones y recompensas en nuestro <0>Servidor de Discord de la Comunidad</0>. Si eres una persona con iniciativa y estás motivado para unirte a una DAO impulsada por un propósito, ¡nos encantaría saber de ti!"
 
 #: components/pages/About/Contact/index.tsx:25
 msgid "contact.head.description"
-msgstr ""
+msgstr "Ponte en contacto con alguien de KlimaDAO."
 
 #: components/pages/About/Contact/index.tsx:18
 msgid "contact.head.headline"
@@ -502,49 +505,49 @@ msgstr "Contacto"
 
 #: components/pages/About/Contact/index.tsx:19
 msgid "contact.head.subline"
-msgstr ""
+msgstr "¿Preguntas, preocupaciones, ideas? Aquí tiene algunas formas de ponerse en contacto. Nos encanta reunirnos con instituciones y personas por igual."
 
 #: components/pages/About/Contact/index.tsx:17
 #: components/pages/About/Contact/index.tsx:24
 msgid "contact.head.title"
-msgstr ""
+msgstr "Contactar con KlimaDAO"
 
 #: components/pages/About/Contact/index.tsx:105
 msgid "contact.media"
-msgstr ""
+msgstr "Medios de comunicación"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:108
 msgid "contact.media.if_you_are_a_journalist"
-msgstr ""
+msgstr "Si eres periodista o creador de contenidos, a nuestro equipo de marketing les encantaria conocerte."
 
 #. Use this <0>Media Request Form</0>.
 #: components/pages/About/Contact/index.tsx:117
 msgid "contact.media.use_this_media_request_form"
-msgstr ""
+msgstr "Utilice este <0>Formulario de solicitud de medios</0> o envíe un correo electrónico a <1>press@klimadao.finance</1>"
 
 #: components/pages/About/Contact/index.tsx:85
 msgid "contact.partnerships"
-msgstr ""
+msgstr "Asociaciones"
 
 #. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
 #: components/pages/About/Contact/index.tsx:88
 msgid "contact.partnerships.until_we_finish_building"
-msgstr ""
+msgstr "Hasta que terminemos de crear nuestra página de socios, estamos dirigiendo las consultas sobre posibles asociaciones y colaboraciones a <0>este formulario de contacto</0>."
 
 #: components/pages/About/Contact/index.tsx:35
 msgid "contact.quest_and_support"
-msgstr ""
+msgstr "Preguntas y soporte"
 
 #. Join our <0>community</0>
 #: components/pages/About/Contact/index.tsx:38
 msgid "contact.quest_and_support.join_our_community"
-msgstr ""
+msgstr "Únete a nuestra <0>comunidad</0>"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:46
 msgid "contact.quest_and_support.join_our_discord_server"
-msgstr ""
+msgstr "Únete a nuestro servidor de Discord y pregunta en el canal #questions. Contamos con miles de miembros de la comunidad, amables y conocedores, listos y dispuestos a ayudarte."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:64
@@ -572,73 +575,79 @@ msgstr "3. Ser fiable, completo, legal o seguro."
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:32
 msgid "disclaimer.all_information_on_this_website"
-msgstr ""
+msgstr "Toda la información contenida en este sitio web se publica de buena fe y sólo con fines de información general. KlimaDAO se distribuye sobre la base de que será útil y servirá sólo dentro de los motivos y límites descritos en dicho sitio web."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:159
 msgid "disclaimer.any_action_you_take_upon_the_information"
 msgstr ""
+"Cualquier acción que realice a partir de la información que encuentre en este sitio web es estrictamente por su cuenta y riesgo. Las decisiones basadas en la información contenida en este sitio web son responsabilidad exclusiva del visitante. KlimaDAO no se responsabiliza de las pérdidas y/o daños relacionados con el uso del sitio web, la pérdida de su contraseña/llave secreta, una operación errónea, el envío de un activo a una dirección incorrecta, la pérdida de su activo y los sucesos relacionados con daños causados por estafadores. KlimaDAO no puede asumir ninguna responsabilidad relacionada con los cambios del mercado y su volatilidad. Usted debe llevar a cabo su propia investigación y asegurarse de su propia situación, la familiaridad y el conocimiento de la información o el servicio proporcionado por esta plataforma.\n"
+"\n"
+"Traducción realizada con la versión gratuita del traductor www.DeepL.com/Translator"
 
 #: components/pages/About/Disclaimer/index.tsx:19
 msgid "disclaimer.disclaimer"
-msgstr ""
+msgstr "Aviso legal"
 
 #: components/pages/About/Disclaimer/index.tsx:21
 msgid "disclaimer.head.description"
-msgstr ""
+msgstr "Una importante aviso legal del equipo legal de KlimaDAO."
 
 #: components/pages/About/Disclaimer/index.tsx:15
 #: components/pages/About/Disclaimer/index.tsx:25
 msgid "disclaimer.head.title"
-msgstr ""
+msgstr "Aviso legal KlimaDAO"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:102
 msgid "disclaimer.klimadao_and_its_suppliers"
-msgstr ""
+msgstr "KlimaDAO y sus proveedores no garantizan que la plataforma:"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:43
 msgid "disclaimer.klimadao_is_a_platform"
-msgstr ""
+msgstr "KlimaDAO es una plataforma. No somos un corredor, una institución financiera o un acreedor. Los servicios prestados en este sitio web no incluyen una oferta para mantener o controlar sus valores, opciones, activos, futuros u otros derivados relacionados con los valores en cualquier jurisdicción y su contenido no está prescrito por las leyes de valores."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:130
 msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
 msgstr ""
+"Ni KlimaDAO ni ninguno de sus representantes serán responsables de cualquier pérdida de cualquier tipo por cualquier acción tomada o realizada en base a material o información, contenida en el servicio. KlimaDAO hace que el uso del servicio y del contenido sea seguro, sin embargo no declara ni garantiza que el servicio y el contenido de nuestra plataforma estén libres de virus u otros componentes dañinos.\n"
+"\n"
+"Traducción realizada con la versión gratuita del traductor www.DeepL.com/Translator"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:178
 msgid "disclaimer.nothing_in_this_disclaimer"
-msgstr ""
+msgstr "Nada en esta aviso legal, cualquier contenido de información o material debe o será construido para crear cualquier relación legal entre nosotros y usted ni conceder ningún derecho u obligación a cualquiera de nosotros."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:56
 msgid "disclaimer.nothing_in_this_platform"
-msgstr ""
+msgstr "Nada en esta plataforma constituye o debe interpretarse como:"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:83
 msgid "disclaimer.the_service_available"
-msgstr ""
+msgstr "Los servicios disponibles o accesibles a través del servicio se proporcionan \"tal cual\" y, en la medida en que lo permita la legislación aplicable. KlimaDAO y sus agentes, asesores, directores, funcionarios, empleados y accionistas renuncian a todas las garantías, expresas o implícitas, incluidas, pero sin limitarse a ellas, las garantías implícitas de comerciabilidad, idoneidad para un fin determinado y no infracción, así como las garantías implícitas en el curso de la ejecución o de los negocios. KlimaDAO no ofrece ninguna garantía sobre la integridad, la fiabilidad y la exactitud de esta información, ni sobre la comerciabilidad o la idoneidad para un fin determinado. Esta plataforma no ofrece ninguna garantía sobre la integridad y exactitud de esta información."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:189
 msgid "disclaimer.we_recommend_that_you_visit"
-msgstr ""
+msgstr "Le recomendamos que visite nuestra página Crypto Security 101 para obtener instrucciones de seguridad antes de utilizar el sitio web. Por favor, ten en cuenta: nunca compartas tu clave privada o frase semilla con nadie - ni nuestros miembros ni nuestra app te lo pedirán o solicitarán nunca."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:144
 msgid "disclaimer.you_bear_full_responsibility"
-msgstr ""
+msgstr "El usuario es el único responsable de proporcionar la información privada y de verificar la identidad y la legitimidad. A pesar de los indicadores y mensajes que sugieren proporcionar la información privada y la verificación, KlimaDAO no hace ninguna afirmación sobre la identidad en la plataforma. No podemos garantizar la seguridad de los datos que se revelan en línea, y para las consecuencias sostenidas debido a la vulnerabilidad o cualquier tipo de fallo, el comportamiento anormal de software."
 
 #: components/pages/errors/Custom404.tsx:41
 msgid "error.404.page.text"
-msgstr ""
+msgstr "Lo siento, parece que te hemos enviado por el camino equivocado. <0/>Déjanos guiarte de vuelta a la página de inicio:"
 
 #: components/pages/errors/Custom500.tsx:39
 msgid "error.500.page.text"
-msgstr ""
+msgstr "Lo siento, ha ocurrido algo malo.<0/>Intenta volver a la página de inicio:"
 
 #: components/pages/errors/Custom500.tsx:34
 msgid "error.500.page.title"
@@ -654,206 +663,209 @@ msgstr "500 - Página no encontrada"
 
 #: components/pages/Home/index.tsx:236
 msgid "home.backed_by_carbon"
-msgstr ""
+msgstr "Respaldado por Carbono."
 
 #: components/pages/Home/index.tsx:327
 msgid "home.cars_annual"
-msgstr ""
+msgstr "automóvil (anual)"
 
 #: components/pages/Home/index.tsx:296
 msgid "home.equivalent_to"
-msgstr ""
+msgstr "EQUIVALENTE A"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:411
 msgid "home.every_klima_token_is_backed"
-msgstr ""
+msgstr "Cada token KLIMA está respaldado por un activo de carbono del mundo real. Los tokens se utilizan para compensar las emisiones de carbono, interactuar con las aplicaciones DeFi y exponerse al creciente mercado mundial del carbono."
 
 #: components/SocialProof/index.tsx:19
 msgid "home.featured_on"
-msgstr ""
+msgstr "KlimaDAO aparece en"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:107
 msgid "home.fight_climate_change"
-msgstr ""
+msgstr "Lucha contra el cambio climático y gana recompensas con KLIMA, una moneda digital respaldada por activos de carbono reales."
 
 #: components/pages/Home/index.tsx:462
 msgid "home.get_exposure_to_the_growing_carbon_economy"
-msgstr ""
+msgstr "Consiga exposición a la creciente economía del carbono hoy mismo. Adquiere, haz staking y se recompensado. Activismo financiero por el clima."
 
 #: components/pages/Home/index.tsx:459
 msgid "home.get_klima"
-msgstr ""
+msgstr "Obtener KLIMA"
 
 #: components/pages/Home/index.tsx:310
 msgid "home.hectares_of_forest"
-msgstr ""
+msgstr "hectáreas de bosque"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:154
 msgid "home.klima_defies_climate_change"
-msgstr ""
+msgstr "KlimaDAO es DeFi que desafía el cambio climático"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:164
 msgid "home.klima_is_the_center"
-msgstr ""
+msgstr "KlimaDAO es el centro de una nueva economía verde. Construida sobre la red Polygon, de gran eficiencia energética, KlimaDAO utiliza una pila de tecnologías para reducir la fragmentación del mercado y acelerar la entrega de financiación climática a los proyectos de sostenibilidad a nivel mundial."
 
 #. Long sentence
 #: components/pages/Home/index.tsx:440
 msgid "home.klima_tokens_are_minted"
-msgstr ""
+msgstr "Los tokens KLIMA se generan y distribuyen automáticamente cada 7 horas a los titulares de sKLIMA. Aumente sus participaciones en KLIMA para que juntos podamos construir un futuro más sostenible."
 
 #: components/pages/Home/index.tsx:83
 msgid "home.latest_news"
-msgstr ""
+msgstr "📰 Últimas noticias:"
 
 #: components/pages/Home/index.tsx:139
 msgid "home.learn_more"
-msgstr ""
+msgstr "CONOCER MÁS"
 
 #: components/pages/Home/index.tsx:342
 msgid "home.liters_if_gasoline"
-msgstr ""
+msgstr "litros de gasolina"
 
 #: components/pages/Home/index.tsx:272
 msgid "home.massive impact"
-msgstr ""
+msgstr "Impacto masivo."
 
 #: components/pages/Home/index.tsx:210
 msgid "home.mechanics"
-msgstr ""
+msgstr "MECÁNICA"
 
 #. <0>{0}% MONTHLY REWARDS</0><1>FOR TOKEN HOLDERS</1>
 #: components/pages/Home/index.tsx:428
 msgid "home.monthly_rewards_for_token_holders"
-msgstr ""
+msgstr "<0>{0}% RECOMPENSAS MENSUALES</0><1>PARA LOS POSEEDORES DE TOKENS</1>"
 
 #: components/pages/Home/index.tsx:491
 msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
-msgstr ""
+msgstr "Todo el Alpha, directo a tu bandeja de entrada"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:499
 msgid "home.newletter.get_the_latest_updates"
-msgstr ""
+msgstr "Recibe las últimas actualizaciones de KlimaDAO, mientras construimos el futuro de la economía del carbono."
 
 #: components/pages/Home/index.tsx:516
 msgid "home.newletter.never_shared_never_spammed"
-msgstr ""
+msgstr "Nunca compartido. Nunca spam."
 
 #: components/pages/Home/index.tsx:510
 msgid "home.newletter.sign_up"
-msgstr ""
+msgstr "Regístrate"
 
 #: components/pages/Home/index.tsx:496
 msgid "home.newsletter"
-msgstr ""
+msgstr "Boletin informativo"
 
 #. <0>Reserve Asset</0><1>Of the carbon economy</1>
 #: components/pages/Home/index.tsx:399
 msgid "home.reserve_asset_of_the_carbon_economy"
-msgstr ""
+msgstr "<0>Activo de reserva</0><1>De la economía del carbono</1>"
 
 #: components/pages/Home/index.tsx:469
 msgid "home.see_tutorial"
-msgstr ""
+msgstr "Ver tutorial"
 
 #: components/pages/Home/index.tsx:357
 msgid "home.source"
-msgstr ""
+msgstr "Fuente"
 
 #: components/pages/Home/index.tsx:254
 msgid "home.strong_incentives"
-msgstr ""
+msgstr "Fuertes incentivos."
 
 #. Long sentence
 #: components/pages/Home/index.tsx:213
 msgid "home.the_dao_sell_bonds"
-msgstr ""
+msgstr "La DAO vende bonos y distribuye recompensas a los titulares de KLIMA. Cada bono que vendemos se suma a una tesorería verde en constante crecimiento, o mejora la liquidez de los activos medioambientales clave. Un beneficio para las personas y el planeta."
 
 #. TONS OF <0>CARBON ABSORBED</0> BY KLIMADAO
 #: components/pages/Home/index.tsx:283
 msgid "home.tons_of_carbon_absorbed_by_klimadao"
-msgstr ""
+msgstr "TONELADAS DE <0>CARBONO ABSORBIDO</0> POR KLIMADAO"
 
 #. <0>WELCOME TO</0><1>KlimaDAO</1>
 #: components/pages/Home/index.tsx:94
 msgid "home.welcome_to_klimadao"
-msgstr ""
+msgstr "<0>BIENVENIDO A</0> <1>KlimaDAO</1>"
 
 #: components/pages/Infinity/index.tsx:162
 msgid "infinity.affordable_subtitle"
-msgstr ""
+msgstr "Asequible"
 
 #: components/pages/Infinity/index.tsx:157
 msgid "infinity.affordable_title"
-msgstr ""
+msgstr "Precios en tiempo real, bajos costes de transacción"
 
 #: components/pages/Infinity/index.tsx:418
 msgid "infinity.box_amount_104k"
-msgstr ""
+msgstr "104k"
 
 #: components/pages/Infinity/index.tsx:404
 msgid "infinity.box_amount_11k"
-msgstr ""
+msgstr "11k"
 
 #: components/pages/Infinity/index.tsx:400
 msgid "infinity.box_title"
-msgstr ""
+msgstr "Última compensación de carbono"
 
 #: components/pages/Infinity/index.tsx:414
 msgid "infinity.box_title2"
-msgstr ""
+msgstr "Carbono total retirado"
 
 #: components/pages/Infinity/index.tsx:665
 msgid "infinity.button.read_blog_faq"
-msgstr ""
+msgstr "Lea en profundidad las preguntas frecuentes de los clientes de KI"
 
 #: components/pages/Infinity/index.tsx:368
 msgid "infinity.button.read_blog_polygon"
-msgstr ""
+msgstr "Lea la historia de Polygon"
 
 #: components/pages/Infinity/Cards/CardsSlider.tsx:89
 msgid "infinity.cards_slider.title"
-msgstr ""
+msgstr "Decenas de organizaciones han compensado más de 150.000 toneladas de carbono con Klima Infinity"
 
 #: components/pages/Infinity/index.tsx:331
 msgid "infinity.carousel_image_description"
-msgstr ""
+msgstr "Proyecto de energía eólica en Jaibhim, India"
 
 #: components/pages/Infinity/index.tsx:343
 msgid "infinity.carousel_info_subtitle"
-msgstr ""
+msgstr "Impulsar la financiación de proyectos que muevan la aguja de la mitigación del cambio climático"
 
 #: components/pages/Infinity/index.tsx:338
 msgid "infinity.carousel_info_title"
-msgstr ""
+msgstr "Apoyar proyectos de alta calidad"
 
 #: components/pages/Infinity/index.tsx:685
 msgid "infinity.cta_title"
-msgstr ""
+msgstr "El kit de herramientas de carbono de próxima generación para su organización"
 
 #: components/pages/Infinity/index.tsx:557
 msgid "infinity.faq_answer1"
-msgstr ""
+msgstr "Una unidad de compensación de carbono representa la eliminación de una tonelada de dióxido de carbono equivalente (tCO2e) de la atmósfera, o la evitación de una tonelada de emisiones."
 
 #: components/pages/Infinity/index.tsx:593
 msgid "infinity.faq_answer2_paragraph1"
-msgstr ""
+msgstr "Los créditos de carbono son un mecanismo de alta integridad que permite que la financiación del carbono fluya desde quienes contaminan hacia proyectos de todo el mundo que ayudan a mitigar o eliminar el carbono de la atmósfera. Son una herramienta valiosa para cubrir las emisiones difíciles de eliminar que pueden ser costosas o técnicamente difíciles de eliminar hoy en día."
 
 #: components/pages/Infinity/index.tsx:603
 msgid "infinity.faq_answer2_paragraph2"
-msgstr ""
+msgstr "Cuando usted compra un crédito de carbono, Klima Infinity le permite retirar este crédito de carbono, retirándolo permanentemente de la circulación. Esta retirada es el momento en el que puede reclamar el beneficio de una compensación"
 
 #: components/pages/Infinity/index.tsx:611
 msgid "infinity.faq_answer2_paragraph3"
-msgstr ""
+msgstr "Las compensaciones compradas conducen a reducciones de emisiones medibles y responsables en otros sectores de la economía, y pueden utilizarse para \"compensar\" una huella de carbono inevitable. El comercio y la retirada de los créditos de carbono permiten la aparición de un mecanismo de mercado que pone precio al carbono."
 
 #: components/pages/Infinity/index.tsx:648
 msgid "infinity.faq_answer3"
 msgstr ""
+"El objetivo de los mercados de carbono es reducir las emisiones de gases de efecto invernadero (GEI, o \"carbono\") de forma rentable estableciendo límites a las emisiones y permitiendo el comercio de unidades de emisión, que son instrumentos financieros que representan reducciones de emisiones. El comercio permite que las entidades que pueden reducir las emisiones a un coste menor sean pagadas por los emisores de mayor coste, reduciendo así el coste económico de la reducción de las emisiones.\n"
+"\n"
+"Traducción realizada con la versión gratuita del traductor www.DeepL.com/Translator"
 
 #: components/pages/Infinity/index.tsx:543
 msgid "infinity.faq_question1"
@@ -869,27 +881,27 @@ msgstr "3. What are carbon markets?"
 
 #: components/pages/Infinity/index.tsx:137
 msgid "infinity.fast_subtitle"
-msgstr ""
+msgstr "Compensación en segundos, sin trámites burocráticos"
 
 #: components/pages/Infinity/index.tsx:142
 msgid "infinity.fast_title"
-msgstr ""
+msgstr "Rápido"
 
 #: components/pages/Infinity/GetStartedModal.tsx:47
 msgid "infinity.getStartedModal_business"
-msgstr ""
+msgstr "Soy una <0/>empresa."
 
 #: components/pages/Infinity/GetStartedModal.tsx:70
 msgid "infinity.getStartedModal_individual"
-msgstr ""
+msgstr "Soy un<0/>individuo."
 
 #: components/pages/Infinity/GetStartedModal.tsx:104
 msgid "infinity.getStartedModal_needAssistance"
-msgstr ""
+msgstr "Me gustaría recibir ayuda con la huella de carbono de mi organización."
 
 #: components/pages/Infinity/GetStartedModal.tsx:94
 msgid "infinity.getStartedModal_offsetCrypto"
-msgstr ""
+msgstr "Quiero <0/>compensar crypto."
 
 #: components/pages/Infinity/index.tsx:258
 msgid "infinity.getStarted_1"
@@ -901,23 +913,23 @@ msgstr "2"
 
 #: components/pages/Infinity/index.tsx:261
 msgid "infinity.getStarted_calculate"
-msgstr ""
+msgstr "Calcular"
 
 #: components/pages/Infinity/index.tsx:264
 msgid "infinity.getStarted_calculate_subtitle"
-msgstr ""
+msgstr "Calcule la huella de carbono de su organización y defina el alcance de su compensación con Klima Infinity."
 
 #: components/pages/Infinity/index.tsx:301
 msgid "infinity.getStarted_cta"
-msgstr ""
+msgstr "Acelere su camino hacia la neutralidad de carbono - y más allá"
 
 #: components/pages/Infinity/index.tsx:278
 msgid "infinity.getStarted_second_subtitle"
-msgstr ""
+msgstr "Implante su compensación con unos pocos clics y con un tiempo de transacción casi instantáneo."
 
 #: components/pages/Infinity/index.tsx:275
 msgid "infinity.getStarted_second_title"
-msgstr ""
+msgstr "Implementar"
 
 #: components/pages/Infinity/index.tsx:286
 msgid "infinity.getStarted_third"
@@ -925,35 +937,35 @@ msgstr "3"
 
 #: components/pages/Infinity/index.tsx:292
 msgid "infinity.getStarted_third_subtitle"
-msgstr ""
+msgstr "Haga un seguimiento de su compromiso y amplíe la concienciación en torno a sus acciones de Clima Positivo."
 
 #: components/pages/Infinity/index.tsx:289
 msgid "infinity.getStarted_third_title"
-msgstr ""
+msgstr "Amplificar"
 
 #: components/pages/Infinity/index.tsx:67
 msgid "infinity.head.metaDescription"
-msgstr ""
+msgstr "Un conjunto de herramientas de carbono de nueva generación para su organización."
 
 #: components/pages/Infinity/index.tsx:63
 msgid "infinity.head.metaTitle"
-msgstr ""
+msgstr "Klima Infinity - Sea neutro en carbono"
 
 #: components/pages/Infinity/index.tsx:59
 msgid "infinity.head.title"
-msgstr ""
+msgstr "KlimaDAO | Klima Infinity"
 
 #: components/pages/Infinity/index.tsx:178
 msgid "infinity.info_subtitle1"
-msgstr ""
+msgstr "Para las organizaciones pioneras del planeta"
 
 #: components/pages/Infinity/index.tsx:183
 msgid "infinity.info_subtitle2"
-msgstr ""
+msgstr "La solución de compensación más potente y fácil de usar del mundo"
 
 #: components/pages/Infinity/index.tsx:450
 msgid "infinity.mission_card1_subtitle"
-msgstr ""
+msgstr "Toneladas de carbono en poder de KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:447
 msgid "infinity.mission_card1_title"
@@ -961,7 +973,7 @@ msgstr "18,1 millones"
 
 #: components/pages/Infinity/index.tsx:472
 msgid "infinity.mission_card2_description"
-msgstr ""
+msgstr "Liquidez de carbono en manos de KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:469
 msgid "infinity.mission_card2_number"
@@ -969,7 +981,7 @@ msgstr "$ 10 millones +"
 
 #: components/pages/Infinity/index.tsx:494
 msgid "infinity.mission_card3_description"
-msgstr ""
+msgstr "Toneladas de carbono compensadas vía KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:491
 msgid "infinity.mission_card3_number"
@@ -977,19 +989,19 @@ msgstr "150,000+"
 
 #: components/pages/Infinity/index.tsx:387
 msgid "infinity.polygon_manifesto_description"
-msgstr ""
+msgstr "Al compensar las emisiones históricas de toda su red, Polygon se ha asegurado de que se tenga en cuenta cada interacción dentro de su red, ya sea una acuñación de NFT o una transacción de DeFi. Esta es una razón clave por la que Meta eligió a Polygon para emitir sus NFT."
 
 #: components/pages/Infinity/index.tsx:381
 msgid "infinity.polygon_manifesto_title"
-msgstr ""
+msgstr "La compensación forma parte del Manifiesto Verde de Polygon"
 
 #: components/pages/Infinity/index.tsx:361
 msgid "infinity.polygon_story_description"
-msgstr ""
+msgstr "Polygon ha compensado las emisiones de carbono de la red desde su creación -aproximadamente 90.000 toneladas- y se ha comprometido a ser climáticamente positivo en todas las transacciones futuras de la red."
 
 #: components/pages/Infinity/index.tsx:356
 msgid "infinity.polygon_story_title"
-msgstr ""
+msgstr "Polygon eligió a Klima Infinity para compensar su red de blockchain"
 
 #: components/pages/Infinity/Cards/Card.tsx:66
 #: components/pages/Infinity/index.tsx:407
@@ -999,77 +1011,77 @@ msgstr "Toneladas"
 
 #: components/pages/Infinity/index.tsx:196
 msgid "infinity.transparent_subtitle"
-msgstr ""
+msgstr "Transparente"
 
 #: components/pages/Infinity/index.tsx:191
 msgid "infinity.transparent_title"
-msgstr ""
+msgstr "Registrado inmutablemente en el blockchain"
 
 #: components/pages/Infinity/index.tsx:98
 msgid "infinity.welcome_subtitle"
-msgstr ""
+msgstr "Klima Infinity es un conjunto de herramientas de carbono de última generación para su organización"
 
 #: components/pages/Infinity/index.tsx:93
 msgid "infinity.welcome_title"
-msgstr ""
+msgstr "La forma más fácil de ser neutro en carbono"
 
 #: components/pages/Infinity/index.tsx:224
 msgid "infinity.why_description"
-msgstr ""
+msgstr "KlimaDAO aprovecha una serie de tecnologías DeFi para reducir la fragmentación del mercado y acelerar la entrega de financiación climática a proyectos de sostenibilidad en todo el mundo."
 
 #: components/pages/Infinity/index.tsx:219
 msgid "infinity.why_subtitle"
-msgstr ""
+msgstr "DeFi que desafía el cambio climático"
 
 #: components/pages/Infinity/index.tsx:216
 msgid "infinity.why_title"
-msgstr ""
+msgstr "¿Por qué KlimaDAO?"
 
 #: components/pages/Home/index.tsx:384
 msgid "invest_in_the_future"
-msgstr ""
+msgstr "Invierte en el futuro."
 
 #: components/pages/Infinity/index.tsx:439
 msgid "mission.header"
-msgstr ""
+msgstr "La misión de KlimaDAO es democratizar la acción climática"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:79
 #: components/pages/Pledge/PledgeForm/index.tsx:83
 #: components/pages/Pledge/PledgeForm/index.tsx:99
 msgid "pledge.errors.default"
-msgstr ""
+msgstr "Ha ocurrido un error"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:91
 msgid "pledge.errors.method_not_allowed"
-msgstr ""
+msgstr "Método no permitido."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:75
 msgid "pledge.errors.pledge_not_found"
-msgstr ""
+msgstr "No se encontró un compromiso para esta dirección."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:87
 msgid "pledge.errors.unknown_error"
-msgstr ""
+msgstr "Ha ocurrido un error desconocido."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:191
 msgid "pledge.form.error.cannot_add_yourself"
-msgstr ""
+msgstr "No puede añadir su propio monedero como monedero secundario"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:227
 msgid "pledge.form.error.default_error_message"
-msgstr ""
+msgstr "Algo salió mal. Vuelva a intentarlo en breve."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:175
 msgid "pledge.form.error.duplicate_wallets"
-msgstr ""
+msgstr "Por favor, elimine la(s) cartera(s) duplicada(s)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:616
 msgid "pledge.form.wallets.confirm_remove_wallet"
-msgstr ""
+msgstr "¿Estás seguro de que quieres eliminar {0} de tu compromiso?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:340
 msgid "pledge.form.wallets.tooltip"
-msgstr ""
+msgstr "Añade otras carteras para que contribuyan a tu compromiso. Si el propietario de la cartera acepta tu invitación, su cartera aparecerá en tu tablero de compromisos. Cualquier retirada realizada por un monedero secundario contribuirá a tu compromiso. Mantendrás la propiedad exclusiva y el acceso de edición de este compromiso."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:41
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:111
@@ -1078,79 +1090,79 @@ msgstr "Aceptar la invitacion"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:70
 msgid "pledge.invitation.error.wallet_already_pinned"
-msgstr ""
+msgstr "Este monedero ya está vinculado a otro compromiso. Por favor, desvincula tu monedero e inténtalo de nuevo."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:49
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:44
 msgid "pledge.invitation.error_title"
-msgstr ""
+msgstr "Error del Servidor"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:102
 msgid "pledge.invitation.join_message"
-msgstr ""
+msgstr "{direcciónacortada} te ha invitado a sumar tu monedero a este compromiso. Si aceptas, tus retiros de carbono contarán para el compromiso de {shortenedAddress}. Puede retirar su monedero de este compromiso en cualquier momento."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:130
 msgid "pledge.invitation.later"
-msgstr ""
+msgstr "Recuérdame más tarde"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:118
 msgid "pledge.invitation.reject"
-msgstr ""
+msgstr "Rechazar invitación"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:57
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:52
 msgid "pledge.invitation.signing"
-msgstr ""
+msgstr "Firma"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:193
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:179
 msgid "pledge.invitations.awaiting_signature"
-msgstr ""
+msgstr "En espera de la firma..."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:199
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:185
 msgid "pledge.invitations.signature_instructions"
-msgstr ""
+msgstr "Utilice su cartera para firmar y confirmar esta modificación."
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:129
 msgid "pledge.modal.are_you_sure"
-msgstr ""
+msgstr "¿Estás seguro de que quieres retirar tu cartera de este compromiso?"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:153
 msgid "pledge.modal.confirm"
-msgstr ""
+msgstr "Confirmar"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:40
 msgid "pledge.modal.confirm_remove"
-msgstr ""
+msgstr "Confirmar la eliminación"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:39
 msgid "pledge.modal.edit_pledge"
-msgstr ""
+msgstr "Editar compromiso"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:101
 msgid "pledge.modal.unable_to_edit"
-msgstr ""
+msgstr "Este monedero no tiene permiso para editar esta promesa. Para editarlo, debe volver a conectarse con el monedero del autor original ({0})."
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:110
 msgid "pledge.modal.unpin_wallet"
-msgstr ""
+msgstr "desprender mi monedero"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:144
 msgid "pledge.modal.wallet_add_confirm"
-msgstr ""
+msgstr "Sólo puede tener una página de compromiso por dirección de monedero. Si ya ha creado una página de compromiso con este monedero, los visitantes serán redirigidos a este compromiso en su lugar. Puede eliminar este monedero en cualquier momento."
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:110
 msgid "pledges.dashboard.assets.emptyBalance"
-msgstr ""
+msgstr "No hay activos de carbono para mostrar."
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:87
 msgid "pledges.dashboard.assets.title"
-msgstr ""
+msgstr "Activos de carbono"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
 msgid "pledges.dashboard.footprint.title"
-msgstr ""
+msgstr "Huella"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
 msgid "pledges.dashboard.footprint.tonnes"
@@ -1158,27 +1170,27 @@ msgstr "Toneladas"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:104
 msgid "pledges.dashboard.footprint.tooltip.category_percent"
-msgstr ""
+msgstr "{0}% de la huella"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:110
 msgid "pledges.dashboard.footprint.tooltip.quantity"
-msgstr ""
+msgstr "{0} Toneladas de carbono"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:137
 msgid "pledges.dashboard.head.metaDescription"
-msgstr ""
+msgstr "{pledgeOwnerTitle} se compromete a compensar {currentTotalFootprint} toneladas de carbono. Vea su historial de compensación de carbono y lea más sobre su compromiso."
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:133
 msgid "pledges.dashboard.head.metaTitle"
-msgstr ""
+msgstr "Compromiso de {pledgeOwnerTitle}"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:129
 msgid "pledges.dashboard.head.title"
-msgstr ""
+msgstr "Compromiso de {pledgeOwnerTitle} | KlimaDAO"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:14
 msgid "pledges.dashboard.metholodogy.default_text"
-msgstr ""
+msgstr "¿Cómo va a cumplir su promesa?"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:21
 msgid "pledges.dashboard.metholodogy.title"
@@ -1186,139 +1198,139 @@ msgstr "Metodología"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:14
 msgid "pledges.dashboard.pledge.default_text"
-msgstr ""
+msgstr "Escriba su promesa hoy mismo."
 
 #: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:21
 msgid "pledges.dashboard.pledge.title"
-msgstr ""
+msgstr "Compromiso"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:64
 msgid "pledges.dashboard.profile.pledge_met"
-msgstr ""
+msgstr "≥ 100% del compromiso cumplido"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:73
 msgid "pledges.dashboard.profile.pledge_progress"
-msgstr ""
+msgstr "{0}% del compromiso cumplido"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:106
 msgid "pledges.dashboard.profile.pledged_to_offset"
-msgstr ""
+msgstr "Compromiso de compensar <0>{0}</0> toneladas de carbono"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:104
 msgid "pledges.dashboard.retirements.title"
-msgstr ""
+msgstr "Retiros"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
 msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
-msgstr ""
+msgstr "{0} Toneladas de carbono retiradas"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:123
 msgid "pledges.dashboard.retirements.total_tonnes_retired"
-msgstr ""
+msgstr "Total de toneladas de carbono retiradas"
 
 #: components/pages/Pledge/HeaderDesktop/index.tsx:37
 msgid "pledges.edit_pledge"
-msgstr ""
+msgstr "Editar la promesa"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:562
 msgid "pledges.form.add_footprint_category_button"
-msgstr ""
+msgstr "Añadir categoría"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:446
 msgid "pledges.form.add_wallet_button"
-msgstr ""
+msgstr "Añadir cartera"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:242
 msgid "pledges.form.awaiting_signature"
-msgstr ""
+msgstr "En espera de la firma..."
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:197
 msgid "pledges.form.confirm_delete"
-msgstr ""
+msgstr "Confirmar la eliminación"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:622
 msgid "pledges.form.confirm_remove"
-msgstr ""
+msgstr "eliminar"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:635
 msgid "pledges.form.confirm_remove_cancel"
-msgstr ""
+msgstr "cancelar"
 
 #: components/pages/Pledge/index.tsx:212
 msgid "pledges.form.error"
-msgstr ""
+msgstr "Introduzca una dirección de monedero, dominio .klima o .eth"
 
 #: components/pages/Pledge/lib/formSchema.ts:74
 msgid "pledges.form.errors.categoryName.max"
-msgstr ""
+msgstr "Introduzca menos de 32 caracteres"
 
 #: components/pages/Pledge/lib/formSchema.ts:70
 msgid "pledges.form.errors.categoryName.required"
-msgstr ""
+msgstr "Introduzca una categoría"
 
 #: components/pages/Pledge/lib/formSchema.ts:78
 msgid "pledges.form.errors.categoryQuantity.min"
-msgstr ""
+msgstr "Introduzca un valor mayor que 0"
 
 #: components/pages/Pledge/lib/formSchema.ts:50
 msgid "pledges.form.errors.description.max"
-msgstr ""
+msgstr "Introduzca menos de 500 caracteres"
 
 #: components/pages/Pledge/lib/formSchema.ts:46
 msgid "pledges.form.errors.description.required"
-msgstr ""
+msgstr "Introduzca un compromiso"
 
 #: components/pages/Pledge/lib/formSchema.ts:62
 msgid "pledges.form.errors.footprint.generic_error"
-msgstr ""
+msgstr "Introduzca una estimación de toneladas de carbono"
 
 #: components/pages/Pledge/lib/formSchema.ts:66
 msgid "pledges.form.errors.footprint.min"
-msgstr ""
+msgstr "Introduzca un valor mayor que 0"
 
 #: components/pages/Pledge/lib/formSchema.ts:58
 msgid "pledges.form.errors.methodology.max"
-msgstr ""
+msgstr "Introduzca menos de 1000 caracteres"
 
 #: components/pages/Pledge/lib/formSchema.ts:54
 msgid "pledges.form.errors.methodology.required"
-msgstr ""
+msgstr "Introduzca una metodología"
 
 #: components/pages/Pledge/lib/formSchema.ts:34
 msgid "pledges.form.errors.name.required"
-msgstr ""
+msgstr "Introduzca un nombre"
 
 #: components/pages/Pledge/lib/formSchema.ts:38
 msgid "pledges.form.errors.profileImageUrl.url"
-msgstr ""
+msgstr "Introduzca una url válida"
 
 #: components/pages/Pledge/lib/formSchema.ts:42
 msgid "pledges.form.errors.profileWebsiteUrl.url"
-msgstr ""
+msgstr "Introduzca una url válida"
 
 #: components/pages/Pledge/lib/formSchema.ts:86
 msgid "pledges.form.errors.walletAddress.isAddress"
-msgstr ""
+msgstr "Por favor introduce una dirección válida"
 
 #: components/pages/Pledge/lib/formSchema.ts:90
 msgid "pledges.form.errors.walletAddress.isOwner"
-msgstr ""
+msgstr "No puedes añadir al propietario de la prenda"
 
 #: components/pages/Pledge/lib/formSchema.ts:82
 msgid "pledges.form.errors.walletAddress.required"
-msgstr ""
+msgstr "Dirección requerida"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:489
 msgid "pledges.form.footprint.label"
-msgstr ""
+msgstr "Huella"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:497
 msgid "pledges.form.footprint.prompt"
-msgstr ""
+msgstr "Añada una categoría y empieza a calcular su huella de carbono"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:260
 msgid "pledges.form.generic_error"
-msgstr ""
+msgstr "Algo ha ido mal. Por favor, inténtelo de nuevo."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:518
 msgid "pledges.form.input.categoryName.label"
@@ -1326,23 +1338,23 @@ msgstr "Categoría"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:510
 msgid "pledges.form.input.categoryName.placeholder"
-msgstr ""
+msgstr "Nombre de la categoría"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:538
 msgid "pledges.form.input.categoryQuantity.label"
-msgstr ""
+msgstr "Cantidad"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:530
 msgid "pledges.form.input.categoryQuantity.placeholder"
-msgstr ""
+msgstr "Toneladas de carbono"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:323
 msgid "pledges.form.input.description.label"
-msgstr ""
+msgstr "Compromiso"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:316
 msgid "pledges.form.input.description.placeholder"
-msgstr ""
+msgstr "¿Cuál es su compromiso?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:476
 msgid "pledges.form.input.methodology.label"
@@ -1350,31 +1362,31 @@ msgstr "Metodología"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:468
 msgid "pledges.form.input.methodology.placeholder"
-msgstr ""
+msgstr "¿Qué herramientas o metodologías ha utilizado para calcular su huella de carbono?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:280
 msgid "pledges.form.input.name.label"
-msgstr ""
+msgstr "Nombre"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:273
 msgid "pledges.form.input.name.placeholder"
-msgstr ""
+msgstr "Nombre o denominación de la empresa"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:291
 msgid "pledges.form.input.profileImageUrl.label"
-msgstr ""
+msgstr "URL de la imagen de perfil (opcional)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:305
 msgid "pledges.form.input.profileWebsiteUrl.label"
-msgstr ""
+msgstr "Sitio web (opcional)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:579
 msgid "pledges.form.input.totalFootprint.label"
-msgstr ""
+msgstr "Huella total"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:380
 msgid "pledges.form.input.walletAddress.label"
-msgstr ""
+msgstr "Dirección"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:372
 msgid "pledges.form.input.walletAddress.placeholder"
@@ -1382,35 +1394,35 @@ msgstr "0x..."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:595
 msgid "pledges.form.submit_button"
-msgstr ""
+msgstr "Guardar el compromiso"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:193
 msgid "pledges.form.title"
-msgstr ""
+msgstr "Tu compromiso"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:52
 msgid "pledges.form.total_footprint_summary"
-msgstr ""
+msgstr "Huella total: {0} Toneladas de carbono"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:607
 msgid "pledges.form.use_your_wallet"
-msgstr ""
+msgstr "Utilice su cartera para firmar y confirmar esta modificación."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:332
 msgid "pledges.form.wallets.label"
-msgstr ""
+msgstr "Monederos secundarios"
 
 #: components/pages/Pledge/index.tsx:94
 msgid "pledges.head.metaDescription"
-msgstr ""
+msgstr "Demuestre su compromiso con el clima solicitando su panel de compromisos para destacar toda su actividad de compensación de carbono"
 
 #: components/pages/Pledge/index.tsx:90
 msgid "pledges.head.metaTitle"
-msgstr ""
+msgstr "Cree un compromiso de carbono y muestre su impacto"
 
 #: components/pages/Pledge/index.tsx:86
 msgid "pledges.head.title"
-msgstr ""
+msgstr "KlimaDAO | Compromisos"
 
 #: components/pages/Pledge/index.tsx:66
 msgid "pledges.home.hero.connecting"
@@ -1418,23 +1430,23 @@ msgstr "Conectando..."
 
 #: components/pages/Pledge/index.tsx:77
 msgid "pledges.home.hero.create"
-msgstr ""
+msgstr "Crear un compromiso"
 
 #: components/pages/Pledge/index.tsx:170
 msgid "pledges.home.hero.learn_more"
-msgstr ""
+msgstr "Aprende más"
 
 #: components/pages/Pledge/index.tsx:72
 msgid "pledges.home.hero.view"
-msgstr ""
+msgstr "Ver tu compromiso"
 
 #: components/pages/Pledge/index.tsx:206
 msgid "pledges.home.search.label"
-msgstr ""
+msgstr "Dirección ENS o 0x"
 
 #: components/pages/Pledge/index.tsx:200
 msgid "pledges.home.search.placeholder"
-msgstr ""
+msgstr "Ingrese la dirección ENS, KNS o 0x"
 
 #: components/pages/Pledge/index.tsx:226
 msgid "pledges.home.search.submit"
@@ -1470,51 +1482,51 @@ msgstr "Seleccione"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:53
 msgid "resources.form.medium.header"
-msgstr ""
+msgstr "Medio"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:41
 msgid "resources.form.sub_topics.header"
-msgstr ""
+msgstr "Sub-temas"
 
 #: components/pages/Resources/index.tsx:31
 msgid "resources.head.metaDescription"
-msgstr ""
+msgstr "Actualizaciones y liderazgo de pensamiento de los fundadores, colaboradores de la DAO, asesores y comunidad."
 
 #: components/pages/Resources/index.tsx:27
 msgid "resources.head.metaTitle"
-msgstr ""
+msgstr "KlimaDAO Resources - Ir más allá de la neutralidad del carbono"
 
 #: components/pages/Resources/index.tsx:23
 msgid "resources.head.title"
-msgstr ""
+msgstr "KlimaDAO | Recursos"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:71
 msgid "resources.list.filter.tag.basics"
-msgstr ""
+msgstr "Conceptos básicos"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:111
 msgid "resources.list.filter.tag.carbon_footprint"
-msgstr ""
+msgstr "Huella de Carbono"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:79
 msgid "resources.list.filter.tag.deep_dives"
-msgstr ""
+msgstr "Inmersión en profundidad"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:52
 msgid "resources.list.filter.tag.klima_infinity"
-msgstr ""
+msgstr "Klima Infinity"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:44
 msgid "resources.list.filter.tag.klima_overview"
-msgstr ""
+msgstr "Panorama general de Klima"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:60
 msgid "resources.list.filter.tag.partnerships"
-msgstr ""
+msgstr "Asociaciones"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:103
 msgid "resources.list.filter.tag.policy"
-msgstr ""
+msgstr "Normativa"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:95
 msgid "resources.list.filter.tag.press_releases"
@@ -1526,11 +1538,11 @@ msgstr "Guías de usuario"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:121
 msgid "resources.list.filter.type.blog"
-msgstr ""
+msgstr "Blog"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:129
 msgid "resources.list.filter.type.podcast"
-msgstr ""
+msgstr "Podcast"
 
 #: components/pages/Resources/SortyByDropDown/index.tsx:62
 msgid "resources.list.select.sort_by.toggle"
@@ -1562,15 +1574,15 @@ msgstr "Ordenar por"
 
 #: components/pages/Resources/index.tsx:46
 msgid "resources.page.header.subline"
-msgstr ""
+msgstr "Actualizaciones y liderazgo de pensamiento de los fundadores, colaboradores de la DAO, asesores y comunidad."
 
 #: components/pages/Resources/index.tsx:43
 msgid "resources.page.header.title"
-msgstr ""
+msgstr "Artículos destacados"
 
 #: components/pages/Resources/ResourcesList/index.tsx:167
 msgid "resources.page.list.header"
-msgstr ""
+msgstr "Explorar todo"
 
 #: components/pages/Resources/ResourcesList/index.tsx:249
 msgid "resources.page.list.no_search_results.title"
@@ -1590,15 +1602,15 @@ msgstr "Compruebe si hay errores tipográficos en su búsqueda o pruebe con otro
 
 #: components/pages/Retirements/Footer/index.tsx:18
 msgid "retirement.footer.aboutKlima.left"
-msgstr ""
+msgstr "KlimaDAO está incentivando la sostenibilidad y catalizando un mercado de carbono más transparente y líquido. Nuestras herramientas hacen posible que cualquier persona o empresa comercie y retire activos de carbono de calidad en el Blockchain."
 
 #: components/pages/Retirements/Footer/index.tsx:28
 msgid "retirement.footer.aboutKlima.right"
-msgstr ""
+msgstr "Los tokens KLIMA están en el centro de una floreciente economía del carbono en el blockchain. Visite nuestra <0>base de conocimientos</0> para obtener más información sobre KLIMA, la compensación de carbono, los mercados de carbono y los activos de carbono subyacentes."
 
 #: components/pages/Retirements/Footer/index.tsx:13
 msgid "retirement.footer.aboutKlima.title"
-msgstr ""
+msgstr "Acerca de Klima"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:37
 msgid "retirement.footer.buy_klima.button.buy"
@@ -1610,135 +1622,135 @@ msgstr "Compensación"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:30
 msgid "retirement.footer.buy_klima.text"
-msgstr ""
+msgstr "Utiliza tokens KLIMA respaldados por carbono para gobernar, intercambiar y ganar recompensas de staking, ¡y luego utiliza esas recompensas para compensar tus emisiones!"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:25
 msgid "retirement.footer.buy_klima.title"
-msgstr ""
+msgstr "Adquirir, hacer staking y ser recompensado."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:122
 msgid "retirement.head.metaDescription"
-msgstr ""
+msgstr "Compensaciones transparentes en el blockchain con la ayuda de KlimaDAO."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:118
 msgid "retirement.head.metaTitle"
-msgstr ""
+msgstr "{retiree} ha retirado {formattedAmount} Toneladas de carbono"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:114
 msgid "retirement.head.title"
-msgstr ""
+msgstr "KlimaDAO | Recibo de Retiro de Carbono"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:266
 msgid "retirement.share.title"
-msgstr ""
+msgstr "Comparte tu impacto"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:176
 msgid "retirement.single.beneficiary.placeholder"
-msgstr ""
+msgstr "No se ha facilitado el nombre del beneficiario"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:170
 msgid "retirement.single.beneficiary.title"
-msgstr ""
+msgstr "Beneficiario"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:184
 msgid "retirement.single.beneficiaryAddress.title"
-msgstr ""
+msgstr "Dirección del beneficiario"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:245
 msgid "retirement.single.create_a_pledge"
-msgstr ""
+msgstr "Crear un compromiso"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:231
 msgid "retirement.single.disclaimer"
-msgstr ""
+msgstr "Esto representa la retirada permanente de los activos de carbono tokenizados en la blockchain de Polygon. Esta retirada y los datos asociados son registros públicos inmutables."
 
 #: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:30
 msgid "retirement.single.download_certificate_button"
-msgstr ""
+msgstr "Descargar PDF"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:134
 msgid "retirement.single.header.subline"
-msgstr ""
+msgstr "Compensación de emisiones de CO2 equivalente (toneladas métricas)"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:241
 msgid "retirement.single.is_this_your_retirement"
-msgstr ""
+msgstr "¿Es ésta tu retirada?"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
 msgid "retirement.single.message.title"
-msgstr ""
+msgstr "Mensaje de Retiro"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:30
 msgid "retirement.single.no_pledge"
-msgstr ""
+msgstr "Este usuario no ha creado una promesa"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
 msgid "retirement.single.project_details.title"
-msgstr ""
+msgstr "Detalles del proyecto"
 
 #: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
 msgid "retirement.single.quantity"
-msgstr ""
+msgstr "CANTIDAD RETIRADA"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:205
 msgid "retirement.single.retirementCertificate.title"
-msgstr ""
+msgstr "Certificado"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:21
 msgid "retirement.single.retirementDate.title"
-msgstr ""
+msgstr "Fecha"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:24
 msgid "retirement.single.timestamp.placeholder"
-msgstr ""
+msgstr "No se proporcionó una marca de tiempo de retiro"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:302
 msgid "retirement.single.view_on_polygon_scan"
-msgstr ""
+msgstr "Ver en Polygonscan"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:18
 msgid "retirement.single.view_pledge"
-msgstr ""
+msgstr "Ver compromiso"
 
 #: components/pages/Retirements/List/index.tsx:40
 msgid "retirement.totals.all_retirements_list.empty"
-msgstr ""
+msgstr "No se han encontrado retiros"
 
 #: components/pages/Retirements/List/index.tsx:24
 msgid "retirement.totals.all_retirements_list.headline"
-msgstr ""
+msgstr "Todos los retiros"
 
 #: components/pages/Retirements/index.tsx:46
 msgid "retirement.totals.head.metaTitle"
-msgstr ""
+msgstr "KlimaDAO - Retiradas de carbono para el beneficiario {0}"
 
 #: components/pages/Retirements/index.tsx:40
 msgid "retirement.totals.head.title"
-msgstr ""
+msgstr "KlimaDAO - Retiradas de carbono para el beneficiario {0}"
 
 #: components/pages/Retirements/index.tsx:65
 msgid "retirement.totals.page_headline"
-msgstr ""
+msgstr "Retiradas de carbono"
 
 #: components/pages/Retirements/index.tsx:71
 msgid "retirement.totals.page_subline"
-msgstr ""
+msgstr "para el beneficiario"
 
 #: components/pages/Retirements/index.tsx:95
 msgid "retirement.totals.retired_assets"
-msgstr ""
+msgstr "Activos retirados"
 
 #: components/pages/Retirements/index.tsx:111
 msgid "retirement.totals.retirements"
-msgstr ""
+msgstr "Retiros"
 
 #: components/pages/Retirements/index.tsx:103
 msgid "retirement.totals.total_carbon_tonnes"
-msgstr ""
+msgstr "Total de toneladas de carbono retiradas"
 
 #: components/pages/Retirements/index.tsx:117
 msgid "retirement.totals.total_retirement_transactions"
-msgstr ""
+msgstr "Total de transacciones de retirada"
 
 #: components/pages/errors/Custom404.tsx:20
 #: components/pages/errors/Custom404.tsx:24
@@ -1755,23 +1767,23 @@ msgstr "Acerca de"
 #: components/Navigation/index.tsx:115
 #: components/Navigation/index.tsx:261
 msgid "shared.app"
-msgstr ""
+msgstr "Aplicación"
 
 #: components/Footer/index.tsx:49
 msgid "shared.blog"
-msgstr ""
+msgstr "Blog"
 
 #: components/Footer/index.tsx:43
 #: components/Navigation/index.tsx:133
 #: components/Navigation/index.tsx:278
 msgid "shared.bond"
-msgstr ""
+msgstr "Bond Klima"
 
 #: components/Footer/index.tsx:37
 #: components/Navigation/index.tsx:117
 #: components/Navigation/index.tsx:265
 msgid "shared.buy"
-msgstr ""
+msgstr "Comprar Klima"
 
 #: components/Navigation/index.tsx:157
 #: components/Navigation/index.tsx:302
@@ -1782,15 +1794,15 @@ msgstr "Comprar Carbono"
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:118
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:147
 msgid "shared.cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: components/Navigation/index.tsx:352
 msgid "shared.carbon_dashboard"
-msgstr ""
+msgstr "Dashboard de carbono"
 
 #: components/Navigation/index.tsx:203
 msgid "shared.carbon_dashboards"
-msgstr ""
+msgstr "Dashboard de carbono"
 
 #: components/Navigation/index.tsx:174
 #: components/Navigation/index.tsx:321
@@ -1802,11 +1814,11 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:31
 #: components/pages/About/AboutHeader/index.tsx:61
 msgid "shared.community"
-msgstr ""
+msgstr "Comunidad"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:45
 msgid "shared.confirm"
-msgstr ""
+msgstr "Confirmar"
 
 #: components/Footer/index.tsx:52
 #: components/Navigation/index.tsx:241
@@ -1818,14 +1830,14 @@ msgstr "Contacto"
 #: components/pages/Infinity/index.tsx:117
 #: components/pages/Infinity/index.tsx:701
 msgid "shared.contact_sales"
-msgstr ""
+msgstr "Contactar con Ventas"
 
 #: components/Navigation/index.tsx:96
 #: components/pages/About/AboutHeader/index.tsx:40
 #: components/pages/About/Community/index.tsx:129
 #: components/pages/About/Community/index.tsx:374
 msgid "shared.contact_us"
-msgstr ""
+msgstr "Contáctenos"
 
 #: components/Footer/index.tsx:55
 #: components/Navigation/index.tsx:105
@@ -1833,52 +1845,52 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:49
 #: components/pages/About/AboutHeader/index.tsx:73
 msgid "shared.disclaimer"
-msgstr ""
+msgstr "Aviso legal"
 
 #: components/Footer/index.tsx:46
 #: components/Navigation/index.tsx:211
 #: components/Navigation/index.tsx:360
 msgid "shared.docs"
-msgstr ""
+msgstr "Documentos oficiales"
 
 #: components/Navigation/index.tsx:63
 #: components/pages/Home/index.tsx:115
 msgid "shared.enter_app"
-msgstr ""
+msgstr "Entrar a la aplicación"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:157
 msgid "shared.error"
-msgstr ""
+msgstr "Error"
 
 #: components/pages/Infinity/GetStartedModal.tsx:25
 msgid "shared.get_started"
-msgstr ""
+msgstr "Cómo empezar"
 
 #: components/pages/Buy/index.tsx:29
 #: components/pages/Home/index.tsx:69
 #: components/pages/Retirements/index.tsx:52
 #: components/pages/errors/Custom500.tsx:23
 msgid "shared.head.description"
-msgstr ""
+msgstr "Impulsa la acción climática y gana recompensas con una moneda digital respaldada por carbono."
 
 #: components/Footer/index.tsx:34
 msgid "shared.home"
-msgstr ""
+msgstr "Casa"
 
 #: components/Navigation/index.tsx:194
 #: components/Navigation/index.tsx:343
 msgid "shared.how_to_buy"
-msgstr ""
+msgstr "Cómo comprar Klima"
 
 #: components/pages/Infinity/index.tsx:108
 #: components/pages/Infinity/index.tsx:309
 #: components/pages/Infinity/index.tsx:692
 msgid "shared.infinity.get_started"
-msgstr ""
+msgstr "Cómo empezar"
 
 #: components/pages/Home/index.tsx:186
 msgid "shared.infinity_cta"
-msgstr ""
+msgstr "DEFI PARA ORGANIZACIONES"
 
 #: components/Navigation/index.tsx:165
 #: components/Navigation/index.tsx:310
@@ -1905,12 +1917,12 @@ msgstr "Iniciar sesión / Conectar"
 
 #: components/pages/Home/index.tsx:193
 msgid "shared.loveletter_cta"
-msgstr ""
+msgstr "DEFI PARA PARTICULARES"
 
 #: components/Navigation/index.tsx:179
 #: components/Navigation/index.tsx:325
 msgid "shared.loveletters"
-msgstr ""
+msgstr "Love Letters"
 
 #: components/Navigation/index.tsx:149
 #: components/Navigation/index.tsx:294
@@ -1920,15 +1932,15 @@ msgstr "Compensación"
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:175
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:161
 msgid "shared.okay"
-msgstr ""
+msgstr "Ok"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:421
 msgid "shared.pending"
-msgstr ""
+msgstr "Pendiente"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:135
 msgid "shared.remove"
-msgstr ""
+msgstr "eliminar"
 
 #: components/Navigation/index.tsx:185
 #: components/Navigation/index.tsx:334
@@ -1949,20 +1961,20 @@ msgstr "Ordenar por:"
 #: components/Navigation/index.tsx:125
 #: components/Navigation/index.tsx:270
 msgid "shared.stake"
-msgstr ""
+msgstr "Stake KLIMA"
 
 #: components/pages/Infinity/index.tsx:512
 msgid "shared.visit_klimadao_blog"
-msgstr ""
+msgstr "Visite el blog de KlimaDAO"
 
 #: components/Navigation/index.tsx:141
 #: components/Navigation/index.tsx:286
 msgid "shared.wrap"
-msgstr ""
+msgstr "Empaquetar sKLIMA"
 
 #: lib/getWeb3ModalStrings.ts:13
 msgid "web3modal.injected.des"
-msgstr "Conéctate con el proveedor de tu navegador web3"
+msgstr "Conéctese con su proveedor de navegador web3"
 
 #: lib/getWeb3ModalStrings.ts:21
 msgid "web3modal.torus.desc"
@@ -1982,8 +1994,8 @@ msgstr "Escanea con Coinbase para conectarte"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:62
 msgid "{trimCurrentSupply} Tonnes remaining"
-msgstr ""
+msgstr "{trimCurrentSupply} Toneladas restantes"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:57
 msgid "{trimTotalRetired} Tonnes retired in total"
-msgstr ""
+msgstr "{trimTotalRetired} Toneladas retiradas en total"

--- a/site/locale/fr/messages.po
+++ b/site/locale/fr/messages.po
@@ -13,35 +13,35 @@ msgstr "Changer de langue"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:33
 msgid "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
-msgstr ""
+msgstr "Chaque compensation KlimaDAO est lié à un projet vérifié. Cliquez pour en savoir plus sur le projet."
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:68
 msgid "Explore MCO2 on carbon.klimadao.finance"
-msgstr ""
+msgstr "Découvrez MCO2 sur carbon.klimadao.finance"
 
 #: components/pages/Infinity/index.tsx:530
 msgid "Frequently Asked Questions"
-msgstr ""
+msgstr "Foire Aux Questions"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:47
 msgid "Location: {0}"
-msgstr ""
+msgstr "Lieu : {0}"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:50
 msgid "MCO2 Token"
-msgstr ""
+msgstr "Jeton MCO2"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:52
 msgid "Methodology: {0}"
-msgstr ""
+msgstr "Méthodologie : {0}"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:23
 msgid "No retirement message provided."
-msgstr ""
+msgstr "Aucun message de compensation fourni."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:146
 msgid "Processing data..."
-msgstr ""
+msgstr "Traitement des données..."
 
 #: components/InvalidNetworkModal/index.tsx:80
 msgid "Switch to Polygon"
@@ -53,11 +53,11 @@ msgstr "Cette application fonctionne uniquement sur le réseau Polygon principal
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:74
 msgid "View on Polygonscan"
-msgstr ""
+msgstr "Voir sur Polygonscan"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:150
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
-msgstr ""
+msgstr "Nous n'avons pas fini de traiter les données de la blockchain pour cette compensation. Cela prend généralement quelques secondes, mais peut prendre plus longtemps si le réseau est encombré."
 
 #: components/InvalidNetworkModal/index.tsx:65
 msgid "Wrong Network"
@@ -74,370 +74,372 @@ msgstr "Avertissement légal"
 
 #: components/pages/Buy/index.tsx:433
 msgid "buy.answer_exchange"
-msgstr ""
+msgstr "Les utilisateurs avancés peuvent utiliser le <0>Polygon Bridge</0> pour déplacer n'importe quel actif d'Ethereum vers Polygon, et/ou le <1>Polygon Gas Swap</1> pour échanger des actifs comme USDC contre MATIC."
 
 #: components/pages/Buy/index.tsx:390
 msgid "buy.bond_answer_cedit_card"
-msgstr ""
+msgstr "Oui, certains fournisseurs \"on-ramp\" comme <0>Transak</0> vous permettent d'acheter des KLIMA directement avec une carte de crédit, moyennant des frais. Cependant, si votre portefeuille n'a pas de MATIC, vous ne pourrez pas effectuer de transfert ou d'autres actions. Pour cette raison, et pour garantir le meilleur taux du marché, nous vous recommandons d'acheter directement des MATIC et d'échanger vos MATIC contre des KLIMA sur Sushi.com."
 
 #: components/pages/Buy/index.tsx:408
 msgid "buy.bond_answer_cex1"
-msgstr ""
+msgstr "KLIMA n'est pas négocié sur une bourse centralisée comme Coinbase, Binance ou Crypto.com, car ces bourses facturent généralement des frais de cotation très élevés et nécessitent le financement de teneurs de marché coûteux."
 
 #: components/pages/Buy/index.tsx:416
 msgid "buy.bond_answer_cex2"
-msgstr ""
+msgstr "Au lieu de cela, les jetons KLIMA sont échangés sur un \"échange décentralisé\" (DEX) qui est alimenté par des contrats intelligents (smart contrats) et fonctionne directement sur la blockchain. Les DEX présentent des avantages majeurs. Les DEX ont permis à la DAO de détenir la majorité des liquidités, ce qui lui permet de conserver une autonomie totale et de générer des revenus pour rémunérer les contributeurs. Nous avons choisi d'utiliser la technologie DEX de Sushi car elle facilite déjà des dizaines de millions de dollars de transactions par jour."
 
 #: components/pages/Buy/index.tsx:371
 msgid "buy.bond_description1"
-msgstr ""
+msgstr "Les utilisateurs de crypto expérimentés peuvent acheter des KLIMA directement à partir du protocole via des obligations. Pour acquérir des KLIMA par le biais d'obligations, vous fournissez un jeton carbone ou un jeton de liquidité et obtenez en retour des jetons KLIMA à prix réduit. C'est le mécanisme que la DAO utilise pour accroître sa réserve de carbone numérique."
 
 #: components/pages/Buy/index.tsx:380
 msgid "buy.bond_description_capacity"
-msgstr ""
+msgstr "La capacité de financement est limitée et les obligations ne sont pas toujours disponibles."
 
 #: components/pages/Buy/index.tsx:401
 msgid "buy.bond_question_cex"
-msgstr ""
+msgstr "Pourquoi ne puis-je pas trouver KLIMA sur Coinbase ou d'autres échanges centralisés ? Pourquoi dois-je utiliser <0>Sushi.com</0> ?"
 
 #: components/pages/Buy/index.tsx:385
 msgid "buy.bond_question_credit_card"
-msgstr ""
+msgstr "Puis-je acheter des KLIMA directement avec une carte de crédit ?"
 
 #: components/pages/Buy/index.tsx:190
 msgid "buy.connect_advanced"
-msgstr ""
+msgstr "Remarque : ces instructions sont destinées aux utilisateurs de portefeuilles Torus uniquement. Sushi supporte une variété de portefeuilles différents."
 
 #: components/pages/Buy/index.tsx:185
 msgid "buy.connect_torus_sushi"
-msgstr ""
+msgstr "3A. Connecter Torus à Sushi.com en utilisant WalletConnect"
 
 #: components/pages/Buy/index.tsx:212
 msgid "buy.connect_torus_sushi_description2"
-msgstr ""
+msgstr "Dans un autre onglet du navigateur, visitez <0>Sushi.com</0> et cliquez sur \"Connecter\" dans le coin supérieur droit. Quelques options de portefeuille vous seront présentées. Choisissez WalletConnect. Après avoir choisi WalletConnect, vous verrez un code QR - cliquez sur \"Copier dans le presse-papiers\"."
 
 #: components/pages/Buy/index.tsx:229
 msgid "buy.connect_torus_sushi_description3"
-msgstr ""
+msgstr "Retournez à l'application du portefeuille Torus et collez ce code dans le widget WalletConnect. Cela créera une connexion temporaire entre votre portefeuille et <0>Sushi.com</0>."
 
 #: components/pages/Buy/index.tsx:237
 msgid "buy.connect_torus_sushi_description4"
-msgstr ""
+msgstr "Lorsque vous revenez à l'onglet Sushi de votre navigateur, vous devriez voir que votre adresse Torus est maintenant visible dans le coin supérieur droit."
 
 #: components/pages/Buy/index.tsx:243
 msgid "buy.connect_torus_sushi_description5"
-msgstr ""
+msgstr "Enfin, utilisez le menu déroulant sur <0>Sushi.com</0> pour passer au réseau Polygon."
 
 #: components/pages/Buy/index.tsx:72
 msgid "buy.create_wallet_description"
-msgstr ""
+msgstr "<0>Créer un portefeuille.</0> Nous recommandons Torus Wallet, mais notre application supporte la plupart des portefeuilles Web3 (Metamask, Coinbase Wallet, Brave, MyEtherWallet, et bien d'autres)."
 
 #: components/pages/Buy/index.tsx:114
 msgid "buy.create_wallet_description1"
-msgstr ""
+msgstr "Rendez-vous sur <0>app.klimadao.finance</0> et cliquez sur \"Connecter\" dans le coin supérieur droit."
 
 #: components/pages/Buy/index.tsx:120
 msgid "buy.create_wallet_description2"
-msgstr ""
+msgstr "Choisissez l'option de connexion \"Email ou social\", qui vous conduira à vous connecter avec Torus. Torus est une technologie qui génère un porte-monnaie sécurisé en utilisant votre email ou votre identifiant social existant. Vous pourrez utiliser ce nouveau porte-monnaie Torus dans des centaines d'autres applications Web3 et DeFi."
 
 #: components/pages/Buy/index.tsx:129
 msgid "buy.create_wallet_description3"
-msgstr ""
+msgstr "Lorsque vous êtes connecté, vous devriez voir l'adresse de votre nouveau portefeuille dans le coin supérieur gauche de l'application."
 
 #: components/pages/Buy/index.tsx:135
 msgid "buy.create_wallet_description4"
-msgstr ""
+msgstr "Avancé : si vous ne voulez pas utiliser Torus, n'hésitez pas à utiliser n'importe quel porte-monnaie Web3 compatible avec Polygon."
 
 #: components/pages/Buy/index.tsx:111
 msgid "buy.create_wallet_item"
-msgstr ""
+msgstr "1. Créer un portefeuille"
 
 #: components/pages/Buy/index.tsx:319
 msgid "buy.faq_title"
-msgstr ""
+msgstr "FAQ"
 
 #: components/pages/Buy/index.tsx:27
 #: components/pages/Buy/index.tsx:28
 msgid "buy.head.title"
-msgstr ""
+msgstr "Comment acheter des jetons KLIMA"
 
 #: components/pages/Buy/index.tsx:41
 msgid "buy.how_to_buy"
-msgstr ""
+msgstr "Comment acheter des jetons KLIMA"
 
 #: components/pages/Buy/index.tsx:44
 msgid "buy.how_to_paragraph_part_1"
-msgstr ""
+msgstr "Le KLIMA est un actif numérique adossé au carbone et peut être misé pour obtenir des récompenses ou être utilisé pour compenser des émissions de carbone numérique. La détention d'un KLIMA vous donne également le droit de voter et de participer à la gouvernance du marché du carbone numérique."
 
 #: components/pages/Buy/index.tsx:51
 msgid "buy.how_to_paragraph_part_2"
-msgstr ""
+msgstr "Voici un court tutoriel pour les débutants qui ne connaissent pas le Web3 et la DeFi."
 
 #: components/pages/Buy/index.tsx:143
 msgid "buy.load_wallet"
-msgstr ""
+msgstr "2. Charger votre portefeuille avec des jetons MATIC"
 
 #: components/pages/Buy/index.tsx:85
 msgid "buy.load_wallet_description"
-msgstr ""
+msgstr "<0>Chargez votre nouveau portefeuille avec des jetons MATIC.</0> MATIC est le gaz qui permet au réseau Polygon de fonctionner. Chaque transaction que vous exécutez sur Polygon nécessitera quelques centimes de MATIC pour payer les frais de réseau."
 
 #: components/pages/Buy/index.tsx:148
 msgid "buy.load_wallet_description1"
-msgstr ""
+msgstr "Utilisez un service comme <0>MoonPay</0> ou <1>Transak</1> ou un échange centralisé comme <2>Coinbase</2> pour acheter des jetons MATIC de Polygon et l'envoyer dans votre portefeuille nouvellement créé."
 
 #: components/pages/Buy/index.tsx:158
 msgid "buy.load_wallet_description2"
-msgstr ""
+msgstr "<0>Assurez-vous que les jetons MATIC sont bien envoyés à votre nouvelle adresse de portefeuille !</0> Vous pouvez copier l'adresse dans votre presse-papiers en vous connectant à notre app et en cliquant sur l'adresse dans le menu de navigation."
 
 #: components/pages/Buy/index.tsx:168
 msgid "buy.load_wallet_description3"
-msgstr ""
+msgstr "<0>Assurez-vous d'acheter et d'envoyer des MATIC par le réseau Polygon !</0> Certains échanges comme Coinbase vous demanderont sur quel réseau envoyer les jetons MATIC. Vérifiez que vous choisissez toujours Polygon."
 
 #: components/pages/Buy/index.tsx:427
 msgid "buy.question_exchange"
-msgstr ""
+msgstr "Que se passe-t-il si je veux utiliser un autre échange, mais qu'il ne vend pas de jetons MATIC de Polygon ?"
 
 #: components/pages/Buy/index.tsx:322
 msgid "buy.question_why_matic"
-msgstr ""
+msgstr "Pourquoi dois-je d'abord acheter des jetons MATIC ?"
 
 #: components/pages/Buy/index.tsx:327
 msgid "buy.question_why_matic_answer"
-msgstr ""
+msgstr "Le jeton et le protocole KLIMA vivent sur la blockchain Polygon. Le MATIC est le \"gaz\" qui fait fonctionner chaque transaction sur Polygon. Il n'est pas possible d'exécuter une transaction sans payer les frais de transaction. Cela signifie que vous devrez payer quelques centimes de MATIC pour les actions suivantes :"
 
 #: components/pages/Buy/index.tsx:338
 msgid "buy.question_why_matic_answer_bullet1"
-msgstr ""
+msgstr "Mettre en jeu des KLIMA pour des sKLIMA"
 
 #: components/pages/Buy/index.tsx:345
 msgid "buy.question_why_matic_answer_bullet2"
-msgstr ""
+msgstr "Échange entre différents jetons"
 
 #: components/pages/Buy/index.tsx:352
 msgid "buy.question_why_matic_answer_bullet3"
-msgstr ""
+msgstr "Envoi de jetons vers un autre portefeuille"
 
 #: components/pages/Buy/index.tsx:359
 msgid "buy.question_why_matic_answer_bullet4"
-msgstr ""
+msgstr "Utilisation de jetons KLIMA ou autres pour compenser les émissions carbone"
 
 #: components/pages/Buy/index.tsx:292
 msgid "buy.staking_cta"
-msgstr ""
+msgstr "Misez, récoltez, votez et compensez !"
 
 #: components/pages/Buy/index.tsx:295
 msgid "buy.staking_description1"
-msgstr ""
+msgstr "Félicitations ! Maintenant que vous avez un peu de KLIMA dans votre portefeuille, nous vous recommandons vivement de <0>mettre en jeu</0> ce KLIMA pour sKLIMA, qui accumule des récompenses au fil du temps à mesure que le protocole se développe."
 
 #: components/pages/Buy/index.tsx:303
 msgid "buy.staking_description2"
-msgstr ""
+msgstr "Vous pouvez également utiliser l'application pour dépenser des KLIMA et <0> compenser des émissions de carbone numérique</0> sur la blockchain."
 
 #: components/pages/Buy/index.tsx:310
 msgid "buy.staking_description3"
-msgstr ""
+msgstr "Enfin, gardez un œil sur les <0>votes en cours</0> et contribuez à faire évoluer le protocole dans la bonne direction."
 
 #: components/pages/Buy/index.tsx:69
 msgid "buy.step_1"
-msgstr ""
+msgstr "1."
 
 #: components/pages/Buy/index.tsx:82
 msgid "buy.step_2"
-msgstr ""
+msgstr "2."
 
 #: components/pages/Buy/index.tsx:97
 msgid "buy.step_3"
-msgstr ""
+msgstr "3."
 
 #: components/pages/Buy/index.tsx:62
 msgid "buy.summary_steps_title"
-msgstr ""
+msgstr "Le moyen le plus simple et le plus efficace d'obtenir KLIMA est de suivre ces trois étapes :"
 
 #: components/pages/Buy/index.tsx:59
 msgid "buy.summary_title"
-msgstr ""
+msgstr "Sommaire"
 
 #: components/pages/Buy/index.tsx:253
 msgid "buy.swap_description1"
-msgstr ""
+msgstr "Après avoir connecté votre portefeuille et être passé sur le réseau du Polygon, vous devriez maintenant être en mesure d'échanger des MATIC contre des KLIMA."
 
 #: components/pages/Buy/index.tsx:259
 msgid "buy.swap_description2"
-msgstr ""
+msgstr "<0>Note importante : n'échangez pas tous vos MATIC contre des KLIMA !</0> Gardez au moins 0,5 MATIC pour payer les frais de transaction futurs."
 
 #: components/pages/Buy/index.tsx:275
 msgid "buy.swap_description3"
-msgstr ""
+msgstr "Si vous utilisez Torus, gardez l'onglet du navigateur avec l'application Torus ouvert. Vous devrez revenir à votre portefeuille pour approuver et autoriser les transactions."
 
 #: components/pages/Buy/index.tsx:282
 msgid "buy.swap_description4"
-msgstr ""
+msgstr "Facultatif : Si vous souhaitez que vos transactions de Sushi soient positives pour le climat, vous devriez activer le \"Green Fee\" de Sushi, développé par KlimaDAO. Vous dépenserez ainsi 0,02 MATIC par transaction pour acheter et compenser automatiquement avec du carbone numérique !"
 
 #: components/pages/Buy/index.tsx:100
 msgid "buy.swap_for_klima_description"
-msgstr ""
+msgstr "<0>Échanger contre des KLIMA.</0> Sushi est un échange décentralisé où vous pouvez échanger instantanément certains de vos jetons MATIC contre des jetons KLIMA au prix le plus bas possible."
 
 #: components/pages/Buy/index.tsx:250
 msgid "buy.swap_subtitle"
-msgstr ""
+msgstr "3B. Echanger des MATIC contre des KLIMA"
 
 #: components/pages/Buy/index.tsx:179
 msgid "buy.swap_wallet"
-msgstr ""
+msgstr "3. Échangez sur <0>Sushi.com</0> contre des KLIMA"
 
 #: components/pages/Buy/index.tsx:196
 msgid "buy.torus_login_description"
-msgstr ""
+msgstr "Dans un nouvel onglet du navigateur, allez sur la <0>Torus Polygon webapp</0> et connectez-vous avec votre nouveau compte Torus. Lorsque vous vous connectez, vous devriez voir un widget WalletConnect."
 
 #: components/pages/Buy/index.tsx:205
 msgid "buy.wallet_connect_example"
-msgstr ""
+msgstr "exemple d'entrée wallet connect"
 
 #: components/pages/Buy/index.tsx:222
 #: components/pages/Buy/index.tsx:268
 msgid "buy.wallet_connect_example_qr_code"
-msgstr ""
+msgstr "exemple de QR code wallet connect"
 
 #: components/pages/Buy/index.tsx:366
 msgid "buy.what_are_bonds"
-msgstr ""
+msgstr "Y a-t-il d'autres moyens d'obtenir KLIMA ? Que sont les obligations ?"
 
 #: components/pages/About/Community/index.tsx:116
 msgid "community.become_a_partner"
-msgstr ""
+msgstr "DEVENIR UN PARTENAIRE"
 
 #: components/pages/About/Community/index.tsx:180
 msgid "community.bigcowg_logo"
-msgstr ""
+msgstr "Logo BICOWG"
 
 #: components/pages/About/Community/index.tsx:172
 msgid "community.blockchainforclimatefondation_logo"
-msgstr ""
+msgstr "Logo de Blockchain for Climate Foundation"
 
 #: components/pages/About/Community/index.tsx:314
 msgid "community.come_on_in"
-msgstr ""
+msgstr "Entrez donc"
 
 #: components/pages/About/Community/index.tsx:228
 msgid "community.deltawave_logo"
-msgstr ""
+msgstr "Logo Delta Wave"
 
 #: components/pages/About/Community/index.tsx:265
 msgid "community.digitalcharityart_logo"
-msgstr ""
+msgstr "Logo Digital Charity Art"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:329
 msgid "community.discord_is_where_we_share"
-msgstr ""
+msgstr "Discord est l'endroit où nous publions des annonces importantes, organisons des réunions, répondons aux questions et échangeons des mêmes. Notre serveur Discord est extrêmement actif et modéré 24h/24. Nous avons des canaux pour tout les sujets, du commerce à la durabilité et aux marchés du carbone."
 
 #: components/pages/About/Community/index.tsx:244
 msgid "community.dovu_logo"
-msgstr ""
+msgstr "Logo Dovu"
 
 #: components/pages/About/Community/index.tsx:249
 msgid "community.eco_logo"
-msgstr ""
+msgstr "Logo Eco"
 
 #: components/pages/About/Community/index.tsx:236
 msgid "community.etcgroup_logo"
-msgstr ""
+msgstr "Logo Etc Group"
 
 #: components/pages/About/Community/index.tsx:361
 msgid "community.get_in_touch"
-msgstr ""
+msgstr "Vous voulez nous contacter?"
 
 #: components/pages/About/Community/index.tsx:204
 msgid "community.gitcoin_logo"
-msgstr ""
+msgstr "Logo Gitcoin"
 
 #: components/pages/About/Community/index.tsx:95
 msgid "community.head.headline"
-msgstr ""
+msgstr "Communauté"
 
 #: components/pages/About/Community/index.tsx:102
 msgid "community.head.metadescription"
-msgstr ""
+msgstr "Découvrez notre communauté de passionnés Klimates"
 
 #: components/pages/About/Community/index.tsx:96
 msgid "community.head.subline"
-msgstr ""
+msgstr "KlimaDAO est une Organisation Autonome Décentralisée pour le Changement. KlimaDAO est pilotée et construite par une communauté passionnée de Klimates."
 
 #: components/pages/About/Community/index.tsx:94
 #: components/pages/About/Community/index.tsx:101
 msgid "community.head.title"
-msgstr ""
+msgstr "Communauté KlimaDAO"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:364
 msgid "community.if_you_ve_got_questions"
-msgstr ""
+msgstr "Si vous avez des questions, des idées, des conseils ou quoi que ce soit d'autre : nous trouverons la personne adéquate pour vous aider."
 
 #: components/pages/About/Community/index.tsx:317
 msgid "community.join_our_discord"
-msgstr ""
+msgstr "Rejoignez notre Discord"
 
 #: components/pages/About/Community/index.tsx:304
 msgid "community.join_the_klima_community"
-msgstr ""
+msgstr "Rejoignez la communauté Klima"
 
 #: components/pages/About/Community/index.tsx:281
 msgid "community.landx_logo"
-msgstr ""
+msgstr "Logo LandX"
 
 #: components/pages/About/Community/index.tsx:113
 #: components/pages/About/Community/index.tsx:358
 msgid "community.lets_work_together"
-msgstr ""
+msgstr "Travaillons ensemble"
 
 #: components/pages/About/Community/index.tsx:156
 msgid "community.moss_logo"
-msgstr ""
+msgstr "Logo Moss"
 
 #: components/pages/About/Community/index.tsx:196
 msgid "community.oceandrop_logo"
-msgstr ""
+msgstr "Logo Oceandrop"
 
 #: components/pages/About/Community/index.tsx:257
 msgid "community.offsetra_logo"
-msgstr ""
+msgstr "Logo Offsetra"
 
 #: components/pages/About/Community/index.tsx:212
 msgid "community.olympusdao_logo"
-msgstr ""
+msgstr "Logo OlympusDAO"
 
 #: components/pages/About/Community/index.tsx:220
 msgid "community.openearth_logo"
-msgstr ""
+msgstr "Logo Open Earth"
 
 #: components/pages/About/Community/index.tsx:151
 msgid "community.our_partners"
-msgstr ""
+msgstr "NOS PARTENAIRES"
 
 #: components/pages/About/Community/index.tsx:188
 msgid "community.polygon_logo"
-msgstr ""
+msgstr "Logo Polygon"
 
 #: components/pages/About/Community/index.tsx:164
 msgid "community.toucan_logo"
-msgstr ""
+msgstr "Logo toucan"
 
 #: components/pages/About/Community/index.tsx:273
 msgid "community.toughtforfood_logo"
 msgstr ""
+"Logo Thought for Food\n"
+""
 
 #: components/pages/About/Community/index.tsx:132
 msgid "community.tree_grove"
-msgstr ""
+msgstr "Bosquet d'arbres"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:119
 msgid "community.we_work_with_traditionnal"
-msgstr ""
+msgstr "Nous travaillons avec des acteurs traditionnels du marché du carbone, des plateformes gérant des crypto-assets, des entreprises et ceux qui orbitent entre ces acteurs."
 
 #: components/pages/About/Contact/index.tsx:63
 msgid "concat.careers"
-msgstr ""
+msgstr "Carrières"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:170
 #: components/pages/Pledge/index.tsx:112
@@ -478,21 +480,21 @@ msgstr "Erreur de connexion"
 
 #: components/pages/About/Contact/index.tsx:140
 msgid "contact.bug_reports"
-msgstr ""
+msgstr "Rapport de bogues"
 
 #. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
 #: components/pages/About/Contact/index.tsx:143
 msgid "contact.bug_reports.to_file_a_bug_report"
-msgstr ""
+msgstr "Pour soumettre un rapport de bogue, rejoignez notre serveur Discord et posez votre question dans le canal #bug-reports. Notre <0>communauté</0> se fera un plaisir d'investiguer et de vous trouver une solution."
 
 #. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
 #: components/pages/About/Contact/index.tsx:66
 msgid "contact.careers.we_re_hiring"
-msgstr ""
+msgstr "Nous sommes une équipe entièrement à distance qui embauche sur tous les fuseaux horaires. Nous publions régulièrement des offres d'emploi et des missions sur notre <0>Serveur Discord Communautaire</0>. Si vous êtes une personne autonome et motivée pour rejoindre une DAO déterminée, nous aimerions avoir de vos nouvelles !"
 
 #: components/pages/About/Contact/index.tsx:25
 msgid "contact.head.description"
-msgstr ""
+msgstr "Entrez en contact avec quelqu'un de KlimaDAO."
 
 #: components/pages/About/Contact/index.tsx:18
 msgid "contact.head.headline"
@@ -500,49 +502,49 @@ msgstr "Nous contacter"
 
 #: components/pages/About/Contact/index.tsx:19
 msgid "contact.head.subline"
-msgstr ""
+msgstr "Des questions, des préoccupations, des idées? Voici quelques façons d'entrer en contact avec nous. Nous sommes toujours ravis de partager avec de nouvelles institutions et de personnes."
 
 #: components/pages/About/Contact/index.tsx:17
 #: components/pages/About/Contact/index.tsx:24
 msgid "contact.head.title"
-msgstr ""
+msgstr "Contacter KlimaDAO"
 
 #: components/pages/About/Contact/index.tsx:105
 msgid "contact.media"
-msgstr ""
+msgstr "Médias"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:108
 msgid "contact.media.if_you_are_a_journalist"
-msgstr ""
+msgstr "Si vous êtes un journaliste ou un créateur de contenu, notre équipe marketing sera ravie de vous rencontrer."
 
 #. Use this <0>Media Request Form</0>.
 #: components/pages/About/Contact/index.tsx:117
 msgid "contact.media.use_this_media_request_form"
-msgstr ""
+msgstr "Utilisez ce <0>formulaire de demande média</0> ou envoyez un email à <1>press@klimadao.finance</1>"
 
 #: components/pages/About/Contact/index.tsx:85
 msgid "contact.partnerships"
-msgstr ""
+msgstr "Partenariats"
 
 #. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
 #: components/pages/About/Contact/index.tsx:88
 msgid "contact.partnerships.until_we_finish_building"
-msgstr ""
+msgstr "Notre page partenariats est en cours de création. En attendant, vous pouvez adresser vos demandes de partenariat via ce <0>formulaire de contact</0>."
 
 #: components/pages/About/Contact/index.tsx:35
 msgid "contact.quest_and_support"
-msgstr ""
+msgstr "Questions et assistance"
 
 #. Join our <0>community</0>
 #: components/pages/About/Contact/index.tsx:38
 msgid "contact.quest_and_support.join_our_community"
-msgstr ""
+msgstr "Rejoignez notre <0>communauté</0>"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:46
 msgid "contact.quest_and_support.join_our_discord_server"
-msgstr ""
+msgstr "Rejoignez notre serveur Discord et posez vos questions dans le canal #questions. Des milliers de membres sympathiques, compétents et disposés à vous aider vous y attendent."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:64
@@ -551,443 +553,446 @@ msgstr "1. Une offre ou une sollicitation d'une offre pour détenir ou contrôle
 
 #: components/pages/About/Disclaimer/index.tsx:111
 msgid "disclaimer.1_meet_your_requirements"
-msgstr ""
+msgstr "1. Réponde à vos exigences"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:116
 msgid "disclaimer.2_be_available_on_an_uninterrupted"
-msgstr ""
+msgstr "2. Disponible de manière permanente, opportune, sécurisée ou sans erreur ;"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:74
 msgid "disclaimer.2_financial_investment_or_trading_advice"
-msgstr ""
+msgstr "2. Des conseils financiers, d'investissement ou de trading ou une offre à la fourniture de tels conseils et/ou services."
 
 #: components/pages/About/Disclaimer/index.tsx:125
 msgid "disclaimer.3_be_reliable_complete_legal_or_safe"
-msgstr ""
+msgstr "3. Fiable, complète, conforme aux exigences légales ou sûr."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:32
 msgid "disclaimer.all_information_on_this_website"
-msgstr ""
+msgstr "Toutes les informations sur ce site sont publiées de bonne foi et à des fins pédagogiques uniquement. KlimaDAO est mis en ligne dans l'espoir d'être utile et de ne servir que dans les limites décrites sur ce même site."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:159
 msgid "disclaimer.any_action_you_take_upon_the_information"
-msgstr ""
+msgstr "Toute actions que vous entreprendriez sur la base des informations contenues dans ce site seront à vos seuls risques et périls. Les décisions prises sur la base des informations contenues sur ce site relèvent de la seule responsabilité du visiteur. La responsabilité de KlimaDAO ne pourra être engagée en cas de pertes et/ou de dommages liées à l'utilisation du site, de la perte de votre mot de passe/phrase mémotechnique, d'une mauvais transaction, de l'envoi d'un actif à la mauvaise adresse, de la perte de vos actifs ou de dommages causés par l'action de fraudeurs. La responsabilité de KlimaDAO ne pourra pas non plus être engagée du fait de l'évolution du marché et à sa volatilité. Vous devez effectuer vos propres recherches et vous assurer de votre propre position, et d'avoir acquis la connaissance et la maîtrise des informations et des services fournis par cette plateforme."
 
 #: components/pages/About/Disclaimer/index.tsx:19
 msgid "disclaimer.disclaimer"
-msgstr ""
+msgstr "Avertissement légal"
 
 #: components/pages/About/Disclaimer/index.tsx:21
 msgid "disclaimer.head.description"
-msgstr ""
+msgstr "Un avertissement important de l'équipe juridique de KlimaDAO."
 
 #: components/pages/About/Disclaimer/index.tsx:15
 #: components/pages/About/Disclaimer/index.tsx:25
 msgid "disclaimer.head.title"
-msgstr ""
+msgstr "Clause de non-responsabilité KlimaDAO"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:102
 msgid "disclaimer.klimadao_and_its_suppliers"
-msgstr ""
+msgstr "KlimaDAO et ses sous-traitants ne garantissent pas que la plateforme sera:"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:43
 msgid "disclaimer.klimadao_is_a_platform"
-msgstr ""
+msgstr "KlimaDAO est une plateforme. Nous ne sommes pas un courtier, une institution financière ou un créancier. Les services fournis sur ce site n'incluent pas une offre de détention ou de contrôle de vos titres, options, actifs, contrats à terme ou autres dérivés liés à des titres et son contenu n'est pas conforme aux lois réglementant la gestion des valeurs mobilières."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:130
 msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
-msgstr ""
+msgstr "Ni KlimaDAO ni aucun de ses représentants ne pourront être tenus pour responsables de toute perte de quelque nature que ce soit résultant de toute action entreprise sur la base de contenus ou d'informations disponibles sur ce site. KlimaDAO sécurise l'utilisation du service et du contenu, mais ne déclare ni ne garantit que le service et le contenu de la plate-forme sont exempts de virus ou d'autres éléments nuisibles."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:178
 msgid "disclaimer.nothing_in_this_disclaimer"
-msgstr ""
+msgstr "Rien dans cette clause de non-responsabilité, contenu ou information ne peut ou ne pourra utilisé pour initier une action juridique ou pour établir une relation de droits et/ou de devoir  entre vous et nous."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:56
 msgid "disclaimer.nothing_in_this_platform"
-msgstr ""
+msgstr "Rien dans cette plate-forme ne constitue ou ne peut être interprété comme :"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:83
 msgid "disclaimer.the_service_available"
-msgstr ""
+msgstr "Les service disponibles ou accessibles via le site sont fournis « tels quels » et, dans toute la mesure permise par la loi applicable. KlimaDAO et ses agents, conseillers, administrateurs, dirigeants, employés et actionnaires déclinent toute garantie, explicite ou implicite, y compris, mais sans s'y limiter, les garanties implicites de qualité marchande, d'adéquation à un usage particulier et de non-contrefaçon, et les garanties implicites d'un cours d'éxécution et d'accords entre les parties. KlimaDAO ne donne aucune garantie quant à l'exhaustivité, la fiabilité et l'exactitude de ces informations et services, ou à la valeur marchande et à l'adéquation à un usage particulier. Cette plate-forme ne donne aucune garantie quant à l'exhaustivité et à l'exactitude de ces informations."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:189
 msgid "disclaimer.we_recommend_that_you_visit"
-msgstr ""
+msgstr "Nous vous recommandons de visiter notre page Crypto Security 101 afin de prendre connaissance des consignes de sécurité avant l'utilisation des sites Web. Nous vous prions de prendre en compte ces quelques conseils : ne partagez jamais, avec quiconque, votre clé privée ou votre phrase mnémotechnique - ni nos membres ni notre application ne vous les demanderont jamais."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:144
 msgid "disclaimer.you_bear_full_responsibility"
-msgstr ""
+msgstr "Vous assumez l'entière responsabilité de fournir des informations privées, de vérifier l'identité et la légitimité de ce site. Nonobstant les indicateurs et les messages pouvant suggérer que l'identité et la légitimité du site sont conformes, KlimaDAO ne fait aucune déclaration sur l'identité sur la plate-forme. Nous ne garantissons ni la sécurité des données divulguées en ligne, ni la prévention de pertes subies en raison d'une vulnérabilité, de défaillance quel quelle soit ou d'un comportement inattendu du logiciel."
 
 #: components/pages/errors/Custom404.tsx:41
 msgid "error.404.page.text"
-msgstr ""
+msgstr "Désolé, on dirait qu'on vous a envoyé au mauvais endroit. <0/>Laissez nous vous guider vers la page d'accueil :"
 
 #: components/pages/errors/Custom500.tsx:39
 msgid "error.500.page.text"
-msgstr ""
+msgstr "Veuillez nous excuser, Une erreur s'est produite.<0/>Veuillez retourner à la page d’accueil :"
 
 #: components/pages/errors/Custom500.tsx:34
 msgid "error.500.page.title"
-msgstr ""
+msgstr "500 - Une erreur s'est produite de notre côté"
 
 #: components/pages/errors/Custom500.tsx:19
 msgid "error.page.500.head.title"
-msgstr ""
+msgstr "500 - Une erreur s'est produite"
 
 #: components/pages/errors/Custom500.tsx:15
 msgid "error.page.500.title"
-msgstr ""
+msgstr "500 - Une erreur s'est produite"
 
 #: components/pages/Home/index.tsx:236
 msgid "home.backed_by_carbon"
-msgstr ""
+msgstr "Collatéralisé par du carbone."
 
 #: components/pages/Home/index.tsx:327
 msgid "home.cars_annual"
-msgstr ""
+msgstr "Voitures (par année)"
 
 #: components/pages/Home/index.tsx:296
 msgid "home.equivalent_to"
-msgstr ""
+msgstr "ÉQUIVALENT À"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:411
 msgid "home.every_klima_token_is_backed"
-msgstr ""
+msgstr "Chaque jeton KLIMA est collatéralisé par un actif carbone réel. Les jetons sont utilisés pour compenser les émissions carbone, interagir avec les applications DeFi et prendre part au marché mondial carbone qui est en croissance rapide."
 
 #: components/SocialProof/index.tsx:19
 msgid "home.featured_on"
-msgstr ""
+msgstr "Ils parlent de KlimaDAO"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:107
 msgid "home.fight_climate_change"
-msgstr ""
+msgstr "Combattez le changement climatique et soyez récompensé avec KLIMA, une monnaie numérique collatéralisée par de vrais actifs carbone."
 
 #: components/pages/Home/index.tsx:462
 msgid "home.get_exposure_to_the_growing_carbon_economy"
-msgstr ""
+msgstr "Prenez part dès aujourd'hui à l'économie croissante du carbone. Achetez, mettez en jeu et soyez récompensé. L'activisme financier au service du climat."
 
 #: components/pages/Home/index.tsx:459
 msgid "home.get_klima"
-msgstr ""
+msgstr "OBTENEZ DES JETONS KLIMA"
 
 #: components/pages/Home/index.tsx:310
 msgid "home.hectares_of_forest"
-msgstr ""
+msgstr "Hectares de forêt"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:154
 msgid "home.klima_defies_climate_change"
-msgstr ""
+msgstr "KlimaDAO est la DeFi qui défie le changement climatique"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:164
 msgid "home.klima_is_the_center"
-msgstr ""
+msgstr "KlimaDAO est le centre d'une nouvelle économie verte. Construit sur le réseau économe en énergie Polygon, KlimaDAO utilise un ensemble de technologies pour réduire la fragmentation du marché et accélérer l'octroi de financements pour le climat à des projets de développement durable dans le monde entier."
 
 #. Long sentence
 #: components/pages/Home/index.tsx:440
 msgid "home.klima_tokens_are_minted"
-msgstr ""
+msgstr "Les jetons KLIMA sont créés et distribués automatiquement toutes les ~7 heures aux détenteurs de KLIMA mis en jeu. Développez votre capital KLIMA  et participons ensemble à la construction d'un avenir plus durable."
 
 #: components/pages/Home/index.tsx:83
 msgid "home.latest_news"
-msgstr ""
+msgstr "Dernières nouvelles"
 
 #: components/pages/Home/index.tsx:139
 msgid "home.learn_more"
-msgstr ""
+msgstr "EN SAVOIR PLUS"
 
 #: components/pages/Home/index.tsx:342
 msgid "home.liters_if_gasoline"
-msgstr ""
+msgstr "Litres d'essence"
 
 #: components/pages/Home/index.tsx:272
 msgid "home.massive impact"
-msgstr ""
+msgstr "Impact massif."
 
 #: components/pages/Home/index.tsx:210
 msgid "home.mechanics"
-msgstr ""
+msgstr "MÉCANIQUES"
 
 #. <0>{0}% MONTHLY REWARDS</0><1>FOR TOKEN HOLDERS</1>
 #: components/pages/Home/index.tsx:428
 msgid "home.monthly_rewards_for_token_holders"
-msgstr ""
+msgstr "<0>{0} % DE RÉCOMPENSES MENSUELLES</0> <1>POUR LES DÉTENTEURS DE JETONS</1>"
 
 #: components/pages/Home/index.tsx:491
 msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
-msgstr ""
+msgstr "Toute l'Alpha, directement dans votre boîte de réception"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:499
 msgid "home.newletter.get_the_latest_updates"
-msgstr ""
+msgstr "Recevez les dernières informations concernant KlimaDAO, tandis que nous construisons l'avenir de l'économie du carbone."
 
 #: components/pages/Home/index.tsx:516
 msgid "home.newletter.never_shared_never_spammed"
-msgstr ""
+msgstr "Jamais partagé. Jamais spammé."
 
 #: components/pages/Home/index.tsx:510
 msgid "home.newletter.sign_up"
-msgstr ""
+msgstr "S'inscrire"
 
 #: components/pages/Home/index.tsx:496
 msgid "home.newsletter"
-msgstr ""
+msgstr "Bulletin d'information"
 
 #. <0>Reserve Asset</0><1>Of the carbon economy</1>
 #: components/pages/Home/index.tsx:399
 msgid "home.reserve_asset_of_the_carbon_economy"
-msgstr ""
+msgstr "<0>Actif de réserve</0> <1>De l'économie carbone</1>"
 
 #: components/pages/Home/index.tsx:469
 msgid "home.see_tutorial"
-msgstr ""
+msgstr "Voir le tutoriel"
 
 #: components/pages/Home/index.tsx:357
 msgid "home.source"
-msgstr ""
+msgstr "Source"
 
 #: components/pages/Home/index.tsx:254
 msgid "home.strong_incentives"
-msgstr ""
+msgstr "Fortes incitations."
 
 #. Long sentence
 #: components/pages/Home/index.tsx:213
 msgid "home.the_dao_sell_bonds"
-msgstr ""
+msgstr "La DAO vend des obligations et reverse les intérêts aux détenteurs de KLIMA. Chaque obligation que nous vendons s'ajoute à une trésorerie verte en croissance constante ou améliore la liquidité d'actifs environnementaux clés. Un processus  gagnant-gagnant pour l'Humanité et notre Planète."
 
 #. TONS OF <0>CARBON ABSORBED</0> BY KLIMADAO
 #: components/pages/Home/index.tsx:283
 msgid "home.tons_of_carbon_absorbed_by_klimadao"
-msgstr ""
+msgstr "TONNES DE <0>CARBONE ABSORBÉES</0> PAR KLIMADAO"
 
 #. <0>WELCOME TO</0><1>KlimaDAO</1>
 #: components/pages/Home/index.tsx:94
 msgid "home.welcome_to_klimadao"
-msgstr ""
+msgstr "<0>BIENVENUE CHEZ</0> <1>KlimaDAO</1>"
 
 #: components/pages/Infinity/index.tsx:162
 msgid "infinity.affordable_subtitle"
-msgstr ""
+msgstr "Abordable"
 
 #: components/pages/Infinity/index.tsx:157
 msgid "infinity.affordable_title"
-msgstr ""
+msgstr "Prix en temps réel, faibles coûts de transaction"
 
 #: components/pages/Infinity/index.tsx:418
 msgid "infinity.box_amount_104k"
-msgstr ""
+msgstr "104k"
 
 #: components/pages/Infinity/index.tsx:404
 msgid "infinity.box_amount_11k"
-msgstr ""
+msgstr "11k"
 
 #: components/pages/Infinity/index.tsx:400
 msgid "infinity.box_title"
-msgstr ""
+msgstr "Dernière compensation carbone"
 
 #: components/pages/Infinity/index.tsx:414
 msgid "infinity.box_title2"
-msgstr ""
+msgstr "Total du carbone compensé"
 
 #: components/pages/Infinity/index.tsx:665
 msgid "infinity.button.read_blog_faq"
-msgstr ""
+msgstr "Lire les FAQs détaillées pour les clients KI"
 
 #: components/pages/Infinity/index.tsx:368
 msgid "infinity.button.read_blog_polygon"
-msgstr ""
+msgstr "Lire l'article sur Polygon"
 
 #: components/pages/Infinity/Cards/CardsSlider.tsx:89
 msgid "infinity.cards_slider.title"
-msgstr ""
+msgstr "Des dizaines d'organisations ont compensé plus de 150 000 tonnes de carbone avec Klima Infinity."
 
 #: components/pages/Infinity/index.tsx:331
 msgid "infinity.carousel_image_description"
-msgstr ""
+msgstr "Projet d'énergie éolienne à Jaibhim, Inde"
 
 #: components/pages/Infinity/index.tsx:343
 msgid "infinity.carousel_info_subtitle"
-msgstr ""
+msgstr "Promouvoir le financement de projets qui contribuent à l'atténuation du changement climatique."
 
 #: components/pages/Infinity/index.tsx:338
 msgid "infinity.carousel_info_title"
-msgstr ""
+msgstr "Soutenir des projets de haute qualité"
 
 #: components/pages/Infinity/index.tsx:685
 msgid "infinity.cta_title"
-msgstr ""
+msgstr "La boîte à outils carbone de prochaine génération pour votre organisation"
 
 #: components/pages/Infinity/index.tsx:557
 msgid "infinity.faq_answer1"
-msgstr ""
+msgstr "Une unité de compensation carbone représente la suppression d'une tonne d'équivalent dioxyde de carbone (tCO2e) de l'atmosphère, ou l'évitement d'une tonne d'émissions."
 
 #: components/pages/Infinity/index.tsx:593
 msgid "infinity.faq_answer2_paragraph1"
-msgstr ""
+msgstr "Les crédits carbone sont un mécanisme à haute intégrité qui permet au financement du carbone de passer de ceux qui polluent à des projets dans le monde entier qui contribuent à atténuer ou à éliminer le carbone de l'atmosphère. Ils constituent un outil précieux pour couvrir les émissions difficiles à éliminer qui peuvent être coûteuses ou techniquement difficiles à éliminer aujourd'hui."
 
 #: components/pages/Infinity/index.tsx:603
 msgid "infinity.faq_answer2_paragraph2"
-msgstr ""
+msgstr "Lorsque vous achetez un crédit carbone, Klima Infinity vous permet de retirer ce crédit carbone, le retirant définitivement de la circulation. C'est à partir de ce retrait que vous pouvez réclamer le bénéfice de la compensation carbone."
 
 #: components/pages/Infinity/index.tsx:611
 msgid "infinity.faq_answer2_paragraph3"
-msgstr ""
+msgstr "Les compensations achetées entraînent des réductions d'émissions mesurables et responsables dans d'autres secteurs de l'économie et peuvent être utilisées pour \"compenser\" une empreinte carbone inévitable. Le commerce et le retrait des crédits de carbone permettent l'émergence d'un mécanisme de marché qui fixe un prix au carbone."
 
 #: components/pages/Infinity/index.tsx:648
 msgid "infinity.faq_answer3"
 msgstr ""
+"L'objectif des marchés du carbone est de réduire les émissions de gaz à effet de serre (GES, ou \"carbone\") de manière rentable en fixant des limites aux émissions et en permettant l'échange d'unités d'émission, qui sont des instruments financiers représentant les réductions d'émissions. L'échange permet aux entités qui peuvent réduire leurs émissions à moindre coût d'être payées pour le faire par les émetteurs dont les coûts sont plus élevés, ce qui réduit le coût économique de la réduction des émissions.\n"
+"\n"
+"Traduit avec www.DeepL.com/Translator (version gratuite)"
 
 #: components/pages/Infinity/index.tsx:543
 msgid "infinity.faq_question1"
-msgstr ""
+msgstr "1. Qu'est-ce qu'une compensation carbone ?"
 
 #: components/pages/Infinity/index.tsx:577
 msgid "infinity.faq_question2"
-msgstr ""
+msgstr "2. Comment la compensation contribue-t-elle à la lutte contre le changement climatique ?"
 
 #: components/pages/Infinity/index.tsx:634
 msgid "infinity.faq_question3"
-msgstr ""
+msgstr "3. Que sont les marchés du carbone ?"
 
 #: components/pages/Infinity/index.tsx:137
 msgid "infinity.fast_subtitle"
-msgstr ""
+msgstr "Compensation en quelques secondes, sans paperasserie"
 
 #: components/pages/Infinity/index.tsx:142
 msgid "infinity.fast_title"
-msgstr ""
+msgstr "Rapide"
 
 #: components/pages/Infinity/GetStartedModal.tsx:47
 msgid "infinity.getStartedModal_business"
-msgstr ""
+msgstr "Je suis une entreprise <0/>."
 
 #: components/pages/Infinity/GetStartedModal.tsx:70
 msgid "infinity.getStartedModal_individual"
-msgstr ""
+msgstr "Je suis un particulier <0/>."
 
 #: components/pages/Infinity/GetStartedModal.tsx:104
 msgid "infinity.getStartedModal_needAssistance"
-msgstr ""
+msgstr "J'aimerais qu'on m'aide à évaluer l'empreinte carbone de mon entreprise."
 
 #: components/pages/Infinity/GetStartedModal.tsx:94
 msgid "infinity.getStartedModal_offsetCrypto"
-msgstr ""
+msgstr "Je veux compenser <0/> de la crypto."
 
 #: components/pages/Infinity/index.tsx:258
 msgid "infinity.getStarted_1"
-msgstr ""
+msgstr "1"
 
 #: components/pages/Infinity/index.tsx:272
 msgid "infinity.getStarted_2"
-msgstr ""
+msgstr "2"
 
 #: components/pages/Infinity/index.tsx:261
 msgid "infinity.getStarted_calculate"
-msgstr ""
+msgstr "Calculer"
 
 #: components/pages/Infinity/index.tsx:264
 msgid "infinity.getStarted_calculate_subtitle"
-msgstr ""
+msgstr "Calculez l'empreinte carbone de votre organisation et définissez la portée de votre compensation avec Klima Infinity."
 
 #: components/pages/Infinity/index.tsx:301
 msgid "infinity.getStarted_cta"
-msgstr ""
+msgstr "Accélérez votre démarche vers la neutralité carbone - et au-delà"
 
 #: components/pages/Infinity/index.tsx:278
 msgid "infinity.getStarted_second_subtitle"
-msgstr ""
+msgstr "Mettez en œuvre votre compensation en quelques clics seulement, et avec un temps de transaction quasi instantané."
 
 #: components/pages/Infinity/index.tsx:275
 msgid "infinity.getStarted_second_title"
-msgstr ""
+msgstr "Mettre en œuvre"
 
 #: components/pages/Infinity/index.tsx:286
 msgid "infinity.getStarted_third"
-msgstr ""
+msgstr "3"
 
 #: components/pages/Infinity/index.tsx:292
 msgid "infinity.getStarted_third_subtitle"
-msgstr ""
+msgstr "Suivez votre engagement et renforcez la sensibilisation à vos actions en faveur du climat."
 
 #: components/pages/Infinity/index.tsx:289
 msgid "infinity.getStarted_third_title"
-msgstr ""
+msgstr "Amplifier"
 
 #: components/pages/Infinity/index.tsx:67
 msgid "infinity.head.metaDescription"
-msgstr ""
+msgstr "Une boîte à outils carbone de prochaine génération pour votre organisation."
 
 #: components/pages/Infinity/index.tsx:63
 msgid "infinity.head.metaTitle"
-msgstr ""
+msgstr "Klima Infinity - Devenez neutre en carbon"
 
 #: components/pages/Infinity/index.tsx:59
 msgid "infinity.head.title"
-msgstr ""
+msgstr "KlimaDAO | Klima Infinity"
 
 #: components/pages/Infinity/index.tsx:178
 msgid "infinity.info_subtitle1"
-msgstr ""
+msgstr "Pour les organisations pionnières de la planète"
 
 #: components/pages/Infinity/index.tsx:183
 msgid "infinity.info_subtitle2"
-msgstr ""
+msgstr "La solution de compensation la plus puissante et la plus facile à utiliser au monde"
 
 #: components/pages/Infinity/index.tsx:450
 msgid "infinity.mission_card1_subtitle"
-msgstr ""
+msgstr "Tonnes de carbone détenues par KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:447
 msgid "infinity.mission_card1_title"
-msgstr ""
+msgstr "18,1 millions"
 
 #: components/pages/Infinity/index.tsx:472
 msgid "infinity.mission_card2_description"
-msgstr ""
+msgstr "Liquidité carbone détenue par KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:469
 msgid "infinity.mission_card2_number"
-msgstr ""
+msgstr "$10m+"
 
 #: components/pages/Infinity/index.tsx:494
 msgid "infinity.mission_card3_description"
-msgstr ""
+msgstr "Tonnes de carbone compensées via KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:491
 msgid "infinity.mission_card3_number"
-msgstr ""
+msgstr "150 000+"
 
 #: components/pages/Infinity/index.tsx:387
 msgid "infinity.polygon_manifesto_description"
-msgstr ""
+msgstr "En compensant les émissions historiques de l'ensemble de son réseau, Polygon s'est assuré que chaque interaction au sein de son réseau - qu'il s'agisse d'une frappe de NFT ou d'une transaction DeFi - est prise en compte. C'est l'une des principales raisons pour lesquelles Meta a choisi Polygon pour émettre ses NFT."
 
 #: components/pages/Infinity/index.tsx:381
 msgid "infinity.polygon_manifesto_title"
-msgstr ""
+msgstr "La compensation fait partie du Manifeste Vert de Polygon."
 
 #: components/pages/Infinity/index.tsx:361
 msgid "infinity.polygon_story_description"
-msgstr ""
+msgstr "Polygon a compensé les émissions de carbone du réseau depuis sa création - environ 90 000 tonnes - et s'est engagé à adopter une approche climatiquement positive pour toutes les transactions futures du réseau."
 
 #: components/pages/Infinity/index.tsx:356
 msgid "infinity.polygon_story_title"
-msgstr ""
+msgstr "Polygon a choisi Klima Infinity pour compenser son réseau de blockchain."
 
 #: components/pages/Infinity/Cards/Card.tsx:66
 #: components/pages/Infinity/index.tsx:407
@@ -997,158 +1002,158 @@ msgstr "Tonnes"
 
 #: components/pages/Infinity/index.tsx:196
 msgid "infinity.transparent_subtitle"
-msgstr ""
+msgstr "Transparente"
 
 #: components/pages/Infinity/index.tsx:191
 msgid "infinity.transparent_title"
-msgstr ""
+msgstr "Immuablement enregistré sur la blockchain"
 
 #: components/pages/Infinity/index.tsx:98
 msgid "infinity.welcome_subtitle"
-msgstr ""
+msgstr "Klima Infinity est une boîte à outils carbone de prochaine génération pour votre organisation."
 
 #: components/pages/Infinity/index.tsx:93
 msgid "infinity.welcome_title"
-msgstr ""
+msgstr "Le moyen le plus simple de devenir neutre en carbone"
 
 #: components/pages/Infinity/index.tsx:224
 msgid "infinity.why_description"
-msgstr ""
+msgstr "KlimaDAO s'appuie sur une pile de technologies DeFi pour réduire la fragmentation du marché et accélérer la fourniture de financements climatiques à des projets de développement durable dans le monde entier."
 
 #: components/pages/Infinity/index.tsx:219
 msgid "infinity.why_subtitle"
-msgstr ""
+msgstr "La DeFi qui défie le changement climatique"
 
 #: components/pages/Infinity/index.tsx:216
 msgid "infinity.why_title"
-msgstr ""
+msgstr "Pourquoi KlimaDAO ?"
 
 #: components/pages/Home/index.tsx:384
 msgid "invest_in_the_future"
-msgstr ""
+msgstr "Investissez dans l'avenir."
 
 #: components/pages/Infinity/index.tsx:439
 msgid "mission.header"
-msgstr ""
+msgstr "La mission de KlimaDAO est de démocratiser l'action climatique."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:79
 #: components/pages/Pledge/PledgeForm/index.tsx:83
 #: components/pages/Pledge/PledgeForm/index.tsx:99
 msgid "pledge.errors.default"
-msgstr ""
+msgstr "Une erreur est survenue"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:91
 msgid "pledge.errors.method_not_allowed"
-msgstr ""
+msgstr "Méthode non autorisée."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:75
 msgid "pledge.errors.pledge_not_found"
-msgstr ""
+msgstr "Aucun engagement n'a été trouvé pour cette adresse."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:87
 msgid "pledge.errors.unknown_error"
-msgstr ""
+msgstr "Une erreur inconnue est survenue."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:191
 msgid "pledge.form.error.cannot_add_yourself"
-msgstr ""
+msgstr "Vous ne pouvez pas ajouter votre propre portefeuille comme portefeuille secondaire."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:227
 msgid "pledge.form.error.default_error_message"
-msgstr ""
+msgstr "Un problème est survenu. Veuillez réessayer sous peu."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:175
 msgid "pledge.form.error.duplicate_wallets"
-msgstr ""
+msgstr "Veuillez supprimer le(s) portefeuille(s) en double"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:616
 msgid "pledge.form.wallets.confirm_remove_wallet"
-msgstr ""
+msgstr "Êtes-vous sûr de vouloir supprimer {0} de votre engagement ?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:340
 msgid "pledge.form.wallets.tooltip"
-msgstr ""
+msgstr "Ajoutez d'autres portefeuilles pour contribuer à votre engagement. Si le propriétaire du portefeuille accepte votre invitation, son portefeuille apparaîtra sur le tableau de bord de votre engagement. Tous les retraits effectués par un portefeuille secondaire contribueront à votre engagement. Vous resterez le seul propriétaire et le seul éditeur de cet engagement."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:41
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:111
 msgid "pledge.invitation.accept"
-msgstr ""
+msgstr "Accepter l'invitation"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:70
 msgid "pledge.invitation.error.wallet_already_pinned"
-msgstr ""
+msgstr "Ce portefeuille est déjà associé à un autre engagement. Veuillez désépingler votre portefeuille et réessayer."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:49
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:44
 msgid "pledge.invitation.error_title"
-msgstr ""
+msgstr "Erreur du serveur"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:102
 msgid "pledge.invitation.join_message"
-msgstr ""
+msgstr "{shortenedAddress} vous a invité à ajouter votre portefeuille à cet engagement. Si vous acceptez, vos retraits de carbone seront comptabilisés dans l'engagement de {shortenedAddress}. Vous pouvez retirer votre porte-monnaie de cet engagement à tout moment."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:130
 msgid "pledge.invitation.later"
-msgstr ""
+msgstr "Rappelez-moi plus tard"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:118
 msgid "pledge.invitation.reject"
-msgstr ""
+msgstr "Rejeter l'invitation"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:57
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:52
 msgid "pledge.invitation.signing"
-msgstr ""
+msgstr "Signature en cours"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:193
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:179
 msgid "pledge.invitations.awaiting_signature"
-msgstr ""
+msgstr "En attente de signature..."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:199
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:185
 msgid "pledge.invitations.signature_instructions"
-msgstr ""
+msgstr "Utilisez votre portefeuille pour signer et confirmer cette modification."
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:129
 msgid "pledge.modal.are_you_sure"
-msgstr ""
+msgstr "Êtes-vous sûr de vouloir retirer votre portefeuille de cette engagement ?"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:153
 msgid "pledge.modal.confirm"
-msgstr ""
+msgstr "Confirmer"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:40
 msgid "pledge.modal.confirm_remove"
-msgstr ""
+msgstr "Confirmer la compensation"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:39
 msgid "pledge.modal.edit_pledge"
-msgstr ""
+msgstr "Modifier l'engagement"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:101
 msgid "pledge.modal.unable_to_edit"
-msgstr ""
+msgstr "Ce portefeuille n'a pas la permission de modifier cet engagement. Pour le modifier, vous devez vous reconnecter avec le portefeuille de l'auteur original ({0})."
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:110
 msgid "pledge.modal.unpin_wallet"
-msgstr ""
+msgstr "désépingler mon portefeuille"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:144
 msgid "pledge.modal.wallet_add_confirm"
-msgstr ""
+msgstr "Vous ne pouvez avoir qu'une seule page d'engagement par adresse de portefeuille. Si vous avez déjà créé une page d'engagement avec ce portefeuille, les visiteurs seront redirigés vers cet engagement. Vous pouvez supprimer ce portefeuille à tout moment."
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:110
 msgid "pledges.dashboard.assets.emptyBalance"
-msgstr ""
+msgstr "Aucun actif carbone à afficher."
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:87
 msgid "pledges.dashboard.assets.title"
-msgstr ""
+msgstr "Actifs Carbone"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
 msgid "pledges.dashboard.footprint.title"
-msgstr ""
+msgstr "Empreinte"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
 msgid "pledges.dashboard.footprint.tonnes"
@@ -1156,27 +1161,27 @@ msgstr "Tonnes"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:104
 msgid "pledges.dashboard.footprint.tooltip.category_percent"
-msgstr ""
+msgstr "{0}% de l'empreinte"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:110
 msgid "pledges.dashboard.footprint.tooltip.quantity"
-msgstr ""
+msgstr "{0} Tonnes de carbone"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:137
 msgid "pledges.dashboard.head.metaDescription"
-msgstr ""
+msgstr "Engagements de {pledgeOwnerTitle} à compenser {currentTotalFootprint} Tonnes de carbone. Consultez l'historique de leur compensation carbone et lisez plus sur leur implication."
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:133
 msgid "pledges.dashboard.head.metaTitle"
-msgstr ""
+msgstr "Engagement de {pledgeOwnerTitle}"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:129
 msgid "pledges.dashboard.head.title"
-msgstr ""
+msgstr "Engagement de {pledgeOwnerTitle} | KlimaDAO"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:14
 msgid "pledges.dashboard.metholodogy.default_text"
-msgstr ""
+msgstr "Comment allez-vous tenir votre engagement ?"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:21
 msgid "pledges.dashboard.metholodogy.title"
@@ -1184,139 +1189,139 @@ msgstr "Méthodologie"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:14
 msgid "pledges.dashboard.pledge.default_text"
-msgstr ""
+msgstr "Rédigez votre engagement aujourd'hui !"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:21
 msgid "pledges.dashboard.pledge.title"
-msgstr ""
+msgstr "Engagement"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:64
 msgid "pledges.dashboard.profile.pledge_met"
-msgstr ""
+msgstr "≥ 100% de l'engagement atteint"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:73
 msgid "pledges.dashboard.profile.pledge_progress"
-msgstr ""
+msgstr "{0}% de l'engagement atteint"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:106
 msgid "pledges.dashboard.profile.pledged_to_offset"
-msgstr ""
+msgstr "Engagé à compenser <0>{0}</0> tonnes de carbone"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:104
 msgid "pledges.dashboard.retirements.title"
-msgstr ""
+msgstr "Compensations"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
 msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
-msgstr ""
+msgstr "{0} Tonne(s) de carbone compensée(s)"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:123
 msgid "pledges.dashboard.retirements.total_tonnes_retired"
-msgstr ""
+msgstr "Total des tonnes de Carbone compensées"
 
 #: components/pages/Pledge/HeaderDesktop/index.tsx:37
 msgid "pledges.edit_pledge"
-msgstr ""
+msgstr "Modifier l'engagement"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:562
 msgid "pledges.form.add_footprint_category_button"
-msgstr ""
+msgstr "Ajouter une catégorie"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:446
 msgid "pledges.form.add_wallet_button"
-msgstr ""
+msgstr "Ajouter un portefeuille"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:242
 msgid "pledges.form.awaiting_signature"
-msgstr ""
+msgstr "En attente de signature..."
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:197
 msgid "pledges.form.confirm_delete"
-msgstr ""
+msgstr "Confirmer la compensation"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:622
 msgid "pledges.form.confirm_remove"
-msgstr ""
+msgstr "supprimer"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:635
 msgid "pledges.form.confirm_remove_cancel"
-msgstr ""
+msgstr "annuler"
 
 #: components/pages/Pledge/index.tsx:212
 msgid "pledges.form.error"
-msgstr ""
+msgstr "Entrez une adresse de portefeuille, un domaine .klima ou .eth"
 
 #: components/pages/Pledge/lib/formSchema.ts:74
 msgid "pledges.form.errors.categoryName.max"
-msgstr ""
+msgstr "Saisir moins de 32 caractères"
 
 #: components/pages/Pledge/lib/formSchema.ts:70
 msgid "pledges.form.errors.categoryName.required"
-msgstr ""
+msgstr "Saisir une catégorie"
 
 #: components/pages/Pledge/lib/formSchema.ts:78
 msgid "pledges.form.errors.categoryQuantity.min"
-msgstr ""
+msgstr "Saisir une valeur supérieure à 0"
 
 #: components/pages/Pledge/lib/formSchema.ts:50
 msgid "pledges.form.errors.description.max"
-msgstr ""
+msgstr "Saisir moins de 500 caractères"
 
 #: components/pages/Pledge/lib/formSchema.ts:46
 msgid "pledges.form.errors.description.required"
-msgstr ""
+msgstr "Saisir un engagement"
 
 #: components/pages/Pledge/lib/formSchema.ts:62
 msgid "pledges.form.errors.footprint.generic_error"
-msgstr ""
+msgstr "Saisir une estimation de tonne de carbone"
 
 #: components/pages/Pledge/lib/formSchema.ts:66
 msgid "pledges.form.errors.footprint.min"
-msgstr ""
+msgstr "Saisir une valeur supérieure à 0"
 
 #: components/pages/Pledge/lib/formSchema.ts:58
 msgid "pledges.form.errors.methodology.max"
-msgstr ""
+msgstr "Saisir moins de 1000 caractères"
 
 #: components/pages/Pledge/lib/formSchema.ts:54
 msgid "pledges.form.errors.methodology.required"
-msgstr ""
+msgstr "Saisir une méthodologie"
 
 #: components/pages/Pledge/lib/formSchema.ts:34
 msgid "pledges.form.errors.name.required"
-msgstr ""
+msgstr "Saisir un nom"
 
 #: components/pages/Pledge/lib/formSchema.ts:38
 msgid "pledges.form.errors.profileImageUrl.url"
-msgstr ""
+msgstr "Saisir une URL valide"
 
 #: components/pages/Pledge/lib/formSchema.ts:42
 msgid "pledges.form.errors.profileWebsiteUrl.url"
-msgstr ""
+msgstr "Saisir une URL valide"
 
 #: components/pages/Pledge/lib/formSchema.ts:86
 msgid "pledges.form.errors.walletAddress.isAddress"
-msgstr ""
+msgstr "Veuillez saisir une adresse valide"
 
 #: components/pages/Pledge/lib/formSchema.ts:90
 msgid "pledges.form.errors.walletAddress.isOwner"
-msgstr ""
+msgstr "Vous ne pouvez pas ajouter le propriétaire de l'engagement"
 
 #: components/pages/Pledge/lib/formSchema.ts:82
 msgid "pledges.form.errors.walletAddress.required"
-msgstr ""
+msgstr "Adresse requise"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:489
 msgid "pledges.form.footprint.label"
-msgstr ""
+msgstr "Empreinte"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:497
 msgid "pledges.form.footprint.prompt"
-msgstr ""
+msgstr "Ajoutez une catégorie et commencez à calculer votre empreinte carbone"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:260
 msgid "pledges.form.generic_error"
-msgstr ""
+msgstr "Un problème est survenu. Veuillez réessayer."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:518
 msgid "pledges.form.input.categoryName.label"
@@ -1324,23 +1329,23 @@ msgstr "Catégorie"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:510
 msgid "pledges.form.input.categoryName.placeholder"
-msgstr ""
+msgstr "Nom de catégorie"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:538
 msgid "pledges.form.input.categoryQuantity.label"
-msgstr ""
+msgstr "Quantité"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:530
 msgid "pledges.form.input.categoryQuantity.placeholder"
-msgstr ""
+msgstr "Tonnes de carbone"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:323
 msgid "pledges.form.input.description.label"
-msgstr ""
+msgstr "Engagement"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:316
 msgid "pledges.form.input.description.placeholder"
-msgstr ""
+msgstr "Quel est votre engagement ?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:476
 msgid "pledges.form.input.methodology.label"
@@ -1348,67 +1353,67 @@ msgstr "Méthodologie"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:468
 msgid "pledges.form.input.methodology.placeholder"
-msgstr ""
+msgstr "Quels outils ou méthodologies avez-vous utilisés pour calculer votre empreinte carbone ?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:280
 msgid "pledges.form.input.name.label"
-msgstr ""
+msgstr "Nom"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:273
 msgid "pledges.form.input.name.placeholder"
-msgstr ""
+msgstr "Nom ou nom de l'entreprise"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:291
 msgid "pledges.form.input.profileImageUrl.label"
-msgstr ""
+msgstr "URL de l'image de profil (facultatif)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:305
 msgid "pledges.form.input.profileWebsiteUrl.label"
-msgstr ""
+msgstr "Site Internet (facultatif)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:579
 msgid "pledges.form.input.totalFootprint.label"
-msgstr ""
+msgstr "Empreinte totale"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:380
 msgid "pledges.form.input.walletAddress.label"
-msgstr ""
+msgstr "Adresse"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:372
 msgid "pledges.form.input.walletAddress.placeholder"
-msgstr ""
+msgstr "0x..."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:595
 msgid "pledges.form.submit_button"
-msgstr ""
+msgstr "Sauvegarder l'engagement"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:193
 msgid "pledges.form.title"
-msgstr ""
+msgstr "Votre engagement"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:52
 msgid "pledges.form.total_footprint_summary"
-msgstr ""
+msgstr "Empreinte totale : {0} Tonnes de carbone"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:607
 msgid "pledges.form.use_your_wallet"
-msgstr ""
+msgstr "Utilisez votre portefeuille pour signer et confirmer cette modification."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:332
 msgid "pledges.form.wallets.label"
-msgstr ""
+msgstr "Portefeuille(s) secondaire(s)"
 
 #: components/pages/Pledge/index.tsx:94
 msgid "pledges.head.metaDescription"
-msgstr ""
+msgstr "Montrez votre engagement climatique en utilisant votre tableau de bord pour mettre en évidence toutes vos activités de compensation du carbone."
 
 #: components/pages/Pledge/index.tsx:90
 msgid "pledges.head.metaTitle"
-msgstr ""
+msgstr "Créez un engagement carbone et montrez votre impact."
 
 #: components/pages/Pledge/index.tsx:86
 msgid "pledges.head.title"
-msgstr ""
+msgstr "KlimaDAO | Engagements"
 
 #: components/pages/Pledge/index.tsx:66
 msgid "pledges.home.hero.connecting"
@@ -1416,23 +1421,23 @@ msgstr "Connexion en cours..."
 
 #: components/pages/Pledge/index.tsx:77
 msgid "pledges.home.hero.create"
-msgstr ""
+msgstr "Créer un engagement"
 
 #: components/pages/Pledge/index.tsx:170
 msgid "pledges.home.hero.learn_more"
-msgstr ""
+msgstr "En savoir plus"
 
 #: components/pages/Pledge/index.tsx:72
 msgid "pledges.home.hero.view"
-msgstr ""
+msgstr "Voir votre engagement"
 
 #: components/pages/Pledge/index.tsx:206
 msgid "pledges.home.search.label"
-msgstr ""
+msgstr "Adresse ENS ou 0x"
 
 #: components/pages/Pledge/index.tsx:200
 msgid "pledges.home.search.placeholder"
-msgstr ""
+msgstr "Entrez une adresse ENS, KNS ou 0x"
 
 #: components/pages/Pledge/index.tsx:226
 msgid "pledges.home.search.submit"
@@ -1468,51 +1473,51 @@ msgstr "Sélectionner"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:53
 msgid "resources.form.medium.header"
-msgstr ""
+msgstr "Média"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:41
 msgid "resources.form.sub_topics.header"
-msgstr ""
+msgstr "Sous-thèmes"
 
 #: components/pages/Resources/index.tsx:31
 msgid "resources.head.metaDescription"
-msgstr ""
+msgstr "Nouvelles et opinions des fondateurs, des contributeurs de la DAO, des conseillers et des membres de la communauté."
 
 #: components/pages/Resources/index.tsx:27
 msgid "resources.head.metaTitle"
-msgstr ""
+msgstr "Ressources KlimaDAO - Aller au-delà de la neutralité carbone"
 
 #: components/pages/Resources/index.tsx:23
 msgid "resources.head.title"
-msgstr ""
+msgstr "KlimaDAO | Ressources"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:71
 msgid "resources.list.filter.tag.basics"
-msgstr ""
+msgstr "Bases"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:111
 msgid "resources.list.filter.tag.carbon_footprint"
-msgstr ""
+msgstr "Empreinte carbone"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:79
 msgid "resources.list.filter.tag.deep_dives"
-msgstr ""
+msgstr "Dossiers approfondis"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:52
 msgid "resources.list.filter.tag.klima_infinity"
-msgstr ""
+msgstr "Klima Infinity"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:44
 msgid "resources.list.filter.tag.klima_overview"
-msgstr ""
+msgstr "Vue d'ensemble de Klima"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:60
 msgid "resources.list.filter.tag.partnerships"
-msgstr ""
+msgstr "Partenariats"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:103
 msgid "resources.list.filter.tag.policy"
-msgstr ""
+msgstr "Politique"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:95
 msgid "resources.list.filter.tag.press_releases"
@@ -1524,11 +1529,11 @@ msgstr "Guide de l'utilisateur"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:121
 msgid "resources.list.filter.type.blog"
-msgstr ""
+msgstr "Blog"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:129
 msgid "resources.list.filter.type.podcast"
-msgstr ""
+msgstr "Podcast"
 
 #: components/pages/Resources/SortyByDropDown/index.tsx:62
 msgid "resources.list.select.sort_by.toggle"
@@ -1560,15 +1565,15 @@ msgstr "Trier par"
 
 #: components/pages/Resources/index.tsx:46
 msgid "resources.page.header.subline"
-msgstr ""
+msgstr "Nouvelles et opinions des fondateurs, des contributeurs de la DAO, des conseillers et des membres de la communauté."
 
 #: components/pages/Resources/index.tsx:43
 msgid "resources.page.header.title"
-msgstr ""
+msgstr "Articles en vedette"
 
 #: components/pages/Resources/ResourcesList/index.tsx:167
 msgid "resources.page.list.header"
-msgstr ""
+msgstr "Tout explorer"
 
 #: components/pages/Resources/ResourcesList/index.tsx:249
 msgid "resources.page.list.no_search_results.title"
@@ -1588,15 +1593,15 @@ msgstr "Vérifiez que votre recherche ne comporte pas de fautes de frappe ou ess
 
 #: components/pages/Retirements/Footer/index.tsx:18
 msgid "retirement.footer.aboutKlima.left"
-msgstr ""
+msgstr "KlimaDAO encourage la durabilité et catalyse un marché du carbone plus transparent et plus liquide. Nos outils permettent à tout individu ou entreprise d'échanger et de retirer des actifs carbone de qualité sur la blockchain."
 
 #: components/pages/Retirements/Footer/index.tsx:28
 msgid "retirement.footer.aboutKlima.right"
-msgstr ""
+msgstr "Les jetons KLIMA sont au centre d'une économie du carbone on-chain en plein essor. Visitez notre <0>base de connaissances</0> pour en savoir plus sur KLIMA, la compensation carbone, les marchés du carbone et les actifs carbone sous-jacents."
 
 #: components/pages/Retirements/Footer/index.tsx:13
 msgid "retirement.footer.aboutKlima.title"
-msgstr ""
+msgstr "À propos de Klima"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:37
 msgid "retirement.footer.buy_klima.button.buy"
@@ -1604,139 +1609,141 @@ msgstr "Achat"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:44
 msgid "retirement.footer.buy_klima.button.offset"
-msgstr "Compenser"
+msgstr "Compensation"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:30
 msgid "retirement.footer.buy_klima.text"
-msgstr ""
+msgstr "Utilisez des jetons KLIMA collatéralisés par du au carbone pour gouverner, échanger et obtenir du rendement-- puis utilisez ces récompenses pour compenser vos émissions !"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:25
 msgid "retirement.footer.buy_klima.title"
-msgstr ""
+msgstr "Achetez, mettez en jeu et soyez récompensé."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:122
 msgid "retirement.head.metaDescription"
-msgstr ""
+msgstr "Compensations carbones transparentes, activées par la blockchain et alimentées par KlimaDAO."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:118
 msgid "retirement.head.metaTitle"
-msgstr ""
+msgstr "{retiree} a compensé {formattedAmount} Tonnes de carbone"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:114
 msgid "retirement.head.title"
-msgstr ""
+msgstr "Klimadao | Reçu de compensation carbone"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:266
 msgid "retirement.share.title"
-msgstr ""
+msgstr "Partagez votre impact"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:176
 msgid "retirement.single.beneficiary.placeholder"
-msgstr ""
+msgstr "Aucun bénéficiaire associé"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:170
 msgid "retirement.single.beneficiary.title"
-msgstr ""
+msgstr "Bénéficiaire"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:184
 msgid "retirement.single.beneficiaryAddress.title"
-msgstr ""
+msgstr "Adresse du bénéficiaire"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:245
 msgid "retirement.single.create_a_pledge"
-msgstr ""
+msgstr "Créer un engagement maintenant."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:231
 msgid "retirement.single.disclaimer"
-msgstr ""
+msgstr "Ceci représente la compensation permanente des actifs carbone sous formes de jetons présents sur la blockchain Polygon. Cette compensation et les données associées constituent des entrées publiques immuables."
 
 #: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:30
 msgid "retirement.single.download_certificate_button"
-msgstr ""
+msgstr "Télécharger le PDF"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:134
 msgid "retirement.single.header.subline"
-msgstr ""
+msgstr "Compensation d'émissions en équivalent CO2 (en tonnes)"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:241
 msgid "retirement.single.is_this_your_retirement"
-msgstr ""
+msgstr "Est-ce votre compensation ?"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
 msgid "retirement.single.message.title"
-msgstr ""
+msgstr "Message de compensation"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:30
 msgid "retirement.single.no_pledge"
-msgstr ""
+msgstr "Cet utilisateur n'a pas créé d'engagement"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
 msgid "retirement.single.project_details.title"
-msgstr ""
+msgstr "Détails du projet"
 
 #: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
 msgid "retirement.single.quantity"
-msgstr ""
+msgstr "QUANTITÉ COMPENSÉE"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:205
 msgid "retirement.single.retirementCertificate.title"
-msgstr ""
+msgstr "Certificat"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:21
 msgid "retirement.single.retirementDate.title"
-msgstr ""
+msgstr "Date"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:24
 msgid "retirement.single.timestamp.placeholder"
-msgstr ""
+msgstr "Compensation carbone non horodatée"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:302
 msgid "retirement.single.view_on_polygon_scan"
-msgstr ""
+msgstr "Voir sur Polygonscan"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:18
 msgid "retirement.single.view_pledge"
-msgstr ""
+msgstr "Voir l'engagement"
 
 #: components/pages/Retirements/List/index.tsx:40
 msgid "retirement.totals.all_retirements_list.empty"
-msgstr ""
+msgstr "Aucune compensation trouvée"
 
 #: components/pages/Retirements/List/index.tsx:24
 msgid "retirement.totals.all_retirements_list.headline"
-msgstr ""
+msgstr "Toutes les compensations"
 
 #: components/pages/Retirements/index.tsx:46
 msgid "retirement.totals.head.metaTitle"
-msgstr ""
+msgstr "KlimaDAO - Compensations carbone pour le bénéficiaire {0}"
 
 #: components/pages/Retirements/index.tsx:40
 msgid "retirement.totals.head.title"
 msgstr ""
+"KlimaDAO - Compensations carbone pour le bénéficiaire {0}\n"
+""
 
 #: components/pages/Retirements/index.tsx:65
 msgid "retirement.totals.page_headline"
-msgstr ""
+msgstr "Compensations carbone"
 
 #: components/pages/Retirements/index.tsx:71
 msgid "retirement.totals.page_subline"
-msgstr ""
+msgstr "pour le bénéficiaire"
 
 #: components/pages/Retirements/index.tsx:95
 msgid "retirement.totals.retired_assets"
-msgstr ""
+msgstr "Actifs compensés"
 
 #: components/pages/Retirements/index.tsx:111
 msgid "retirement.totals.retirements"
-msgstr ""
+msgstr "Compensations"
 
 #: components/pages/Retirements/index.tsx:103
 msgid "retirement.totals.total_carbon_tonnes"
-msgstr ""
+msgstr "Total des tonnes de Carbone compensées"
 
 #: components/pages/Retirements/index.tsx:117
 msgid "retirement.totals.total_retirement_transactions"
-msgstr ""
+msgstr "Total des transactions de compensation"
 
 #: components/pages/errors/Custom404.tsx:20
 #: components/pages/errors/Custom404.tsx:24
@@ -1753,23 +1760,23 @@ msgstr "À propos"
 #: components/Navigation/index.tsx:115
 #: components/Navigation/index.tsx:261
 msgid "shared.app"
-msgstr ""
+msgstr "App"
 
 #: components/Footer/index.tsx:49
 msgid "shared.blog"
-msgstr ""
+msgstr "Blog"
 
 #: components/Footer/index.tsx:43
 #: components/Navigation/index.tsx:133
 #: components/Navigation/index.tsx:278
 msgid "shared.bond"
-msgstr ""
+msgstr "Obligations Klima"
 
 #: components/Footer/index.tsx:37
 #: components/Navigation/index.tsx:117
 #: components/Navigation/index.tsx:265
 msgid "shared.buy"
-msgstr ""
+msgstr "Acheter des Klima"
 
 #: components/Navigation/index.tsx:157
 #: components/Navigation/index.tsx:302
@@ -1780,15 +1787,15 @@ msgstr "Acheter du Carbone"
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:118
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:147
 msgid "shared.cancel"
-msgstr ""
+msgstr "Annuler"
 
 #: components/Navigation/index.tsx:352
 msgid "shared.carbon_dashboard"
-msgstr ""
+msgstr "Tableau de bord Carbone"
 
 #: components/Navigation/index.tsx:203
 msgid "shared.carbon_dashboards"
-msgstr ""
+msgstr "Tableaux de bord Carbone"
 
 #: components/Navigation/index.tsx:174
 #: components/Navigation/index.tsx:321
@@ -1800,30 +1807,30 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:31
 #: components/pages/About/AboutHeader/index.tsx:61
 msgid "shared.community"
-msgstr ""
+msgstr "Communauté"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:45
 msgid "shared.confirm"
-msgstr ""
+msgstr "Confirmer"
 
 #: components/Footer/index.tsx:52
 #: components/Navigation/index.tsx:241
 #: components/pages/About/AboutHeader/index.tsx:67
 msgid "shared.contact"
-msgstr "Nous contacter"
+msgstr "Contact"
 
 #: components/Navigation/index.tsx:71
 #: components/pages/Infinity/index.tsx:117
 #: components/pages/Infinity/index.tsx:701
 msgid "shared.contact_sales"
-msgstr ""
+msgstr "Nous contacter"
 
 #: components/Navigation/index.tsx:96
 #: components/pages/About/AboutHeader/index.tsx:40
 #: components/pages/About/Community/index.tsx:129
 #: components/pages/About/Community/index.tsx:374
 msgid "shared.contact_us"
-msgstr ""
+msgstr "Contact"
 
 #: components/Footer/index.tsx:55
 #: components/Navigation/index.tsx:105
@@ -1831,52 +1838,52 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:49
 #: components/pages/About/AboutHeader/index.tsx:73
 msgid "shared.disclaimer"
-msgstr ""
+msgstr "Avertissement légal"
 
 #: components/Footer/index.tsx:46
 #: components/Navigation/index.tsx:211
 #: components/Navigation/index.tsx:360
 msgid "shared.docs"
-msgstr ""
+msgstr "Docs officielles"
 
 #: components/Navigation/index.tsx:63
 #: components/pages/Home/index.tsx:115
 msgid "shared.enter_app"
-msgstr ""
+msgstr "Visitez l'application"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:157
 msgid "shared.error"
-msgstr ""
+msgstr "Erreur"
 
 #: components/pages/Infinity/GetStartedModal.tsx:25
 msgid "shared.get_started"
-msgstr ""
+msgstr "Commencer"
 
 #: components/pages/Buy/index.tsx:29
 #: components/pages/Home/index.tsx:69
 #: components/pages/Retirements/index.tsx:52
 #: components/pages/errors/Custom500.tsx:23
 msgid "shared.head.description"
-msgstr ""
+msgstr "Influez sur l'action climatique et soyez récompensés avec une monnaie numérique garantie par du carbone."
 
 #: components/Footer/index.tsx:34
 msgid "shared.home"
-msgstr ""
+msgstr "Accueil"
 
 #: components/Navigation/index.tsx:194
 #: components/Navigation/index.tsx:343
 msgid "shared.how_to_buy"
-msgstr ""
+msgstr "Comment acheter des Klima"
 
 #: components/pages/Infinity/index.tsx:108
 #: components/pages/Infinity/index.tsx:309
 #: components/pages/Infinity/index.tsx:692
 msgid "shared.infinity.get_started"
-msgstr ""
+msgstr "Commencer"
 
 #: components/pages/Home/index.tsx:186
 msgid "shared.infinity_cta"
-msgstr ""
+msgstr "DEFI POUR LES ENTREPRISES"
 
 #: components/Navigation/index.tsx:165
 #: components/Navigation/index.tsx:310
@@ -1903,30 +1910,30 @@ msgstr "S'identifier / Se connecter"
 
 #: components/pages/Home/index.tsx:193
 msgid "shared.loveletter_cta"
-msgstr ""
+msgstr "DEFI POUR LES PARTICULIERS"
 
 #: components/Navigation/index.tsx:179
 #: components/Navigation/index.tsx:325
 msgid "shared.loveletters"
-msgstr ""
+msgstr "Love Letters"
 
 #: components/Navigation/index.tsx:149
 #: components/Navigation/index.tsx:294
 msgid "shared.offset"
-msgstr "Compenser"
+msgstr "Compensation"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:175
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:161
 msgid "shared.okay"
-msgstr ""
+msgstr "Ok"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:421
 msgid "shared.pending"
-msgstr ""
+msgstr "En attente"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:135
 msgid "shared.remove"
-msgstr ""
+msgstr "supprimer"
 
 #: components/Navigation/index.tsx:185
 #: components/Navigation/index.tsx:334
@@ -1947,16 +1954,16 @@ msgstr "Trier par :"
 #: components/Navigation/index.tsx:125
 #: components/Navigation/index.tsx:270
 msgid "shared.stake"
-msgstr ""
+msgstr "Mettre en jeu vos Klima"
 
 #: components/pages/Infinity/index.tsx:512
 msgid "shared.visit_klimadao_blog"
-msgstr ""
+msgstr "Visitez le blog KlimaDAO"
 
 #: components/Navigation/index.tsx:141
 #: components/Navigation/index.tsx:286
 msgid "shared.wrap"
-msgstr ""
+msgstr "Encapsuler sKlima"
 
 #: lib/getWeb3ModalStrings.ts:13
 msgid "web3modal.injected.des"
@@ -1980,8 +1987,8 @@ msgstr "Scannez avec Coinbase pour vous connecter"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:62
 msgid "{trimCurrentSupply} Tonnes remaining"
-msgstr ""
+msgstr "{trimCurrentSupply} Tonnes restantes"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:57
 msgid "{trimTotalRetired} Tonnes retired in total"
-msgstr ""
+msgstr "{trimTotalRetired} Tonnes compensées au total"

--- a/site/locale/hi/messages.po
+++ b/site/locale/hi/messages.po
@@ -13,35 +13,35 @@ msgstr "भाषा बदलें"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:33
 msgid "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
-msgstr ""
+msgstr "प्रत्येक KlimaDAO सेवानिवृत्ति एक सत्यापित ऑफ़सेट परियोजना से जुड़ी हुई है। परियोजना के बारे में अधिक जानने के लिए क्लिक करें।"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:68
 msgid "Explore MCO2 on carbon.klimadao.finance"
-msgstr ""
+msgstr "MCO2 को Carbon.klimadao.finance पर एक्सप्लोर करें"
 
 #: components/pages/Infinity/index.tsx:530
 msgid "Frequently Asked Questions"
-msgstr ""
+msgstr "अक्सर पूछे जाने वाले प्रश्न"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:47
 msgid "Location: {0}"
-msgstr ""
+msgstr "स्थान:{0}"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:50
 msgid "MCO2 Token"
-msgstr ""
+msgstr "MCO2 टोकन"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:52
 msgid "Methodology: {0}"
-msgstr ""
+msgstr "कार्यप्रणाली: {0}"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:23
 msgid "No retirement message provided."
-msgstr ""
+msgstr "कोई रिटायरमेंट टाइमस्टैम्प प्रदान नहीं किया गया"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:146
 msgid "Processing data..."
-msgstr ""
+msgstr "डाटा प्रोसेसिंग..."
 
 #: components/InvalidNetworkModal/index.tsx:80
 msgid "Switch to Polygon"
@@ -53,11 +53,11 @@ msgstr "यह ऐप केवल Polygon Mainnet (पॉलीगॉन मे
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:74
 msgid "View on Polygonscan"
-msgstr ""
+msgstr "Polygonscan (पॉलीगॉनस्कैन) पर देखें"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:150
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
-msgstr ""
+msgstr "हमने इस सेवानिवृत्ति के लिए ब्लॉकचैन डेटा को संसाधित करना समाप्त नहीं किया है। इसमें आमतौर पर कुछ सेकंड लगते हैं, लेकिन नेटवर्क भीड़भाड़ होने पर इसमें अधिक समय लग सकता है।"
 
 #: components/InvalidNetworkModal/index.tsx:65
 msgid "Wrong Network"
@@ -74,370 +74,370 @@ msgstr "अस्वीकरण:"
 
 #: components/pages/Buy/index.tsx:433
 msgid "buy.answer_exchange"
-msgstr ""
+msgstr "उन्नत उपयोगकर्ता <0>बहुभुज ब्रिज का उपयोग कर सकते हैं</0> एथेरियम से पॉलीगॉन, और/या <1>पॉलीगॉन गैस स्वैप में किसी भी संपत्ति को स्थानांतरित करने के लिए</1> MATIC के लिए USDC जैसी संपत्तियों की अदला-बदली करना।"
 
 #: components/pages/Buy/index.tsx:390
 msgid "buy.bond_answer_cedit_card"
-msgstr ""
+msgstr "हां, कुछ ऑन-रैंप प्रदाता जैसे <0>Transak</0> शुल्क देकर आप सीधे क्रेडिट कार्ड से KLIMA खरीद सकते हैं। हालांकि, यदि आपके बटुए में MATIC नहीं है, तो आप अन्य कार्यों को स्थानांतरित करने या निष्पादित करने में सक्षम नहीं होंगे। इस कारण से, और सर्वोत्तम बाजार दर की गारंटी देने के लिए, हम इसके बजाय सीधे MATIC खरीदने और Sushi.com पर KLIMA के लिए अपने MATIC की अदला-बदली करने की सलाह देते हैं।"
 
 #: components/pages/Buy/index.tsx:408
 msgid "buy.bond_answer_cex1"
-msgstr ""
+msgstr "KLIMA को कॉइनबेस, बिनेंस या क्रिप्टो डॉट कॉम जैसे केंद्रीकृत एक्सचेंज पर कारोबार नहीं किया जाता है क्योंकि ये एक्सचेंज आमतौर पर बहुत अधिक लिस्टिंग शुल्क लेते हैं और महंगे बाजार निर्माताओं से वित्तपोषण की आवश्यकता होती है।"
 
 #: components/pages/Buy/index.tsx:416
 msgid "buy.bond_answer_cex2"
-msgstr ""
+msgstr "इसके बजाय, KLIMA टोकन एक \"विकेंद्रीकृत एक्सचेंज\" (DEX) पर कारोबार करते हैं जो स्मार्ट अनुबंधों द्वारा संचालित होता है और सीधे ब्लॉकचेन पर चलता है। DEX के कुछ प्रमुख लाभ हैं। DEX ने DAO के लिए अधिकांश तरलता का स्वामित्व संभव बना दिया है, इसलिए यह पूर्ण स्वायत्तता बनाए रख सकता है और योगदानकर्ताओं को भुगतान करने के लिए राजस्व उत्पन्न कर सकता है। हमने सुशी की DEX तकनीक का उपयोग करना चुना क्योंकि यह पहले से ही प्रतिदिन करोड़ों डॉलर के लेन-देन की सुविधा प्रदान करती है।"
 
 #: components/pages/Buy/index.tsx:371
 msgid "buy.bond_description1"
-msgstr ""
+msgstr "अनुभवी क्रिप्टो उपयोगकर्ता सीधे KLIMA को बॉन्ड के माध्यम से प्रोटोकॉल से खरीद सकते हैं। KLIMA को बांड के माध्यम से प्राप्त करने के लिए, आप एक कार्बन टोकन या तरलता टोकन प्रदान करते हैं और बदले में KLIMA टोकन पर छूट प्राप्त करते हैं। यह वह तंत्र है जिसका उपयोग DAO अपने डिजिटल कार्बन के खजाने को बढ़ाने के लिए करता है।"
 
 #: components/pages/Buy/index.tsx:380
 msgid "buy.bond_description_capacity"
-msgstr ""
+msgstr "बांड की क्षमता सीमित है और बांड हमेशा उपलब्ध नहीं होते हैं।"
 
 #: components/pages/Buy/index.tsx:401
 msgid "buy.bond_question_cex"
-msgstr ""
+msgstr "मुझे कॉइनबेस या अन्य केंद्रीकृत एक्सचेंजों पर KLIMA क्यों नहीं मिल रहा है? मुझे <0>Sushi.com का उपयोग क्यों करना है</0> ?"
 
 #: components/pages/Buy/index.tsx:385
 msgid "buy.bond_question_credit_card"
-msgstr ""
+msgstr "क्या मैं KLIMA को सीधे क्रेडिट कार्ड से खरीद सकता हूँ?"
 
 #: components/pages/Buy/index.tsx:190
 msgid "buy.connect_advanced"
-msgstr ""
+msgstr "नोट: ये निर्देश केवल टोरस वॉलेट उपयोगकर्ताओं के लिए हैं। सुशी विभिन्न प्रकार के पर्स का समर्थन करती है।"
 
 #: components/pages/Buy/index.tsx:185
 msgid "buy.connect_torus_sushi"
-msgstr ""
+msgstr "३ए। वॉलेटकनेक्ट का उपयोग करके टोरस को Sushi.com से कनेक्ट करें"
 
 #: components/pages/Buy/index.tsx:212
 msgid "buy.connect_torus_sushi_description2"
-msgstr ""
+msgstr "एक अलग ब्राउज़र टैब में, <0>Sushi.com पर जाएं</0> और ऊपरी-दाएँ कोने में \"कनेक्ट\" पर क्लिक करें। आपको कुछ वॉलेट विकल्पों के साथ प्रस्तुत किया जाएगा। वॉलेटकनेक्ट चुनें। आपके द्वारा WalletConnect को चुनने के बाद आपको एक QR कोड दिखाई देगा—\"कॉपी टू क्लिपबोर्ड\" पर क्लिक करें।"
 
 #: components/pages/Buy/index.tsx:229
 msgid "buy.connect_torus_sushi_description3"
-msgstr ""
+msgstr "टोरस वॉलेट ऐप पर लौटें और इस कोड को वॉलेटकनेक्ट विजेट में पेस्ट करें। यह आपके बटुए और <0>Sushi.com के बीच एक अस्थायी संबंध बनाएगा</0> ."
 
 #: components/pages/Buy/index.tsx:237
 msgid "buy.connect_torus_sushi_description4"
-msgstr ""
+msgstr "जब आप अपने ब्राउज़र में सुशी टैब पर लौटते हैं, तो आपको यह देखना चाहिए कि आपका टोरस पता अब ऊपरी-दाएँ कोने में दिखाई दे रहा है।"
 
 #: components/pages/Buy/index.tsx:243
 msgid "buy.connect_torus_sushi_description5"
-msgstr ""
+msgstr "अंत में, <0>Sushi.com पर ड्रॉप-डाउन मेनू का उपयोग करें</0> बहुभुज नेटवर्क पर स्विच करने के लिए।"
 
 #: components/pages/Buy/index.tsx:72
 msgid "buy.create_wallet_description"
-msgstr ""
+msgstr "<0>एक वॉलेट बनाएं।</0> हम टोरस वॉलेट की सलाह देते हैं, लेकिन हमारा ऐप अधिकांश वेब3 वॉलेट (मेटामास्क, कॉइनबेस वॉलेट, ब्रेव, मायएथर वॉलेट और कई अन्य) का समर्थन करता है।"
 
 #: components/pages/Buy/index.tsx:114
 msgid "buy.create_wallet_description1"
-msgstr ""
+msgstr "<0>app.klimadao.finance</0> एकमात्र आधिकारिक डोमेन है।"
 
 #: components/pages/Buy/index.tsx:120
 msgid "buy.create_wallet_description2"
-msgstr ""
+msgstr "\"ईमेल या सामाजिक\" साइन-इन विकल्प चुनें, जो आपको टोरस के साथ लॉग इन करने के लिए निर्देशित करेगा। टोरस एक ऐसी तकनीक है जो आपके मौजूदा ईमेल या सामाजिक लॉगिन का उपयोग करके एक सुरक्षित वॉलेट उत्पन्न करती है। आप इस नए टोरस वॉलेट का उपयोग सैकड़ों अन्य Web3 और DeFi ऐप्स में कर सकेंगे।"
 
 #: components/pages/Buy/index.tsx:129
 msgid "buy.create_wallet_description3"
-msgstr ""
+msgstr "जब आप कनेक्ट हो जाते हैं, तो आपको ऐप के ऊपरी बाएँ कोने में अपना नया वॉलेट पता देखना चाहिए।"
 
 #: components/pages/Buy/index.tsx:135
 msgid "buy.create_wallet_description4"
-msgstr ""
+msgstr "उन्नत: यदि आप टोरस का उपयोग नहीं करना चाहते हैं, तो बेझिझक किसी भी बहुभुज-संगत वेब3 वॉलेट का उपयोग करें।"
 
 #: components/pages/Buy/index.tsx:111
 msgid "buy.create_wallet_item"
-msgstr ""
+msgstr "1. वॉलेट बनाएं"
 
 #: components/pages/Buy/index.tsx:319
 msgid "buy.faq_title"
-msgstr ""
+msgstr "सामान्य प्रश्न"
 
 #: components/pages/Buy/index.tsx:27
 #: components/pages/Buy/index.tsx:28
 msgid "buy.head.title"
-msgstr ""
+msgstr "KLIMA कैसे ख़रीदें?"
 
 #: components/pages/Buy/index.tsx:41
 msgid "buy.how_to_buy"
-msgstr ""
+msgstr "KLIMA कैसे ख़रीदें?"
 
 #: components/pages/Buy/index.tsx:44
 msgid "buy.how_to_paragraph_part_1"
-msgstr ""
+msgstr "KLIMA एक कार्बन-समर्थित डिजिटल संपत्ति है और इसे पुरस्कारों के लिए दांव पर लगाया जा सकता है या डिजिटल कार्बन को ऑफसेट करने के लिए उपयोग किया जा सकता है। KLIMA को होल्ड करना आपको वोट देने और डिजिटल कार्बन मार्केट को नियंत्रित करने में मदद करने का अधिकार भी देता है।"
 
 #: components/pages/Buy/index.tsx:51
 msgid "buy.how_to_paragraph_part_2"
-msgstr ""
+msgstr "यह उन शुरुआती लोगों के लिए एक छोटा ट्यूटोरियल है जो Web3 और DeFi में नए हैं"
 
 #: components/pages/Buy/index.tsx:143
 msgid "buy.load_wallet"
-msgstr ""
+msgstr "2. अपने वॉलेट को MATIC टोकन से लोड करें"
 
 #: components/pages/Buy/index.tsx:85
 msgid "buy.load_wallet_description"
-msgstr ""
+msgstr "<0>अपने नए वॉलेट को MATIC टोकन से लोड करें।</0> MATIC वह गैस है जो बहुभुज नेटवर्क को शक्ति प्रदान करती है। पॉलीगॉन पर आपके द्वारा निष्पादित प्रत्येक लेनदेन को नेटवर्क शुल्क का भुगतान करने के लिए MATIC के कुछ सेंट मूल्य की आवश्यकता होगी।"
 
 #: components/pages/Buy/index.tsx:148
 msgid "buy.load_wallet_description1"
-msgstr ""
+msgstr "<0>MoonPay जैसी सेवा का उपयोग करें</0> या <1>ट्रांसक</1> या एक केंद्रीकृत विनिमय जैसे <2>Coinbase</2> पॉलीगॉन मैटिक खरीदने और इसे अपने नए बनाए गए वॉलेट में भेजने के लिए।"
 
 #: components/pages/Buy/index.tsx:158
 msgid "buy.load_wallet_description2"
-msgstr ""
+msgstr "<0>सुनिश्चित करें कि MATIC टोकन आपके नए वॉलेट पते पर भेजे गए हैं!</0> आप हमारे ऐप से जुड़कर और नेविगेशन मेनू में पते पर क्लिक करके पते को अपने क्लिपबोर्ड पर कॉपी कर सकते हैं।"
 
 #: components/pages/Buy/index.tsx:168
 msgid "buy.load_wallet_description3"
-msgstr ""
+msgstr "<0>पॉलीगॉन नेटवर्क के माध्यम से MATIC खरीदना और भेजना सुनिश्चित करें!</0> कॉइनबेस जैसे कुछ एक्सचेंज आपसे पूछेंगे कि किस नेटवर्क पर MATIC टोकन भेजना है। हमेशा बहुभुज चुनना सुनिश्चित करें।"
 
 #: components/pages/Buy/index.tsx:427
 msgid "buy.question_exchange"
-msgstr ""
+msgstr "क्या होगा अगर मैं एक अलग एक्सचेंज का उपयोग करना चाहता हूं, लेकिन वे पॉलीगॉन MATIC नहीं बेचते हैं?"
 
 #: components/pages/Buy/index.tsx:322
 msgid "buy.question_why_matic"
-msgstr ""
+msgstr "मुझे पहले मैटिक क्यों खरीदना चाहिए?"
 
 #: components/pages/Buy/index.tsx:327
 msgid "buy.question_why_matic_answer"
-msgstr ""
+msgstr "KLIMA टोकन और प्रोटोकॉल पॉलीगॉन ब्लॉकचेन पर रहता है। MATIC वह \"गैस\" है जो बहुभुज पर प्रत्येक लेनदेन को शक्ति प्रदान करती है। लेन-देन शुल्क का भुगतान किए बिना लेन-देन निष्पादित करना संभव नहीं है। इसका मतलब है कि आपको निम्नलिखित कार्यों के लिए MATIC के कुछ सेंट मूल्य का भुगतान करना होगा:"
 
 #: components/pages/Buy/index.tsx:338
 msgid "buy.question_why_matic_answer_bullet1"
-msgstr ""
+msgstr "क्लिमा दाँव पर लगाएँ"
 
 #: components/pages/Buy/index.tsx:345
 msgid "buy.question_why_matic_answer_bullet2"
-msgstr ""
+msgstr "विभिन्न टोकन के बीच अदला-बदली"
 
 #: components/pages/Buy/index.tsx:352
 msgid "buy.question_why_matic_answer_bullet3"
-msgstr ""
+msgstr "दूसरे वॉलेट में टोकन भेजना"
 
 #: components/pages/Buy/index.tsx:359
 msgid "buy.question_why_matic_answer_bullet4"
-msgstr ""
+msgstr "KlimaDAO के माध्यम से ऑफ़सेट किए गए कार्बन टन"
 
 #: components/pages/Buy/index.tsx:292
 msgid "buy.staking_cta"
-msgstr ""
+msgstr "हिस्सेदारी, कमाई, वोट और ऑफसेट!"
 
 #: components/pages/Buy/index.tsx:295
 msgid "buy.staking_description1"
-msgstr ""
+msgstr "बधाई! अब जबकि आपके बटुए में कुछ KLIMA है, तो हम अत्यधिक सलाह देते हैं <0>दांव लगाने की</0> sKLIMA के लिए वह KLIMA, जो प्रोटोकॉल बढ़ने पर समय के साथ पुरस्कार अर्जित करता है।"
 
 #: components/pages/Buy/index.tsx:303
 msgid "buy.staking_description2"
-msgstr ""
+msgstr "आप KLIMA खर्च करने और <0>डिजिटल कार्बन को रिटायर करने के लिए भी ऐप का उपयोग कर सकते हैं</0> ब्लॉकचेन पर।"
 
 #: components/pages/Buy/index.tsx:310
 msgid "buy.staking_description3"
-msgstr ""
+msgstr "अंत में, <0>चल रहे वोटों पर नज़र रखें</0> और प्रोटोकॉल को सही दिशा में निर्देशित करने में मदद करें।"
 
 #: components/pages/Buy/index.tsx:69
 msgid "buy.step_1"
-msgstr ""
+msgstr "१ "
 
 #: components/pages/Buy/index.tsx:82
 msgid "buy.step_2"
-msgstr ""
+msgstr "२ "
 
 #: components/pages/Buy/index.tsx:97
 msgid "buy.step_3"
-msgstr ""
+msgstr "३ "
 
 #: components/pages/Buy/index.tsx:62
 msgid "buy.summary_steps_title"
-msgstr ""
+msgstr "KLIMA प्राप्त करने का सबसे अच्छा और आसान तरीका इन तीन चरणों का पालन करना है:"
 
 #: components/pages/Buy/index.tsx:59
 msgid "buy.summary_title"
-msgstr ""
+msgstr "सारांश"
 
 #: components/pages/Buy/index.tsx:253
 msgid "buy.swap_description1"
-msgstr ""
+msgstr "अपने वॉलेट को जोड़ने और पॉलीगॉन नेटवर्क पर स्विच करने के बाद, अब आपको MATIC से KLIMA में स्वैप करने में सक्षम होना चाहिए।"
 
 #: components/pages/Buy/index.tsx:259
 msgid "buy.swap_description2"
-msgstr ""
+msgstr "<0>महत्वपूर्ण नोट: KLIMA के लिए अपने सभी MATIC की अदला-बदली न करें!</0> भविष्य के लेनदेन शुल्क का भुगतान करने के लिए कम से कम 0.5 MATIC बचाएं।"
 
 #: components/pages/Buy/index.tsx:275
 msgid "buy.swap_description3"
-msgstr ""
+msgstr "यदि आप टोरस का उपयोग कर रहे हैं, तो ब्राउज़र टैब को टोरस ऐप के साथ खुला रखें। लेन-देन को स्वीकृत और अधिकृत करने के लिए आपको अपने वॉलेट पर वापस लौटना होगा।"
 
 #: components/pages/Buy/index.tsx:282
 msgid "buy.swap_description4"
-msgstr ""
+msgstr "वैकल्पिक: यदि आप चाहते हैं कि आपका सुशी लेन-देन स्वयं जलवायु सकारात्मक हो, तो आपको KlimaDAO द्वारा संचालित सुशी 'ग्रीन फी' को सक्षम करना चाहिए। यह स्वचालित रूप से डिजिटल कार्बन को खरीदने और रिटायर करने के लिए प्रति लेनदेन 0.02 MATIC खर्च करेगा!"
 
 #: components/pages/Buy/index.tsx:100
 msgid "buy.swap_for_klima_description"
-msgstr ""
+msgstr "<0>KLIMA के लिए स्वैप करें।</0> सुशी एक विकेन्द्रीकृत एक्सचेंज है जहां आप अपने कुछ MATIC टोकन को न्यूनतम संभव कीमत पर KLIMA टोकन के लिए तुरंत व्यापार कर सकते हैं।"
 
 #: components/pages/Buy/index.tsx:250
 msgid "buy.swap_subtitle"
-msgstr ""
+msgstr "३बी। KLIMA के लिए MATIC स्वैप करें"
 
 #: components/pages/Buy/index.tsx:179
 msgid "buy.swap_wallet"
-msgstr ""
+msgstr "3. <0>Sushi.com पर KLIMA के लिए स्वैप करें</0>"
 
 #: components/pages/Buy/index.tsx:196
 msgid "buy.torus_login_description"
-msgstr ""
+msgstr "एक नए ब्राउज़र टैब में, <0>Torus Polygon webapp पर जाएं</0> और अपने नए टोरस खाते से लॉग इन करें। जब आप लॉग इन करते हैं, तो आपको वॉलेटकनेक्ट विजेट देखना चाहिए।"
 
 #: components/pages/Buy/index.tsx:205
 msgid "buy.wallet_connect_example"
-msgstr ""
+msgstr "वॉलेट कनेक्ट इनपुट उदाहरण"
 
 #: components/pages/Buy/index.tsx:222
 #: components/pages/Buy/index.tsx:268
 msgid "buy.wallet_connect_example_qr_code"
-msgstr ""
+msgstr "वॉलेट कनेक्ट qr कोड उदाहरण"
 
 #: components/pages/Buy/index.tsx:366
 msgid "buy.what_are_bonds"
-msgstr ""
+msgstr "क्या KLIMA प्राप्त करने के अन्य तरीके हैं? बांड क्या हैं?"
 
 #: components/pages/About/Community/index.tsx:116
 msgid "community.become_a_partner"
-msgstr ""
+msgstr "भागीदार बनें"
 
 #: components/pages/About/Community/index.tsx:180
 msgid "community.bigcowg_logo"
-msgstr ""
+msgstr "BICOWG लोगो"
 
 #: components/pages/About/Community/index.tsx:172
 msgid "community.blockchainforclimatefondation_logo"
-msgstr ""
+msgstr "Climate Foundation (क्लाइमेट फाउंडेशन) लोगो के लिए ब्लॉकचेन"
 
 #: components/pages/About/Community/index.tsx:314
 msgid "community.come_on_in"
-msgstr ""
+msgstr "अंदर आ जाइए"
 
 #: components/pages/About/Community/index.tsx:228
 msgid "community.deltawave_logo"
-msgstr ""
+msgstr "Delta (डेल्टा वेव) लोगो"
 
 #: components/pages/About/Community/index.tsx:265
 msgid "community.digitalcharityart_logo"
-msgstr ""
+msgstr "Delta Charity Art (डेल्टा चैरिटी आर्ट) लोगो"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:329
 msgid "community.discord_is_where_we_share"
-msgstr ""
+msgstr "Discord (डिस्कॉर्ड) वह स्थान है जहाँ हम महत्वपूर्ण घोषणाएँ साझा करते हैं, ऑफ़िस-आवर्स होल्ड करते हैं, सवालों के जवाब देते हैं, और मीम्स साझा करते हैं। हमारा डिस्कॉर्ड सर्वर बेहद सक्रिय है और चौबीसों घंटे संचालित किया जाता है। हमारे पास ट्रेडिंग से लेकर सस्टेनेबिलिटी और कार्बन मार्केट तक हर चीज़ के लिए चैनल मौजूद हैं।"
 
 #: components/pages/About/Community/index.tsx:244
 msgid "community.dovu_logo"
-msgstr ""
+msgstr "Dovu (दोवू) लोगो"
 
 #: components/pages/About/Community/index.tsx:249
 msgid "community.eco_logo"
-msgstr ""
+msgstr "Eco (इको) लोगो"
 
 #: components/pages/About/Community/index.tsx:236
 msgid "community.etcgroup_logo"
-msgstr ""
+msgstr "Etc Group (ईटीसी ग्रुप) लोगो"
 
 #: components/pages/About/Community/index.tsx:361
 msgid "community.get_in_touch"
-msgstr ""
+msgstr "संपर्क में रहें?"
 
 #: components/pages/About/Community/index.tsx:204
 msgid "community.gitcoin_logo"
-msgstr ""
+msgstr "Gitcoin (गिटकॉइन) लोगो"
 
 #: components/pages/About/Community/index.tsx:95
 msgid "community.head.headline"
-msgstr ""
+msgstr "समुदाय"
 
 #: components/pages/About/Community/index.tsx:102
 msgid "community.head.metadescription"
-msgstr ""
+msgstr "जोशीले क्लीमेट्स वाले हमारे समुदाय के बारे में जानें"
 
 #: components/pages/About/Community/index.tsx:96
 msgid "community.head.subline"
-msgstr ""
+msgstr "KlimaDAO (क्लीमाडाओ) परिवर्तन लाने वाला एक विकेन्द्रीकृत स्वायत्त संगठन है। हम जोशीले क्लीमेट्स के समुदाय द्वारा शासित और निर्मित हैं।"
 
 #: components/pages/About/Community/index.tsx:94
 #: components/pages/About/Community/index.tsx:101
 msgid "community.head.title"
-msgstr ""
+msgstr "KlimaDAO (क्लीमाडाओ) समुदाय"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:364
 msgid "community.if_you_ve_got_questions"
-msgstr ""
+msgstr "यदि आपके पास प्रश्न, विचार, सलाह या और कुछ है: हम बात करने के लिए सही व्यक्ति खोजने में आपकी सहायता कर सकते हैं।"
 
 #: components/pages/About/Community/index.tsx:317
 msgid "community.join_our_discord"
-msgstr ""
+msgstr "हमारे Discord (डिस्कॉर्ड) से जुड़ें"
 
 #: components/pages/About/Community/index.tsx:304
 msgid "community.join_the_klima_community"
-msgstr ""
+msgstr "Klima (क्लीमा) समुदाय में शामिल हों"
 
 #: components/pages/About/Community/index.tsx:281
 msgid "community.landx_logo"
-msgstr ""
+msgstr "LandX (लैंडएक्स) लोगो"
 
 #: components/pages/About/Community/index.tsx:113
 #: components/pages/About/Community/index.tsx:358
 msgid "community.lets_work_together"
-msgstr ""
+msgstr "आइए साथ काम करें"
 
 #: components/pages/About/Community/index.tsx:156
 msgid "community.moss_logo"
-msgstr ""
+msgstr "Moss (मॉस) लोगो"
 
 #: components/pages/About/Community/index.tsx:196
 msgid "community.oceandrop_logo"
-msgstr ""
+msgstr "Oceandrop (ओशनड्रॉप) लोगो"
 
 #: components/pages/About/Community/index.tsx:257
 msgid "community.offsetra_logo"
-msgstr ""
+msgstr "Offsetra (ऑफसेट्रा) लोगो"
 
 #: components/pages/About/Community/index.tsx:212
 msgid "community.olympusdao_logo"
-msgstr ""
+msgstr "OlympusDAO (ओलंपसडाओ) लोगो"
 
 #: components/pages/About/Community/index.tsx:220
 msgid "community.openearth_logo"
-msgstr ""
+msgstr "Open Earth (ओपन अर्थ) लोगो"
 
 #: components/pages/About/Community/index.tsx:151
 msgid "community.our_partners"
-msgstr ""
+msgstr "हमारे सहयोगी"
 
 #: components/pages/About/Community/index.tsx:188
 msgid "community.polygon_logo"
-msgstr ""
+msgstr "Polygon (पॉलीगॉन) लोगो"
 
 #: components/pages/About/Community/index.tsx:164
 msgid "community.toucan_logo"
-msgstr ""
+msgstr "Toucan (टूकन) लोगो"
 
 #: components/pages/About/Community/index.tsx:273
 msgid "community.toughtforfood_logo"
-msgstr ""
+msgstr "Thought for Food (थॉट फ़ॉर फ़ूड) लोगो"
 
 #: components/pages/About/Community/index.tsx:132
 msgid "community.tree_grove"
-msgstr ""
+msgstr "ट्री ग्रोव"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:119
 msgid "community.we_work_with_traditionnal"
-msgstr ""
+msgstr "हम पारंपरिक कार्बन बाज़ार के धुरंधरों, क्रिप्टो प्लैटफ़ॉर्म्स, बड़ी कंपनियों और उनसे सम्बंधित अन्य सभी लोगों के साथ काम करते हैं।"
 
 #: components/pages/About/Contact/index.tsx:63
 msgid "concat.careers"
-msgstr ""
+msgstr "करियर"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:170
 #: components/pages/Pledge/index.tsx:112
@@ -478,21 +478,21 @@ msgstr "संपर्क त्रुटि"
 
 #: components/pages/About/Contact/index.tsx:140
 msgid "contact.bug_reports"
-msgstr ""
+msgstr "दोष रिपोर्ट"
 
 #. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
 #: components/pages/About/Contact/index.tsx:143
 msgid "contact.bug_reports.to_file_a_bug_report"
-msgstr ""
+msgstr "बग रिपोर्ट दर्ज करने के लिए, हमारे समुदाय के Discord (डिस्कॉर्ड) सर्वर से जुड़ें और #bug-reports चैनल में अपना प्रश्न पूछें। हमारे <0>समुदाय</0> में से कोई सदस्य जाँच करने और आपके लिए समाधान खोजने में खुशी महसूस करेगा।"
 
 #. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
 #: components/pages/About/Contact/index.tsx:66
 msgid "contact.careers.we_re_hiring"
-msgstr ""
+msgstr "हम सभी समय क्षेत्रों में नियुक्तियाँ करने वाली एक पूरी तरह से रिमोट टीम हैं। हम अपने <0>Community Discord Server</0> (सामुदायिक डिस्कॉर्ड सर्वर) में नियमित रूप से भूमिकाएँ और बाउंटीज़ पोस्ट करते हैं। यदि आप एक सेल्फ़-स्टार्टर हैं जो किसी उद्देश्य से प्रेरित एक DAO (डाओ) में शामिल होने के लिए प्रेरित है, तो हमें आपसे बात करके ख़ुशी होगी!"
 
 #: components/pages/About/Contact/index.tsx:25
 msgid "contact.head.description"
-msgstr ""
+msgstr "KlimaDAO के किसी व्यक्ति से संपर्क करें।"
 
 #: components/pages/About/Contact/index.tsx:18
 msgid "contact.head.headline"
@@ -500,494 +500,494 @@ msgstr "संपर्क करें"
 
 #: components/pages/About/Contact/index.tsx:19
 msgid "contact.head.subline"
-msgstr ""
+msgstr "प्रश्न, चिंताएँ, विचार? यहाँ कुछ माध्यम दिए गए हैं जिनके द्वारा आप संपर्क कर सकते हैं। हम संस्थानों और व्यक्तियों से समान रूप से मिलना पसंद करते हैं।"
 
 #: components/pages/About/Contact/index.tsx:17
 #: components/pages/About/Contact/index.tsx:24
 msgid "contact.head.title"
-msgstr ""
+msgstr "KlimaDAO से संपर्क करें"
 
 #: components/pages/About/Contact/index.tsx:105
 msgid "contact.media"
-msgstr ""
+msgstr "मीडिया"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:108
 msgid "contact.media.if_you_are_a_journalist"
-msgstr ""
+msgstr "यदि आप एक पत्रकार या सामग्री निर्माता हैं, तो हमारी मार्केटिंग टीम आपसे मिलना पसंद करेगी।"
 
 #. Use this <0>Media Request Form</0>.
 #: components/pages/About/Contact/index.tsx:117
 msgid "contact.media.use_this_media_request_form"
-msgstr ""
+msgstr "इस <0>मीडिया अनुरोध फ़ॉर्म</0> का उपयोग करें या <1>press@klimadao.finance</1> पर ईमेल भेजें।"
 
 #: components/pages/About/Contact/index.tsx:85
 msgid "contact.partnerships"
-msgstr ""
+msgstr "भागीदारियाँ"
 
 #. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
 #: components/pages/About/Contact/index.tsx:88
 msgid "contact.partnerships.until_we_finish_building"
-msgstr ""
+msgstr "जब तक हम अपने partnerships page (साझेदारी पृष्ठ) का निर्माण पूरा नहीं कर लेते, हम संभावित साझेदारी और सहयोग पूछताछ को <0>इस संपर्क फ़ॉर्म</0> पर निर्देशित कर रहे हैं।"
 
 #: components/pages/About/Contact/index.tsx:35
 msgid "contact.quest_and_support"
-msgstr ""
+msgstr "प्रश्न और समर्थन"
 
 #. Join our <0>community</0>
 #: components/pages/About/Contact/index.tsx:38
 msgid "contact.quest_and_support.join_our_community"
-msgstr ""
+msgstr "हमारे <0>समुदाय</0> में शामिल हों"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:46
 msgid "contact.quest_and_support.join_our_discord_server"
-msgstr ""
+msgstr "हमारे Discord (डिस्कॉर्ड) सर्वर से जुड़ें और #questions चैनल में प्रश्न करें। हमारे पास हजारों मित्रवत, जानकार समुदाय सदस्य हैं जो आपकी मदद् करने के लिए इच्छुक और तैयार हैं।"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:64
 msgid "disclaimer.1_an_offer_or_sollicitation"
-msgstr ""
+msgstr "1. अमूर्त लाभों से सम्बंधित किसी सुरक्षा, अन्य संपत्ति या सेवा को होल्ड करने या नियंत्रित करने का एक प्रस्ताव, या प्रस्ताव का आग्रह;"
 
 #: components/pages/About/Disclaimer/index.tsx:111
 msgid "disclaimer.1_meet_your_requirements"
-msgstr ""
+msgstr "1. आपकी आवश्यकताओं को पूरा करेगा;"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:116
 msgid "disclaimer.2_be_available_on_an_uninterrupted"
-msgstr ""
+msgstr "2. एक निर्बाध, समयोचित, सुरक्षित, या त्रुटि मुक्त आधार पर उपलब्ध रहेगा;"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:74
 msgid "disclaimer.2_financial_investment_or_trading_advice"
-msgstr ""
+msgstr "2. वित्तीय, निवेश या व्यापारिक सलाह या ऐसी सलाह और/या सेवा प्रदान करने का प्रस्ताव।"
 
 #: components/pages/About/Disclaimer/index.tsx:125
 msgid "disclaimer.3_be_reliable_complete_legal_or_safe"
-msgstr ""
+msgstr "3. विश्वसनीय, पूर्ण, क़ानूनन वैध या सुरक्षित रहेगा।"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:32
 msgid "disclaimer.all_information_on_this_website"
-msgstr ""
+msgstr "इस वेबसाइट पर संपूर्ण जानकारी सद्भावना के साथ और सामान्य जानकारी के उद्देश्य से ही प्रकाशित की जाती है। KlimaDAO को इस आधार पर वितरित किया जाता है कि यह उपयोगी होगा और उपरोक्त वेबसाइट पर वर्णित तर्कों और सीमाओं के भीतर ही काम करेगा।"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:159
 msgid "disclaimer.any_action_you_take_upon_the_information"
-msgstr ""
+msgstr "इस वेबसाइट पर आपको जो जानकारी मिलती है, उस पर आप जो भी कार्रवाई करते हैं, वह पूरी तरह से आपके अपने जोखिम पर है। इस वेबसाइट पर निहित जानकारी के आधार पर निर्णय पूरी तरह से आगंतुक की जिम्मेदारी है। KlimaDAO इस वेबसाइट के उपयोग के संबंध में किसी भी नुकसान और/या क्षति के लिए उत्तरदायी नहीं होगा, आपके पासवर्ड/सीड वाक्यांश की हानि, एक ख़राब व्यापार, ग़लत पते पर संपत्ति भेजना, आपकी संपत्ति के खोने और स्कैमर्स के कारण क्षति से संबंधित घटनाओं के लिए उत्तरदायी नहीं होगा। KlimaDAO बाज़ार में बदलाव और इसकी अस्थिरता से जुड़ी कोई जिम्मेदारी या दायित्व नहीं ले सकता है। आपको अपना शोध स्वयं करना चाहिए और इस मंच द्वारा प्रदान की गई जानकारी या सेवा के बारे में अपनी स्थिति, परिचय और ज्ञान से खुद को संतुष्ट करना चाहिए।"
 
 #: components/pages/About/Disclaimer/index.tsx:19
 msgid "disclaimer.disclaimer"
-msgstr ""
+msgstr "अस्वीकरण"
 
 #: components/pages/About/Disclaimer/index.tsx:21
 msgid "disclaimer.head.description"
-msgstr ""
+msgstr "KlimaDAO विधिक टीम की ओर से एक महत्वपूर्ण अस्वीकरण।"
 
 #: components/pages/About/Disclaimer/index.tsx:15
 #: components/pages/About/Disclaimer/index.tsx:25
 msgid "disclaimer.head.title"
-msgstr ""
+msgstr "KlimaDAO (क्लीमाडाओ) अस्वीकरण"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:102
 msgid "disclaimer.klimadao_and_its_suppliers"
-msgstr ""
+msgstr "KlimaDAO और उसके आपूर्त्तिकर्ता इस बात की कोई वारंटी नहीं देते हैं कि प्लैटफ़ॉर्म:"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:43
 msgid "disclaimer.klimadao_is_a_platform"
-msgstr ""
+msgstr "KlimaDAO क्लीमाडाओ एक मंच है। हम ब्रोकर, वित्तीय संस्थान या लेनदार नहीं हैं। इस वेबसाइट पर प्रदान की जाने वाली सेवाओं में किसी भी अधिकार क्षेत्र में आपकी प्रतिभूतियों, विकल्पों, परिसंपत्तियों, वायदा या प्रतिभूतियों से संबंधित अन्य डेरिवेटिव को रखने या नियंत्रित करने का प्रस्ताव शामिल नहीं है और इसकी सामग्री प्रतिभूति क़ानूनों द्वारा निर्धारित नहीं की हुयी है।"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:130
 msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
-msgstr ""
+msgstr "सेवा में निहित सामग्री या जानकारी के आधार पर की गई या की गई किसी भी कार्रवाई से किसी भी प्रकार के नुकसान के लिए न तो KlimaDAO और न ही इसका कोई प्रतिनिधि उत्तरदायी होगा। KlimaDAO सेवा और सामग्री के उपयोग को सुरक्षित बना रहा है, फिर भी यह इस बात का प्रतिनिधित्व नहीं करता अथवा यह वारंटी नहीं देता है कि हमारे प्लैटफ़ॉर्म पर सेवा और सामग्री वायरस या अन्य हानिकारक घटकों से मुक्त हैं।"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:178
 msgid "disclaimer.nothing_in_this_disclaimer"
-msgstr ""
+msgstr "इस अस्वीकरण में कुछ भी, कोई भी सूचना सामग्री या सामग्री हमारे और आपके बीच कोई क़ानूनी संबंध बनाने के लिए नहीं बनाई जाएगी और न ही हम में से किसी को कोई अधिकार या दायित्व प्रदान करेगी।"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:56
 msgid "disclaimer.nothing_in_this_platform"
-msgstr ""
+msgstr "इस मंच की किसी भी चीज़ का अर्थ नहीं लगाया जा सकता है:"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:83
 msgid "disclaimer.the_service_available"
-msgstr ""
+msgstr "सेवा में उपलब्ध या सेवा के माध्यम से सुलभ सेवा \"जैसी है, वैसी ही\" प्रदान की जाती है और, लागू क़ानून के अनुसार अनुमेय पूर्ण सीमा तक। KlimaDAO और उसके एजेंट, सलाहकार, निदेशक, अधिकारी, कर्मचारी और शेयरधारक सभी वारंटी, व्यक्त या निहित, सहित, लेकिन इन्हीं तक सीमित नहीं, प्रदर्शन या व्यवहार के दौरान व्यापारिकता की निहित वारंटी, किसी विशेष उद्देश्य के लिए उपयुक्तता और ग़ैर-उल्लंघन, और एक कोर्स से निहित वारंटी को अस्वीकार करते हैं। KlimaDAO इस जानकारी की पूर्णता, विश्वसनीयता और सटीकता, व्यापारिकता की वारंटी या किसी विशेष उद्देश्य के लिए उपयुक्तता के बारे में कोई वारंटी नहीं देता है। यह  प्लैटफ़ॉर्म इस जानकारी की पूर्णता और सटीकता के बारे में कोई वारंटी नहीं देता है।"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:189
 msgid "disclaimer.we_recommend_that_you_visit"
-msgstr ""
+msgstr "हम सलाह देते हैं कि आप इस वेबसाइट के उपयोग से पहले सुरक्षा निर्देशों के लिए हमारे Crypto Security 101 (क्रिप्टो सुरक्षा 101) पृष्ठ पर जाएँ। कृपया, ध्यान रखें: कभी भी अपनी private key (प्राइवेट की) या seed phrase (सीड फ़्रेज़) को किसी के साथ साझा न करें – न तो हमारे सदस्य और न ही हमारा ऐप आपसे कभी भी इसके लिए अनुरोध करेगा/करेंगे।"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:144
 msgid "disclaimer.you_bear_full_responsibility"
-msgstr ""
+msgstr "निजी जानकारी प्रदान करने, पहचान और वैधता की पुष्टि करने के लिए पूरी ज़िम्मेदारी आप लेते हैं। निजी जानकारी और सत्यापन प्रदान करने का सुझाव देने वाले संकेतकों और संदेशों के बावजूद, KlimaDAO मंच पर पहचान के बारे में कोई दावा नहीं करता है। किसी भी डेटा जो ऑनलाइन प्रकट किया जाता है, और भेद्यता या किसी भी प्रकार की विफलता, सॉफ़्टवेयर के असामान्य व्यवहार के कारण निरंतर दुर्घटनाओं के लिए हम की सुरक्षा की गारंटी नहीं दे सकते।"
 
 #: components/pages/errors/Custom404.tsx:41
 msgid "error.404.page.text"
-msgstr ""
+msgstr "क्षमा करें, लगता है हमने आपको ग़लत जगह भेज दिया। <0/>आइए हम आपको होम पेज पर वापस जाने के लिए मार्गदर्शन करते हैं:"
 
 #: components/pages/errors/Custom500.tsx:39
 msgid "error.500.page.text"
-msgstr ""
+msgstr "क्षमा करें, कुछ बुरा हो गया।<0/>स्टार्ट पेज पर वापस जाने का प्रयास करें:"
 
 #: components/pages/errors/Custom500.tsx:34
 msgid "error.500.page.title"
-msgstr ""
+msgstr "500 - सर्वर-संबंधी त्रुटि हो गयी"
 
 #: components/pages/errors/Custom500.tsx:19
 msgid "error.page.500.head.title"
-msgstr ""
+msgstr "500 - पृष्ठ नहीं मिला"
 
 #: components/pages/errors/Custom500.tsx:15
 msgid "error.page.500.title"
-msgstr ""
+msgstr "500 - पृष्ठ नहीं मिला"
 
 #: components/pages/Home/index.tsx:236
 msgid "home.backed_by_carbon"
-msgstr ""
+msgstr "Carbon (कार्बन) द्वारा समर्थित।"
 
 #: components/pages/Home/index.tsx:327
 msgid "home.cars_annual"
-msgstr ""
+msgstr "कारें (वार्षिक)"
 
 #: components/pages/Home/index.tsx:296
 msgid "home.equivalent_to"
-msgstr ""
+msgstr "के बराबर"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:411
 msgid "home.every_klima_token_is_backed"
-msgstr ""
+msgstr "प्रत्येक KLIMA टोकन वास्तविक दुनिया की एक कार्बन संपत्ति द्वारा समर्थित है। टोकन का उपयोग कार्बन उत्सर्जन को ऑफ़सेट करने, DeFi (डीफ़ाई) ऐप्लिकेशंस से आदान-प्रदान करने और तेज़ी से बढ़ते वैश्विक कार्बन बाज़ार के संपर्क में आने के लिए किया जाता है।"
 
 #: components/SocialProof/index.tsx:19
 msgid "home.featured_on"
-msgstr ""
+msgstr "KlimaDAO (क्लीमाडाओ) को यहाँ जगह दी गयी"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:107
 msgid "home.fight_climate_change"
-msgstr ""
+msgstr "जलवायु परिवर्तन से लड़ें और वास्तविक कार्बन परिसंपत्तियों द्वारा समर्थित डिजिटल मुद्रा KLIMA के साथ पुरस्कार अर्जित करें।"
 
 #: components/pages/Home/index.tsx:462
 msgid "home.get_exposure_to_the_growing_carbon_economy"
-msgstr ""
+msgstr "आज ही बढ़ती कार्बन अर्थव्यवस्था से रूबरू हों। प्राप्त करें, दाँव लगाएँ, और पुरस्कृत हों। जलवायु के लिए वित्तीय सक्रियता।"
 
 #: components/pages/Home/index.tsx:459
 msgid "home.get_klima"
-msgstr ""
+msgstr "KLIMA (क्लीमा) प्राप्त करें"
 
 #: components/pages/Home/index.tsx:310
 msgid "home.hectares_of_forest"
-msgstr ""
+msgstr "हेक्टेयरों जंगल"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:154
 msgid "home.klima_defies_climate_change"
-msgstr ""
+msgstr "KlimaDAO, DeFi (डीफ़ाई) है जो जलवायु परिवर्तन की उपेक्षा करता है"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:164
 msgid "home.klima_is_the_center"
-msgstr ""
+msgstr "KlimaDAO एक नई हरित अर्थव्यवस्था का केंद्र है। ऊर्जा कुशल Polygon (पॉलीगॉन) नेटवर्क पर निर्मित, KlimaDAO वैश्विक स्तर पर स्थिरता परियोजनाओं के लिए बाज़ार के विखंडन को कम करने और जलवायु वित्त के वितरण में तेज़ी लाने के लिए कई प्रौद्योगिकियों का उपयोग करता है।"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:440
 msgid "home.klima_tokens_are_minted"
-msgstr ""
+msgstr "KLIMA टोकन मिंट किए जाते हैं और हर ~ 7 घंटे में स्वचालित रूप से KLIMA धारकों को वितरित किए जाते हैं। हमारे एक साथ अधिक टिकाऊ भविष्य की शुरुआत करने के साथ अपनी KLIMA होल्डिंग्स को बढ़ाऍं।"
 
 #: components/pages/Home/index.tsx:83
 msgid "home.latest_news"
-msgstr ""
+msgstr "📰 ताजा खबर:"
 
 #: components/pages/Home/index.tsx:139
 msgid "home.learn_more"
-msgstr ""
+msgstr "और जानें"
 
 #: components/pages/Home/index.tsx:342
 msgid "home.liters_if_gasoline"
-msgstr ""
+msgstr "लीटर पेट्रोल"
 
 #: components/pages/Home/index.tsx:272
 msgid "home.massive impact"
-msgstr ""
+msgstr "भारी प्रभाव।"
 
 #: components/pages/Home/index.tsx:210
 msgid "home.mechanics"
-msgstr ""
+msgstr "यांत्रिकी"
 
 #. <0>{0}% MONTHLY REWARDS</0><1>FOR TOKEN HOLDERS</1>
 #: components/pages/Home/index.tsx:428
 msgid "home.monthly_rewards_for_token_holders"
-msgstr ""
+msgstr "<0>{0}% मासिक पुरस्कार</0> <1>टोकन धारकों के लिए</1>"
 
 #: components/pages/Home/index.tsx:491
 msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
-msgstr ""
+msgstr "सभी अल्फ़ा साथियों, सीधे आपके इनबॉक्स में"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:499
 msgid "home.newletter.get_the_latest_updates"
-msgstr ""
+msgstr "KlimaDAO पर नवीनतम अपडेट प्राप्त करें, जैसे-जैसे हम कार्बन अर्थव्यवस्था के भविष्य का निर्माण कर रहे हैं।"
 
 #: components/pages/Home/index.tsx:516
 msgid "home.newletter.never_shared_never_spammed"
-msgstr ""
+msgstr "न कभी साझा किया जाता है। न स्पैम।"
 
 #: components/pages/Home/index.tsx:510
 msgid "home.newletter.sign_up"
-msgstr ""
+msgstr "साइन अप करें"
 
 #: components/pages/Home/index.tsx:496
 msgid "home.newsletter"
-msgstr ""
+msgstr "न्यूज़लेटर"
 
 #. <0>Reserve Asset</0><1>Of the carbon economy</1>
 #: components/pages/Home/index.tsx:399
 msgid "home.reserve_asset_of_the_carbon_economy"
-msgstr ""
+msgstr "<1>कार्बन अर्थव्यवस्था की</1><0>आरक्षित संपत्ति</0>"
 
 #: components/pages/Home/index.tsx:469
 msgid "home.see_tutorial"
-msgstr ""
+msgstr "ट्यूटॉरियल देखें"
 
 #: components/pages/Home/index.tsx:357
 msgid "home.source"
-msgstr ""
+msgstr "स्रोत"
 
 #: components/pages/Home/index.tsx:254
 msgid "home.strong_incentives"
-msgstr ""
+msgstr "बढ़िया इंसेंटिव्ज़।"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:213
 msgid "home.the_dao_sell_bonds"
-msgstr ""
+msgstr "DAO (डाओ) बॉन्ड बेचता है और KLIMA धारकों को पुरस्कार वितरित करता है। हमारे द्वारा बेचा जाने वाला प्रत्येक बॉन्ड एक सतत बढ़ते हरे खजाने में जुड़ता है, या प्रमुख पर्यावरणीय संपत्तियों के लिए लिक्विडिटी में सुधार करता है। लोगों और ग्रह के लिए एक जीत वाली स्थिति।"
 
 #. TONS OF <0>CARBON ABSORBED</0> BY KLIMADAO
 #: components/pages/Home/index.tsx:283
 msgid "home.tons_of_carbon_absorbed_by_klimadao"
-msgstr ""
+msgstr "KLIMADAO द्वारा कई टन <0>कार्बन अवशोषित</0>"
 
 #. <0>WELCOME TO</0><1>KlimaDAO</1>
 #: components/pages/Home/index.tsx:94
 msgid "home.welcome_to_klimadao"
-msgstr ""
+msgstr "<1>KlimaDAO</1><0>में आपका स्वागत है</0>"
 
 #: components/pages/Infinity/index.tsx:162
 msgid "infinity.affordable_subtitle"
-msgstr ""
+msgstr "वहनयोग्य"
 
 #: components/pages/Infinity/index.tsx:157
 msgid "infinity.affordable_title"
-msgstr ""
+msgstr "रीयल-टाइम मूल्य निर्धारण, कम लेनदेन लागत"
 
 #: components/pages/Infinity/index.tsx:418
 msgid "infinity.box_amount_104k"
-msgstr ""
+msgstr "104k"
 
 #: components/pages/Infinity/index.tsx:404
 msgid "infinity.box_amount_11k"
-msgstr ""
+msgstr "11k"
 
 #: components/pages/Infinity/index.tsx:400
 msgid "infinity.box_title"
-msgstr ""
+msgstr "अंतिम कार्बन ऑफ़सेट"
 
 #: components/pages/Infinity/index.tsx:414
 msgid "infinity.box_title2"
-msgstr ""
+msgstr "कुल रिटायर किया गया कार्बन"
 
 #: components/pages/Infinity/index.tsx:665
 msgid "infinity.button.read_blog_faq"
-msgstr ""
+msgstr "KI ग्राहकों के लिए गहन अधिक पूछे जाने वाले प्रश्न पढ़ें"
 
 #: components/pages/Infinity/index.tsx:368
 msgid "infinity.button.read_blog_polygon"
-msgstr ""
+msgstr "Polygon (पॉलीगॉन) की कहानी पढ़ें"
 
 #: components/pages/Infinity/Cards/CardsSlider.tsx:89
 msgid "infinity.cards_slider.title"
-msgstr ""
+msgstr "दर्जनों संस्थाओं ने Klima Infinity (क्लीमा इन्फिनिटी) के साथ 150,000 कार्बन टन से अधिक ऑफ़सेट किया है"
 
 #: components/pages/Infinity/index.tsx:331
 msgid "infinity.carousel_image_description"
-msgstr ""
+msgstr "जयभीम, भारत, में पवन ऊर्जा परियोजना"
 
 #: components/pages/Infinity/index.tsx:343
 msgid "infinity.carousel_info_subtitle"
-msgstr ""
+msgstr "उन परियोजनाओं के लिए वित्त पोषण करें जो जलवायु परिवर्तन शमन में कुछ मदद् करती हैं"
 
 #: components/pages/Infinity/index.tsx:338
 msgid "infinity.carousel_info_title"
-msgstr ""
+msgstr "उच्च गुणवत्ता वाले प्रॉजेक्ट्स का समर्थन"
 
 #: components/pages/Infinity/index.tsx:685
 msgid "infinity.cta_title"
-msgstr ""
+msgstr "आपके संगठन के लिए अगली पीढ़ी का कार्बन टूलकिट।"
 
 #: components/pages/Infinity/index.tsx:557
 msgid "infinity.faq_answer1"
-msgstr ""
+msgstr "एक कार्बन ऑफ़सेट यूनिट का अर्थ वातावरण से एक टन कार्बन डाइऑक्साइड समकक्ष (tCO2e) को हटाना, अथवा एक टन उत्सर्जन से बचना है।"
 
 #: components/pages/Infinity/index.tsx:593
 msgid "infinity.faq_answer2_paragraph1"
-msgstr ""
+msgstr "कार्बन क्रेडिट एक उच्च-अखंडता तंत्र है जो कार्बन वित्त को, प्रदूषित करने वालों से दुनिया भर की उन परियोजनाओं में प्रवाहित करने की अनुमति देता है जो वातावरण से कार्बन को कम करने या हटाने में मदद् करते हैं। वे ऐसे कठोर उत्सर्जनों को कवर करने के लिए एक मूल्यवान उपकरण हैं जिन्हें आज खत्म करना महँगा या तकनीकी रूप से चुनौतीपूर्ण हो सकता है।"
 
 #: components/pages/Infinity/index.tsx:603
 msgid "infinity.faq_answer2_paragraph2"
-msgstr ""
+msgstr "जब आप कार्बन क्रेडिट ख़रीदते हैं, तो Klima Infinity (क्लीमा इन्फिनिटी) आपको इस कार्बन क्रेडिट को रिटायर करने में सक्षम बनाता है, इसे स्थायी रूप से प्रचलन से हटा देता है। यह रिटायरमेंट वह बिंदु है जिस पर आप कार्बन ऑफ़सेट के लाभ को क्लेम कर सकते हैं।"
 
 #: components/pages/Infinity/index.tsx:611
 msgid "infinity.faq_answer2_paragraph3"
-msgstr ""
+msgstr "ख़रीदे गए ऑफ़सेट से अर्थव्यवस्था में कहीं और मापने योग्य और बड़ी मात्रा में उत्सर्जन में कमी आती है, और इसका उपयोग एक अपरिहार्य कार्बन फ़ुटप्रिंट को 'ऑफ़सेट' करने के लिए किया जा सकता है। कार्बन क्रेडिट का व्यापार और रिटायरमेंट एक बाज़ार तंत्र को उभरने में सक्षम बनाता है जो कार्बन पर मूल्य डालता है।"
 
 #: components/pages/Infinity/index.tsx:648
 msgid "infinity.faq_answer3"
-msgstr ""
+msgstr "कार्बन बाज़ारों का उद्देश्य उत्सर्जन पर सीमा निर्धारित करके और उत्सर्जन इकाइयों के व्यापार को सक्षम करके ग्रीनहाउस गैस (GHG/जीएचजी, या \"कार्बन\") उत्सर्जन को प्रभावी ढंग से कम करना है, जो उत्सर्जन में कमी का प्रतिनिधित्व करने वाले वित्तीय साधन हैं। व्यापार उन संस्थाओं को सक्षम बनाता है जो उच्च लागत वाले उत्सर्जकों द्वारा भुगतान करने के लिए कम लागत पर उत्सर्जन को कम कर सकते हैं, इस प्रकार उत्सर्जन को कम करने की आर्थिक लागत को कम कर सकते हैं।"
 
 #: components/pages/Infinity/index.tsx:543
 msgid "infinity.faq_question1"
-msgstr ""
+msgstr "1. कार्बन ऑफ़सेट क्या है?"
 
 #: components/pages/Infinity/index.tsx:577
 msgid "infinity.faq_question2"
-msgstr ""
+msgstr "2. जलवायु परिवर्तन के विरुद्ध लड़ाई में ऑफ़सेटिंग कैसे मदद् करती है?"
 
 #: components/pages/Infinity/index.tsx:634
 msgid "infinity.faq_question3"
-msgstr ""
+msgstr "3. कार्बन बाज़ार क्या हैं?"
 
 #: components/pages/Infinity/index.tsx:137
 msgid "infinity.fast_subtitle"
-msgstr ""
+msgstr "बिना किसी परेशानी के, सेकंडों में ऑफ़सेट करें"
 
 #: components/pages/Infinity/index.tsx:142
 msgid "infinity.fast_title"
-msgstr ""
+msgstr "तेज़"
 
 #: components/pages/Infinity/GetStartedModal.tsx:47
 msgid "infinity.getStartedModal_business"
-msgstr ""
+msgstr "मैं एक <0/>व्यवसाय हूं।"
 
 #: components/pages/Infinity/GetStartedModal.tsx:70
 msgid "infinity.getStartedModal_individual"
-msgstr ""
+msgstr "मैं एक<0/>व्यक्ति हूं।"
 
 #: components/pages/Infinity/GetStartedModal.tsx:104
 msgid "infinity.getStartedModal_needAssistance"
-msgstr ""
+msgstr "मुझे अपने संगठन के कार्बन फुटप्रिंट में सहायता चाहिए."
 
 #: components/pages/Infinity/GetStartedModal.tsx:94
 msgid "infinity.getStartedModal_offsetCrypto"
-msgstr ""
+msgstr "मैं क्रिप्टो को ऑफसेट करना चाहता हूं<0/>।"
 
 #: components/pages/Infinity/index.tsx:258
 msgid "infinity.getStarted_1"
-msgstr ""
+msgstr "1"
 
 #: components/pages/Infinity/index.tsx:272
 msgid "infinity.getStarted_2"
-msgstr ""
+msgstr "2"
 
 #: components/pages/Infinity/index.tsx:261
 msgid "infinity.getStarted_calculate"
-msgstr ""
+msgstr "गणना करें"
 
 #: components/pages/Infinity/index.tsx:264
 msgid "infinity.getStarted_calculate_subtitle"
-msgstr ""
+msgstr "अपने संगठन के कार्बन फुटप्रिंट की गणना करें और Klima Infinity (क्लीमा इनफिनिटी) के साथ अपने ऑफ़सेट के दायरे को परिभाषित करें।"
 
 #: components/pages/Infinity/index.tsx:301
 msgid "infinity.getStarted_cta"
-msgstr ""
+msgstr "कार्बन न्यूट्रल होने - और उससे आगे के लिए अपनी रफ़्तार तेज़ करें"
 
 #: components/pages/Infinity/index.tsx:278
 msgid "infinity.getStarted_second_subtitle"
-msgstr ""
+msgstr "अपने ऑफ़सेट को कुछ ही क्लिक में और लगभग तत्काल लेन-देन समय के साथ कार्यान्वित करें।"
 
 #: components/pages/Infinity/index.tsx:275
 msgid "infinity.getStarted_second_title"
-msgstr ""
+msgstr "कार्यान्वित करना"
 
 #: components/pages/Infinity/index.tsx:286
 msgid "infinity.getStarted_third"
-msgstr ""
+msgstr "3"
 
 #: components/pages/Infinity/index.tsx:292
 msgid "infinity.getStarted_third_subtitle"
-msgstr ""
+msgstr "अपनी प्रतिबद्धता को ट्रैक करें, और अपने जलवायु सकारात्मक कार्यों के बारे में जागरूकता बढ़ाएँ।"
 
 #: components/pages/Infinity/index.tsx:289
 msgid "infinity.getStarted_third_title"
-msgstr ""
+msgstr "विस्तार करें"
 
 #: components/pages/Infinity/index.tsx:67
 msgid "infinity.head.metaDescription"
-msgstr ""
+msgstr "आपके संगठन के लिए अगली पीढ़ी का कार्बन टूलकिट।"
 
 #: components/pages/Infinity/index.tsx:63
 msgid "infinity.head.metaTitle"
-msgstr ""
+msgstr "Klima Infinity (क्लिमा इन्फिनिटी) - गो कार्बन न्यूट्रल"
 
 #: components/pages/Infinity/index.tsx:59
 msgid "infinity.head.title"
-msgstr ""
+msgstr "KlimaDAO (क्लीमाडाओ) | Klima Infinity (क्लीमा इन्फिनिटी)"
 
 #: components/pages/Infinity/index.tsx:178
 msgid "infinity.info_subtitle1"
-msgstr ""
+msgstr "इस ग्रह के अग्रणी संगठनों के लिए"
 
 #: components/pages/Infinity/index.tsx:183
 msgid "infinity.info_subtitle2"
-msgstr ""
+msgstr "दुनिया का सबसे शक्तिशाली और उपयोग-में-आसान ऑफ़सेटिंग समाधान"
 
 #: components/pages/Infinity/index.tsx:450
 msgid "infinity.mission_card1_subtitle"
-msgstr ""
+msgstr "KlimaDAO द्वारा होल्ड किए गए कार्बन टन"
 
 #: components/pages/Infinity/index.tsx:447
 msgid "infinity.mission_card1_title"
-msgstr ""
+msgstr "18.1 मिलियन"
 
 #: components/pages/Infinity/index.tsx:472
 msgid "infinity.mission_card2_description"
-msgstr ""
+msgstr "KlimaDAO द्वारा होल्ड की गयी कार्बन तरलता"
 
 #: components/pages/Infinity/index.tsx:469
 msgid "infinity.mission_card2_number"
-msgstr ""
+msgstr "$10m+"
 
 #: components/pages/Infinity/index.tsx:494
 msgid "infinity.mission_card3_description"
-msgstr ""
+msgstr "KlimaDAO के माध्यम से ऑफ़सेट किए गए कार्बन टन"
 
 #: components/pages/Infinity/index.tsx:491
 msgid "infinity.mission_card3_number"
-msgstr ""
+msgstr "150,000+"
 
 #: components/pages/Infinity/index.tsx:387
 msgid "infinity.polygon_manifesto_description"
-msgstr ""
+msgstr "अपने पूरे नेटवर्क के ऐतिहासिक उत्सर्जन को ऑफसेट करके, पॉलीगॉन ने यह सुनिश्चित किया है कि उसके नेटवर्क के भीतर हर आदान-प्रदान - चाहे वह NFT (एनएफटी) मिंट हो या DeFi (डीफ़ाई) लेनदेन - को ध्यान में रखा जाता है। यह एक प्रमुख कारण है कि मेटा ने अपने NFT (एनएफटी) जारी करने के लिए बहुभुज को चुना।"
 
 #: components/pages/Infinity/index.tsx:381
 msgid "infinity.polygon_manifesto_title"
-msgstr ""
+msgstr "ऑफ़सेट Polygon (पॉलीगॉन) के ग्रीन मैनिफ़ेस्टो का हिस्सा है"
 
 #: components/pages/Infinity/index.tsx:361
 msgid "infinity.polygon_story_description"
-msgstr ""
+msgstr "Polygon (पॉलीगॉन) ने स्थापना के बाद से नेटवर्क के कार्बन उत्सर्जन को ऑफ़सेट किया - लगभग 90,000 टन - और नेटवर्क के भविष्य के सभी लेनदेन के लिए जलवायु सकारात्मक होने का वचन दिया।"
 
 #: components/pages/Infinity/index.tsx:356
 msgid "infinity.polygon_story_title"
-msgstr ""
+msgstr "Polygon (पॉलीगॉन) ने अपने ब्लॉकचेन नेटवर्क को ऑफ़सेट करने के लिए Klima Infinity (क्लीमा इन्फिनिटी) को चुना"
 
 #: components/pages/Infinity/Cards/Card.tsx:66
 #: components/pages/Infinity/index.tsx:407
@@ -997,158 +997,158 @@ msgstr "टन"
 
 #: components/pages/Infinity/index.tsx:196
 msgid "infinity.transparent_subtitle"
-msgstr ""
+msgstr "पारदर्शी"
 
 #: components/pages/Infinity/index.tsx:191
 msgid "infinity.transparent_title"
-msgstr ""
+msgstr "ब्लॉकचेन पर अपरिवर्तनीय रूप से रिकॉर्ड किया गया"
 
 #: components/pages/Infinity/index.tsx:98
 msgid "infinity.welcome_subtitle"
-msgstr ""
+msgstr "Klima Infinity (क्लिमा इन्फिनिटी) आपके संगठन के लिए अगली पीढ़ी का कार्बन टूलकिट है"
 
 #: components/pages/Infinity/index.tsx:93
 msgid "infinity.welcome_title"
-msgstr ""
+msgstr "कार्बन न्यूट्रल होने का सबसे आसान तरीका"
 
 #: components/pages/Infinity/index.tsx:224
 msgid "infinity.why_description"
-msgstr ""
+msgstr "KlimaDAO बाज़ार के विखंडन को कम करने और दुनिया भर में स्थिरता परियोजनाओं के लिए जलवायु वित्त के वितरण में तेज़ी लाने के लिए कई DeFi प्रौद्योगिकियों का लाभ उठा रहा है।"
 
 #: components/pages/Infinity/index.tsx:219
 msgid "infinity.why_subtitle"
-msgstr ""
+msgstr "DeFi (डीफ़ाई) जो जलवायु परिवर्तन की उपेक्षा करता है"
 
 #: components/pages/Infinity/index.tsx:216
 msgid "infinity.why_title"
-msgstr ""
+msgstr "KlimaDAO (क्लीमाडाओ) क्यों?"
 
 #: components/pages/Home/index.tsx:384
 msgid "invest_in_the_future"
-msgstr ""
+msgstr "भविष्य में निवेश करें।"
 
 #: components/pages/Infinity/index.tsx:439
 msgid "mission.header"
-msgstr ""
+msgstr "KlimaDAO का मिशन जलवायु कार्रवाई का लोकतंत्रीकरण करना है"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:79
 #: components/pages/Pledge/PledgeForm/index.tsx:83
 #: components/pages/Pledge/PledgeForm/index.tsx:99
 msgid "pledge.errors.default"
-msgstr ""
+msgstr "एक त्रुटि हूँई है"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:91
 msgid "pledge.errors.method_not_allowed"
-msgstr ""
+msgstr "विधि अनुमत नहीं।"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:75
 msgid "pledge.errors.pledge_not_found"
-msgstr ""
+msgstr "इस पते के लिए प्रतिज्ञा नहीं मिली।"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:87
 msgid "pledge.errors.unknown_error"
-msgstr ""
+msgstr "एक अज्ञात त्रुटि हुई है।"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:191
 msgid "pledge.form.error.cannot_add_yourself"
-msgstr ""
+msgstr "आप अपने स्वयं के वॉलेट को द्वितीयक वॉलेट के रूप में नहीं जोड़ सकते"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:227
 msgid "pledge.form.error.default_error_message"
-msgstr ""
+msgstr "कुछ गलत हो गया। कृपया शीघ्र ही पुन: प्रयास करें।"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:175
 msgid "pledge.form.error.duplicate_wallets"
-msgstr ""
+msgstr "कृपया डुप्लीकेट वॉलेट निकालें"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:616
 msgid "pledge.form.wallets.confirm_remove_wallet"
-msgstr ""
+msgstr "क्या आप वाकई {0} को अपने गिरवी से हटाना चाहते हैं?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:340
 msgid "pledge.form.wallets.tooltip"
-msgstr ""
+msgstr "अपनी प्रतिज्ञा में योगदान करने के लिए अन्य वॉलेट जोड़ें। अगर वॉलेट का मालिक आपका निमंत्रण स्वीकार करता है, तो उनका वॉलेट आपके प्लेज डैशबोर्ड पर दिखाई देगा। द्वितीयक वॉलेट द्वारा की गई कोई भी सेवानिवृत्ति आपकी प्रतिज्ञा में योगदान देगी। आप इस प्रतिज्ञा के लिए एकमात्र स्वामित्व और संपादन पहुंच बनाए रखेंगे।"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:41
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:111
 msgid "pledge.invitation.accept"
-msgstr ""
+msgstr "निमंत्रण स्वीकार करो"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:70
 msgid "pledge.invitation.error.wallet_already_pinned"
-msgstr ""
+msgstr "यह बटुआ पहले से ही अन्य गिरवी पर पिन किया हुआ है। कृपया अपने वॉलेट को अनपिन करें और पुनः प्रयास करें।"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:49
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:44
 msgid "pledge.invitation.error_title"
-msgstr ""
+msgstr "सर्वर-संबंधी त्रुटि हो गयी"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:102
 msgid "pledge.invitation.join_message"
-msgstr ""
+msgstr "{shortenedAddress} ने आपको इस प्रतिज्ञा में अपना बटुआ जोड़ने के लिए आमंत्रित किया है। यदि आप स्वीकार करते हैं, तो आपकी कार्बन सेवानिवृत्ति {shortenedAddress} की प्रतिज्ञा में गिनी जाएगी। आप किसी भी समय अपने बटुए को इस प्रतिज्ञा से हटा सकते हैं।"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:130
 msgid "pledge.invitation.later"
-msgstr ""
+msgstr "मुझे बाद में याद दिलाना"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:118
 msgid "pledge.invitation.reject"
-msgstr ""
+msgstr "आमंत्रण अस्वीकार करें"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:57
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:52
 msgid "pledge.invitation.signing"
-msgstr ""
+msgstr "हस्ताक्षर"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:193
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:179
 msgid "pledge.invitations.awaiting_signature"
-msgstr ""
+msgstr "हस्ताक्षर की प्रतीक्षा में..."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:199
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:185
 msgid "pledge.invitations.signature_instructions"
-msgstr ""
+msgstr "इस संपादन पर हस्ताक्षर करने और पुष्टि करने के लिए अपने वॉलेट का उपयोग करें।"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:129
 msgid "pledge.modal.are_you_sure"
-msgstr ""
+msgstr "क्या आप सुनिश्चित हैं कि आप अपने बटुए को इस प्रतिज्ञा से हटाना चाहते हैं?"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:153
 msgid "pledge.modal.confirm"
-msgstr ""
+msgstr "पुष्टि करें"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:40
 msgid "pledge.modal.confirm_remove"
-msgstr ""
+msgstr "हटाने की पुष्टि करें"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:39
 msgid "pledge.modal.edit_pledge"
-msgstr ""
+msgstr "प्लेज संपादित करें"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:101
 msgid "pledge.modal.unable_to_edit"
-msgstr ""
+msgstr "इस वॉलेट के पास इस प्रतिज्ञा को संपादित करने की अनुमति नहीं है। संपादित करने के लिए, आपको मूल लेखक वॉलेट ({0}) से फिर से जुड़ना होगा।"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:110
 msgid "pledge.modal.unpin_wallet"
-msgstr ""
+msgstr "मेरा बटुआ खोलो"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:144
 msgid "pledge.modal.wallet_add_confirm"
-msgstr ""
+msgstr "आपके पास प्रति वॉलेट पते पर केवल एक प्रतिज्ञा पृष्ठ हो सकता है। यदि आपने पहले ही इस बटुए के साथ प्रतिज्ञा पृष्ठ बना लिया है, तो इसके बजाय आगंतुकों को इस प्रतिज्ञा पर पुनर्निर्देशित किया जाएगा। आप इस वॉलेट को किसी भी समय निकाल सकते हैं।"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:110
 msgid "pledges.dashboard.assets.emptyBalance"
-msgstr ""
+msgstr "दिखाने के लिए कोई कार्बन संपत्ति नहीं है।"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:87
 msgid "pledges.dashboard.assets.title"
-msgstr ""
+msgstr "कार्बन एसेट्स"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
 msgid "pledges.dashboard.footprint.title"
-msgstr ""
+msgstr "फ़ुटप्रिंट"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
 msgid "pledges.dashboard.footprint.tonnes"
@@ -1156,27 +1156,27 @@ msgstr "टन"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:104
 msgid "pledges.dashboard.footprint.tooltip.category_percent"
-msgstr ""
+msgstr "{0}% फ़ुटप्रिंट"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:110
 msgid "pledges.dashboard.footprint.tooltip.quantity"
-msgstr ""
+msgstr "{0} कार्बन टन"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:137
 msgid "pledges.dashboard.head.metaDescription"
-msgstr ""
+msgstr "{pledgeOwnerTitle} ऑफसेट {currentTotalFootprint} कार्बन टन का वचन देता है। उनका कार्बन ऑफसेट इतिहास देखें और उनकी प्रतिबद्धता के बारे में और पढ़ें।"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:133
 msgid "pledges.dashboard.head.metaTitle"
-msgstr ""
+msgstr "{pledgeOwnerTitle} की प्रतिज्ञा"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:129
 msgid "pledges.dashboard.head.title"
-msgstr ""
+msgstr "{pledgeOwnerTitle} की प्रतिज्ञा | क्लीमाडाओ"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:14
 msgid "pledges.dashboard.metholodogy.default_text"
-msgstr ""
+msgstr "आप अपनी प्लेज को कैसे पूरा करेंगे?"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:21
 msgid "pledges.dashboard.metholodogy.title"
@@ -1184,139 +1184,139 @@ msgstr "कार्यप्रणाली"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:14
 msgid "pledges.dashboard.pledge.default_text"
-msgstr ""
+msgstr "आज ही अपनी प्लेज लें!"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:21
 msgid "pledges.dashboard.pledge.title"
-msgstr ""
+msgstr "प्लेज"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:64
 msgid "pledges.dashboard.profile.pledge_met"
-msgstr ""
+msgstr "≥ 100% "
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:73
 msgid "pledges.dashboard.profile.pledge_progress"
-msgstr ""
+msgstr "{0}% प्लेज पूरी हुयी"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:106
 msgid "pledges.dashboard.profile.pledged_to_offset"
-msgstr ""
+msgstr "कार्बन टन <0>{0}</0> जिन्हें ऑफ़सेट करने का वचन दिया गया"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:104
 msgid "pledges.dashboard.retirements.title"
-msgstr ""
+msgstr "रिटायरमेंट्स"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
 msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
-msgstr ""
+msgstr "{0} रिटायर्ड कार्बन टन"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:123
 msgid "pledges.dashboard.retirements.total_tonnes_retired"
-msgstr ""
+msgstr "कुल रिटायर किए गए कार्बन टन"
 
 #: components/pages/Pledge/HeaderDesktop/index.tsx:37
 msgid "pledges.edit_pledge"
-msgstr ""
+msgstr "प्लेज संपादित करें"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:562
 msgid "pledges.form.add_footprint_category_button"
-msgstr ""
+msgstr "कैटेगरी जोड़ें"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:446
 msgid "pledges.form.add_wallet_button"
-msgstr ""
+msgstr "बटुआ जोड़ें"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:242
 msgid "pledges.form.awaiting_signature"
-msgstr ""
+msgstr "हस्ताक्षर की प्रतीक्षा में..."
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:197
 msgid "pledges.form.confirm_delete"
-msgstr ""
+msgstr "हटाने की पुष्टि करें"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:622
 msgid "pledges.form.confirm_remove"
-msgstr ""
+msgstr "हटाना"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:635
 msgid "pledges.form.confirm_remove_cancel"
-msgstr ""
+msgstr "रद्द करें"
 
 #: components/pages/Pledge/index.tsx:212
 msgid "pledges.form.error"
-msgstr ""
+msgstr "वॉलेट पता, .klima अथवा .eth डोमेन दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:74
 msgid "pledges.form.errors.categoryName.max"
-msgstr ""
+msgstr "32 से कम अक्षर दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:70
 msgid "pledges.form.errors.categoryName.required"
-msgstr ""
+msgstr "कैटेगरी दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:78
 msgid "pledges.form.errors.categoryQuantity.min"
-msgstr ""
+msgstr "0 से बड़ा मान दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:50
 msgid "pledges.form.errors.description.max"
-msgstr ""
+msgstr "500 से कम अक्षर दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:46
 msgid "pledges.form.errors.description.required"
-msgstr ""
+msgstr "एक प्लेज दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:62
 msgid "pledges.form.errors.footprint.generic_error"
-msgstr ""
+msgstr "एक कार्बन टन अनुमान दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:66
 msgid "pledges.form.errors.footprint.min"
-msgstr ""
+msgstr "0 से बड़ा मान दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:58
 msgid "pledges.form.errors.methodology.max"
-msgstr ""
+msgstr "1000 से कम अक्षर दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:54
 msgid "pledges.form.errors.methodology.required"
-msgstr ""
+msgstr "एक कार्यप्रणाली दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:34
 msgid "pledges.form.errors.name.required"
-msgstr ""
+msgstr "नाम डालें"
 
 #: components/pages/Pledge/lib/formSchema.ts:38
 msgid "pledges.form.errors.profileImageUrl.url"
-msgstr ""
+msgstr "एक मान्य यूआरएल दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:42
 msgid "pledges.form.errors.profileWebsiteUrl.url"
-msgstr ""
+msgstr "एक मान्य यूआरएल दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:86
 msgid "pledges.form.errors.walletAddress.isAddress"
-msgstr ""
+msgstr "कृपया एक वैध पता दर्ज करें"
 
 #: components/pages/Pledge/lib/formSchema.ts:90
 msgid "pledges.form.errors.walletAddress.isOwner"
-msgstr ""
+msgstr "आप गिरवी स्वामी को नहीं जोड़ सकते"
 
 #: components/pages/Pledge/lib/formSchema.ts:82
 msgid "pledges.form.errors.walletAddress.required"
-msgstr ""
+msgstr "पता आवश्यक है"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:489
 msgid "pledges.form.footprint.label"
-msgstr ""
+msgstr "फ़ुटप्रिंट"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:497
 msgid "pledges.form.footprint.prompt"
-msgstr ""
+msgstr "एक कैटेगरी जोड़ें और अपने कार्बन फुटप्रिंट की गणना शुरू करें"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:260
 msgid "pledges.form.generic_error"
-msgstr ""
+msgstr "कुछ गड़बड़ हो गयी। कृपया पुन: प्रयास करें।"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:518
 msgid "pledges.form.input.categoryName.label"
@@ -1324,23 +1324,23 @@ msgstr "कैटेगरी"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:510
 msgid "pledges.form.input.categoryName.placeholder"
-msgstr ""
+msgstr "कैटेगरी नाम"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:538
 msgid "pledges.form.input.categoryQuantity.label"
-msgstr ""
+msgstr "मात्रा"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:530
 msgid "pledges.form.input.categoryQuantity.placeholder"
-msgstr ""
+msgstr "कार्बन टन"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:323
 msgid "pledges.form.input.description.label"
-msgstr ""
+msgstr "प्लेज"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:316
 msgid "pledges.form.input.description.placeholder"
-msgstr ""
+msgstr "आपने क्या प्लेज ली है?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:476
 msgid "pledges.form.input.methodology.label"
@@ -1348,67 +1348,67 @@ msgstr "कार्यप्रणाली"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:468
 msgid "pledges.form.input.methodology.placeholder"
-msgstr ""
+msgstr "आपने अपने कार्बन फ़ुटप्रिंट की गणना के लिए किन उपकरणों या विधियों का उपयोग किया?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:280
 msgid "pledges.form.input.name.label"
-msgstr ""
+msgstr "नाम"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:273
 msgid "pledges.form.input.name.placeholder"
-msgstr ""
+msgstr "नाम या कंपनी का नाम"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:291
 msgid "pledges.form.input.profileImageUrl.label"
-msgstr ""
+msgstr "प्रोफ़ाइल छवि url (वैकल्पिक)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:305
 msgid "pledges.form.input.profileWebsiteUrl.label"
-msgstr ""
+msgstr "वेबसाइट (वैकल्पिक)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:579
 msgid "pledges.form.input.totalFootprint.label"
-msgstr ""
+msgstr "कुल फ़ुटप्रिंट"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:380
 msgid "pledges.form.input.walletAddress.label"
-msgstr ""
+msgstr "पता"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:372
 msgid "pledges.form.input.walletAddress.placeholder"
-msgstr ""
+msgstr "0x..."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:595
 msgid "pledges.form.submit_button"
-msgstr ""
+msgstr "प्लेज सेव करें"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:193
 msgid "pledges.form.title"
-msgstr ""
+msgstr "आपकी प्रतिज्ञा"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:52
 msgid "pledges.form.total_footprint_summary"
-msgstr ""
+msgstr "कुल फ़ुटप्रिंट: {0} कार्बन टन"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:607
 msgid "pledges.form.use_your_wallet"
-msgstr ""
+msgstr "इस संपादन पर हस्ताक्षर करने और पुष्टि करने के लिए अपने वॉलेट का उपयोग करें।"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:332
 msgid "pledges.form.wallets.label"
-msgstr ""
+msgstr "द्वितीयक बटुआ"
 
 #: components/pages/Pledge/index.tsx:94
 msgid "pledges.head.metaDescription"
-msgstr ""
+msgstr "अपनी सभी कार्बन ऑफसेटिंग गतिविधि को उजागर करने के लिए अपने प्रतिज्ञा डैशबोर्ड का दावा करके जलवायु सकारात्मकता के प्रति अपनी प्रतिबद्धता प्रदर्शित करें"
 
 #: components/pages/Pledge/index.tsx:90
 msgid "pledges.head.metaTitle"
-msgstr ""
+msgstr "कार्बन प्रतिज्ञा बनाएं और अपना प्रभाव दिखाएं"
 
 #: components/pages/Pledge/index.tsx:86
 msgid "pledges.head.title"
-msgstr ""
+msgstr "KlimaDAO (क्लीमाडाओ) | Pledges (प्लेजेज़)"
 
 #: components/pages/Pledge/index.tsx:66
 msgid "pledges.home.hero.connecting"
@@ -1416,23 +1416,23 @@ msgstr "कनेक्ट हो रहा है..."
 
 #: components/pages/Pledge/index.tsx:77
 msgid "pledges.home.hero.create"
-msgstr ""
+msgstr "एक प्रतिज्ञा बनाएँ"
 
 #: components/pages/Pledge/index.tsx:170
 msgid "pledges.home.hero.learn_more"
-msgstr ""
+msgstr "और जानें"
 
 #: components/pages/Pledge/index.tsx:72
 msgid "pledges.home.hero.view"
-msgstr ""
+msgstr "अपनी प्रतिज्ञा देखें"
 
 #: components/pages/Pledge/index.tsx:206
 msgid "pledges.home.search.label"
-msgstr ""
+msgstr "ENS या 0x पता दर्ज करें"
 
 #: components/pages/Pledge/index.tsx:200
 msgid "pledges.home.search.placeholder"
-msgstr ""
+msgstr "ईनस (ENS) , केनस (KNS) या 0x पता दर्ज करें"
 
 #: components/pages/Pledge/index.tsx:226
 msgid "pledges.home.search.submit"
@@ -1468,51 +1468,51 @@ msgstr "चुने"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:53
 msgid "resources.form.medium.header"
-msgstr ""
+msgstr "मध्यम"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:41
 msgid "resources.form.sub_topics.header"
-msgstr ""
+msgstr "उप-विषय"
 
 #: components/pages/Resources/index.tsx:31
 msgid "resources.head.metaDescription"
-msgstr ""
+msgstr "संस्थापकों, DAO (डाओ) योगदानकर्ताओं, सलाहकारों और समुदाय द्वारा अपडेटेड और विचार नेतृत्व।"
 
 #: components/pages/Resources/index.tsx:27
 msgid "resources.head.metaTitle"
-msgstr ""
+msgstr "KlimaDAO (क्लीमाडाओ) संसाधन - कार्बन न्यूट्रल से भी आगे की सोचें"
 
 #: components/pages/Resources/index.tsx:23
 msgid "resources.head.title"
-msgstr ""
+msgstr "KlimaDAO (क्लीमाडाओ) | Resources (रिसोर्सेज़)"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:71
 msgid "resources.list.filter.tag.basics"
-msgstr ""
+msgstr "बेसिक्स "
 
 #: components/pages/Resources/lib/cmsDataMap.ts:111
 msgid "resources.list.filter.tag.carbon_footprint"
-msgstr ""
+msgstr "कार्बन पदचिह्न"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:79
 msgid "resources.list.filter.tag.deep_dives"
-msgstr ""
+msgstr "डीप डाइव्स"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:52
 msgid "resources.list.filter.tag.klima_infinity"
-msgstr ""
+msgstr "क्लिमा इन्फिनिटी"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:44
 msgid "resources.list.filter.tag.klima_overview"
-msgstr ""
+msgstr "क्लिमा अवलोकन"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:60
 msgid "resources.list.filter.tag.partnerships"
-msgstr ""
+msgstr "भागीदारियाँ"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:103
 msgid "resources.list.filter.tag.policy"
-msgstr ""
+msgstr "नीति"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:95
 msgid "resources.list.filter.tag.press_releases"
@@ -1524,11 +1524,11 @@ msgstr "उपयोगकर्ता मार्गदर्शक"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:121
 msgid "resources.list.filter.type.blog"
-msgstr ""
+msgstr "ब्लॉग"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:129
 msgid "resources.list.filter.type.podcast"
-msgstr ""
+msgstr "पॉडकास्ट"
 
 #: components/pages/Resources/SortyByDropDown/index.tsx:62
 msgid "resources.list.select.sort_by.toggle"
@@ -1536,7 +1536,7 @@ msgstr "मेनू द्वारा क्रमबद्ध टॉगल �
 
 #: components/pages/Resources/lib/cmsDataMap.ts:155
 msgid "resources.list.sort_by.a-z"
-msgstr "ए तू ज़ेड"
+msgstr "ए तू ज़ेड "
 
 #: components/pages/Resources/lib/cmsDataMap.ts:139
 msgid "resources.list.sort_by.latest_first"
@@ -1560,15 +1560,15 @@ msgstr "इसके अनुसार क्रमबद्ध करें"
 
 #: components/pages/Resources/index.tsx:46
 msgid "resources.page.header.subline"
-msgstr ""
+msgstr "संस्थापकों, DAO (डाओ) योगदानकर्ताओं, सलाहकारों और समुदाय द्वारा अपडेटेड और विचार नेतृत्व।"
 
 #: components/pages/Resources/index.tsx:43
 msgid "resources.page.header.title"
-msgstr ""
+msgstr "सम्मिलित लेख"
 
 #: components/pages/Resources/ResourcesList/index.tsx:167
 msgid "resources.page.list.header"
-msgstr ""
+msgstr "सभी का अन्वेषण करें"
 
 #: components/pages/Resources/ResourcesList/index.tsx:249
 msgid "resources.page.list.no_search_results.title"
@@ -1588,15 +1588,15 @@ msgstr "टाइपो के लिए अपनी खोज की जाँ
 
 #: components/pages/Retirements/Footer/index.tsx:18
 msgid "retirement.footer.aboutKlima.left"
-msgstr ""
+msgstr "KlimaDAO स्थिरता को प्रोत्साहित कर रहा है और अधिक पारदर्शी और लिक्विड कार्बन बाज़ार को उत्प्रेरित कर रहा है। हमारे टूल्स किसी भी व्यक्ति या व्यवसायों के लिए ब्लॉकचेन पर गुणवत्तापूर्ण कार्बन परिसंपत्तियों का व्यापार और उनको रिटायर करना संभव बनाते हैं।"
 
 #: components/pages/Retirements/Footer/index.tsx:28
 msgid "retirement.footer.aboutKlima.right"
-msgstr ""
+msgstr "KLIMA टोकन एक बढ़ती ऑन-चेन कार्बन अर्थव्यवस्था के केंद्र में हैं। KLIMA,कार्बन ऑफ़सेटिंग, कार्बन मार्केट और अंतर्निहित कार्बन परिसंपत्तियों के बारे में अधिक जानने के लिए हमारे <0>knowledge base</0> (नॉलेज बेस) पर जाएँ।"
 
 #: components/pages/Retirements/Footer/index.tsx:13
 msgid "retirement.footer.aboutKlima.title"
-msgstr ""
+msgstr "Klima के बारे में"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:37
 msgid "retirement.footer.buy_klima.button.buy"
@@ -1604,139 +1604,139 @@ msgstr "ख़रीदें"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:44
 msgid "retirement.footer.buy_klima.button.offset"
-msgstr "ऑफ़सेट"
+msgstr "ऑफ़सेट"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:30
 msgid "retirement.footer.buy_klima.text"
-msgstr ""
+msgstr "कार्बन-समर्थित KLIMA टोकन का उपयोग शासन चलाने, अदला-बदली करने और दाँव पुरस्कार अर्जित करने के लिए करें- फिर अपने उत्सर्जन को ऑफ़सेट करने के लिए उन पुरस्कारों का उपयोग करें!"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:25
 msgid "retirement.footer.buy_klima.title"
-msgstr ""
+msgstr "खरीदें, दाँव पर लगाएँ, और पुरस्कृत हों।"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:122
 msgid "retirement.head.metaDescription"
-msgstr ""
+msgstr "KlimaDAO द्वारा संचालित पारदर्शी, ऑन-चेन ऑफ़सेट।"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:118
 msgid "retirement.head.metaTitle"
-msgstr ""
+msgstr "{retiree} सेवानिवृत्त {formattedAmount} टन कार्बन"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:114
 msgid "retirement.head.title"
-msgstr ""
+msgstr "क्लीमाडाओ | कार्बन रिटायरमेंट रसीद"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:266
 msgid "retirement.share.title"
-msgstr ""
+msgstr "अपना प्रभाव साझा करें"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:176
 msgid "retirement.single.beneficiary.placeholder"
-msgstr ""
+msgstr "कोई लाभार्थी-नाम प्रदान नहीं किया गया"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:170
 msgid "retirement.single.beneficiary.title"
-msgstr ""
+msgstr "लाभार्थी"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:184
 msgid "retirement.single.beneficiaryAddress.title"
-msgstr ""
+msgstr "लाभार्थी पता"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:245
 msgid "retirement.single.create_a_pledge"
-msgstr ""
+msgstr "एक प्रतिज्ञा बनाएँ"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:231
 msgid "retirement.single.disclaimer"
-msgstr ""
+msgstr "यह Polygon (पॉलीगॉन) ब्लॉकचेन पर टोकनयुक्त कार्बन परिसंपत्तियों के स्थायी रिटायरमेंट का प्रतिनिधित्व करता है। यह रिटायरमेंट और संबंधित डेटा अपरिवर्तनीय सार्वजनिक रिकॉर्ड हैं।"
 
 #: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:30
 msgid "retirement.single.download_certificate_button"
-msgstr ""
+msgstr "PDF (पीडीएफ़) डाउनलोड करें"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:134
 msgid "retirement.single.header.subline"
-msgstr ""
+msgstr "CO2-समतुल्य उत्सर्जन ऑफ़सेट (मीट्रिक टन)"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:241
 msgid "retirement.single.is_this_your_retirement"
-msgstr ""
+msgstr "क्या यह आपकी सेवानिवृत्ति है?"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
 msgid "retirement.single.message.title"
-msgstr ""
+msgstr "रिटायरमेंट सन्देश"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:30
 msgid "retirement.single.no_pledge"
-msgstr ""
+msgstr "इस उपयोगकर्ता ने प्रतिज्ञा नहीं बनाई है"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
 msgid "retirement.single.project_details.title"
-msgstr ""
+msgstr "प्रॉजेक्ट का विवरण"
 
 #: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
 msgid "retirement.single.quantity"
-msgstr ""
+msgstr "रिटायर की गयी मात्रा"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:205
 msgid "retirement.single.retirementCertificate.title"
-msgstr ""
+msgstr "प्रमाणपत्र"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:21
 msgid "retirement.single.retirementDate.title"
-msgstr ""
+msgstr "दिनांक"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:24
 msgid "retirement.single.timestamp.placeholder"
-msgstr ""
+msgstr "कोई रिटायरमेंट टाइमस्टैम्प प्रदान नहीं किया गया"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:302
 msgid "retirement.single.view_on_polygon_scan"
-msgstr ""
+msgstr "Polygonscan (पॉलीगॉनस्कैन) पर देखें"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:18
 msgid "retirement.single.view_pledge"
-msgstr ""
+msgstr "प्रतिज्ञा देखें"
 
 #: components/pages/Retirements/List/index.tsx:40
 msgid "retirement.totals.all_retirements_list.empty"
-msgstr ""
+msgstr "कोई रिटायरमेंट नहीं मिली"
 
 #: components/pages/Retirements/List/index.tsx:24
 msgid "retirement.totals.all_retirements_list.headline"
-msgstr ""
+msgstr "समस्त रिटायरमेन्ट्स"
 
 #: components/pages/Retirements/index.tsx:46
 msgid "retirement.totals.head.metaTitle"
-msgstr ""
+msgstr "KlimaDAO - लाभार्थी हेतु कार्बन रिटायरमेंट्स {0}"
 
 #: components/pages/Retirements/index.tsx:40
 msgid "retirement.totals.head.title"
-msgstr ""
+msgstr "KlimaDAO - लाभार्थी हेतु कार्बन रिटायरमेंट्स {0}"
 
 #: components/pages/Retirements/index.tsx:65
 msgid "retirement.totals.page_headline"
-msgstr ""
+msgstr "कार्बन रिटायरमेंट्स"
 
 #: components/pages/Retirements/index.tsx:71
 msgid "retirement.totals.page_subline"
-msgstr ""
+msgstr "लाभार्थी के लिए"
 
 #: components/pages/Retirements/index.tsx:95
 msgid "retirement.totals.retired_assets"
-msgstr ""
+msgstr "रिटायर की गयी संपत्ति"
 
 #: components/pages/Retirements/index.tsx:111
 msgid "retirement.totals.retirements"
-msgstr ""
+msgstr "रिटायरमेंट्स"
 
 #: components/pages/Retirements/index.tsx:103
 msgid "retirement.totals.total_carbon_tonnes"
-msgstr ""
+msgstr "कुल रिटायर किए गए कार्बन टन"
 
 #: components/pages/Retirements/index.tsx:117
 msgid "retirement.totals.total_retirement_transactions"
-msgstr ""
+msgstr "कुल रिटायरमेंट लेनदेन"
 
 #: components/pages/errors/Custom404.tsx:20
 #: components/pages/errors/Custom404.tsx:24
@@ -1753,23 +1753,23 @@ msgstr "के बारे में"
 #: components/Navigation/index.tsx:115
 #: components/Navigation/index.tsx:261
 msgid "shared.app"
-msgstr ""
+msgstr "ऐप"
 
 #: components/Footer/index.tsx:49
 msgid "shared.blog"
-msgstr ""
+msgstr "ब्लॉग"
 
 #: components/Footer/index.tsx:43
 #: components/Navigation/index.tsx:133
 #: components/Navigation/index.tsx:278
 msgid "shared.bond"
-msgstr ""
+msgstr "बॉन्ड क्लीमा"
 
 #: components/Footer/index.tsx:37
 #: components/Navigation/index.tsx:117
 #: components/Navigation/index.tsx:265
 msgid "shared.buy"
-msgstr ""
+msgstr "क्लिमा खरीदें"
 
 #: components/Navigation/index.tsx:157
 #: components/Navigation/index.tsx:302
@@ -1780,15 +1780,15 @@ msgstr "कार्बन खरीदें"
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:118
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:147
 msgid "shared.cancel"
-msgstr ""
+msgstr "रद्द करें"
 
 #: components/Navigation/index.tsx:352
 msgid "shared.carbon_dashboard"
-msgstr ""
+msgstr "कार्बन डैशबोर्ड"
 
 #: components/Navigation/index.tsx:203
 msgid "shared.carbon_dashboards"
-msgstr ""
+msgstr "कार्बन डैशबोर्ड"
 
 #: components/Navigation/index.tsx:174
 #: components/Navigation/index.tsx:321
@@ -1800,11 +1800,11 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:31
 #: components/pages/About/AboutHeader/index.tsx:61
 msgid "shared.community"
-msgstr ""
+msgstr "समुदाय"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:45
 msgid "shared.confirm"
-msgstr ""
+msgstr "पुष्टि करें"
 
 #: components/Footer/index.tsx:52
 #: components/Navigation/index.tsx:241
@@ -1816,14 +1816,14 @@ msgstr "संपर्क करें"
 #: components/pages/Infinity/index.tsx:117
 #: components/pages/Infinity/index.tsx:701
 msgid "shared.contact_sales"
-msgstr ""
+msgstr "सेल्स से संपर्क करें"
 
 #: components/Navigation/index.tsx:96
 #: components/pages/About/AboutHeader/index.tsx:40
 #: components/pages/About/Community/index.tsx:129
 #: components/pages/About/Community/index.tsx:374
 msgid "shared.contact_us"
-msgstr ""
+msgstr "संपर्क करें"
 
 #: components/Footer/index.tsx:55
 #: components/Navigation/index.tsx:105
@@ -1831,52 +1831,52 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:49
 #: components/pages/About/AboutHeader/index.tsx:73
 msgid "shared.disclaimer"
-msgstr ""
+msgstr "अस्वीकरण"
 
 #: components/Footer/index.tsx:46
 #: components/Navigation/index.tsx:211
 #: components/Navigation/index.tsx:360
 msgid "shared.docs"
-msgstr ""
+msgstr "आधिकारिक डॉक्स"
 
 #: components/Navigation/index.tsx:63
 #: components/pages/Home/index.tsx:115
 msgid "shared.enter_app"
-msgstr ""
+msgstr "ऐप दर्ज करें"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:157
 msgid "shared.error"
-msgstr ""
+msgstr "ग़लती"
 
 #: components/pages/Infinity/GetStartedModal.tsx:25
 msgid "shared.get_started"
-msgstr ""
+msgstr "शुरुआत करें"
 
 #: components/pages/Buy/index.tsx:29
 #: components/pages/Home/index.tsx:69
 #: components/pages/Retirements/index.tsx:52
 #: components/pages/errors/Custom500.tsx:23
 msgid "shared.head.description"
-msgstr ""
+msgstr "जलवायु कार्रवाई करें और एक कार्बन-समर्थित डिजिटल मुद्रा के साथ पुरस्कार अर्जित करें।"
 
 #: components/Footer/index.tsx:34
 msgid "shared.home"
-msgstr ""
+msgstr "घर"
 
 #: components/Navigation/index.tsx:194
 #: components/Navigation/index.tsx:343
 msgid "shared.how_to_buy"
-msgstr ""
+msgstr "क्लिमा कैसे खरीदें?"
 
 #: components/pages/Infinity/index.tsx:108
 #: components/pages/Infinity/index.tsx:309
 #: components/pages/Infinity/index.tsx:692
 msgid "shared.infinity.get_started"
-msgstr ""
+msgstr "शुरुआत करें"
 
 #: components/pages/Home/index.tsx:186
 msgid "shared.infinity_cta"
-msgstr ""
+msgstr "संगठनों के लिए डेफी"
 
 #: components/Navigation/index.tsx:165
 #: components/Navigation/index.tsx:310
@@ -1903,12 +1903,12 @@ msgstr "साइन इन / कनेक्ट करें"
 
 #: components/pages/Home/index.tsx:193
 msgid "shared.loveletter_cta"
-msgstr ""
+msgstr "व्यक्तियों के लिए डेफी"
 
 #: components/Navigation/index.tsx:179
 #: components/Navigation/index.tsx:325
 msgid "shared.loveletters"
-msgstr ""
+msgstr "प्रेम पत्र"
 
 #: components/Navigation/index.tsx:149
 #: components/Navigation/index.tsx:294
@@ -1918,15 +1918,15 @@ msgstr "ऑफ़सेट"
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:175
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:161
 msgid "shared.okay"
-msgstr ""
+msgstr "ठीक"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:421
 msgid "shared.pending"
-msgstr ""
+msgstr "लंबित"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:135
 msgid "shared.remove"
-msgstr ""
+msgstr "हटाना"
 
 #: components/Navigation/index.tsx:185
 #: components/Navigation/index.tsx:334
@@ -1947,16 +1947,16 @@ msgstr "इसके अनुसार क्रमबद्ध करें"
 #: components/Navigation/index.tsx:125
 #: components/Navigation/index.tsx:270
 msgid "shared.stake"
-msgstr ""
+msgstr "क्लिमा दाँव पर लगाएँ"
 
 #: components/pages/Infinity/index.tsx:512
 msgid "shared.visit_klimadao_blog"
-msgstr ""
+msgstr "KlimaDAO ब्लॉग पर जाएँ"
 
 #: components/Navigation/index.tsx:141
 #: components/Navigation/index.tsx:286
 msgid "shared.wrap"
-msgstr ""
+msgstr "sKLIMA (एसक्लिमा) रैप करें"
 
 #: lib/getWeb3ModalStrings.ts:13
 msgid "web3modal.injected.des"
@@ -1964,7 +1964,7 @@ msgstr "अपने ब्राउज़र web3 प्रदाता से 
 
 #: lib/getWeb3ModalStrings.ts:21
 msgid "web3modal.torus.desc"
-msgstr "Torus (टोरस) द्वारा आसान एक-क्लिक वॉलेट"
+msgstr "Torus (टोरस) की तरफ़ से आसान एक-क्लिक वॉलेट"
 
 #: lib/getWeb3ModalStrings.ts:17
 msgid "web3modal.torus.name"
@@ -1980,8 +1980,8 @@ msgstr "जुड़ने के लिए Coinbase (कॉइनबेस) के
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:62
 msgid "{trimCurrentSupply} Tonnes remaining"
-msgstr ""
+msgstr "{trimCurrentSupply} टन शेष"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:57
 msgid "{trimTotalRetired} Tonnes retired in total"
-msgstr ""
+msgstr "{trimTotalRetired} कुल रिटायर किए गए कार्बन टन"

--- a/site/locale/ru/messages.po
+++ b/site/locale/ru/messages.po
@@ -13,35 +13,35 @@ msgstr "измененить язык"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:33
 msgid "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
-msgstr ""
+msgstr "Каждое выбивание углерода KlimaDAO привязана к проверенному проекту компенсации. Нажмите, чтобы узнать больше о проекте."
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:68
 msgid "Explore MCO2 on carbon.klimadao.finance"
-msgstr ""
+msgstr "Узнайте больше о MCO2 на сайте carbon.klimadao.finance"
 
 #: components/pages/Infinity/index.tsx:530
 msgid "Frequently Asked Questions"
-msgstr ""
+msgstr "Часто задаваемые вопросы"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:47
 msgid "Location: {0}"
-msgstr ""
+msgstr "Местоположение: {0}"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:50
 msgid "MCO2 Token"
-msgstr ""
+msgstr "Токен MCO2"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:52
 msgid "Methodology: {0}"
-msgstr ""
+msgstr "Методология: {0}"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:23
 msgid "No retirement message provided."
-msgstr ""
+msgstr "Сообщение о выводе не предоставляется."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:146
 msgid "Processing data..."
-msgstr ""
+msgstr "Обработка данных..."
 
 #: components/InvalidNetworkModal/index.tsx:80
 msgid "Switch to Polygon"
@@ -53,11 +53,11 @@ msgstr "Это приложение работает только в Polygon Mai
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:74
 msgid "View on Polygonscan"
-msgstr ""
+msgstr "Посмотреть на Polygonscan"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:150
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
-msgstr ""
+msgstr "Мы еще не закончили обработку данных блокчейна для этого вывода. Обычно это занимает несколько секунд, но может занять больше времени, если сеть перегружена."
 
 #: components/InvalidNetworkModal/index.tsx:65
 msgid "Wrong Network"
@@ -74,7 +74,7 @@ msgstr "Отказ от ответственности"
 
 #: components/pages/Buy/index.tsx:433
 msgid "buy.answer_exchange"
-msgstr ""
+msgstr "Продвинутые пользователи могут использовать <0>Polygon Bridge</0> для перевода любого актива из Ethereum в Polygon, и/или <1>Polygon Gas Swap</1> для обмена таких активов, как USDC на MATIC."
 
 #: components/pages/Buy/index.tsx:390
 msgid "buy.bond_answer_cedit_card"
@@ -82,19 +82,19 @@ msgstr "Да, некоторые провайдеры, например <0>Trans
 
 #: components/pages/Buy/index.tsx:408
 msgid "buy.bond_answer_cex1"
-msgstr ""
+msgstr "KLIMA не торгуется на централизованных биржах, таких как Coinbase, Binance или Crypto.com, поскольку эти биржи обычно взимают очень высокие комиссии за листинг и требуют финансирования со стороны дорогих маркет-мейкеров."
 
 #: components/pages/Buy/index.tsx:416
 msgid "buy.bond_answer_cex2"
-msgstr ""
+msgstr "Вместо этого токены KLIMA торгуются на «децентрализованной бирже» (DEX), которая работает на основе смарт-контрактов и работает непосредственно на блокчейне. У DEX есть несколько важных преимуществ. DEX позволили DAO владеть большей частью ликвидности, поэтому он может сохранять полную автономию и получать доход для выплаты вкладчикам. Мы решили использовать технологию DEX от Sushi, поскольку она уже обеспечивает транзакции на десятки миллионов долларов в день."
 
 #: components/pages/Buy/index.tsx:371
 msgid "buy.bond_description1"
-msgstr ""
+msgstr "Опытные пользователи криптовалют могут купить KLIMA прямо из протокола через облигации. Чтобы приобрести KLIMA через облигации, вы предоставляете токен углерода или токен ликвидности и получаете взамен токены KLIMA со скидкой. Это механизм, который DAO использует для увеличения своей сокровищницы цифрового углерода."
 
 #: components/pages/Buy/index.tsx:380
 msgid "buy.bond_description_capacity"
-msgstr ""
+msgstr "Возможности облигаций ограничены, и облигации не всегда доступны."
 
 #: components/pages/Buy/index.tsx:401
 msgid "buy.bond_question_cex"
@@ -102,11 +102,11 @@ msgstr "Почему я не могу найти KLIMA на Coinbase или др
 
 #: components/pages/Buy/index.tsx:385
 msgid "buy.bond_question_credit_card"
-msgstr ""
+msgstr "Могу ли я купить KLIMA напрямую с помощью кредитной карты?"
 
 #: components/pages/Buy/index.tsx:190
 msgid "buy.connect_advanced"
-msgstr ""
+msgstr "Примечание: эти инструкции предназначены только для пользователей кошелька Torus. Sushi поддерживает множество различных кошельков."
 
 #: components/pages/Buy/index.tsx:185
 msgid "buy.connect_torus_sushi"
@@ -114,11 +114,11 @@ msgstr "3A. Подключите Torus к Sushi.com с помощью WalletConn
 
 #: components/pages/Buy/index.tsx:212
 msgid "buy.connect_torus_sushi_description2"
-msgstr ""
+msgstr "В отдельной вкладке браузера зайдите на сайт <0>Sushi.com</0> и нажмите кнопку \"Подключиться\" в правом верхнем углу. Вам будет предложено несколько вариантов кошельков. Выберите WalletConnect. После выбора WalletConnect вы увидите QR-код - нажмите \"Скопировать в буфер обмена\"."
 
 #: components/pages/Buy/index.tsx:229
 msgid "buy.connect_torus_sushi_description3"
-msgstr ""
+msgstr "Вернитесь в приложение кошелька Torus и вставьте этот код в виджет WalletConnect. Это создаст временное соединение между вашим кошельком и <0>Sushi.com.</0> ."
 
 #: components/pages/Buy/index.tsx:237
 msgid "buy.connect_torus_sushi_description4"
@@ -126,19 +126,19 @@ msgstr "Когда вы вернетесь на вкладку Sushi в свое
 
 #: components/pages/Buy/index.tsx:243
 msgid "buy.connect_torus_sushi_description5"
-msgstr ""
+msgstr "Наконец, используйте выпадающее меню на <0>Sushi.com</0>, чтобы переключиться на сеть Polygon."
 
 #: components/pages/Buy/index.tsx:72
 msgid "buy.create_wallet_description"
-msgstr ""
+msgstr "<0>Создайте кошелек.</0> Мы рекомендуем Torus Wallet, но наше приложение поддерживает большинство Web3-кошельков (Metamask, Coinbase Wallet, Brave, MyEtherWallet и многие другие)."
 
 #: components/pages/Buy/index.tsx:114
 msgid "buy.create_wallet_description1"
-msgstr ""
+msgstr "Зайдите на сайт <0>app.klimadao.finance</0> и нажмите кнопку \"Подключиться\" в правом верхнем углу."
 
 #: components/pages/Buy/index.tsx:120
 msgid "buy.create_wallet_description2"
-msgstr ""
+msgstr "Выберите вариант входа «Электронная почта или социальная сеть», после чего вам будет предложено войти в систему с помощью Torus. Torus — это технология, которая создает безопасный кошелек, используя вашу существующую электронную почту или социальный логин. Вы сможете использовать этот новый кошелек Torus в сотнях других приложений Web3 и DeFi."
 
 #: components/pages/Buy/index.tsx:129
 msgid "buy.create_wallet_description3"
@@ -146,7 +146,7 @@ msgstr "После подключения вы должны увидеть ад�
 
 #: components/pages/Buy/index.tsx:135
 msgid "buy.create_wallet_description4"
-msgstr ""
+msgstr "Дополнительно: если вы не хотите использовать Torus, смело используйте любой Web3-кошелек, совместимый с Polygon."
 
 #: components/pages/Buy/index.tsx:111
 msgid "buy.create_wallet_item"
@@ -154,24 +154,24 @@ msgstr "1. Создайте кошелек"
 
 #: components/pages/Buy/index.tsx:319
 msgid "buy.faq_title"
-msgstr ""
+msgstr "Часто задаваемые вопросы"
 
 #: components/pages/Buy/index.tsx:27
 #: components/pages/Buy/index.tsx:28
 msgid "buy.head.title"
-msgstr ""
+msgstr "Как купить KLIMA"
 
 #: components/pages/Buy/index.tsx:41
 msgid "buy.how_to_buy"
-msgstr ""
+msgstr "Как купить KLIMA"
 
 #: components/pages/Buy/index.tsx:44
 msgid "buy.how_to_paragraph_part_1"
-msgstr ""
+msgstr "KLIMA - это цифровой актив, обеспеченный углеродом, который можно заложить для получения вознаграждения или использовать для компенсации цифрового углерода. Владение KLIMA также дает вам право голосовать и участвовать в управлении цифровым рынком углерода."
 
 #: components/pages/Buy/index.tsx:51
 msgid "buy.how_to_paragraph_part_2"
-msgstr ""
+msgstr "Это краткое руководство для новичков, которые только начинают знакомиться с Web3 и DeFi"
 
 #: components/pages/Buy/index.tsx:143
 msgid "buy.load_wallet"
@@ -179,23 +179,23 @@ msgstr "2. Пополните свой кошелек токенами MATIC"
 
 #: components/pages/Buy/index.tsx:85
 msgid "buy.load_wallet_description"
-msgstr ""
+msgstr "<0> Пополните свой новый кошелек токенами MATIC.</0> MATIC - это газ, на котором работает сеть Polygon. Каждая транзакция, которую вы совершаете в Polygon, требует несколько центов MATIC для оплаты сетевого сбора."
 
 #: components/pages/Buy/index.tsx:148
 msgid "buy.load_wallet_description1"
-msgstr ""
+msgstr "Используйте такой сервис, как <0>MoonPay</0> или <1>Transak</1> или централизованную биржу, например <2>Coinbase</2>, чтобы купить Polygon MATIC и отправить его на ваш вновь созданный кошелек. "
 
 #: components/pages/Buy/index.tsx:158
 msgid "buy.load_wallet_description2"
-msgstr ""
+msgstr "<0>Убедитесь, что токены MATIC отправлены на ваш новый адрес кошелька!</0> Вы можете скопировать адрес в буфер обмена, подключившись к нашему приложению и щелкнув адрес в меню навигации."
 
 #: components/pages/Buy/index.tsx:168
 msgid "buy.load_wallet_description3"
-msgstr ""
+msgstr "<0>Обязательно купите и отправьте MATIC через сеть Polygon!</0> Некоторые биржи, такие как Coinbase, спросят вас, в какую сеть отправлять токены MATIC. Обязательно всегда выбирайте Polygon."
 
 #: components/pages/Buy/index.tsx:427
 msgid "buy.question_exchange"
-msgstr ""
+msgstr "Что делать, если я хочу использовать другую биржу, а они не продают Polygon MATIC?"
 
 #: components/pages/Buy/index.tsx:322
 msgid "buy.question_why_matic"
@@ -203,31 +203,31 @@ msgstr "Почему я должен сначала купить MATIC?"
 
 #: components/pages/Buy/index.tsx:327
 msgid "buy.question_why_matic_answer"
-msgstr ""
+msgstr "Токен и протокол KLIMA находятся в блокчейне Polygon. MATIC - это \"газ\", который питает каждую транзакцию на Polygon. Невозможно выполнить транзакцию, не заплатив комиссию за транзакцию. Это означает, что вам придется заплатить несколько центов MATIC за следующие действия:"
 
 #: components/pages/Buy/index.tsx:338
 msgid "buy.question_why_matic_answer_bullet1"
-msgstr ""
+msgstr "Стейкинг KLIMA для sKLIMA"
 
 #: components/pages/Buy/index.tsx:345
 msgid "buy.question_why_matic_answer_bullet2"
-msgstr ""
+msgstr "Обмен между разными токенами"
 
 #: components/pages/Buy/index.tsx:352
 msgid "buy.question_why_matic_answer_bullet3"
-msgstr ""
+msgstr "Отправка токенов на другой кошелек"
 
 #: components/pages/Buy/index.tsx:359
 msgid "buy.question_why_matic_answer_bullet4"
-msgstr ""
+msgstr "Использование KLIMA или других токенов для компенсации выбросов углерода"
 
 #: components/pages/Buy/index.tsx:292
 msgid "buy.staking_cta"
-msgstr ""
+msgstr "Ставьте, зарабатывайте, голосуйте и компенсируйте!"
 
 #: components/pages/Buy/index.tsx:295
 msgid "buy.staking_description1"
-msgstr ""
+msgstr "Поздравляем! Теперь, когда в вашем кошельке есть немного KLIMA, мы настоятельно рекомендуем <0>разместить</0> эти KLIMA на sKLIMA, который со временем начисляет вознаграждение по мере роста протокола."
 
 #: components/pages/Buy/index.tsx:303
 msgid "buy.staking_description2"
@@ -235,7 +235,7 @@ msgstr "Вы также можете использовать приложени
 
 #: components/pages/Buy/index.tsx:310
 msgid "buy.staking_description3"
-msgstr ""
+msgstr "Наконец, следите за <0>продолжающимися голосованиями</0> и помогайте направлять протокол в правильном направлении."
 
 #: components/pages/Buy/index.tsx:69
 msgid "buy.step_1"
@@ -251,31 +251,31 @@ msgstr "3."
 
 #: components/pages/Buy/index.tsx:62
 msgid "buy.summary_steps_title"
-msgstr ""
+msgstr "Лучший и самый простой способ получить KLIMA — это выполнить следующие три шага:"
 
 #: components/pages/Buy/index.tsx:59
 msgid "buy.summary_title"
-msgstr ""
+msgstr "Резюме"
 
 #: components/pages/Buy/index.tsx:253
 msgid "buy.swap_description1"
-msgstr ""
+msgstr "После подключения кошелька и переключения на сеть Polygon вы сможете обменять MATIC на KLIMA."
 
 #: components/pages/Buy/index.tsx:259
 msgid "buy.swap_description2"
-msgstr ""
+msgstr "<0> Важное замечание: не меняйте все свои MATIC на KLIMA! </0> Оставьте хотя бы 0,5 MATIC для оплаты комиссий за будущие транзакции."
 
 #: components/pages/Buy/index.tsx:275
 msgid "buy.swap_description3"
-msgstr ""
+msgstr "Если вы используете Torus, держите открытой вкладку браузера с приложением Torus. Вам нужно будет вернуться в кошелек, чтобы одобрить и авторизовать транзакции."
 
 #: components/pages/Buy/index.tsx:282
 msgid "buy.swap_description4"
-msgstr ""
+msgstr "Дополнительно: Если вы хотите, чтобы ваши транзакции в Sushi были положительными для климата, включите \"Зеленый сбор\" Sushi, разработанный KlimaDAO. Это позволит тратить 0,02 MATIC за транзакцию на приобретение и автоматическое удаление цифрового углерода!"
 
 #: components/pages/Buy/index.tsx:100
 msgid "buy.swap_for_klima_description"
-msgstr ""
+msgstr "<0>Обменять на KLIMA.</0> Sushi — это децентрализованная биржа, на которой вы можете мгновенно обменять часть ваших токенов MATIC на токены KLIMA по минимально возможной цене."
 
 #: components/pages/Buy/index.tsx:250
 msgid "buy.swap_subtitle"
@@ -287,7 +287,7 @@ msgstr "3. Обменяйте на KLIMA на <0>Sushi.com</0>"
 
 #: components/pages/Buy/index.tsx:196
 msgid "buy.torus_login_description"
-msgstr ""
+msgstr "В новой вкладке браузера перейдите на веб-приложение <0>Torus Polygon</0> и войдите в систему, используя свою новую учетную запись Torus. Когда вы войдете в систему, вы должны увидеть виджет WalletConnect."
 
 #: components/pages/Buy/index.tsx:205
 msgid "buy.wallet_connect_example"
@@ -300,144 +300,144 @@ msgstr "пример кода qr для подключения кошелька"
 
 #: components/pages/Buy/index.tsx:366
 msgid "buy.what_are_bonds"
-msgstr ""
+msgstr "Есть ли другие способы получить KLIMA? Что такое облигации?"
 
 #: components/pages/About/Community/index.tsx:116
 msgid "community.become_a_partner"
-msgstr ""
+msgstr "СТАТЬ ПАРТНЕРОМ"
 
 #: components/pages/About/Community/index.tsx:180
 msgid "community.bigcowg_logo"
-msgstr ""
+msgstr "Логотип BICOWG"
 
 #: components/pages/About/Community/index.tsx:172
 msgid "community.blockchainforclimatefondation_logo"
-msgstr ""
+msgstr "Логотип Blockchain for Climate Foundation"
 
 #: components/pages/About/Community/index.tsx:314
 msgid "community.come_on_in"
-msgstr ""
+msgstr "Войдите"
 
 #: components/pages/About/Community/index.tsx:228
 msgid "community.deltawave_logo"
-msgstr ""
+msgstr "Delta Wave логотип"
 
 #: components/pages/About/Community/index.tsx:265
 msgid "community.digitalcharityart_logo"
-msgstr ""
+msgstr "Digital Charity Art логотип"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:329
 msgid "community.discord_is_where_we_share"
-msgstr ""
+msgstr "Discord - это место, где мы делимся важными объявлениями, проводим  рабочее время, отвечаем на вопросы и обмениваемся мемами. Наш сервер Discord очень активен и круглосуточно модерируется. У нас есть каналы для всего, начиная от торговли и заканчивая устойчивостью и углеродными рынками."
 
 #: components/pages/About/Community/index.tsx:244
 msgid "community.dovu_logo"
-msgstr ""
+msgstr "Dovu логотип "
 
 #: components/pages/About/Community/index.tsx:249
 msgid "community.eco_logo"
-msgstr ""
+msgstr "Есо логотип"
 
 #: components/pages/About/Community/index.tsx:236
 msgid "community.etcgroup_logo"
-msgstr ""
+msgstr "Etc Group логотип"
 
 #: components/pages/About/Community/index.tsx:361
 msgid "community.get_in_touch"
-msgstr ""
+msgstr "Связаться?"
 
 #: components/pages/About/Community/index.tsx:204
 msgid "community.gitcoin_logo"
-msgstr ""
+msgstr "Gitcoin логотип"
 
 #: components/pages/About/Community/index.tsx:95
 msgid "community.head.headline"
-msgstr ""
+msgstr "Сообщество"
 
 #: components/pages/About/Community/index.tsx:102
 msgid "community.head.metadescription"
-msgstr ""
+msgstr "Узнайте о нашем сообществе увлеченных Klimates"
 
 #: components/pages/About/Community/index.tsx:96
 msgid "community.head.subline"
-msgstr ""
+msgstr "KlimaDAO — это децентрализованная автономная организация перемен. Мы управляемся и создаемся сообществом увлеченных Klimates."
 
 #: components/pages/About/Community/index.tsx:94
 #: components/pages/About/Community/index.tsx:101
 msgid "community.head.title"
-msgstr ""
+msgstr "KlimaDAO Сообщество"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:364
 msgid "community.if_you_ve_got_questions"
-msgstr ""
+msgstr "Если у вас есть вопросы, идеи, советы или что-то еще: мы поможем вам найти нужного человека, с которым можно это обсудить."
 
 #: components/pages/About/Community/index.tsx:317
 msgid "community.join_our_discord"
-msgstr ""
+msgstr "Присоединяйтесь к нашему Discord"
 
 #: components/pages/About/Community/index.tsx:304
 msgid "community.join_the_klima_community"
-msgstr ""
+msgstr "Присоединяйтесь к сообществу Klima "
 
 #: components/pages/About/Community/index.tsx:281
 msgid "community.landx_logo"
-msgstr ""
+msgstr "Логотип LandX"
 
 #: components/pages/About/Community/index.tsx:113
 #: components/pages/About/Community/index.tsx:358
 msgid "community.lets_work_together"
-msgstr ""
+msgstr "Давайте работать вместе"
 
 #: components/pages/About/Community/index.tsx:156
 msgid "community.moss_logo"
-msgstr ""
+msgstr "Moss логотип"
 
 #: components/pages/About/Community/index.tsx:196
 msgid "community.oceandrop_logo"
-msgstr ""
+msgstr "Oceandrop логотип "
 
 #: components/pages/About/Community/index.tsx:257
 msgid "community.offsetra_logo"
-msgstr ""
+msgstr "Offsetra Логотип "
 
 #: components/pages/About/Community/index.tsx:212
 msgid "community.olympusdao_logo"
-msgstr ""
+msgstr "Логотип OlympusDAO"
 
 #: components/pages/About/Community/index.tsx:220
 msgid "community.openearth_logo"
-msgstr ""
+msgstr "Логотип Открытой Земли"
 
 #: components/pages/About/Community/index.tsx:151
 msgid "community.our_partners"
-msgstr ""
+msgstr "НАШИ ПАРТНЕРЫ"
 
 #: components/pages/About/Community/index.tsx:188
 msgid "community.polygon_logo"
-msgstr ""
+msgstr "Логотип Polygon "
 
 #: components/pages/About/Community/index.tsx:164
 msgid "community.toucan_logo"
-msgstr ""
+msgstr "Toucan логотип"
 
 #: components/pages/About/Community/index.tsx:273
 msgid "community.toughtforfood_logo"
-msgstr ""
+msgstr "Thought for Food логотип"
 
 #: components/pages/About/Community/index.tsx:132
 msgid "community.tree_grove"
-msgstr ""
+msgstr "Роща деревьев"
 
 #. Long sentence
 #: components/pages/About/Community/index.tsx:119
 msgid "community.we_work_with_traditionnal"
-msgstr ""
+msgstr "Мы работаем с традиционными участниками углеродного рынка, криптовалютными платформами, корпорациями и всеми, кто находится между ними."
 
 #: components/pages/About/Contact/index.tsx:63
 msgid "concat.careers"
-msgstr ""
+msgstr "Карьера"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:170
 #: components/pages/Pledge/index.tsx:112
@@ -478,21 +478,21 @@ msgstr "Ошибка подключения"
 
 #: components/pages/About/Contact/index.tsx:140
 msgid "contact.bug_reports"
-msgstr ""
+msgstr "Отчет об ошибках"
 
 #. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
 #: components/pages/About/Contact/index.tsx:143
 msgid "contact.bug_reports.to_file_a_bug_report"
-msgstr ""
+msgstr "Чтобы отправить сообщение об ошибке, присоединитесь к нашему сообществу на сервере Discord и задайте свой вопрос в канале #bug-reports. Кто-то из нашего <0>сообщества</0> будет рад разобраться и найти решение для вас."
 
 #. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
 #: components/pages/About/Contact/index.tsx:66
 msgid "contact.careers.we_re_hiring"
-msgstr ""
+msgstr "Мы полностью удаленная команда, нанимающая сотрудников во всех часовых поясах. Мы регулярно публикуем роли и предложения в нашем <0>Community Discord Server</0>. Если вы самостоятельный человек, стремящийся присоединиться к целеустремленной DAO, мы будем рады услышать вас!"
 
 #: components/pages/About/Contact/index.tsx:25
 msgid "contact.head.description"
-msgstr ""
+msgstr "Свяжитесь с кем-нибудь из KlimaDAO."
 
 #: components/pages/About/Contact/index.tsx:18
 msgid "contact.head.headline"
@@ -500,49 +500,49 @@ msgstr "Связаться"
 
 #: components/pages/About/Contact/index.tsx:19
 msgid "contact.head.subline"
-msgstr ""
+msgstr "Вопросы, проблемы, идеи? Вот несколько способов связаться с нами. Мы любим встречаться как с компаниями, так и с частными лицами."
 
 #: components/pages/About/Contact/index.tsx:17
 #: components/pages/About/Contact/index.tsx:24
 msgid "contact.head.title"
-msgstr ""
+msgstr "Связаться с KlimaDAO"
 
 #: components/pages/About/Contact/index.tsx:105
 msgid "contact.media"
-msgstr ""
+msgstr "Медиа"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:108
 msgid "contact.media.if_you_are_a_journalist"
-msgstr ""
+msgstr "Если вы журналист или создатель контента, наша маркетинговая команда будет рада познакомиться с вами."
 
 #. Use this <0>Media Request Form</0>.
 #: components/pages/About/Contact/index.tsx:117
 msgid "contact.media.use_this_media_request_form"
-msgstr ""
+msgstr "Используйте эту <0>форму запроса СМИ</0> или отправьте электронное письмо по адресу <1>press@klimadao.finance</1>"
 
 #: components/pages/About/Contact/index.tsx:85
 msgid "contact.partnerships"
-msgstr ""
+msgstr "Партнерство"
 
 #. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
 #: components/pages/About/Contact/index.tsx:88
 msgid "contact.partnerships.until_we_finish_building"
-msgstr ""
+msgstr "Пока мы не закончим создание страницы партнерства, мы направляем запросы о потенциальном партнерстве и сотрудничестве в <0>эту контактную форму</0>."
 
 #: components/pages/About/Contact/index.tsx:35
 msgid "contact.quest_and_support"
-msgstr ""
+msgstr "Вопросы и поддержка"
 
 #. Join our <0>community</0>
 #: components/pages/About/Contact/index.tsx:38
 msgid "contact.quest_and_support.join_our_community"
-msgstr ""
+msgstr "Присоединяйтесь к нашему <0>сообществу</0>"
 
 #. Long sentence
 #: components/pages/About/Contact/index.tsx:46
 msgid "contact.quest_and_support.join_our_discord_server"
-msgstr ""
+msgstr "Присоединяйтесь к нашему серверу Discord и задавайте вопросы в канале #questions. У нас тысячи дружелюбных и знающих членов сообщества, готовых помочь вам."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:64
@@ -570,60 +570,62 @@ msgstr "3. Быть надежным, полным, законным или бе
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:32
 msgid "disclaimer.all_information_on_this_website"
-msgstr ""
+msgstr "Вся информация на этом сайте публикуется добросовестно и только для общего ознакомления. KlimaDAO распространяет эту информацию на основании того, что она будет полезна и будет служить только в рамках оснований и ограничений, описанных на вышеупомянутом сайте."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:159
 msgid "disclaimer.any_action_you_take_upon_the_information"
-msgstr ""
+msgstr "Любые действия, которые вы предпринимаете на основании информации, найденной на этом сайте, осуществляются строго на ваш страх и риск. Решения, основанные на информации, содержащейся на этом веб-сайте, являются исключительной ответственностью посетителя. KlimaDAO не несет ответственности за любые убытки и/или ущерб, связанные с использованием веб-сайта, потерей вашего пароля/начальной фразы, неудачной сделкой, отправкой актива по неправильному адресу, потерей вашего актива и событиями, связанными с ущербом. по вине мошенников. KlimaDAO не может нести никакой ответственности или обязательств, связанных с изменением рынка и его волатильностью. Вы должны сами изучить информацию и убедиться в своей ситуации, осведомленности и знании информации или услуг, предоставляемых этой платформой."
 
 #: components/pages/About/Disclaimer/index.tsx:19
 msgid "disclaimer.disclaimer"
-msgstr ""
+msgstr "Отказ от ответственности"
 
 #: components/pages/About/Disclaimer/index.tsx:21
 msgid "disclaimer.head.description"
-msgstr ""
+msgstr "Важная оговорка от команды юристов KlimaDAO."
 
 #: components/pages/About/Disclaimer/index.tsx:15
 #: components/pages/About/Disclaimer/index.tsx:25
 msgid "disclaimer.head.title"
-msgstr ""
+msgstr "Отказ от ответственности KlimaDAO"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:102
 msgid "disclaimer.klimadao_and_its_suppliers"
-msgstr ""
+msgstr "KlimaDAO и его поставщики не дают никаких гарантий, что платформа:"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:43
 msgid "disclaimer.klimadao_is_a_platform"
-msgstr ""
+msgstr "limaDAO - это платформа. Мы не являемся брокером, финансовым учреждением или кредитором. Услуги, предоставляемые на этом сайте, не включают предложение держать или контролировать ваши ценные бумаги, опционы, активы, фьючерсы или другие производные, связанные с ценными бумагами в любой юрисдикции, и их содержание не регулируется законами о ценных бумагах."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:130
 msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
-msgstr ""
+msgstr "Ни KlimaDAO, ни ее представители не несут ответственности за убытки любого рода от любых действий, предпринятых или сделанных в расчете на материалы или информацию, содержащуюся на сервисе. KlimaDAO обеспечивает безопасность использования сервиса и контента, однако не заявляет и не гарантирует, что сервис и контент на нашей платформе не содержат вирусов или других вредных компонентов."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:178
 msgid "disclaimer.nothing_in_this_disclaimer"
-msgstr ""
+msgstr "Ничто в этом отказе от ответственности, любой информационный контент или материал не должны быть использованы для создания каких-либо правовых отношений между нами и вами, а также для предоставления каких-либо прав или обязательств кому-либо из нас."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:56
 msgid "disclaimer.nothing_in_this_platform"
-msgstr ""
+msgstr "Ничто в этой платформе не является и не может быть истолковано как:"
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:83
 msgid "disclaimer.the_service_available"
 msgstr ""
+"Услуги, имеющиеся в сервисе или доступные через сервис, предоставляются \"Как есть\" и в максимально допустимой степени в соответствии с действующим законодательством. KlimaDAO и ее агенты, консультанты, директора, должностные лица, сотрудники и акционеры отказываются от всех гарантий, явных или подразумеваемых, включая, но не ограничиваясь, подразумеваемыми гарантиями товарного состояния, пригодности для определенной цели и ненарушения, а также гарантиями, вытекающими из хода выполнения или ведения дел. KlimaDAO не дает никаких гарантий относительно полноты, достоверности и точности этой информации, гарантий товарного состояния или пригодности для конкретной цели. Данная платформа не дает никаких гарантий относительно полноты и точности этой информации.\n"
+""
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:189
 msgid "disclaimer.we_recommend_that_you_visit"
-msgstr ""
+msgstr "Мы рекомендуем вам посетить нашу страницу Crypto Security 101 для получения инструкций по безопасности перед использованием сайта. Пожалуйста,имейте в виду: никогда и никому не сообщайте свой закрытый ключ или сид фразу - ни наши пользователи, ни наше приложение никогда не будут запрашивать или требовать этого от вас."
 
 #. Long sentence
 #: components/pages/About/Disclaimer/index.tsx:144
@@ -632,11 +634,11 @@ msgstr "Вы несете полную ответственность за пр�
 
 #: components/pages/errors/Custom404.tsx:41
 msgid "error.404.page.text"
-msgstr ""
+msgstr "Извините, похоже, мы отправили вас не туда. <0/>Позвольте нам вернуться на главную страницу:"
 
 #: components/pages/errors/Custom500.tsx:39
 msgid "error.500.page.text"
-msgstr ""
+msgstr "Извините, что-то случилось.<0/>Попробуйте вернуться на стартовую страницу:"
 
 #: components/pages/errors/Custom500.tsx:34
 msgid "error.500.page.title"
@@ -652,56 +654,56 @@ msgstr "500 - Страница не найдена"
 
 #: components/pages/Home/index.tsx:236
 msgid "home.backed_by_carbon"
-msgstr ""
+msgstr "поддерживается Carbon"
 
 #: components/pages/Home/index.tsx:327
 msgid "home.cars_annual"
-msgstr ""
+msgstr "Автомобили (ежегодно)"
 
 #: components/pages/Home/index.tsx:296
 msgid "home.equivalent_to"
-msgstr ""
+msgstr "ЭКВИВАЛЕНТ"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:411
 msgid "home.every_klima_token_is_backed"
-msgstr ""
+msgstr "Каждый токен KLIMA обеспечен реальным углеродным активом. Токены используются для компенсации выбросов углерода, взаимодействия с приложениями DeFi и получения доступа к быстрорастущему глобальному углеродному рынку."
 
 #: components/SocialProof/index.tsx:19
 msgid "home.featured_on"
-msgstr ""
+msgstr "KlimaDAO представлен на"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:107
 msgid "home.fight_climate_change"
-msgstr ""
+msgstr "Боритесь с изменением климата и получайте вознаграждения с помощью KLIMA - цифровой валютой обеспеченной реальными углеродными активами."
 
 #: components/pages/Home/index.tsx:462
 msgid "home.get_exposure_to_the_growing_carbon_economy"
-msgstr ""
+msgstr "Получите возможность участвовать в растущей углеродной экономике уже сегодня. Приобретайте, стекайте и получайте вознаграждение. Финансовая активность в защиту климата."
 
 #: components/pages/Home/index.tsx:459
 msgid "home.get_klima"
-msgstr ""
+msgstr "ПОЛУЧИТЬ KLIMA"
 
 #: components/pages/Home/index.tsx:310
 msgid "home.hectares_of_forest"
-msgstr ""
+msgstr "Гектары леса"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:154
 msgid "home.klima_defies_climate_change"
-msgstr ""
+msgstr "KlimaDAO — это DeFi, который бросает вызов изменению климата"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:164
 msgid "home.klima_is_the_center"
-msgstr ""
+msgstr "KlimaDAO — центр новой зеленой экономики. Основанная на энергоэффективной сети Polygon, KlimaDAO использует набор технологий для уменьшения фрагментации рынка и ускорения предоставления климатического финансирования для проектов устойчивого развития по всему миру."
 
 #. Long sentence
 #: components/pages/Home/index.tsx:440
 msgid "home.klima_tokens_are_minted"
-msgstr ""
+msgstr "Токены KLIMA майнятся и автоматически распределяются каждые ~7 часов среди держателей акций KLIMA. Приумножайте свои KLIMA, ведь мы вместе создаем более устойчивое будущее."
 
 #: components/pages/Home/index.tsx:83
 msgid "home.latest_news"
@@ -709,85 +711,87 @@ msgstr "📰 Последние новости:"
 
 #: components/pages/Home/index.tsx:139
 msgid "home.learn_more"
-msgstr ""
+msgstr "УЗНАТЬ БОЛЬШЕ"
 
 #: components/pages/Home/index.tsx:342
 msgid "home.liters_if_gasoline"
 msgstr ""
+"Литры бензина\n"
+""
 
 #: components/pages/Home/index.tsx:272
 msgid "home.massive impact"
-msgstr ""
+msgstr "Массовое влияние."
 
 #: components/pages/Home/index.tsx:210
 msgid "home.mechanics"
-msgstr ""
+msgstr "МЕХАНИКА"
 
 #. <0>{0}% MONTHLY REWARDS</0><1>FOR TOKEN HOLDERS</1>
 #: components/pages/Home/index.tsx:428
 msgid "home.monthly_rewards_for_token_holders"
-msgstr ""
+msgstr "<0>{0}% ЕЖЕМЕСЯЧНЫХ ВОЗНАГРАЖДЕНИЙ</0><1>ДЛЯ ДЕРЖАТЕЛЕЙ ТОКЕНОВ</1>"
 
 #: components/pages/Home/index.tsx:491
 msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
-msgstr ""
+msgstr "Вся Альфа, прямо в ваш почтовый ящик"
 
 #. Long sentence
 #: components/pages/Home/index.tsx:499
 msgid "home.newletter.get_the_latest_updates"
-msgstr ""
+msgstr "Получайте последние новости о KlimaDAO, поскольку мы строим будущее углеродной экономики."
 
 #: components/pages/Home/index.tsx:516
 msgid "home.newletter.never_shared_never_spammed"
-msgstr ""
+msgstr "Никогда не делились. Никогда не спамили."
 
 #: components/pages/Home/index.tsx:510
 msgid "home.newletter.sign_up"
-msgstr ""
+msgstr "Зарегистрироваться"
 
 #: components/pages/Home/index.tsx:496
 msgid "home.newsletter"
-msgstr ""
+msgstr "Рассылка новостей"
 
 #. <0>Reserve Asset</0><1>Of the carbon economy</1>
 #: components/pages/Home/index.tsx:399
 msgid "home.reserve_asset_of_the_carbon_economy"
-msgstr ""
+msgstr "<0>Резервный актив</0><1>Углеродная экономика</1>"
 
 #: components/pages/Home/index.tsx:469
 msgid "home.see_tutorial"
-msgstr ""
+msgstr "См. инструкции"
 
 #: components/pages/Home/index.tsx:357
 msgid "home.source"
-msgstr ""
+msgstr "Источник"
 
 #: components/pages/Home/index.tsx:254
 msgid "home.strong_incentives"
-msgstr ""
+msgstr "Сильные стимулы."
 
 #. Long sentence
 #: components/pages/Home/index.tsx:213
 msgid "home.the_dao_sell_bonds"
-msgstr ""
+msgstr "DAO продает бонды и распределяет вознаграждение между держателями KLIMA. Каждый проданный бонд пополняет постоянно растущую \"зеленую\" казну или повышает ликвидность ключевых экологических активов. Беспроигрышный вариант для людей и планеты."
 
 #. TONS OF <0>CARBON ABSORBED</0> BY KLIMADAO
 #: components/pages/Home/index.tsx:283
 msgid "home.tons_of_carbon_absorbed_by_klimadao"
-msgstr ""
+msgstr "ТОНН <0>ПОГЛОЩЕННОГО УГЛЕРОДА</0> ОТ KLIMADAO"
 
 #. <0>WELCOME TO</0><1>KlimaDAO</1>
 #: components/pages/Home/index.tsx:94
 msgid "home.welcome_to_klimadao"
-msgstr ""
+msgstr "<0>ДОБРО ПОЖАЛОВАТЬ</0> <1>KlimaDAO</1>"
 
 #: components/pages/Infinity/index.tsx:162
 msgid "infinity.affordable_subtitle"
-msgstr ""
+msgstr "Доступный"
 
 #: components/pages/Infinity/index.tsx:157
 msgid "infinity.affordable_title"
-msgstr ""
+msgstr "Ценообразование в режиме реального времени, низкие операционные издержки"
 
 #: components/pages/Infinity/index.tsx:418
 msgid "infinity.box_amount_104k"
@@ -799,23 +803,23 @@ msgstr "11к"
 
 #: components/pages/Infinity/index.tsx:400
 msgid "infinity.box_title"
-msgstr ""
+msgstr "Последняя углеродная компенсация"
 
 #: components/pages/Infinity/index.tsx:414
 msgid "infinity.box_title2"
-msgstr ""
+msgstr "Общее количество выбывшего углерода"
 
 #: components/pages/Infinity/index.tsx:665
 msgid "infinity.button.read_blog_faq"
-msgstr ""
+msgstr "Прочтите подробные ответы на часто задаваемые вопросы для клиентов KI"
 
 #: components/pages/Infinity/index.tsx:368
 msgid "infinity.button.read_blog_polygon"
-msgstr ""
+msgstr "Читайте статью Polygon"
 
 #: components/pages/Infinity/Cards/CardsSlider.tsx:89
 msgid "infinity.cards_slider.title"
-msgstr ""
+msgstr "Десятки организаций компенсировали более 150 000 тонн углерода с помощью Klima Infinity."
 
 #: components/pages/Infinity/index.tsx:331
 msgid "infinity.carousel_image_description"
@@ -823,23 +827,23 @@ msgstr "Проект ветроэнергетики в Джайбхиме, Ин�
 
 #: components/pages/Infinity/index.tsx:343
 msgid "infinity.carousel_info_subtitle"
-msgstr ""
+msgstr "Направляйте финансирование на проекты, способствующие смягчению последствий изменения климата"
 
 #: components/pages/Infinity/index.tsx:338
 msgid "infinity.carousel_info_title"
-msgstr ""
+msgstr "Поддержка высококачественных проектов"
 
 #: components/pages/Infinity/index.tsx:685
 msgid "infinity.cta_title"
-msgstr ""
+msgstr "Набор инструментов нового поколения по борьбе с выбросами углеродов для вашей организации."
 
 #: components/pages/Infinity/index.tsx:557
 msgid "infinity.faq_answer1"
-msgstr ""
+msgstr "Единица компенсации углерода представляет собой удаление из атмосферы одной тонны эквивалента углекислого газа (tCO2e) или предотвращение одной тонны выбросов."
 
 #: components/pages/Infinity/index.tsx:593
 msgid "infinity.faq_answer2_paragraph1"
-msgstr ""
+msgstr "Углеродные кредиты - это высокоинтегрированный механизм, позволяющий направлять углеродное финансирование от тех, кто загрязняет окружающую среду, к проектам по всему миру, которые помогают уменьшить или удалить выбросы углерода из атмосферы. Они являются ценным инструментом для покрытия труднопреодолимых выбросов, ликвидация которых сегодня может оказаться дорогостоящей или технически сложной."
 
 #: components/pages/Infinity/index.tsx:603
 msgid "infinity.faq_answer2_paragraph2"
@@ -847,11 +851,11 @@ msgstr "Когда вы приобретаете углеродный креди
 
 #: components/pages/Infinity/index.tsx:611
 msgid "infinity.faq_answer2_paragraph3"
-msgstr ""
+msgstr "Приобретенные квоты ведут к измеримому и подотчетному сокращению выбросов в других областях экономики и могут быть использованы для \"компенсации\" неизбежного углеродного следа. Торговля углеродными квотами и их изъятие из обращения позволяют появиться рыночному механизму, который устанавливает цену на углерод."
 
 #: components/pages/Infinity/index.tsx:648
 msgid "infinity.faq_answer3"
-msgstr ""
+msgstr "Целью углеродных рынков является рентабельное сокращение выбросов парниковых газов (ПГ или «углерод») путем установления ограничений на выбросы и предоставления возможности торговли единицами выбросов, которые являются финансовыми инструментами, отражающими сокращение выбросов. Торговля позволяет организациям, которые могут сократить выбросы с меньшими затратами, получать оплату от источников выбросов с более высокими затратами, тем самым снижая экономические затраты на сокращение выбросов."
 
 #: components/pages/Infinity/index.tsx:543
 msgid "infinity.faq_question1"
@@ -867,27 +871,27 @@ msgstr "3. Что такое углеродные рынки?"
 
 #: components/pages/Infinity/index.tsx:137
 msgid "infinity.fast_subtitle"
-msgstr ""
+msgstr "Компенсация в считанные секунды, без волокиты"
 
 #: components/pages/Infinity/index.tsx:142
 msgid "infinity.fast_title"
-msgstr ""
+msgstr "Быстро"
 
 #: components/pages/Infinity/GetStartedModal.tsx:47
 msgid "infinity.getStartedModal_business"
-msgstr ""
+msgstr "Я <0/>предприниматель."
 
 #: components/pages/Infinity/GetStartedModal.tsx:70
 msgid "infinity.getStartedModal_individual"
-msgstr ""
+msgstr "Я<0/>частное лицо."
 
 #: components/pages/Infinity/GetStartedModal.tsx:104
 msgid "infinity.getStartedModal_needAssistance"
-msgstr ""
+msgstr "Я хотел бы получить помощь по вопросам углеродного следа моей организации."
 
 #: components/pages/Infinity/GetStartedModal.tsx:94
 msgid "infinity.getStartedModal_offsetCrypto"
-msgstr ""
+msgstr "Я хочу<0/>компенсировать криптовалюту."
 
 #: components/pages/Infinity/index.tsx:258
 msgid "infinity.getStarted_1"
@@ -899,23 +903,23 @@ msgstr "2"
 
 #: components/pages/Infinity/index.tsx:261
 msgid "infinity.getStarted_calculate"
-msgstr ""
+msgstr "Рассчитать"
 
 #: components/pages/Infinity/index.tsx:264
 msgid "infinity.getStarted_calculate_subtitle"
-msgstr ""
+msgstr "Рассчитайте углеродный след вашей организации и определите объем компенсации с помощью Klima Infinity."
 
 #: components/pages/Infinity/index.tsx:301
 msgid "infinity.getStarted_cta"
-msgstr ""
+msgstr "Ускорьте свой путь к нулевому выбросу углерода — и не только"
 
 #: components/pages/Infinity/index.tsx:278
 msgid "infinity.getStarted_second_subtitle"
-msgstr ""
+msgstr "Внедряйте свои смещение всего несколькими щелчками мыши и практически мгновенно."
 
 #: components/pages/Infinity/index.tsx:275
 msgid "infinity.getStarted_second_title"
-msgstr ""
+msgstr "Внедрить"
 
 #: components/pages/Infinity/index.tsx:286
 msgid "infinity.getStarted_third"
@@ -923,35 +927,37 @@ msgstr "3"
 
 #: components/pages/Infinity/index.tsx:292
 msgid "infinity.getStarted_third_subtitle"
-msgstr ""
+msgstr "Отслеживайте свои обязательства и повышайте осведомленность о своих действиях, направленных на улучшение климата."
 
 #: components/pages/Infinity/index.tsx:289
 msgid "infinity.getStarted_third_title"
-msgstr ""
+msgstr "Усилить"
 
 #: components/pages/Infinity/index.tsx:67
 msgid "infinity.head.metaDescription"
-msgstr ""
+msgstr "Набор инструментов нового поколения по борьбе с выбросами углеродов для вашей организации."
 
 #: components/pages/Infinity/index.tsx:63
 msgid "infinity.head.metaTitle"
-msgstr ""
+msgstr "Klima Infinity — станьте углеродно-нейтральным"
 
 #: components/pages/Infinity/index.tsx:59
 msgid "infinity.head.title"
 msgstr ""
+"KlimaDAO | Klima Infinity\n"
+""
 
 #: components/pages/Infinity/index.tsx:178
 msgid "infinity.info_subtitle1"
-msgstr ""
+msgstr "Для новаторских организаций планеты"
 
 #: components/pages/Infinity/index.tsx:183
 msgid "infinity.info_subtitle2"
-msgstr ""
+msgstr "Самое мощное и простое в использовании компенсационное решение в мире"
 
 #: components/pages/Infinity/index.tsx:450
 msgid "infinity.mission_card1_subtitle"
-msgstr ""
+msgstr "Тонны углерода, удерживаемые KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:447
 msgid "infinity.mission_card1_title"
@@ -959,7 +965,7 @@ msgstr "18,1 миллиона"
 
 #: components/pages/Infinity/index.tsx:472
 msgid "infinity.mission_card2_description"
-msgstr ""
+msgstr "Углеродная ликвидность, принадлежащая KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:469
 msgid "infinity.mission_card2_number"
@@ -967,7 +973,7 @@ msgstr "$10 млн+"
 
 #: components/pages/Infinity/index.tsx:494
 msgid "infinity.mission_card3_description"
-msgstr ""
+msgstr "Тонны углерода компенсированы через KlimaDAO"
 
 #: components/pages/Infinity/index.tsx:491
 msgid "infinity.mission_card3_number"
@@ -975,19 +981,19 @@ msgstr "150 000+"
 
 #: components/pages/Infinity/index.tsx:387
 msgid "infinity.polygon_manifesto_description"
-msgstr ""
+msgstr "Компенсируя исторические выбросы всей своей сети, Polygon гарантирует, что каждое взаимодействие в сети - будь то майнинг NFT или транзакция DeFi - учитывается. Это ключевая причина, по которой Meta выбрала Polygon для выпуска своих NFT."
 
 #: components/pages/Infinity/index.tsx:381
 msgid "infinity.polygon_manifesto_title"
-msgstr ""
+msgstr "Смещение является частью \"Зеленого манифеста\" Polygon"
 
 #: components/pages/Infinity/index.tsx:361
 msgid "infinity.polygon_story_description"
-msgstr ""
+msgstr "Polygon компенсировал выбросы углерода в сети с момента ее создания (примерно 90 000 тонн) и пообещал обеспечить положительное воздействие на климат во всех будущих транзакциях сети."
 
 #: components/pages/Infinity/index.tsx:356
 msgid "infinity.polygon_story_title"
-msgstr ""
+msgstr "Polygon выбрал Klima Infinity для компенсации своей блокчейн-сети"
 
 #: components/pages/Infinity/Cards/Card.tsx:66
 #: components/pages/Infinity/index.tsx:407
@@ -997,27 +1003,27 @@ msgstr "Тонны"
 
 #: components/pages/Infinity/index.tsx:196
 msgid "infinity.transparent_subtitle"
-msgstr ""
+msgstr "Прозрачный"
 
 #: components/pages/Infinity/index.tsx:191
 msgid "infinity.transparent_title"
-msgstr ""
+msgstr "Неизменно записывается в блокчейн"
 
 #: components/pages/Infinity/index.tsx:98
 msgid "infinity.welcome_subtitle"
-msgstr ""
+msgstr "Набор инструментов нового поколения по борьбе с выбросами углеродов для вашей организации."
 
 #: components/pages/Infinity/index.tsx:93
 msgid "infinity.welcome_title"
-msgstr ""
+msgstr "Самый простой способ стать углеродно-нейтральным"
 
 #: components/pages/Infinity/index.tsx:224
 msgid "infinity.why_description"
-msgstr ""
+msgstr "KlimaDAO использует стек технологий DeFi для снижения фрагментации рынка и ускорения предоставления климатического финансирования проектам устойчивого развития по всему миру."
 
 #: components/pages/Infinity/index.tsx:219
 msgid "infinity.why_subtitle"
-msgstr ""
+msgstr "DeFi, который бросает вызов изменению климата"
 
 #: components/pages/Infinity/index.tsx:216
 msgid "infinity.why_title"
@@ -1025,29 +1031,29 @@ msgstr "Почему именно KlimaDAO?"
 
 #: components/pages/Home/index.tsx:384
 msgid "invest_in_the_future"
-msgstr ""
+msgstr "Инвестируйте в будущее."
 
 #: components/pages/Infinity/index.tsx:439
 msgid "mission.header"
-msgstr ""
+msgstr "Миссия KlimaDAO — демократизация борьбы с изменением климата"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:79
 #: components/pages/Pledge/PledgeForm/index.tsx:83
 #: components/pages/Pledge/PledgeForm/index.tsx:99
 msgid "pledge.errors.default"
-msgstr ""
+msgstr "Произошла ошибка"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:91
 msgid "pledge.errors.method_not_allowed"
-msgstr ""
+msgstr "Метод не доступен"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:75
 msgid "pledge.errors.pledge_not_found"
-msgstr ""
+msgstr "Залог по этому адресу не найден."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:87
 msgid "pledge.errors.unknown_error"
-msgstr ""
+msgstr "Произошла неизвестная ошибка."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:191
 msgid "pledge.form.error.cannot_add_yourself"
@@ -1055,33 +1061,33 @@ msgstr "Вы не можете добавить свой собственный 
 
 #: components/pages/Pledge/PledgeForm/index.tsx:227
 msgid "pledge.form.error.default_error_message"
-msgstr ""
+msgstr "Что-то пошло не так. Пожалуйста, попробуйте еще раз."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:175
 msgid "pledge.form.error.duplicate_wallets"
-msgstr ""
+msgstr "Пожалуйста, удалите дубликат(ы) кошелька(ов)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:616
 msgid "pledge.form.wallets.confirm_remove_wallet"
-msgstr ""
+msgstr "Вы уверены, что хотите удалить {0} из своего залога?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:340
 msgid "pledge.form.wallets.tooltip"
-msgstr ""
+msgstr "Добавьте другие кошельки для внесения обеспечения. Если владелец кошелька примет ваше приглашение, его кошелек появится на панели управления залогом. Любые списания, сделанные вторичным кошельком, пойдут в счет вашего залога. Вы сохраните единоличное право собственности и доступ к редактированию этого залога."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:41
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:111
 msgid "pledge.invitation.accept"
-msgstr ""
+msgstr "Принять приглашение"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:70
 msgid "pledge.invitation.error.wallet_already_pinned"
-msgstr ""
+msgstr "Этот кошелек уже привязан к другому залогу. Пожалуйста, открепите кошелек и повторите попытку."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:49
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:44
 msgid "pledge.invitation.error_title"
-msgstr ""
+msgstr "Ошибка сервера"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:102
 msgid "pledge.invitation.join_message"
@@ -1089,46 +1095,46 @@ msgstr "{shortenedAddress} предлагает вам добавить свой
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:130
 msgid "pledge.invitation.later"
-msgstr ""
+msgstr "Напомни мне позже"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:118
 msgid "pledge.invitation.reject"
-msgstr ""
+msgstr "Отклонить приглашение"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:57
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:52
 msgid "pledge.invitation.signing"
-msgstr ""
+msgstr "Подписание"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:193
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:179
 msgid "pledge.invitations.awaiting_signature"
-msgstr ""
+msgstr "Ожидание подписи..."
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:199
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:185
 msgid "pledge.invitations.signature_instructions"
-msgstr ""
+msgstr "Используйте свой кошелек, чтобы подписать и подтвердить эти изменения"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:129
 msgid "pledge.modal.are_you_sure"
-msgstr ""
+msgstr "Вы уверены, что хотите удалить свой кошелек из этого залога?"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:153
 msgid "pledge.modal.confirm"
-msgstr ""
+msgstr "Подтвердить"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:40
 msgid "pledge.modal.confirm_remove"
-msgstr ""
+msgstr "подтвердить удаление"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:39
 msgid "pledge.modal.edit_pledge"
-msgstr ""
+msgstr "Изменить залог"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:101
 msgid "pledge.modal.unable_to_edit"
-msgstr ""
+msgstr "Этот кошелек не имеет права редактировать этот залог. Чтобы отредактировать, вы должны снова соединиться с кошельком автора ({0})."
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:110
 msgid "pledge.modal.unpin_wallet"
@@ -1140,15 +1146,15 @@ msgstr "У вас может быть только одна страница з�
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:110
 msgid "pledges.dashboard.assets.emptyBalance"
-msgstr ""
+msgstr "Нет углеродных активов для отображения."
 
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:87
 msgid "pledges.dashboard.assets.title"
-msgstr ""
+msgstr "Углеродные активы"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
 msgid "pledges.dashboard.footprint.title"
-msgstr ""
+msgstr "След"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
 msgid "pledges.dashboard.footprint.tonnes"
@@ -1176,7 +1182,7 @@ msgstr "{pledgeOwnerTitle} Залог | KlimaDAO"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:14
 msgid "pledges.dashboard.metholodogy.default_text"
-msgstr ""
+msgstr "Как вы будете выполнять свои обязательства?"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:21
 msgid "pledges.dashboard.metholodogy.title"
@@ -1188,7 +1194,7 @@ msgstr "Напишите свое обязательство сегодня!"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:21
 msgid "pledges.dashboard.pledge.title"
-msgstr ""
+msgstr "Залог"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:64
 msgid "pledges.dashboard.profile.pledge_met"
@@ -1200,11 +1206,11 @@ msgstr "{0}% от обязательства выполнено"
 
 #: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:106
 msgid "pledges.dashboard.profile.pledged_to_offset"
-msgstr ""
+msgstr "Обязательство компенсировать <0>{0}</0> Углеродные тонны"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:104
 msgid "pledges.dashboard.retirements.title"
-msgstr ""
+msgstr "Выбытия"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
 msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
@@ -1212,11 +1218,11 @@ msgstr "{0} Углеродная тонна(ы) Списано"
 
 #: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:123
 msgid "pledges.dashboard.retirements.total_tonnes_retired"
-msgstr ""
+msgstr "Всего выбыло тонн углерода"
 
 #: components/pages/Pledge/HeaderDesktop/index.tsx:37
 msgid "pledges.edit_pledge"
-msgstr ""
+msgstr "Изменить залог"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:562
 msgid "pledges.form.add_footprint_category_button"
@@ -1228,7 +1234,7 @@ msgstr "Добавить кошелек"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:242
 msgid "pledges.form.awaiting_signature"
-msgstr ""
+msgstr "Ожидание подписи..."
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:197
 msgid "pledges.form.confirm_delete"
@@ -1244,59 +1250,59 @@ msgstr "Отмена"
 
 #: components/pages/Pledge/index.tsx:212
 msgid "pledges.form.error"
-msgstr ""
+msgstr "Введите адрес кошелька, домен .klima или .eth"
 
 #: components/pages/Pledge/lib/formSchema.ts:74
 msgid "pledges.form.errors.categoryName.max"
-msgstr ""
+msgstr "Введите менее 32 символов"
 
 #: components/pages/Pledge/lib/formSchema.ts:70
 msgid "pledges.form.errors.categoryName.required"
-msgstr ""
+msgstr "Введите категорию"
 
 #: components/pages/Pledge/lib/formSchema.ts:78
 msgid "pledges.form.errors.categoryQuantity.min"
-msgstr ""
+msgstr "Введите значение больше 0"
 
 #: components/pages/Pledge/lib/formSchema.ts:50
 msgid "pledges.form.errors.description.max"
-msgstr ""
+msgstr "Введите менее 500 символов"
 
 #: components/pages/Pledge/lib/formSchema.ts:46
 msgid "pledges.form.errors.description.required"
-msgstr ""
+msgstr "Введите залог"
 
 #: components/pages/Pledge/lib/formSchema.ts:62
 msgid "pledges.form.errors.footprint.generic_error"
-msgstr ""
+msgstr "Введите расчетное количество тонн углерода"
 
 #: components/pages/Pledge/lib/formSchema.ts:66
 msgid "pledges.form.errors.footprint.min"
-msgstr ""
+msgstr "Введите значение больше 0"
 
 #: components/pages/Pledge/lib/formSchema.ts:58
 msgid "pledges.form.errors.methodology.max"
-msgstr ""
+msgstr "Введите менее 1000 символов"
 
 #: components/pages/Pledge/lib/formSchema.ts:54
 msgid "pledges.form.errors.methodology.required"
-msgstr ""
+msgstr "Введите методологию"
 
 #: components/pages/Pledge/lib/formSchema.ts:34
 msgid "pledges.form.errors.name.required"
-msgstr ""
+msgstr "Введите имя"
 
 #: components/pages/Pledge/lib/formSchema.ts:38
 msgid "pledges.form.errors.profileImageUrl.url"
-msgstr ""
+msgstr "Введите действительный URL"
 
 #: components/pages/Pledge/lib/formSchema.ts:42
 msgid "pledges.form.errors.profileWebsiteUrl.url"
-msgstr ""
+msgstr "Введите действительный URL"
 
 #: components/pages/Pledge/lib/formSchema.ts:86
 msgid "pledges.form.errors.walletAddress.isAddress"
-msgstr ""
+msgstr "Пожалуйста, введите правильный адрес"
 
 #: components/pages/Pledge/lib/formSchema.ts:90
 msgid "pledges.form.errors.walletAddress.isOwner"
@@ -1304,19 +1310,19 @@ msgstr "Вы не можете добавить владельца залога"
 
 #: components/pages/Pledge/lib/formSchema.ts:82
 msgid "pledges.form.errors.walletAddress.required"
-msgstr ""
+msgstr "Требуется адрес"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:489
 msgid "pledges.form.footprint.label"
-msgstr ""
+msgstr "След"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:497
 msgid "pledges.form.footprint.prompt"
-msgstr ""
+msgstr "Добавьте категорию и начните рассчитывать свой углеродный след"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:260
 msgid "pledges.form.generic_error"
-msgstr ""
+msgstr "Что-то пошло не так. Пожалуйста, попробуйте еще раз."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:518
 msgid "pledges.form.input.categoryName.label"
@@ -1324,23 +1330,23 @@ msgstr "Категория"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:510
 msgid "pledges.form.input.categoryName.placeholder"
-msgstr ""
+msgstr "Название категории"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:538
 msgid "pledges.form.input.categoryQuantity.label"
-msgstr ""
+msgstr "Количество"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:530
 msgid "pledges.form.input.categoryQuantity.placeholder"
-msgstr ""
+msgstr "Тонны углерода"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:323
 msgid "pledges.form.input.description.label"
-msgstr ""
+msgstr "Залог"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:316
 msgid "pledges.form.input.description.placeholder"
-msgstr ""
+msgstr "Каково ваше обязательство?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:476
 msgid "pledges.form.input.methodology.label"
@@ -1348,27 +1354,27 @@ msgstr "Методология"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:468
 msgid "pledges.form.input.methodology.placeholder"
-msgstr ""
+msgstr "Какие инструменты или методики вы использовали для расчета своего углеродного следа?"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:280
 msgid "pledges.form.input.name.label"
-msgstr ""
+msgstr "Имя"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:273
 msgid "pledges.form.input.name.placeholder"
-msgstr ""
+msgstr "Имя или название компании"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:291
 msgid "pledges.form.input.profileImageUrl.label"
-msgstr ""
+msgstr "URL - изображения профиля (необязательно)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:305
 msgid "pledges.form.input.profileWebsiteUrl.label"
-msgstr ""
+msgstr "Веб-сайт (необязательно)"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:579
 msgid "pledges.form.input.totalFootprint.label"
-msgstr ""
+msgstr "Общий след"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:380
 msgid "pledges.form.input.walletAddress.label"
@@ -1380,7 +1386,7 @@ msgstr "0х..."
 
 #: components/pages/Pledge/PledgeForm/index.tsx:595
 msgid "pledges.form.submit_button"
-msgstr ""
+msgstr "Сохранить залог"
 
 #: components/pages/Pledge/PledgeDashboard/index.tsx:193
 msgid "pledges.form.title"
@@ -1388,27 +1394,29 @@ msgstr "Ваше обязательство"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:52
 msgid "pledges.form.total_footprint_summary"
-msgstr ""
+msgstr "Общий след: {0} тонны углерода"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:607
 msgid "pledges.form.use_your_wallet"
 msgstr ""
+"Используйте свой кошелек, чтобы подписать и подтвердить эти изменения\n"
+""
 
 #: components/pages/Pledge/PledgeForm/index.tsx:332
 msgid "pledges.form.wallets.label"
-msgstr ""
+msgstr "Дополнительный(е) кошелек(и)"
 
 #: components/pages/Pledge/index.tsx:94
 msgid "pledges.head.metaDescription"
-msgstr ""
+msgstr "Продемонстрируйте свою приверженность позитивному отношению к климату, заявив, что ваша панель инструментов обещаний отображает всю вашу деятельность по компенсации выбросов углерода."
 
 #: components/pages/Pledge/index.tsx:90
 msgid "pledges.head.metaTitle"
-msgstr ""
+msgstr "Создайте обязательство по выбросам углерода и продемонстрируйте свое влияние"
 
 #: components/pages/Pledge/index.tsx:86
 msgid "pledges.head.title"
-msgstr ""
+msgstr "KlimaDAO | Залоги"
 
 #: components/pages/Pledge/index.tsx:66
 msgid "pledges.home.hero.connecting"
@@ -1416,23 +1424,23 @@ msgstr "Подключение..."
 
 #: components/pages/Pledge/index.tsx:77
 msgid "pledges.home.hero.create"
-msgstr ""
+msgstr "Создать обязательство"
 
 #: components/pages/Pledge/index.tsx:170
 msgid "pledges.home.hero.learn_more"
-msgstr ""
+msgstr "Подробнее"
 
 #: components/pages/Pledge/index.tsx:72
 msgid "pledges.home.hero.view"
-msgstr ""
+msgstr "Просмотреть свой залог"
 
 #: components/pages/Pledge/index.tsx:206
 msgid "pledges.home.search.label"
-msgstr ""
+msgstr "ENS или 0x адрес"
 
 #: components/pages/Pledge/index.tsx:200
 msgid "pledges.home.search.placeholder"
-msgstr ""
+msgstr "Введите адрес ENS, KNS или 0x"
 
 #: components/pages/Pledge/index.tsx:226
 msgid "pledges.home.search.submit"
@@ -1468,51 +1476,51 @@ msgstr "Выбрать"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:53
 msgid "resources.form.medium.header"
-msgstr ""
+msgstr "Medium"
 
 #: components/pages/Resources/ResourcesFilters/index.tsx:41
 msgid "resources.form.sub_topics.header"
-msgstr ""
+msgstr "Подтемы"
 
 #: components/pages/Resources/index.tsx:31
 msgid "resources.head.metaDescription"
-msgstr ""
+msgstr "Свежие новости и аналитические материалы от основателей, участников DAO, консультантов и сообщества."
 
 #: components/pages/Resources/index.tsx:27
 msgid "resources.head.metaTitle"
-msgstr ""
+msgstr "Ресурсы KlimaDAO - Выйти за рамки углеродной нейтральности"
 
 #: components/pages/Resources/index.tsx:23
 msgid "resources.head.title"
-msgstr ""
+msgstr "KlimaDAO | Ресурсы"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:71
 msgid "resources.list.filter.tag.basics"
-msgstr ""
+msgstr "Основы"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:111
 msgid "resources.list.filter.tag.carbon_footprint"
-msgstr ""
+msgstr "Углеродный след"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:79
 msgid "resources.list.filter.tag.deep_dives"
-msgstr ""
+msgstr "Глубокое погружение"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:52
 msgid "resources.list.filter.tag.klima_infinity"
-msgstr ""
+msgstr "Klima Infinity"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:44
 msgid "resources.list.filter.tag.klima_overview"
-msgstr ""
+msgstr "Обзор Klima"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:60
 msgid "resources.list.filter.tag.partnerships"
-msgstr ""
+msgstr "Партнерство"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:103
 msgid "resources.list.filter.tag.policy"
-msgstr ""
+msgstr "Политика"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:95
 msgid "resources.list.filter.tag.press_releases"
@@ -1524,11 +1532,11 @@ msgstr "Руководства пользователя"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:121
 msgid "resources.list.filter.type.blog"
-msgstr ""
+msgstr "Блог"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:129
 msgid "resources.list.filter.type.podcast"
-msgstr ""
+msgstr "Подкаст"
 
 #: components/pages/Resources/SortyByDropDown/index.tsx:62
 msgid "resources.list.select.sort_by.toggle"
@@ -1560,15 +1568,17 @@ msgstr "Сортировать по"
 
 #: components/pages/Resources/index.tsx:46
 msgid "resources.page.header.subline"
-msgstr ""
+msgstr "Свежие новости и аналитические материалы от основателей, участников DAO, консультантов и сообщества."
 
 #: components/pages/Resources/index.tsx:43
 msgid "resources.page.header.title"
 msgstr ""
+"Популярные статьи\n"
+""
 
 #: components/pages/Resources/ResourcesList/index.tsx:167
 msgid "resources.page.list.header"
-msgstr ""
+msgstr "Просмотреть все"
 
 #: components/pages/Resources/ResourcesList/index.tsx:249
 msgid "resources.page.list.no_search_results.title"
@@ -1588,15 +1598,15 @@ msgstr "Проверьте свой запрос на наличие опеча�
 
 #: components/pages/Retirements/Footer/index.tsx:18
 msgid "retirement.footer.aboutKlima.left"
-msgstr ""
+msgstr "KlimaDAO стимулирует устойчивое развитие и является катализатором более прозрачного и ликвидного углеродного рынка. Наши инструменты позволяют любому физическому или юридическому лицу торговать и списывать качественные углеродные активы на блокчейне."
 
 #: components/pages/Retirements/Footer/index.tsx:28
 msgid "retirement.footer.aboutKlima.right"
-msgstr ""
+msgstr "Токены KLIMA находятся в центре бурно развивающейся углеродной экономики на цепочке. Посетите нашу <0>базу знаний</0>, чтобы узнать больше о KLIMA, компенсации выбросов углерода, углеродных рынках и лежащих в их основе углеродных активах."
 
 #: components/pages/Retirements/Footer/index.tsx:13
 msgid "retirement.footer.aboutKlima.title"
-msgstr ""
+msgstr "О Климе"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:37
 msgid "retirement.footer.buy_klima.button.buy"
@@ -1608,15 +1618,15 @@ msgstr "Офсет"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:30
 msgid "retirement.footer.buy_klima.text"
-msgstr ""
+msgstr "Используйте токены KLIMA, обеспеченные углеродом, для управления, обмена и получения вознаграждений за стейкинг, а затем используйте эти вознаграждения для компенсации своих выбросов!"
 
 #: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:25
 msgid "retirement.footer.buy_klima.title"
-msgstr ""
+msgstr "Приобретайте, стейкайте и получайте вознаграждение."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:122
 msgid "retirement.head.metaDescription"
-msgstr ""
+msgstr "Прозрачные компенсации по цепочке на базе KlimaDAO."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:118
 msgid "retirement.head.metaTitle"
@@ -1624,99 +1634,99 @@ msgstr "{retiree} изъято из эксплуатации {formattedAmount} �
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:114
 msgid "retirement.head.title"
-msgstr ""
+msgstr "KlimaDAO | Квитанция о возврате углерода"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:266
 msgid "retirement.share.title"
-msgstr ""
+msgstr "Поделитесь своим влиянием"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:176
 msgid "retirement.single.beneficiary.placeholder"
-msgstr ""
+msgstr "Имя получателя не указано"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:170
 msgid "retirement.single.beneficiary.title"
-msgstr ""
+msgstr "Бенефициар"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:184
 msgid "retirement.single.beneficiaryAddress.title"
-msgstr ""
+msgstr "Адрес получателя"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:245
 msgid "retirement.single.create_a_pledge"
-msgstr ""
+msgstr "Создайте залог прямо сейчас."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:231
 msgid "retirement.single.disclaimer"
-msgstr ""
+msgstr "Это представляет собой постоянное выбытие токенизированных углеродных активов на блокчейне Polygon. Это выбытие и связанные с ним данные являются неизменяемыми публичными записями."
 
 #: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:30
 msgid "retirement.single.download_certificate_button"
-msgstr ""
+msgstr "Скачать PDF"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:134
 msgid "retirement.single.header.subline"
-msgstr ""
+msgstr "Коррекция выбросов в CO2-эквиваленте (метрические тонны)"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:241
 msgid "retirement.single.is_this_your_retirement"
-msgstr ""
+msgstr "Это ваше выбытие?"
 
 #: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
 msgid "retirement.single.message.title"
-msgstr ""
+msgstr "Сообщение о использовании"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:30
 msgid "retirement.single.no_pledge"
-msgstr ""
+msgstr "Этот пользователь не создал залог"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
 msgid "retirement.single.project_details.title"
-msgstr ""
+msgstr "Детали проекта"
 
 #: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
 msgid "retirement.single.quantity"
-msgstr ""
+msgstr "КОЛИЧЕСТВО УПОТРЕБЛЕННЫХ "
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:205
 msgid "retirement.single.retirementCertificate.title"
-msgstr ""
+msgstr "Сертификат"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:21
 msgid "retirement.single.retirementDate.title"
-msgstr ""
+msgstr "Дата"
 
 #: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:24
 msgid "retirement.single.timestamp.placeholder"
-msgstr ""
+msgstr "Не предоставлена время использования"
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:302
 msgid "retirement.single.view_on_polygon_scan"
-msgstr ""
+msgstr "Посмотреть на Polygonscan"
 
 #: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:18
 msgid "retirement.single.view_pledge"
-msgstr ""
+msgstr "Посмотреть залог"
 
 #: components/pages/Retirements/List/index.tsx:40
 msgid "retirement.totals.all_retirements_list.empty"
-msgstr ""
+msgstr "Выбиваний не найдено"
 
 #: components/pages/Retirements/List/index.tsx:24
 msgid "retirement.totals.all_retirements_list.headline"
-msgstr ""
+msgstr "Итого выведено"
 
 #: components/pages/Retirements/index.tsx:46
 msgid "retirement.totals.head.metaTitle"
-msgstr ""
+msgstr "KlimaDAO - Отказ от углерода для получателя {0}"
 
 #: components/pages/Retirements/index.tsx:40
 msgid "retirement.totals.head.title"
-msgstr ""
+msgstr "KlimaDAO - Отказ от углерода для получателя {0}"
 
 #: components/pages/Retirements/index.tsx:65
 msgid "retirement.totals.page_headline"
-msgstr ""
+msgstr "Выбивание углерода"
 
 #: components/pages/Retirements/index.tsx:71
 msgid "retirement.totals.page_subline"
@@ -1724,19 +1734,19 @@ msgstr "для бенефициара"
 
 #: components/pages/Retirements/index.tsx:95
 msgid "retirement.totals.retired_assets"
-msgstr ""
+msgstr "Выбывшие активы"
 
 #: components/pages/Retirements/index.tsx:111
 msgid "retirement.totals.retirements"
-msgstr ""
+msgstr "Выбытия"
 
 #: components/pages/Retirements/index.tsx:103
 msgid "retirement.totals.total_carbon_tonnes"
-msgstr ""
+msgstr "Всего выбыло тонн углерода"
 
 #: components/pages/Retirements/index.tsx:117
 msgid "retirement.totals.total_retirement_transactions"
-msgstr ""
+msgstr "Всего транзакции выбивания"
 
 #: components/pages/errors/Custom404.tsx:20
 #: components/pages/errors/Custom404.tsx:24
@@ -1753,23 +1763,23 @@ msgstr "О"
 #: components/Navigation/index.tsx:115
 #: components/Navigation/index.tsx:261
 msgid "shared.app"
-msgstr ""
+msgstr "Приложение"
 
 #: components/Footer/index.tsx:49
 msgid "shared.blog"
-msgstr ""
+msgstr "Блог"
 
 #: components/Footer/index.tsx:43
 #: components/Navigation/index.tsx:133
 #: components/Navigation/index.tsx:278
 msgid "shared.bond"
-msgstr ""
+msgstr "Облигация Klima"
 
 #: components/Footer/index.tsx:37
 #: components/Navigation/index.tsx:117
 #: components/Navigation/index.tsx:265
 msgid "shared.buy"
-msgstr ""
+msgstr "Купить Klima"
 
 #: components/Navigation/index.tsx:157
 #: components/Navigation/index.tsx:302
@@ -1780,15 +1790,15 @@ msgstr "Купить углерод"
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:118
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:147
 msgid "shared.cancel"
-msgstr ""
+msgstr "Отмена"
 
 #: components/Navigation/index.tsx:352
 msgid "shared.carbon_dashboard"
-msgstr ""
+msgstr "Приборные панели по углероду"
 
 #: components/Navigation/index.tsx:203
 msgid "shared.carbon_dashboards"
-msgstr ""
+msgstr "Приборные панели по углероду"
 
 #: components/Navigation/index.tsx:174
 #: components/Navigation/index.tsx:321
@@ -1800,11 +1810,11 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:31
 #: components/pages/About/AboutHeader/index.tsx:61
 msgid "shared.community"
-msgstr ""
+msgstr "Сообщество"
 
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:45
 msgid "shared.confirm"
-msgstr ""
+msgstr "Подтвердить"
 
 #: components/Footer/index.tsx:52
 #: components/Navigation/index.tsx:241
@@ -1816,14 +1826,14 @@ msgstr "Связаться"
 #: components/pages/Infinity/index.tsx:117
 #: components/pages/Infinity/index.tsx:701
 msgid "shared.contact_sales"
-msgstr ""
+msgstr "Связаться с отделом продаж"
 
 #: components/Navigation/index.tsx:96
 #: components/pages/About/AboutHeader/index.tsx:40
 #: components/pages/About/Community/index.tsx:129
 #: components/pages/About/Community/index.tsx:374
 msgid "shared.contact_us"
-msgstr ""
+msgstr "Связаться с нами"
 
 #: components/Footer/index.tsx:55
 #: components/Navigation/index.tsx:105
@@ -1831,26 +1841,26 @@ msgstr ""
 #: components/pages/About/AboutHeader/index.tsx:49
 #: components/pages/About/AboutHeader/index.tsx:73
 msgid "shared.disclaimer"
-msgstr ""
+msgstr "Отказ от ответственности"
 
 #: components/Footer/index.tsx:46
 #: components/Navigation/index.tsx:211
 #: components/Navigation/index.tsx:360
 msgid "shared.docs"
-msgstr ""
+msgstr "Официальные документы"
 
 #: components/Navigation/index.tsx:63
 #: components/pages/Home/index.tsx:115
 msgid "shared.enter_app"
-msgstr ""
+msgstr "Войдите в приложение"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:157
 msgid "shared.error"
-msgstr ""
+msgstr "Ошибка"
 
 #: components/pages/Infinity/GetStartedModal.tsx:25
 msgid "shared.get_started"
-msgstr ""
+msgstr "С чего начать"
 
 #: components/pages/Buy/index.tsx:29
 #: components/pages/Home/index.tsx:69
@@ -1858,25 +1868,27 @@ msgstr ""
 #: components/pages/errors/Custom500.tsx:23
 msgid "shared.head.description"
 msgstr ""
+"Стимулируйте действия по защите климата и получайте вознаграждения с цифровой валютой обеспеченной реальными углеродными активами.\n"
+""
 
 #: components/Footer/index.tsx:34
 msgid "shared.home"
-msgstr ""
+msgstr "Домашняя страница"
 
 #: components/Navigation/index.tsx:194
 #: components/Navigation/index.tsx:343
 msgid "shared.how_to_buy"
-msgstr ""
+msgstr "Как купить Klima"
 
 #: components/pages/Infinity/index.tsx:108
 #: components/pages/Infinity/index.tsx:309
 #: components/pages/Infinity/index.tsx:692
 msgid "shared.infinity.get_started"
-msgstr ""
+msgstr "С чего начать"
 
 #: components/pages/Home/index.tsx:186
 msgid "shared.infinity_cta"
-msgstr ""
+msgstr "ДЕФИ ДЛЯ ОРГАНИЗАЦИЙ"
 
 #: components/Navigation/index.tsx:165
 #: components/Navigation/index.tsx:310
@@ -1903,12 +1915,12 @@ msgstr "Войти / Подключиться"
 
 #: components/pages/Home/index.tsx:193
 msgid "shared.loveletter_cta"
-msgstr ""
+msgstr "DEFI ДЛЯ ФИЗИЧЕСКИХ ЛИЦ"
 
 #: components/Navigation/index.tsx:179
 #: components/Navigation/index.tsx:325
 msgid "shared.loveletters"
-msgstr ""
+msgstr "Love Letters"
 
 #: components/Navigation/index.tsx:149
 #: components/Navigation/index.tsx:294
@@ -1918,11 +1930,11 @@ msgstr "Офсет"
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:175
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:161
 msgid "shared.okay"
-msgstr ""
+msgstr "Хорошо"
 
 #: components/pages/Pledge/PledgeForm/index.tsx:421
 msgid "shared.pending"
-msgstr ""
+msgstr "В ожидании"
 
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:135
 msgid "shared.remove"
@@ -1947,11 +1959,11 @@ msgstr "Сортировать по"
 #: components/Navigation/index.tsx:125
 #: components/Navigation/index.tsx:270
 msgid "shared.stake"
-msgstr ""
+msgstr "Стейкинг Klima"
 
 #: components/pages/Infinity/index.tsx:512
 msgid "shared.visit_klimadao_blog"
-msgstr ""
+msgstr "Посетите блог KlimaDAO"
 
 #: components/Navigation/index.tsx:141
 #: components/Navigation/index.tsx:286


### PR DESCRIPTION
This reverts commit 7c41481686c9381fac7ee42dbad1ab9b19ec2310.

This commit destroyed a lot of strings-- we had accidentally set carbonmark to the same translation.io project so it destroyed those strings remotely, and then pulled them in locally and committed the via github actions.