### PR TITLE
make adjustments to footer

### DIFF
--- a/carbonmark/components/Footer/index.tsx
+++ b/carbonmark/components/Footer/index.tsx
@@ -1,16 +1,17 @@
 import { cx } from "@emotion/css";
-import { Trans } from "@lingui/macro";
-import Link from "next/link";
-import { FC } from "react";
-
 import {
   Anchor as A,
+  GithubIcon,
   LinkedInIcon,
   TwitterIcon,
 } from "@klimadao/lib/components";
 import { urls } from "@klimadao/lib/constants";
+import { Trans } from "@lingui/macro";
+import EmailRoundedIcon from "@mui/icons-material/EmailRounded";
 import { Text } from "components/Text";
 import { urls as carbonmarkUrls } from "lib/constants";
+import Link from "next/link";
+import { FC } from "react";
 import * as styles from "./styles";
 
 interface Props {
@@ -33,11 +34,6 @@ export const Footer: FC<Props> = (props) => {
               <Trans>Terms of Use</Trans>
             </Text>
           </Link>
-          <Link href="https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk">
-            <Text t="body4">
-              <Trans>Contact</Trans>
-            </Text>
-          </Link>
           <Link href={carbonmarkUrls.help}>
             <Text t="body4">
               <Trans>Help</Trans>
@@ -53,13 +49,24 @@ export const Footer: FC<Props> = (props) => {
               <Trans>KlimaDAO</Trans>
             </Text>
           </Link>
+          <Link href="https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk">
+            <Text t="body4">
+              <Trans>Contact</Trans>
+            </Text>
+          </Link>
         </nav>
         <nav className={styles.footer_icons}>
           <A href={urls.twitterCarbonmark}>
             <TwitterIcon />
           </A>
+          <A href={urls.github}>
+            <GithubIcon />
+          </A>
           <A href={urls.linkedInCarbonmark}>
             <LinkedInIcon />
+          </A>
+          <A href={urls.carbonmarkEmail}>
+            <EmailRoundedIcon />
           </A>
         </nav>
       </div>

--- a/carbonmark/components/Footer/index.tsx
+++ b/carbonmark/components/Footer/index.tsx
@@ -49,7 +49,7 @@ export const Footer: FC<Props> = (props) => {
               <Trans>KlimaDAO</Trans>
             </Text>
           </Link>
-          <Link href="https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk">
+          <Link href={urls.carbonmarkContactForm}>
             <Text t="body4">
               <Trans>Contact</Trans>
             </Text>

--- a/carbonmark/components/Layout/NavDrawer/index.tsx
+++ b/carbonmark/components/Layout/NavDrawer/index.tsx
@@ -1,4 +1,5 @@
 import { Anchor } from "@klimadao/lib/components";
+import { urls } from "@klimadao/lib/constants";
 import { useWeb3 } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import Close from "@mui/icons-material/Close";
@@ -81,8 +82,8 @@ export const NavDrawer: FC<NavDrawerProps> = (props) => {
       />
       <CarbonmarkButton
         label={t`Book a demo`}
+        href={urls.carbonmarkContactForm}
         className={styles.bookDemoButton}
-        href="https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk"
         renderLink={(linkProps) => <Anchor {...linkProps} />}
       />
       <div className="navFooter">

--- a/carbonmark/components/Layout/NavDrawer/index.tsx
+++ b/carbonmark/components/Layout/NavDrawer/index.tsx
@@ -1,8 +1,10 @@
+import { Anchor } from "@klimadao/lib/components";
 import { useWeb3 } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import Close from "@mui/icons-material/Close";
 import { BetaBadge } from "components/BetaBadge";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
+import { CarbonmarkButton } from "components/CarbonmarkButton";
 import { CarbonmarkLogoFull } from "components/Logos/CarbonmarkLogoFull";
 import { Text } from "components/Text";
 import { useGetDomainFromAddress } from "hooks/useGetDomainFromAddress";
@@ -77,7 +79,12 @@ export const NavDrawer: FC<NavDrawerProps> = (props) => {
         connectedAddress={address}
         connectedDomain={connectedDomain}
       />
-
+      <CarbonmarkButton
+        label={t`Book a demo`}
+        className={styles.bookDemoButton}
+        href="https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk"
+        renderLink={(linkProps) => <Anchor {...linkProps} />}
+      />
       <div className="navFooter">
         <div className="hr" />
         <Text t="body1" align="center">

--- a/carbonmark/components/Layout/NavDrawer/styles.ts
+++ b/carbonmark/components/Layout/NavDrawer/styles.ts
@@ -151,3 +151,9 @@ export const logo = css`
     max-width: 18rem;
   }
 `;
+
+export const bookDemoButton = css`
+  min-height: 3.6rem;
+  color: var(--font-02) !important;
+  border-color: var(--font-03);
+`;

--- a/carbonmark/components/pages/Home/index.tsx
+++ b/carbonmark/components/pages/Home/index.tsx
@@ -513,7 +513,7 @@ export const Home: NextPage<Props> = (props) => {
             <A href={urls.home}>
               <Trans>KlimaDAO</Trans>
             </A>
-            <Link href="https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk">
+            <Link href={urls.carbonmarkContactForm}>
               <Trans>Contact</Trans>
             </Link>
           </nav>

--- a/carbonmark/components/pages/Home/index.tsx
+++ b/carbonmark/components/pages/Home/index.tsx
@@ -1,6 +1,7 @@
 import { cx } from "@emotion/css";
 import {
   Anchor as A,
+  GithubIcon,
   GridContainer,
   LinkedInIcon,
   LogoWithClaim,
@@ -15,6 +16,7 @@ import { getImageSizes } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import CheckCircleOutlineOutlinedIcon from "@mui/icons-material/CheckCircleOutlineOutlined";
 import ControlPointDuplicateOutlinedIcon from "@mui/icons-material/ControlPointDuplicateOutlined";
+import EmailRoundedIcon from "@mui/icons-material/EmailRounded";
 import MouseOutlinedIcon from "@mui/icons-material/MouseOutlined";
 import ParkOutlinedIcon from "@mui/icons-material/ParkOutlined";
 import PaymentOutlinedIcon from "@mui/icons-material/PaymentOutlined";
@@ -502,9 +504,6 @@ export const Home: NextPage<Props> = (props) => {
             <Link href="/blog/terms-of-use">
               <Trans>Terms of use</Trans>
             </Link>
-            <Link href="https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk">
-              <Trans>Contact</Trans>
-            </Link>
             <Link href={carbonmarkUrls.help}>
               <Trans>Help</Trans>
             </Link>
@@ -514,13 +513,22 @@ export const Home: NextPage<Props> = (props) => {
             <A href={urls.home}>
               <Trans>KlimaDAO</Trans>
             </A>
+            <Link href="https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk">
+              <Trans>Contact</Trans>
+            </Link>
           </nav>
           <nav className={styles.footerIcons}>
             <A href={urls.twitterCarbonmark}>
               <TwitterIcon />
             </A>
+            <A href={urls.github}>
+              <GithubIcon />
+            </A>
             <A href={urls.linkedInCarbonmark}>
               <LinkedInIcon />
+            </A>
+            <A href={urls.carbonmarkEmail}>
+              <EmailRoundedIcon />
             </A>
           </nav>
         </div>

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -161,6 +161,7 @@ export const urls = {
   marketplace: "https://www.carbonmark.com/projects",
   portfolio: "https://www.carbonmark.com/portfolio",
   resourcesCarbonmark: "https://www.carbonmark.com/resources",
+  carbonmarkEmail: "mailto:support@carbonmark.com",
 };
 
 export const polygonNetworks = {

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -133,7 +133,7 @@ export const urls = {
   twitterCarbonmark: "https://twitter.com/carbonmarkcom",
   youtube: "https://www.youtube.com/c/klimadaofinance",
   carbonmarkContactForm:
-    "https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk",
+    "https://share-eu1.hsforms.com/1RWJWvyrHT1C_an4cZOHH3gfhhlr",
   mediaRequestForm:
     "https://share-eu1.hsforms.com/1ILV2ALyPSqqUAeLdstfZZgfhhlr",
   partnerShipsContactForm:

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -132,6 +132,8 @@ export const urls = {
   twitter: "https://twitter.com/KlimaDAO",
   twitterCarbonmark: "https://twitter.com/carbonmarkcom",
   youtube: "https://www.youtube.com/c/klimadaofinance",
+  carbonmarkContactForm:
+    "https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk",
   mediaRequestForm:
     "https://share-eu1.hsforms.com/1ILV2ALyPSqqUAeLdstfZZgfhhlr",
   partnerShipsContactForm:


### PR DESCRIPTION
## Description

Currently a WIP

- [x] Footer - On homepage and in-app, move Contact option to the end of the list of footer options
- [x] Footer - On homepage and in-app, add an email logo next to the social media options. Clicking this should open the user's default email client with To: set to [support@carbonmark.com](mailto:support@carbonmark.com)
- [x] Footer - On homepage and in-app, add github as option in the social icons, it should link to https://github.com/KlimaDAO
- [ ] Footer - In the app, shift the icons to the left so on some screen sizes, the icons are not overlapping with the live chat widget
- [x] Primary Nav - In the app, add a BOOK A DEMO button ([design](https://www.figma.com/file/0vb829fJKYWWKszeSOvTTN/Carbonmark-Design-System?type=design&node-id=31-695&t=gPXbyAUDogPZFfNj-4)), which should link to the [Contact form](https://share-eu1.hsforms.com/1_VneTUObQZmJm4kNcRuEoQg3axk)

## Related Ticket

Resolves #1040 

## Checklist

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
