### PR TITLE
Connected buttons to new retirement flow and loading spinner

### DIFF
--- a/carbonmark/components/pages/Portfolio/AssetProject/index.tsx
+++ b/carbonmark/components/pages/Portfolio/AssetProject/index.tsx
@@ -1,20 +1,19 @@
-import { t, Trans } from "@lingui/macro";
+import { Trans } from "@lingui/macro";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { CarbonmarkButton } from "components/CarbonmarkButton";
 import { Card } from "components/Card";
 import { Category } from "components/Category";
-import { ExitModal } from "components/ExitModal";
 import { ProjectImage } from "components/ProjectImage";
 import { ProjectKey } from "components/ProjectKey";
 import { Text } from "components/Text";
 import { Vintage } from "components/Vintage";
-import { createProjectLink, createRetireLink } from "lib/createUrls";
+import { createProjectLink } from "lib/createUrls";
 import { formatToTonnes } from "lib/formatNumbers";
 import { LO } from "lib/luckyOrange";
 import { AssetForListing } from "lib/types/carbonmark";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { FC, useState } from "react";
+import { FC } from "react";
 import * as styles from "./styles";
 
 interface Props {
@@ -24,11 +23,6 @@ interface Props {
 
 export const AssetProject: FC<Props> = (props) => {
   const { locale } = useRouter();
-  const retireLink = createRetireLink({
-    retirementToken: props.asset.tokenAddress,
-  });
-
-  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <Card>
@@ -63,21 +57,17 @@ export const AssetProject: FC<Props> = (props) => {
         <Trans>Quantity Available:</Trans>{" "}
         {formatToTonnes(props.asset.balance, locale)}
       </Text>
+
       <div className={styles.buttons}>
-        <ButtonPrimary
-          label={<Trans>Retire</Trans>}
-          onClick={() => {
-            LO.track("Retire: Retire Button Clicked");
-            setIsOpen(true);
-          }}
-        />
+        <Link href={`/portfolio/${props.asset.tokenAddress}/retire`}>
+          <ButtonPrimary
+            label={<Trans>Retire</Trans>}
+            onClick={() => {
+              LO.track("Retire: Retire Button Clicked");
+            }}
+          />
+        </Link>
         <CarbonmarkButton label={<Trans>Sell</Trans>} onClick={props.onSell} />
-        <ExitModal
-          showModal={isOpen}
-          title={t`Leaving Carbonmark`}
-          retireLink={retireLink}
-          onToggleModal={() => setIsOpen(false)}
-        />
       </div>
     </Card>
   );

--- a/carbonmark/components/pages/Portfolio/AssetProject/index.tsx
+++ b/carbonmark/components/pages/Portfolio/AssetProject/index.tsx
@@ -59,14 +59,14 @@ export const AssetProject: FC<Props> = (props) => {
       </Text>
 
       <div className={styles.buttons}>
-        <Link href={`/portfolio/${props.asset.tokenAddress}/retire`}>
-          <ButtonPrimary
-            label={<Trans>Retire</Trans>}
-            onClick={() => {
-              LO.track("Retire: Retire Button Clicked");
-            }}
-          />
-        </Link>
+        <ButtonPrimary
+          label={<Trans>Retire</Trans>}
+          href={`/portfolio/${props.asset.tokenAddress}/retire`}
+          renderLink={(linkProps) => <Link {...linkProps} />}
+          onClick={() => {
+            LO.track("Retire: Retire Button Clicked");
+          }}
+        />
         <CarbonmarkButton label={<Trans>Sell</Trans>} onClick={props.onSell} />
       </div>
     </Card>

--- a/carbonmark/components/pages/Portfolio/index.tsx
+++ b/carbonmark/components/pages/Portfolio/index.tsx
@@ -4,6 +4,7 @@ import { Layout } from "components/Layout";
 import { LoginButton } from "components/LoginButton";
 import { LoginCard } from "components/LoginCard";
 import { PageHead } from "components/PageHead";
+import { Spinner } from "components/shared/Spinner";
 import { Text } from "components/Text";
 import { Col, TwoColLayout } from "components/TwoColLayout";
 import { useFetchUser } from "hooks/useFetchUser";
@@ -16,7 +17,7 @@ import { PortfolioSidebar } from "./PortfolioSidebar";
 import * as styles from "./styles";
 
 export const Portfolio: NextPage = () => {
-  const { isConnected, address, toggleModal } = useWeb3();
+  const { isConnected, address, toggleModal, initializing } = useWeb3();
   const { carbonmarkUser, isLoading, mutate } = useFetchUser(address);
   const [isPending, setIsPending] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
@@ -74,8 +75,13 @@ export const Portfolio: NextPage = () => {
           </div>
           <TwoColLayout>
             <Col>
-              {!isConnectedUser && (
+              {!isConnectedUser && !initializing && (
                 <LoginCard isLoading={isLoading} onLogin={toggleModal} />
+              )}
+              {!isConnectedUser && initializing && (
+                <div className={styles.spinnerContainer}>
+                  <Spinner />
+                </div>
               )}
 
               {errorMessage && (

--- a/carbonmark/components/pages/Portfolio/styles.ts
+++ b/carbonmark/components/pages/Portfolio/styles.ts
@@ -28,3 +28,10 @@ export const loadingOverlay = css`
   pointer-events: none;
   opacity: 0.5;
 `;
+
+export const spinnerContainer = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;

--- a/carbonmark/components/pages/Retire/CustomizableModal/index.tsx
+++ b/carbonmark/components/pages/Retire/CustomizableModal/index.tsx
@@ -41,6 +41,13 @@ export const CustomizableModal: FC<CustomizableModalProps> = ({
 
   if (!props.showModal) return null;
 
+  const TitleComponent =
+    typeof props.title === "string" ? (
+      <Text t="h4">{props.title}</Text>
+    ) : (
+      props.title
+    );
+
   return (
     <div aria-modal={true} className={props.className}>
       <div className={styles.modalBackground} onClick={handleBackgroundClick} />
@@ -53,7 +60,7 @@ export const CustomizableModal: FC<CustomizableModalProps> = ({
           ref={focusTrapRef}
         >
           <div className="title">
-            <Text t="h4">{props.title}</Text>
+            {TitleComponent}
 
             {showCloseButton && (
               <button onClick={props.onToggleModal}>

--- a/carbonmark/components/pages/Retire/CustomizableModal/index.tsx
+++ b/carbonmark/components/pages/Retire/CustomizableModal/index.tsx
@@ -9,6 +9,7 @@ export type CustomizableModalProps = {
   showModal: boolean;
   closeOnBackgroundClick?: boolean;
   title: ReactNode;
+  overflowY?: string;
   width?: string;
   maxWidth?: string;
   height?: string;
@@ -22,6 +23,7 @@ export const CustomizableModal: FC<CustomizableModalProps> = ({
   maxWidth = "55rem",
   height = "fit-content",
   maxHeight = "calc(100vh - 10rem)",
+  overflowY = "auto",
   ...props
 }) => {
   const showCloseButton = !!props.onToggleModal;
@@ -55,7 +57,7 @@ export const CustomizableModal: FC<CustomizableModalProps> = ({
         <div
           className={cx(
             "modalContent",
-            styles.modalContent(width, maxWidth, height, maxHeight)
+            styles.modalContent(width, maxWidth, height, maxHeight, overflowY)
           )}
           ref={focusTrapRef}
         >

--- a/carbonmark/components/pages/Retire/CustomizableModal/styles.ts
+++ b/carbonmark/components/pages/Retire/CustomizableModal/styles.ts
@@ -30,13 +30,14 @@ export const modalContent = (
   width: string,
   maxWidth: string,
   height: string,
-  maxHeight: string
+  maxHeight: string,
+  overflowY: string
 ) => css`
   ${width >= maxWidth ? "" : `width: ${width};`};
   max-width: ${maxWidth};
   height: ${height};
   max-height: ${maxHeight};
-  overflow-y: auto;
+  overflow-y: ${overflowY};
   border-radius: 1.2rem;
   background-color: var(--surface-01);
   pointer-events: fill;

--- a/carbonmark/components/pages/Retire/RetireForm/index.tsx
+++ b/carbonmark/components/pages/Retire/RetireForm/index.tsx
@@ -419,6 +419,8 @@ export const RetireForm = (props: RetireFormProps) => {
           }/${retirementTotals}`}
           polygonScanUrl={`${urls.polygonscan}/tx/${retirementTransactionHash}`}
           showModal={!!retirementTransactionHash}
+          user={props.address}
+          retirementIndex={retirementTotals}
         />
       )}
     </div>

--- a/carbonmark/components/pages/Retire/RetireModal/index.tsx
+++ b/carbonmark/components/pages/Retire/RetireModal/index.tsx
@@ -102,7 +102,7 @@ export const RetireModal: FC<Props> = (props) => {
           props.title
         )
       }
-      overflowY="hidden"
+      overflowY={processingRetirement ? "hidden" : "auto"}
       maxWidth={processingRetirement ? "43rem" : "50rem"}
       height={processingRetirement ? "26rem" : "fit-content"}
       maxHeight="calc(100vh - 8rem)"

--- a/carbonmark/components/pages/Retire/RetireModal/index.tsx
+++ b/carbonmark/components/pages/Retire/RetireModal/index.tsx
@@ -102,6 +102,7 @@ export const RetireModal: FC<Props> = (props) => {
           props.title
         )
       }
+      overflowY="hidden"
       maxWidth={processingRetirement ? "43rem" : "50rem"}
       height={processingRetirement ? "26rem" : "fit-content"}
       maxHeight="calc(100vh - 8rem)"

--- a/carbonmark/components/pages/Retire/RetirementStatusModal/index.tsx
+++ b/carbonmark/components/pages/Retire/RetirementStatusModal/index.tsx
@@ -35,19 +35,20 @@ export const RetirementStatusModal: FC<Props> = (props) => (
           <Link href={props.polygonScanUrl}>PolygonScan.</Link>
         </Trans>
       </Text>
-      <Link href={`/retirements/${props.user}/${props.retirementIndex}`}>
-        <CarbonmarkButton
-          className={styles.viewButton}
-          target="_blank"
-          label={<Trans>View and share certificate</Trans>}
-        />
-      </Link>
-      <Link href={"/portfolio"}>
-        <CarbonmarkButton
-          className={styles.fullWidthButton}
-          label={<Trans>Retire more carbon</Trans>}
-        />
-      </Link>
+      <CarbonmarkButton
+        className={styles.viewButton}
+        href={`/retirements/${props.user}/${props.retirementIndex}`}
+        renderLink={(linkProps) => <Link {...linkProps} />}
+        target="_blank"
+        label={<Trans>View and share certificate</Trans>}
+      />
+
+      <CarbonmarkButton
+        className={styles.fullWidthButton}
+        href={"/portfolio"}
+        renderLink={(linkProps) => <Link {...linkProps} />}
+        label={<Trans>Retire more carbon</Trans>}
+      />
     </div>
   </Modal>
 );

--- a/carbonmark/components/pages/Retire/RetirementStatusModal/index.tsx
+++ b/carbonmark/components/pages/Retire/RetirementStatusModal/index.tsx
@@ -11,6 +11,8 @@ type Props = {
   polygonScanUrl: string;
   retirementUrl: string;
   showModal: boolean;
+  user: string;
+  retirementIndex: number;
 };
 
 export const RetirementStatusModal: FC<Props> = (props) => (
@@ -33,17 +35,19 @@ export const RetirementStatusModal: FC<Props> = (props) => (
           <Link href={props.polygonScanUrl}>PolygonScan.</Link>
         </Trans>
       </Text>
-
-      <CarbonmarkButton
-        href={props.retirementUrl}
-        className={styles.viewButton}
-        target="_blank"
-        label={<Trans>View and share certificate</Trans>}
-      />
-      <CarbonmarkButton
-        href={"/portfolio"}
-        label={<Trans>Retire more carbon</Trans>}
-      />
+      <Link href={`/retirements/${props.user}/${props.retirementIndex}`}>
+        <CarbonmarkButton
+          className={styles.viewButton}
+          target="_blank"
+          label={<Trans>View and share certificate</Trans>}
+        />
+      </Link>
+      <Link href={"/portfolio"}>
+        <CarbonmarkButton
+          className={styles.fullWidthButton}
+          label={<Trans>Retire more carbon</Trans>}
+        />
+      </Link>
     </div>
   </Modal>
 );

--- a/carbonmark/components/pages/Retire/RetirementStatusModal/styles.tsx
+++ b/carbonmark/components/pages/Retire/RetirementStatusModal/styles.tsx
@@ -20,3 +20,7 @@ export const viewButton = css`
   width: 100%;
   margin-top: 1.6rem;
 `;
+
+export const fullWidthButton = css`
+  width: 100%;
+`;

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -25,10 +25,8 @@ export type RetirePageProps = {
 export const Retire: NextPage<RetirePageProps> = (props) => {
   const { isConnected, address, toggleModal, provider } = useWeb3();
   const { carbonmarkUser, isLoading } = useFetchUser(address);
-  const [loadingTriggered, setLoadingTriggered] = useState(false);
   const [retirementAsset, setRetirementAsset] =
     useState<AssetForRetirement | null>(null);
-
   const isConnectedUser = isConnected && address;
 
   const isCarbonmarkUser = isConnectedUser && !isLoading && !!carbonmarkUser;
@@ -38,19 +36,13 @@ export const Retire: NextPage<RetirePageProps> = (props) => {
   const router = useRouter();
 
   useEffect(() => {
-    if (isLoading) {
-      setLoadingTriggered(true);
-    }
-  }, [isLoading]);
-
-  useEffect(() => {
-    if (!isConnected && !isLoading && loadingTriggered) {
+    if (!isConnected && !isLoading) {
       router.push("/portfolio");
     }
-  }, [isConnected, isLoading, loadingTriggered]);
+  }, [isConnected, isLoading]);
 
   useEffect(() => {
-    if (isConnected && !isLoading && loadingTriggered && carbonmarkUser) {
+    if (isConnected && !isLoading && carbonmarkUser) {
       function createRetirementAsset() {
         // unlikely, but this allows for duplicate projects
         const targetProject = Array.isArray(props.project)
@@ -75,7 +67,7 @@ export const Retire: NextPage<RetirePageProps> = (props) => {
       }
       createRetirementAsset();
     }
-  }, [isConnected, isLoading, loadingTriggered, carbonmarkUser]);
+  }, [isConnected, isLoading, carbonmarkUser]);
 
   return (
     <>
@@ -84,13 +76,11 @@ export const Retire: NextPage<RetirePageProps> = (props) => {
         mediaTitle={t`Retire | Carbonmark`}
         metaDescription={t`View a complete overview of the digital carbon that you own in your Retire. `}
       />
-
       <Layout>
         <div className={styles.container}>
           <div className={styles.portfolioControls}>
             <LoginButton />
           </div>
-
           {!isConnectedUser && (
             <LoginCard isLoading={isLoading} onLogin={toggleModal} />
           )}


### PR DESCRIPTION
## Description

Wired up buttons to new retirement flow and used next/link where previously omitted.

Fixed a `<p>` nesting error in the CustomizableModal to allow for formatted titles w/o nesting error

Included a spinner for while web3 is initializing. With the new wire-ups and using Link it was difficult to find a case where this spinner actually showed.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1174 

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
