### PR TITLE
0xMakka - update links to carbonmark docs

### DIFF
--- a/carbonmark/components/Footer/index.tsx
+++ b/carbonmark/components/Footer/index.tsx
@@ -34,7 +34,7 @@ export const Footer: FC<Props> = (props) => {
               <Trans>Terms of Use</Trans>
             </Text>
           </Link>
-          <Link href={carbonmarkUrls.help}>
+          <Link href={carbonmarkUrls.docs}>
             <Text t="body4">
               <Trans>Help</Trans>
             </Text>

--- a/carbonmark/components/pages/Home/index.tsx
+++ b/carbonmark/components/pages/Home/index.tsx
@@ -506,7 +506,7 @@ export const Home: NextPage<Props> = (props) => {
             <Link href="/blog/terms-of-use">
               <Trans>Terms of use</Trans>
             </Link>
-            <Link href={carbonmarkUrls.help}>
+            <Link href={carbonmarkUrls.docs}>
               <Trans>Help</Trans>
             </Link>
             <Link href="/resources">

--- a/carbonmark/components/shared/Navigation/index.tsx
+++ b/carbonmark/components/shared/Navigation/index.tsx
@@ -8,7 +8,6 @@ import { FC } from "react";
 import { HeaderMobile } from "../Header/HeaderMobile";
 import { LinkItemDesktop } from "./LinkItemDesktop";
 import { NavItemMobile } from "./NavItemMobile";
-
 import * as styles from "./styles";
 // dynamic import for ThemeToggle as its reads the document and localStorage of Browser
 // see https://nextjs.org/docs/advanced-features/dynamic-import#with-no-ssr
@@ -86,7 +85,7 @@ export const Navigation: FC<Props> = ({
         <LinkItemDesktop
           name={t`Help`}
           key="help"
-          url={urls.help}
+          url={urls.docs}
           active={activePage === "Help"}
         />
       </HeaderDesktop>
@@ -124,7 +123,7 @@ export const Navigation: FC<Props> = ({
               name={t`Help`}
               active={activePage === "Help"}
               id="Help"
-              url={urls.help}
+              url={urls.docs}
             />
           </div>
           <div className="buttons">

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -74,6 +74,7 @@ export const urls = {
   },
   blockExplorer: `${config.urls.blockExplorer[DEFAULT_NETWORK]}`,
   baseUrl: config.urls.baseUrl[ENVIRONMENT],
+  docs: "https://docs.carbonmark.com",
   projects: "/projects",
   users: "/users",
   help: "/blog/getting-started",


### PR DESCRIPTION
## Description

Replaces the help link to the carbonmark docs on the carbonmark homepage header/footer & app footer.

## Related Ticket

Resolves #1213 

## Checklist

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
