### PR TITLE
Add link field to methodology type in carbon-projects CMS

### DIFF
--- a/carbon-projects/schemas/methodology.ts
+++ b/carbon-projects/schemas/methodology.ts
@@ -51,5 +51,12 @@ export default defineType({
       },
       validation: (r) => r.required(),
     }),
+    defineField({
+      name: "link",
+      type: "string",
+      description: "Link to the authoritative methodology webpage or PDF document",
+      placeholder: "https://cdm.unfccc.int/methodologies/DB/5SI1IXDIZBL6OAKIB3JFUFAQ86MBEE",
+      validation: (r) => r.required(),
+    }),
   ],
 });


### PR DESCRIPTION
## Description

Adding this link field so we can have a click-through on the tooltip for a project's methodology

This allows the user to learn more about the underlying methodology used by a project without having to dig around on the registry website

Subsequent work is required to surface this link field in the API, and integrate it into the user interface as a link on the tooltip for each project page and the project cards on the search page
