### PR TITLE
Profile Image can be null

### DIFF
--- a/carbonmark/components/pages/Users/ProfileLogo/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileLogo/index.tsx
@@ -5,7 +5,7 @@ import * as styles from "./styles";
 
 type Props = {
   isCarbonmarkUser: boolean;
-  profileImgUrl?: string;
+  profileImgUrl?: string | null;
   className?: string;
   hasBorder?: boolean;
 };
@@ -23,7 +23,7 @@ export const ProfileLogo: FC<Props> = (props) => {
     >
       {props.isCarbonmarkUser && hasValidImageUrl ? (
         <img
-          src={props.profileImgUrl}
+          src={props.profileImgUrl || ""}
           onError={({ currentTarget }) => {
             currentTarget.onerror = null; // prevents looping
             setHasValidImageUrl(false);

--- a/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
@@ -14,12 +14,7 @@ import { ProfileLogo } from "../../ProfileLogo";
 import * as styles from "./styles";
 
 type Props = {
-  user: {
-    handle?: string;
-    username?: string;
-    description?: string;
-    profileImgUrl?: string;
-  } | null;
+  user: User | null;
   onSubmit: (data: User) => void;
   isCarbonmarkUser: boolean;
 };

--- a/carbonmark/lib/types/carbonmark.ts
+++ b/carbonmark/lib/types/carbonmark.ts
@@ -42,7 +42,7 @@ export interface User {
   handle: string;
   username: string;
   description: string;
-  profileImgUrl?: string;
+  profileImgUrl: string | null;
   wallet: string;
   listings: ListingWithProject[];
   activities: UserActivity[];


### PR DESCRIPTION
## Description

See the discussion in this backend ticket https://github.com/KlimaDAO/klimadao/issues/1098

When a user sets the profile image URL to an empty string =?> backend will send down "null"


## Related Ticket

None

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
