### PR TITLE
Fix Connect Modal error strings

### DIFF
--- a/carbonmark/components/Layout/index.tsx
+++ b/carbonmark/components/Layout/index.tsx
@@ -6,7 +6,7 @@ import { BetaBadge } from "components/BetaBadge";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { CarbonmarkLogo } from "components/Logos/CarbonmarkLogo";
 import { InvalidNetworkModal } from "components/shared/InvalidNetworkModal";
-import { connectErrorStrings } from "lib/constants";
+import { getConnectErrorStrings } from "lib/constants";
 import Link from "next/link";
 import { FC, ReactNode, useState } from "react";
 import "tippy.js/dist/tippy.css";
@@ -72,7 +72,7 @@ export const Layout: FC<Props> = (props: Props) => {
       <InvalidNetworkModal />
       {renderModal &&
         renderModal({
-          errors: connectErrorStrings,
+          errors: getConnectErrorStrings(),
           torusText: t({
             message: "social or email",
             id: "connectModal.torus",

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -17,7 +17,7 @@ const ENVIRONMENT = IS_PRODUCTION
 export const MINIMUM_TONNE_PRICE = 0.1;
 export const CARBONMARK_FEE = 0.0; // 0%
 
-export const connectErrorStrings = {
+export const getConnectErrorStrings = () => ({
   default: t({
     message: "We had some trouble connecting. Please try again.",
     id: "connect_modal.error_message_default",
@@ -31,7 +31,7 @@ export const connectErrorStrings = {
       "Request already processing. Please open your wallet and complete the request.",
     id: "connect_modal.error_processing",
   }),
-};
+});
 
 export const NEXT_PUBLIC_MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
 


### PR DESCRIPTION
## Description

The strings haven't been shown at all. This is the fix.

## Related Ticket

None

## Changes

| Before  | After  |
|---------|--------|
| ![Bildschirmfoto 2023-05-03 um 17 13 29](https://user-images.githubusercontent.com/95881624/236200297-7b15e97f-b336-4c37-98ae-d42f6b3a59e2.png) | <img width="469" alt="Bildschirmfoto 2023-05-04 um 14 10 33" src="https://user-images.githubusercontent.com/95881624/236200177-56f98458-bc51-4afd-b7df-60e79a296441.png"> |



## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
