### PR TITLE
Increase github action status check timeout

### DIFF
--- a/.github/workflows/wait_for_status_check.yml
+++ b/.github/workflows/wait_for_status_check.yml
@@ -31,5 +31,5 @@ jobs:
         id: status_check
         with:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          timeoutSeconds: 240
+          timeoutSeconds: 360
           ref: ${{ inputs.branch }}


### PR DESCRIPTION
## Description

The latest workflows for "schedule auto merge" did fail. 
See https://github.com/KlimaDAO/klimadao/actions

The reason for this was that the status checks for the last commit on branch `staging` within the defined threshold of 240 seconds were still in the "pending" status. In this case the merge from `staging` to `main` is never executed.

I assume that since the update of several dependencies in this PR https://github.com/KlimaDAO/klimadao/pull/1070 Vercel needs longer to build all three sites (site, app, carbonmark).
Because since this upgrade commit the actions do fail on `staging`.

This PR increases the timeout for the check-status action with the assumption that this will help the workflow "schedule auto merge" to run successfully again. 

