### PR TITLE
Poll until the latest activity timeStamp is new

### DIFF
--- a/carbonmark/components/pages/Portfolio/CarbonmarkAssets.tsx
+++ b/carbonmark/components/pages/Portfolio/CarbonmarkAssets.tsx
@@ -82,11 +82,10 @@ export const CarbonmarkAssets: FC<Props> = (props) => {
           assets={[assetToSell]}
           showModal={!!assetToSell}
           successScreen={
-            <Text>
+            <Text align="center">
               <Trans>
-                Success. Go to your{" "}
-                <Link href={`/users/${props.address}`}>Profile page</Link> to
-                see your new listing.
+                Success! Your new listing will appear in a few moments on your{" "}
+                <Link href={`/users/${props.address}`}>Profile page</Link>.
               </Trans>
             </Text>
           }

--- a/carbonmark/components/pages/Portfolio/CarbonmarkAssets.tsx
+++ b/carbonmark/components/pages/Portfolio/CarbonmarkAssets.tsx
@@ -28,7 +28,7 @@ export const CarbonmarkAssets: FC<Props> = (props) => {
 
   const isUpdatingUser = props.isLoadingUser || isLoadingAssets;
   const hasAssets = !isLoadingAssets && !!assetWithProjectTokens;
-  const emptyAssets = !isUpdatingUser && !assetWithProjectTokens;
+  const emptyAssets = !isUpdatingUser && !assetsData?.length;
 
   // load Assets every time user changed
   useEffect(() => {

--- a/carbonmark/components/pages/Portfolio/index.tsx
+++ b/carbonmark/components/pages/Portfolio/index.tsx
@@ -7,8 +7,7 @@ import { PageHead } from "components/PageHead";
 import { Text } from "components/Text";
 import { Col, TwoColLayout } from "components/TwoColLayout";
 import { useFetchUser } from "hooks/useFetchUser";
-import { getUserUntil } from "lib/api";
-import { User } from "lib/types/carbonmark";
+import { activityIsAdded, getUserUntil } from "lib/api";
 import { NextPage } from "next";
 import Link from "next/link";
 import { useState } from "react";
@@ -27,20 +26,16 @@ export const Portfolio: NextPage = () => {
   const isUnregistered =
     isConnectedUser && !isLoading && carbonmarkUser === null;
 
-  const userActivityIsUpdated = (userFromApi: User) => {
-    // compare with current user
-    const oldUser = carbonmarkUser;
-    const newActivityLength = userFromApi.activities.length;
-    const currentActivityLength = oldUser?.activities.length || 0;
-    return newActivityLength > currentActivityLength;
-  };
-
   const handleMutateUser = async () => {
     if (!isConnectedUser) return;
 
+    const latestActivity = carbonmarkUser?.activities.sort(
+      (a, b) => Number(b.timeStamp) - Number(a.timeStamp)
+    )[0];
+
     const newUser = await getUserUntil({
       address,
-      retryUntil: userActivityIsUpdated,
+      retryUntil: activityIsAdded(latestActivity?.timeStamp || "0"),
       retryInterval: 1000,
       maxAttempts: 50,
     });

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -11,7 +11,7 @@ import { Text } from "components/Text";
 import { Col, TwoColLayout } from "components/TwoColLayout";
 import { useFetchUser } from "hooks/useFetchUser";
 import { addProjectsToAssets } from "lib/actions";
-import { getUser, getUserUntil } from "lib/api";
+import { activityIsAdded, getUser, getUserUntil } from "lib/api";
 import { getAssetsWithProjectTokens } from "lib/getAssetsData";
 import { getActiveListings, getSortByUpdateListings } from "lib/listingsGetter";
 import { AssetForListing, User } from "lib/types/carbonmark";
@@ -53,18 +53,14 @@ export const SellerConnected: FC<Props> = (props) => {
     scrollToRef.current &&
     scrollToRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
 
-  const userActivityIsUpdated = (userFromApi: User) => {
-    // compare with current user
-    const oldUser = carbonmarkUser;
-    const newActivityLength = userFromApi.activities.length;
-    const currentActivityLength = oldUser?.activities.length || 0;
-    return newActivityLength > currentActivityLength;
-  };
-
   const handleMutateUserUntil = async () => {
+    const latestActivity = carbonmarkUser?.activities.sort(
+      (a, b) => Number(b.timeStamp) - Number(a.timeStamp)
+    )[0];
+
     const newUser = await getUserUntil({
       address: props.userAddress,
-      retryUntil: userActivityIsUpdated,
+      retryUntil: activityIsAdded(latestActivity?.timeStamp || "0"),
       retryInterval: 1000,
       maxAttempts: 50,
     });

--- a/carbonmark/lib/api.ts
+++ b/carbonmark/lib/api.ts
@@ -167,6 +167,15 @@ export const getVintages = async (): Promise<string[]> => {
   return data;
 };
 
+// poll until check for acitivity timeStamps
+export const activityIsAdded = (prevTimeStamp: string) => (newUser: User) => {
+  const latestActivity = newUser.activities.sort(
+    (a, b) => Number(b.timeStamp) - Number(a.timeStamp)
+  )[0];
+
+  return Number(latestActivity?.timeStamp || 0) > Number(prevTimeStamp);
+};
+
 export const getUserUntil = async (params: {
   address: string;
   retryUntil: (u: User) => boolean;

--- a/carbonmark/lib/api.ts
+++ b/carbonmark/lib/api.ts
@@ -167,7 +167,7 @@ export const getVintages = async (): Promise<string[]> => {
   return data;
 };
 
-// poll until check for acitivity timeStamps
+// poll until check for activity timeStamps
 export const activityIsAdded = (prevTimeStamp: string) => (newUser: User) => {
   const latestActivity = newUser.activities.sort(
     (a, b) => Number(b.timeStamp) - Number(a.timeStamp)


### PR DESCRIPTION
## Description

As discusses in this ticket https://github.com/KlimaDAO/klimadao/issues/1100
we can not rely on the activity array length to check when the backend is done with updating the data.

Instead, we can check for the timeStamp in the latest activity. This is the refactoring for that.

Additionally, this PR contains these super tiny fixes:
- fix the check for empty assets which shows an empty state message
- better text for the success modal

## Related Ticket

Closes https://github.com/KlimaDAO/klimadao/issues/1100



## Changes

| Before  | After  |
|---------|--------|
| <img width="634" alt="Bildschirmfoto 2023-05-02 um 17 23 58" src="https://user-images.githubusercontent.com/95881624/235714027-009c84eb-1824-473e-b8ff-65b1fabe4d62.png"> | <img width="635" alt="Bildschirmfoto 2023-05-02 um 17 24 53" src="https://user-images.githubusercontent.com/95881624/235714088-fb2c6a82-f9c0-44cc-ae0f-89d53a12cb46.png"> |


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
