### PR TITLE
Retire default of specific from pool

### DIFF
--- a/carbonmark/components/pages/Project/Retire/AssetDetails.tsx
+++ b/carbonmark/components/pages/Project/Retire/AssetDetails.tsx
@@ -52,7 +52,7 @@ export const AssetDetails: FC<TotalValuesProps> = (props) => {
       <div className={styles.totalsText}>
         <Anchor
           className={styles.iconAndText}
-          href={`https://polygonscan.com/address/${props.project.projectAddress}`}
+          href={`https://polygonscan.com/address/${props.price.poolTokenAddress}`}
         >
           <Text className={styles.externalLink} t="body2">
             {t`View on PolygonScan`} <LaunchIcon />

--- a/carbonmark/components/pages/Project/Retire/RetireForm.tsx
+++ b/carbonmark/components/pages/Project/Retire/RetireForm.tsx
@@ -163,8 +163,9 @@ export const RetireForm: FC<Props> = (props) => {
       const receipt = await retireCarbonTransaction({
         provider,
         address,
-        projectAddress: props.project.projectAddress,
+        projectAddress: props.price.poolTokenAddress,
         paymentMethod: inputValues.paymentMethod,
+        isPoolDefault: props.price.isPoolDefault,
         maxAmountIn: getApprovalValue(),
         retirementToken: props.price.name.toLowerCase() as PoolToken,
         quantity: inputValues.quantity,

--- a/carbonmark/components/pages/Project/Retire/RetireForm.tsx
+++ b/carbonmark/components/pages/Project/Retire/RetireForm.tsx
@@ -216,14 +216,7 @@ export const RetireForm: FC<Props> = (props) => {
           </Card>
           <div className={styles.reverseOrder}>
             <Card>
-              <TotalValues
-                singleUnitPrice={props.price.singleUnitPrice}
-                balance={balance}
-                pool={
-                  props.price.name.toLowerCase() as Lowercase<PriceType["name"]>
-                }
-                projectAddress={props.project.projectAddress}
-              />
+              <TotalValues price={props.price} balance={balance} />
             </Card>
           </div>
           <SubmitButton

--- a/carbonmark/components/pages/Project/Retire/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/TotalValues.tsx
@@ -8,7 +8,6 @@ import { getConsumptionCost, getFeeFactor } from "lib/actions.retire";
 import { AGGREGATOR_FEE, CARBONMARK_FEE, SUSHI_SWAP_FEE } from "lib/constants";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
-import { isDefaultProjectAddress } from "lib/getPoolData";
 import { Price } from "lib/types/carbonmark";
 import Image from "next/legacy/image";
 import { useRouter } from "next/router";
@@ -33,6 +32,8 @@ const getSwapFee = (costs: number, pool: Lowercase<Price["name"]>) => {
 
 export const TotalValues: FC<TotalValuesProps> = (props) => {
   const poolName = props.price.name.toLowerCase() as Lowercase<Price["name"]>;
+  const isPoolDefault = props.price.isPoolDefault;
+
   const { locale } = useRouter();
   const { formState, control, setValue } = useFormContext<FormValues>();
   const [isLoading, setIsLoading] = useState(false);
@@ -73,7 +74,7 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
           inputToken: paymentMethod,
           retirementToken: poolName,
           quantity: amount,
-          isDefaultProject: isDefaultProjectAddress(props.projectAddress),
+          isDefaultProject: isPoolDefault,
         });
 
         setCosts(totalPrice);

--- a/carbonmark/components/pages/Project/Retire/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/TotalValues.tsx
@@ -45,9 +45,12 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
   const amount = useWatch({ name: "quantity", control });
   const paymentMethod = useWatch({ name: "paymentMethod", control });
 
-  const redemptionFee = Number(costs || 0) * feesFactor;
-  const aggregatorFee = Number(amount || 0) * AGGREGATOR_FEE;
-  const swapFee = getSwapFee(Number(costs || 0), props.pool);
+  const redemptionFee =
+    (!isPoolDefault && Number(costs || 0) * feesFactor) || 0;
+  const aggregatorFee =
+    (!isPoolDefault && Number(amount || 0) * AGGREGATOR_FEE) || 0;
+  const swapFee =
+    (!isPoolDefault && getSwapFee(Number(costs || 0), poolName)) || 0;
   const networkFees = redemptionFee + aggregatorFee + swapFee;
 
   useEffect(() => {
@@ -161,15 +164,21 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
             <Text t="h5">
               {isLoading ? t`Loading` : trimWithLocale(networkFees, 5, locale)}
             </Text>
-            <Text
-              t="body3"
-              color="lighter"
-              onClick={() => setIsToggled((prev) => !prev)}
-              className={styles.toggleFees}
-            >
-              {isToggled ? t`Hide Details` : t`Show Details`}
-              {isToggled ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-            </Text>
+            {!isPoolDefault && (
+              <Text
+                t="body3"
+                color="lighter"
+                onClick={() => setIsToggled((prev) => !prev)}
+                className={styles.toggleFees}
+              >
+                {isToggled ? t`Hide Details` : t`Show Details`}
+                {isToggled ? (
+                  <KeyboardArrowUpIcon />
+                ) : (
+                  <KeyboardArrowDownIcon />
+                )}
+              </Text>
+            )}
           </div>
         </div>
         {isToggled && (

--- a/carbonmark/components/pages/Project/Retire/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/TotalValues.tsx
@@ -18,10 +18,8 @@ import * as styles from "./styles";
 import { FormValues } from "./types";
 
 type TotalValuesProps = {
-  singleUnitPrice: Price["singleUnitPrice"];
+  price: Price;
   balance: string | null;
-  pool: Lowercase<Price["name"]>;
-  projectAddress: string;
 };
 
 const getSwapFee = (costs: number, pool: Lowercase<Price["name"]>) => {
@@ -34,6 +32,7 @@ const getSwapFee = (costs: number, pool: Lowercase<Price["name"]>) => {
 };
 
 export const TotalValues: FC<TotalValuesProps> = (props) => {
+  const poolName = props.price.name.toLowerCase() as Lowercase<Price["name"]>;
   const { locale } = useRouter();
   const { formState, control, setValue } = useFormContext<FormValues>();
   const [isLoading, setIsLoading] = useState(false);
@@ -52,7 +51,7 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
 
   useEffect(() => {
     const selectiveFee = async () => {
-      const factor = await getFeeFactor(props.pool);
+      const factor = await getFeeFactor(poolName);
       setFeesFactor(factor);
     };
     selectiveFee();
@@ -72,7 +71,7 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
         setIsLoading(true);
         const totalPrice = await getConsumptionCost({
           inputToken: paymentMethod,
-          retirementToken: props.pool,
+          retirementToken: poolName,
           quantity: amount,
           isDefaultProject: isDefaultProjectAddress(props.projectAddress),
         });
@@ -124,7 +123,7 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
             />
           </div>
           <Text t="h5">
-            {formatToPrice(props.singleUnitPrice, locale, false)}
+            {formatToPrice(props.price.singleUnitPrice, locale, false)}
           </Text>
         </div>
       </div>
@@ -242,7 +241,7 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
               </div>
               <div className={styles.feeText}>
                 <Text t="body2">
-                  {props.pool.toUpperCase()} {t`redemption Fee`}
+                  {props.price.name} {t`redemption Fee`}
                 </Text>
                 <Text t="body2">
                   {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}

--- a/carbonmark/components/pages/Project/Retire/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/TotalValues.tsx
@@ -53,6 +53,12 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
 
   useEffect(() => {
     const selectiveFee = async () => {
+      // No fees for default retirement
+      if (isPoolDefault) {
+        setFeesFactor(0);
+        return;
+      }
+
       const factor = await getFeeFactor(poolName);
       setFeesFactor(factor);
     };

--- a/carbonmark/components/pages/Project/Retire/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/TotalValues.tsx
@@ -47,10 +47,8 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
 
   const redemptionFee =
     (!isPoolDefault && Number(costs || 0) * feesFactor) || 0;
-  const aggregatorFee =
-    (!isPoolDefault && Number(amount || 0) * AGGREGATOR_FEE) || 0;
-  const swapFee =
-    (!isPoolDefault && getSwapFee(Number(costs || 0), poolName)) || 0;
+  const aggregatorFee = Number(amount || 0) * AGGREGATOR_FEE;
+  const swapFee = getSwapFee(Number(costs || 0), poolName);
   const networkFees = redemptionFee + aggregatorFee + swapFee;
 
   useEffect(() => {

--- a/carbonmark/components/pages/Project/Retire/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/TotalValues.tsx
@@ -168,21 +168,16 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
             <Text t="h5">
               {isLoading ? t`Loading` : trimWithLocale(networkFees, 5, locale)}
             </Text>
-            {!isPoolDefault && (
-              <Text
-                t="body3"
-                color="lighter"
-                onClick={() => setIsToggled((prev) => !prev)}
-                className={styles.toggleFees}
-              >
-                {isToggled ? t`Hide Details` : t`Show Details`}
-                {isToggled ? (
-                  <KeyboardArrowUpIcon />
-                ) : (
-                  <KeyboardArrowDownIcon />
-                )}
-              </Text>
-            )}
+
+            <Text
+              t="body3"
+              color="lighter"
+              onClick={() => setIsToggled((prev) => !prev)}
+              className={styles.toggleFees}
+            >
+              {isToggled ? t`Hide Details` : t`Show Details`}
+              {isToggled ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+            </Text>
           </div>
         </div>
         {isToggled && (

--- a/carbonmark/lib/actions.retire.ts
+++ b/carbonmark/lib/actions.retire.ts
@@ -6,7 +6,6 @@ import { PoolToken } from "@klimadao/lib/constants";
 import { RetirementReceipt } from "@klimadao/lib/types/offset";
 import { formatUnits, getTokenDecimals } from "@klimadao/lib/utils";
 import { BigNumber, Contract, providers, utils } from "ethers";
-import { isDefaultProjectAddress } from "lib/getPoolData";
 import { getAddress } from "lib/networkAware/getAddress";
 import { getAllowance } from "lib/networkAware/getAllowance";
 import { getContract } from "lib/networkAware/getContract";
@@ -115,6 +114,7 @@ export const retireCarbonTransaction = async (params: {
   retirementMessage: string;
   onStatus: OnStatusHandler;
   projectAddress: string;
+  isPoolDefault: boolean;
 }): Promise<{ transactionHash: string; retirementIndex: number }> => {
   if (params.paymentMethod === "fiat") {
     throw Error("Unsupported payment method");
@@ -148,7 +148,7 @@ export const retireCarbonTransaction = async (params: {
     const retirementIndex = (retirements.toNumber() || 0) + 1;
 
     let txn;
-    if (isDefaultProjectAddress(params.projectAddress)) {
+    if (params.isPoolDefault) {
       txn = await retireContract.retireExactCarbonDefault(
         getAddress(params.paymentMethod),
         getAddress(params.retirementToken),

--- a/carbonmark/lib/getPoolData.ts
+++ b/carbonmark/lib/getPoolData.ts
@@ -5,14 +5,3 @@ export const isPoolToken = (str: string): str is PoolToken =>
 
 export const getPoolTokenType = (pool: Uppercase<PoolToken>): CarbonToken =>
   pool === "BCT" || pool === "NCT" ? "tco2" : "c3t";
-
-// tmp workaround until https://github.com/KlimaDAO/klimadao/issues/1160
-const knownDefaultProjects = [
-  "0xb139c4cc9d20a3618e9a2268d73eff18c496b991", // bct
-  "0x6362364a37f34d39a1f4993fb595dab4116daf0d", // nct
-  "0xd6ed6fae5b6535cae8d92f40f5ff653db807a4ea", // ubo
-  "0xb6ea7a53fc048d6d3b80b968d696e39482b7e578", // nbo
-].map((addr) => addr.toLowerCase());
-
-export const isDefaultProjectAddress = (projectAddress: string): boolean =>
-  knownDefaultProjects.includes(projectAddress.toLowerCase());

--- a/carbonmark/lib/types/carbonmark.ts
+++ b/carbonmark/lib/types/carbonmark.ts
@@ -80,10 +80,12 @@ export interface PcbProject {
 }
 
 export type Price = {
-  leftToSell: string; // NOT A BIGNUMBER ! Already formatted!
+  name: Uppercase<PoolToken>;
+  poolTokenAddress: string;
+  isPoolDefault: boolean;
   tokenAddress: string;
   singleUnitPrice: string; // NOT A BIGNUMBER ! Already formatted in USDCs
-  name: Uppercase<PoolToken>;
+  leftToSell: string; // NOT A BIGNUMBER ! Already formatted!
 };
 
 export interface User {


### PR DESCRIPTION
## Description

This PR updates the price types according to the updated API schema mentioned in this ticket: https://github.com/KlimaDAO/klimadao/issues/1160

Now, a retirement from a project's pool calculates and shows the total costs correctly.
If a pool token is the default project of a pool => Retire needs only the SushiSwap fee and 0,1% Aggregator fee

### For example two pools for the same project:
**NBO (default => less fees)** 
https://carbonmark-git-lady-prices-schema-klimadao.vercel.app/projects/VCS-981-2014/retire/pools/nbo

**NCT (calculate all fees)** 
https://carbonmark-git-lady-prices-schema-klimadao.vercel.app/projects/VCS-981-2014/retire/pools/nct

See here the **API response** for this project:
https://api.carbonmark.com/api/projects/VCS-981-2014
=> the prices array shows the pools which are rendered in the pages above

### Follow-up
Ticket https://github.com/KlimaDAO/klimadao/issues/1189
=> make pool retirement pages accessible

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1160
Part of https://github.com/KlimaDAO/klimadao/issues/1189

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
