### PR TITLE
[carbon-projects] Add Project Content document type

### DIFF
--- a/carbon-projects/schemas/index.ts
+++ b/carbon-projects/schemas/index.ts
@@ -1,3 +1,4 @@
 import methodology from "./methodology";
 import project from "./project";
-export const schemaTypes = [project, methodology];
+import projectContent from "./projectContent";
+export const schemaTypes = [project, methodology, projectContent];

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -66,7 +66,8 @@ export default defineType({
     },
     {
       name: "description",
-      description: "Project description",
+      description:
+        "Official project description as it appears in the originating registry",
       group: "info",
       type: "string",
       validation: (r) => r.required().min(20),
@@ -210,39 +211,6 @@ export default defineType({
       group: "benefits",
       type: "boolean",
       initialValue: false,
-    }),
-    defineField({
-      name: "coverImage",
-      description: "Primary cover image to be shown on project page",
-      group: "media",
-      type: "image",
-      fields: [
-        {
-          name: "caption",
-          description:
-            "English language caption to show below the image. Can include image attribution if needed.",
-          type: "string",
-        },
-      ],
-    }),
-    defineField({
-      name: "images",
-      description: "Other images associated with this project",
-      group: "media",
-      type: "array",
-      of: [
-        {
-          type: "image",
-          fields: [
-            {
-              name: "caption",
-              description:
-                "English language caption to show below the image. Can include image attribution if needed.",
-              type: "string",
-            },
-          ],
-        },
-      ],
     }),
     defineField({
       name: "url",

--- a/carbon-projects/schemas/projectContent.ts
+++ b/carbon-projects/schemas/projectContent.ts
@@ -1,0 +1,101 @@
+import { defineField, defineType } from "sanity";
+
+export default defineType({
+  name: "projectContent",
+  title: "Project Content",
+  description: "Unofficial data or content associated with a specific project",
+  type: "document",
+  preview: {
+    select: {
+      slug: "project.id",
+    },
+    prepare(selection) {
+      return {
+        title: selection.slug.current || "",
+      };
+    },
+  },
+  groups: [
+    { name: "info", title: "Info" },
+    { name: "media", title: "Media" },
+    { name: "meta", title: "Meta" },
+  ],
+  fields: [
+    defineField({
+      type: "reference",
+      name: "project",
+      to: [{ type: "project" }],
+      description: "The project this content is associated with",
+      group: "info",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "shortDescription",
+      description:
+        "Short description, e.g. for retirement PDFs. Ideally 300-600 chars, no newlines, no bullet points.",
+      group: "info",
+      type: "text",
+      validation: (r) => r.min(20).max(700),
+    }),
+    defineField({
+      name: "longDescription",
+      description: "Longer description",
+      group: "info",
+      type: "text",
+    }),
+    defineField({
+      name: "coverImage",
+      description: "Primary cover image to be shown on project page",
+      group: "media",
+      type: "image",
+      fields: [
+        {
+          name: "caption",
+          description:
+            "English language caption to show below the image. Can include image attribution if needed.",
+          type: "string",
+        },
+      ],
+    }),
+    defineField({
+      name: "images",
+      description: "Other images associated with this project",
+      group: "media",
+      type: "array",
+      of: [
+        {
+          type: "image",
+          fields: [
+            {
+              name: "caption",
+              description:
+                "English language caption to show below the image. Can include image attribution if needed.",
+              type: "string",
+            },
+          ],
+        },
+      ],
+    }),
+    defineField({
+      name: "notes",
+      description:
+        "Use this space to document how this media was generated or procured, so that this work can be reproduced by others.",
+      type: "text",
+      group: "meta",
+    }),
+    defineField({
+      name: "shortDescriptionMeta",
+      description:
+        "Use this space to document how the short description was generated or procured, so that this work can be reproduced by others.",
+      type: "text",
+      group: "meta",
+    }),
+    defineField({
+      name: "longDescriptionMeta",
+      description:
+        "Use this space to document how the short description was generated or procured, so that this work can be reproduced by others.",
+      type: "text",
+      group: "meta",
+    }),
+  ],
+});

--- a/carbon-projects/schemas/projectContent.ts
+++ b/carbon-projects/schemas/projectContent.ts
@@ -93,7 +93,7 @@ export default defineType({
     defineField({
       name: "longDescriptionMeta",
       description:
-        "Use this space to document how the short description was generated or procured, so that this work can be reproduced by others.",
+        "Use this space to document how the long description was generated or procured, so that this work can be reproduced by others.",
       type: "text",
       group: "meta",
     }),


### PR DESCRIPTION
## Description

Adds a top-level document type called Project Content which is where any "unofficial" content should go, whether human or ai-generated.

Moves Image gallery and banner image fields to this new type.
Adds short description, long description, and meta fields