### PR TITLE
Fix: handle should fallback to "You" on connected user

### DIFF
--- a/carbonmark/components/Activities/Activities.constants.ts
+++ b/carbonmark/components/Activities/Activities.constants.ts
@@ -3,22 +3,10 @@ import { ActivityActionT } from "lib/types/carbonmark";
 
 export const getActivityActions = (): Record<ActivityActionT, string> =>
   ({
-    CreatedListing: t({
-      id: "activity.action.createdListing",
-      message: "created listing",
-    }),
-    DeletedListing: t({
-      id: "activity.action.deletedListing",
-      message: "deleted listing",
-    }),
-    Purchase: t({ id: "activity.action.purchase", message: "bought from" }),
-    Sold: t({ id: "activity.action.sold", message: "sold to" }),
-    UpdatedPrice: t({
-      id: "activity.action.updatedPrice",
-      message: "updated price",
-    }),
-    UpdatedQuantity: t({
-      id: "activity.action.updatedQuantity",
-      message: "updated quantity",
-    }),
+    CreatedListing: t`created listing`,
+    DeletedListing: t`deleted listing`,
+    Purchase: t`bought from`,
+    Sold: t`sold to`,
+    UpdatedPrice: t`updated price`,
+    UpdatedQuantity: t`updated quantity`,
   } as const);

--- a/carbonmark/components/Activities/Activity.tsx
+++ b/carbonmark/components/Activities/Activity.tsx
@@ -3,7 +3,7 @@ import { t } from "@lingui/macro";
 import { Text } from "components/Text";
 import { createProjectLink } from "lib/createUrls";
 import { formatBigToPrice, formatBigToTonnes } from "lib/formatNumbers";
-import { formatWalletAddress } from "lib/formatWalletAddress";
+import { formatHandle, formatWalletAddress } from "lib/formatWalletAddress";
 import { getElapsedTime } from "lib/getElapsedTime";
 import { ProjectActivity, UserActivity } from "lib/types/carbonmark";
 import Link from "next/link";
@@ -26,7 +26,7 @@ export const Activity = (props: Props) => {
   const { address: connectedAddress } = useWeb3();
   const { locale } = useRouter();
 
-  let addressA, addressB;
+  let firstActor, secondActor;
   let amountA, amountB;
   let transactionString = t`at`;
 
@@ -38,16 +38,13 @@ export const Activity = (props: Props) => {
   const seller = props.activity.seller;
   const buyer = props.activity.buyer;
 
-  const sellerID = "handle" in seller ? seller.handle : seller.id;
-  const buyerId = buyer && "handle" in buyer ? buyer.handle : buyer?.id;
-
   // type guard
   const project = isUserActivity(props.activity)
     ? props.activity.project
     : null;
 
   /** By default the seller is the "source" of all actions */
-  addressA = sellerID;
+  firstActor = seller;
 
   /** By default activities are buy or sell transactions */
   amountA =
@@ -59,13 +56,13 @@ export const Activity = (props: Props) => {
 
   /** Determine the order in which to display addresses based on the activity type */
   if (isPurchaseActivity) {
-    addressA = buyerId;
-    addressB = sellerID;
+    firstActor = buyer;
+    secondActor = seller;
   }
 
   if (isSaleActivity) {
-    addressA = sellerID;
-    addressB = buyerId;
+    firstActor = seller;
+    secondActor = buyer;
   }
 
   /** Price Labels */
@@ -111,23 +108,34 @@ export const Activity = (props: Props) => {
         </i>
       </Text>
       <Text t="body1">
-        {!!addressA && (
-          <Link className="account" href={`/users/${addressA}`}>
-            {addressA.length >= 11
-              ? formatWalletAddress(addressA, connectedAddress)
-              : addressA}{" "}
+        {!!firstActor && firstActor.handle ? (
+          <Link className="account" href={`/users/${firstActor.handle}`}>
+            {formatHandle(firstActor.id, firstActor.handle, connectedAddress)}{" "}
           </Link>
+        ) : (
+          !!firstActor &&
+          firstActor.id && (
+            <Link className="account" href={`/users/${firstActor.id}`}>
+              {formatWalletAddress(firstActor.id, connectedAddress)}{" "}
+            </Link>
+          )
         )}
 
         {getActivityActions()[props.activity.activityType]}
 
-        {addressB && (
-          <Link className="account" href={`/users/${addressB}`}>
+        {!!secondActor && secondActor.handle ? (
+          <Link className="account" href={`/users/${secondActor.handle}`}>
             {" "}
-            {addressB.length >= 11
-              ? formatWalletAddress(addressB, connectedAddress)
-              : addressB}
+            {formatHandle(secondActor.id, secondActor.handle, connectedAddress)}
           </Link>
+        ) : (
+          !!secondActor &&
+          secondActor.id && (
+            <Link className="account" href={`/users/${secondActor.id}`}>
+              {" "}
+              {formatWalletAddress(secondActor.id, connectedAddress)}{" "}
+            </Link>
+          )
         )}
       </Text>
       {!!amountA && !!amountB && (

--- a/carbonmark/components/Activities/Activity.tsx
+++ b/carbonmark/components/Activities/Activity.tsx
@@ -28,10 +28,7 @@ export const Activity = (props: Props) => {
 
   let addressA, addressB;
   let amountA, amountB;
-  let transactionString = t({
-    id: "props.transaction.conjunction.at",
-    message: "at",
-  });
+  let transactionString = t`at`;
 
   const isPurchaseActivity = props.activity.activityType === "Purchase";
   const isSaleActivity = props.activity.activityType === "Sold";
@@ -90,10 +87,7 @@ export const Activity = (props: Props) => {
 
   /** Determine the conjunction between the labels */
   if (isPurchaseActivity || isSaleActivity) {
-    transactionString = t({
-      id: "props.transaction.conjunction",
-      message: "for",
-    });
+    transactionString = t`for`;
   }
   if (isUpdatePrice || isUpdateQuantity) {
     transactionString = "->";

--- a/carbonmark/lib/formatWalletAddress.ts
+++ b/carbonmark/lib/formatWalletAddress.ts
@@ -12,6 +12,20 @@ export const formatWalletAddress = (
   return concatAddress(address);
 };
 
+export const formatHandle = (
+  address: string,
+  handle: string,
+  connectedAddress?: string
+) => {
+  if (isConnectedAddress(address, connectedAddress)) {
+    return t({ id: "activity.you", message: "You" });
+  }
+
+  if (handle.length >= 11) return concatAddress(handle);
+
+  return handle;
+};
+
 export const isConnectedAddress = (
   sellerID: string,
   connectedAddress?: string

--- a/carbonmark/lib/formatWalletAddress.ts
+++ b/carbonmark/lib/formatWalletAddress.ts
@@ -18,7 +18,7 @@ export const formatHandle = (
   connectedAddress?: string
 ) => {
   if (isConnectedAddress(address, connectedAddress)) {
-    return t({ id: "activity.you", message: "You" });
+    return t`You`;
   }
 
   if (handle.length >= 11) return concatAddress(handle);

--- a/carbonmark/lib/formatWalletAddress.ts
+++ b/carbonmark/lib/formatWalletAddress.ts
@@ -6,7 +6,7 @@ export const formatWalletAddress = (
   connectedAddress?: string
 ) => {
   if (isConnectedAddress(address, connectedAddress)) {
-    return t({ id: "activity.you", message: "You" });
+    return t`You`;
   }
 
   return concatAddress(address);

--- a/carbonmark/lib/types/carbonmark.ts
+++ b/carbonmark/lib/types/carbonmark.ts
@@ -123,11 +123,11 @@ export interface ProjectActivity {
   activityType: ActivityActionT;
   seller: {
     id: string;
-    handle: string;
+    handle?: string;
   };
   buyer: null | {
     id: string;
-    handle: string;
+    handle?: string;
   };
 }
 
@@ -170,12 +170,12 @@ export interface UserActivity {
     registry: string;
   };
   seller: {
-    // TODO: api needs to pass handle
     id: string;
+    handle?: string;
   };
   buyer: null | {
-    // TODO: api needs to pass handle
     id: string;
+    handle?: string;
   };
 }
 

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -631,6 +631,11 @@ msgstr ""
 msgid "Wrong Network"
 msgstr ""
 
+#: lib/formatWalletAddress.ts:9
+#: lib/formatWalletAddress.ts:21
+msgid "You"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:112
 msgid "You chose to reject the transaction."
 msgstr ""
@@ -656,32 +661,8 @@ msgstr ""
 msgid "Z-A"
 msgstr ""
 
-#: components/Activities/Activities.constants.ts:6
-msgid "activity.action.createdListing"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:10
-msgid "activity.action.deletedListing"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:14
-msgid "activity.action.purchase"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:15
-msgid "activity.action.sold"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:16
-msgid "activity.action.updatedPrice"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:20
-msgid "activity.action.updatedQuantity"
-msgstr ""
-
-#: lib/formatWalletAddress.ts:9
-msgid "activity.you"
+#: components/Activities/Activity.tsx:31
+msgid "at"
 msgstr ""
 
 #. Long sentence
@@ -691,6 +672,10 @@ msgstr ""
 
 #: components/pages/Blog/Post/index.tsx:90
 msgid "blog.disclaimer.title"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:8
+msgid "bought from"
 msgstr ""
 
 #: components/pages/Project/BuyOptions/SellerListing.tsx:110
@@ -753,6 +738,14 @@ msgstr ""
 msgid "create.submit_2"
 msgstr ""
 
+#: components/Activities/Activities.constants.ts:6
+msgid "created listing"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:7
+msgid "deleted listing"
+msgstr ""
+
 #: components/pages/Project/Purchase/index.tsx:246
 msgid "each"
 msgstr ""
@@ -783,6 +776,10 @@ msgstr ""
 
 #: components/ExitModal/index.tsx:16
 msgid "exitmodal.you_will_be_taken"
+msgstr ""
+
+#: components/Activities/Activity.tsx:87
+msgid "for"
 msgstr ""
 
 #: components/Layout/NavMenu/index.tsx:34
@@ -847,14 +844,6 @@ msgstr ""
 
 #: components/pages/Purchases/index.tsx:48
 msgid "project.single.button.back_to_project_details"
-msgstr ""
-
-#: components/Activities/Activity.tsx:93
-msgid "props.transaction.conjunction"
-msgstr ""
-
-#: components/Activities/Activity.tsx:31
-msgid "props.transaction.conjunction.at"
 msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:146
@@ -1148,6 +1137,10 @@ msgstr ""
 msgid "shared.resources.sort_by.header"
 msgstr ""
 
+#: components/Activities/Activities.constants.ts:9
+msgid "sold to"
+msgstr ""
+
 #: components/CreateListing/index.tsx:196
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:273
 msgid "tonnes.long"
@@ -1219,6 +1212,14 @@ msgstr ""
 
 #: components/Transaction/index.tsx:56
 msgid "transaction_modal.view.submit.title"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:10
+msgid "updated price"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:11
+msgid "updated quantity"
 msgstr ""
 
 #: components/Activities/index.tsx:29

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -637,6 +637,11 @@ msgstr "We haven't finished processing the blockchain data for this retirement. 
 msgid "Wrong Network"
 msgstr "Wrong Network"
 
+#: lib/formatWalletAddress.ts:9
+#: lib/formatWalletAddress.ts:21
+msgid "You"
+msgstr "You"
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:112
 msgid "You chose to reject the transaction."
 msgstr "You chose to reject the transaction."
@@ -662,33 +667,9 @@ msgstr "Your unique handle"
 msgid "Z-A"
 msgstr "Z-A"
 
-#: components/Activities/Activities.constants.ts:6
-msgid "activity.action.createdListing"
-msgstr "created listing"
-
-#: components/Activities/Activities.constants.ts:10
-msgid "activity.action.deletedListing"
-msgstr "deleted listing"
-
-#: components/Activities/Activities.constants.ts:14
-msgid "activity.action.purchase"
-msgstr "bought from"
-
-#: components/Activities/Activities.constants.ts:15
-msgid "activity.action.sold"
-msgstr "sold to"
-
-#: components/Activities/Activities.constants.ts:16
-msgid "activity.action.updatedPrice"
-msgstr "updated price"
-
-#: components/Activities/Activities.constants.ts:20
-msgid "activity.action.updatedQuantity"
-msgstr "updated quantity"
-
-#: lib/formatWalletAddress.ts:9
-msgid "activity.you"
-msgstr "You"
+#: components/Activities/Activity.tsx:31
+msgid "at"
+msgstr "at"
 
 #. Long sentence
 #: components/pages/Blog/Post/index.tsx:93
@@ -698,6 +679,10 @@ msgstr "The information provided in this blog post pertaining to KlimaDAO (“Kl
 #: components/pages/Blog/Post/index.tsx:90
 msgid "blog.disclaimer.title"
 msgstr "Disclaimer:"
+
+#: components/Activities/Activities.constants.ts:8
+msgid "bought from"
+msgstr "bought from"
 
 #: components/pages/Project/BuyOptions/SellerListing.tsx:110
 msgid "buy"
@@ -759,6 +744,14 @@ msgstr "The previous step granted the approval to transfer this asset from your 
 msgid "create.submit_2"
 msgstr "To finalize the transfer of this asset to Carbonmark and make your listing live, verify all information is correct and then click submit below."
 
+#: components/Activities/Activities.constants.ts:6
+msgid "created listing"
+msgstr "created listing"
+
+#: components/Activities/Activities.constants.ts:7
+msgid "deleted listing"
+msgstr "deleted listing"
+
 #: components/pages/Project/Purchase/index.tsx:246
 msgid "each"
 msgstr "each"
@@ -790,6 +783,10 @@ msgstr "Carbon credits you purchase or any retirements you make on KlimaDAO.fina
 #: components/ExitModal/index.tsx:16
 msgid "exitmodal.you_will_be_taken"
 msgstr "You will be taken to KlimaDAO.finance to complete this transaction."
+
+#: components/Activities/Activity.tsx:87
+msgid "for"
+msgstr "for"
 
 #: components/Layout/NavMenu/index.tsx:34
 msgid "menu.marketplace"
@@ -854,14 +851,6 @@ msgstr "Create a Listing"
 #: components/pages/Purchases/index.tsx:48
 msgid "project.single.button.back_to_project_details"
 msgstr "Back to Project Details"
-
-#: components/Activities/Activity.tsx:93
-msgid "props.transaction.conjunction"
-msgstr "for"
-
-#: components/Activities/Activity.tsx:31
-msgid "props.transaction.conjunction.at"
-msgstr "at"
 
 #: components/pages/Project/Purchase/index.tsx:146
 msgid "purchase.approval_1"
@@ -1154,6 +1143,10 @@ msgstr "Resource Center"
 msgid "shared.resources.sort_by.header"
 msgstr "Sort by:"
 
+#: components/Activities/Activities.constants.ts:9
+msgid "sold to"
+msgstr "sold to"
+
 #: components/CreateListing/index.tsx:196
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:273
 msgid "tonnes.long"
@@ -1226,6 +1219,14 @@ msgstr "1. Approve"
 #: components/Transaction/index.tsx:56
 msgid "transaction_modal.view.submit.title"
 msgstr "2. Submit"
+
+#: components/Activities/Activities.constants.ts:10
+msgid "updated price"
+msgstr "updated price"
+
+#: components/Activities/Activities.constants.ts:11
+msgid "updated quantity"
+msgstr "updated quantity"
 
 #: components/Activities/index.tsx:29
 msgid "user.activities.empty_state"


### PR DESCRIPTION
## Description

Backend sends down the handle for seller and buyer on the activity data.
These handles are shortened if the length is more than 11 characters.

However, if the current connected user is included in the activity data => "You" should be shown and not the user´s handle.
Same as for the wallet addresses.


## Related Ticket
None
## Changes

| Before  | After  |
|---------|--------|
| <img width="484" alt="Bildschirmfoto 2023-05-04 um 15 11 59" src="https://user-images.githubusercontent.com/95881624/236218196-06c1de78-f15a-45b7-82e6-ba2783db5b15.png"> | <img width="537" alt="Bildschirmfoto 2023-05-04 um 15 12 28" src="https://user-images.githubusercontent.com/95881624/236218246-4a3b3f29-72ba-4560-b9ba-7398b5895166.png"> |



## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
