### PR TITLE
tooltips and link added

### DIFF
--- a/carbonmark/components/Stats/StatsBar.tsx
+++ b/carbonmark/components/Stats/StatsBar.tsx
@@ -40,6 +40,7 @@ export const StatsBar: FC<Props> = (props) => {
             </Text>
             <TextInfoTooltip
               className={styles.tooltip}
+              align="start"
               tooltip={t`Amount of credits from this project/vintage combination that have been retired.`}
             >
               <InfoOutlined className={styles.tooltipIcon} />
@@ -59,6 +60,7 @@ export const StatsBar: FC<Props> = (props) => {
             </Text>
             <TextInfoTooltip
               className={styles.tooltip}
+              align="start"
               tooltip={t`Amount of credits that have been bridged from this project/vintage combination but not yet retired.`}
             >
               <InfoOutlined className={styles.tooltipIcon} />

--- a/carbonmark/components/Stats/StatsBar.tsx
+++ b/carbonmark/components/Stats/StatsBar.tsx
@@ -13,7 +13,7 @@ import * as styles from "./styles";
 interface Props {
   currentSupply: Project["currentSupply"];
   totalRetired: Project["totalRetired"];
-  projectAddress: string;
+  projectAddress?: string;
 }
 
 export const StatsBar: FC<Props> = (props) => {
@@ -37,13 +37,13 @@ export const StatsBar: FC<Props> = (props) => {
               <span className="first">
                 <Trans>Total Retirements:</Trans>
               </span>
-              <TextInfoTooltip
-                className={styles.tooltip}
-                tooltip={t`Amount of credits from this project/vintage combination that have been retired.`}
-              >
-                <InfoOutlined />
-              </TextInfoTooltip>
             </Text>
+            <TextInfoTooltip
+              className={styles.tooltip}
+              tooltip={t`Amount of credits from this project/vintage combination that have been retired.`}
+            >
+              <InfoOutlined className={styles.tooltipIcon} />
+            </TextInfoTooltip>
           </div>
 
           <Text t="body1" color="lighter" className={styles.bold}>
@@ -56,13 +56,13 @@ export const StatsBar: FC<Props> = (props) => {
               <span>
                 <Trans>Remaining Supply:</Trans>
               </span>
-              <TextInfoTooltip
-                className={styles.tooltip}
-                tooltip={t`Amount of credits that have been bridged from this project/vintage combination but not yet retired.`}
-              >
-                <InfoOutlined />
-              </TextInfoTooltip>
             </Text>
+            <TextInfoTooltip
+              className={styles.tooltip}
+              tooltip={t`Amount of credits that have been bridged from this project/vintage combination but not yet retired.`}
+            >
+              <InfoOutlined className={styles.tooltipIcon} />
+            </TextInfoTooltip>
           </div>
 
           <Text t="body1" color="lighter" className={styles.bold}>

--- a/carbonmark/components/Stats/StatsBar.tsx
+++ b/carbonmark/components/Stats/StatsBar.tsx
@@ -1,7 +1,11 @@
+import { urls } from "@klimadao/lib/constants";
 import { trimWithLocale } from "@klimadao/lib/utils";
-import { Trans } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
+import { InfoOutlined, LaunchOutlined } from "@mui/icons-material";
 import { Text } from "components/Text";
+import { TextInfoTooltip } from "components/TextInfoTooltip";
 import { Project } from "lib/types/carbonmark";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { FC } from "react";
 import * as styles from "./styles";
@@ -9,6 +13,7 @@ import * as styles from "./styles";
 interface Props {
   currentSupply: Project["currentSupply"];
   totalRetired: Project["totalRetired"];
+  projectAddress: string;
 }
 
 export const StatsBar: FC<Props> = (props) => {
@@ -27,25 +32,49 @@ export const StatsBar: FC<Props> = (props) => {
       />
       <div className={styles.list}>
         <div className={styles.listItem}>
-          <Text t="body1" className={styles.itemWithColor}>
-            <span className="first">
-              <Trans>Total Retirements:</Trans>
-            </span>
-          </Text>
+          <div className={styles.textWithTooltipWrapper}>
+            <Text t="body1" className={styles.itemWithColor}>
+              <span className="first">
+                <Trans>Total Retirements:</Trans>
+              </span>
+              <TextInfoTooltip
+                className={styles.tooltip}
+                tooltip={t`Amount of credits from this project/vintage combination that have been retired.`}
+              >
+                <InfoOutlined />
+              </TextInfoTooltip>
+            </Text>
+          </div>
+
           <Text t="body1" color="lighter" className={styles.bold}>
             {trimWithLocale(retired || 0, 2, locale)}
           </Text>
         </div>
         <div className={styles.listItem}>
-          <Text t="body1" className={styles.itemWithColor}>
-            <span>
-              <Trans>Remaining Supply:</Trans>{" "}
-            </span>
-          </Text>
+          <div className={styles.textWithTooltipWrapper}>
+            <Text t="body1" className={styles.itemWithColor}>
+              <span>
+                <Trans>Remaining Supply:</Trans>
+              </span>
+              <TextInfoTooltip
+                className={styles.tooltip}
+                tooltip={t`Amount of credits that have been bridged from this project/vintage combination but not yet retired.`}
+              >
+                <InfoOutlined />
+              </TextInfoTooltip>
+            </Text>
+          </div>
+
           <Text t="body1" color="lighter" className={styles.bold}>
             {trimWithLocale(remaining || 0, 2, locale)}
           </Text>
         </div>
+        <Link href={urls.polygonscan + "/address/" + props.projectAddress}>
+          <Text t="body2" color="lighter" className={styles.polygonScanLink}>
+            <Trans>View project on PolygonScan</Trans>
+            <LaunchOutlined />
+          </Text>
+        </Link>
       </div>
     </>
   );

--- a/carbonmark/components/Stats/StatsBar.tsx
+++ b/carbonmark/components/Stats/StatsBar.tsx
@@ -13,7 +13,7 @@ import * as styles from "./styles";
 interface Props {
   currentSupply: Project["currentSupply"];
   totalRetired: Project["totalRetired"];
-  projectAddress?: string;
+  projectAddress: string;
 }
 
 export const StatsBar: FC<Props> = (props) => {
@@ -72,7 +72,7 @@ export const StatsBar: FC<Props> = (props) => {
         <Link href={urls.polygonscan + "/address/" + props.projectAddress}>
           <Text t="body2" color="lighter" className={styles.polygonScanLink}>
             <Trans>View project on PolygonScan</Trans>
-            <LaunchOutlined />
+            <LaunchOutlined className={styles.launchIcon} />
           </Text>
         </Link>
       </div>

--- a/carbonmark/components/Stats/index.tsx
+++ b/carbonmark/components/Stats/index.tsx
@@ -28,7 +28,9 @@ export const Stats: FC<Props> = (props) => {
         </Text>
       </div>
 
-      {!!props.currentSupply && !!props.totalRetired ? (
+      {!!props.currentSupply &&
+      !!props.totalRetired &&
+      !!props.projectAddress ? (
         <StatsBar
           currentSupply={props.currentSupply}
           totalRetired={props.totalRetired}

--- a/carbonmark/components/Stats/index.tsx
+++ b/carbonmark/components/Stats/index.tsx
@@ -13,6 +13,7 @@ interface Props {
   currentSupply?: Project["currentSupply"];
   totalRetired?: Project["totalRetired"];
   description: string;
+  projectAddress: string;
 }
 
 export const Stats: FC<Props> = (props) => {
@@ -31,6 +32,7 @@ export const Stats: FC<Props> = (props) => {
         <StatsBar
           currentSupply={props.currentSupply}
           totalRetired={props.totalRetired}
+          projectAddress={props.projectAddress}
         />
       ) : (
         <StatsListings

--- a/carbonmark/components/Stats/index.tsx
+++ b/carbonmark/components/Stats/index.tsx
@@ -13,7 +13,7 @@ interface Props {
   currentSupply?: Project["currentSupply"];
   totalRetired?: Project["totalRetired"];
   description: string;
-  projectAddress: string;
+  projectAddress?: string;
 }
 
 export const Stats: FC<Props> = (props) => {

--- a/carbonmark/components/Stats/styles.ts
+++ b/carbonmark/components/Stats/styles.ts
@@ -16,13 +16,20 @@ export const textWithTooltipWrapper = css`
   display: flex;
   align-items: center;
 `;
+
 export const tooltipIcon = css`
-    margin-top: 0.3rem;
+    margin-top: 0.2rem;
     margin-left: 0.5rem;
-    fill: var(--font-02);
-    align-self: flex-start;
-    
+    fill: var(--manatee) !important;
+    align-self: flex-start;   
+    font-size: 1.8rem !important;
   }
+`;
+
+export const launchIcon = css`
+  fill: var(--font-02);
+  margin-left: 0.2rem;
+  font-size: large !important;
 `;
 
 export const tooltip = css`
@@ -112,5 +119,8 @@ export const polygonScanLink = css`
   margin-top: 0.8rem;
   &:hover {
     color: var(--bright-blue);
+    .launchIcon {
+      fill: var(--bright-blue) !important;
+    }
   }
 `;

--- a/carbonmark/components/Stats/styles.ts
+++ b/carbonmark/components/Stats/styles.ts
@@ -12,6 +12,16 @@ export const listItem = css`
   justify-content: space-between;
 `;
 
+export const textWithTooltipWrapper = css`
+  display: flex;
+  align-items: center;
+`;
+
+export const tooltip = css`
+  width: 20em;
+  padding: 0.3em;
+`;
+
 export const itemWithIcon = css`
   display: flex;
   justify-content: center;
@@ -27,12 +37,13 @@ export const itemWithColor = css`
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 0.8rem;
+  gap: 0.3rem;
 
   span {
     position: relative;
     display: flex;
     align-items: center;
+
     gap: 1.2rem;
   }
 
@@ -40,7 +51,6 @@ export const itemWithColor = css`
     content: "";
     width: 1.2rem;
     height: 1.2rem;
-
     background-color: var(--bisque);
   }
 
@@ -74,4 +84,18 @@ export const titles = css`
   display: flex;
   gap: 0.4rem;
   flex-direction: column;
+`;
+
+export const polygonScanLink = css`
+  display: flex;
+  align-items: center;
+  font-size: 1em;
+  line-height: 1.8em;
+  text-decoration: underline;
+  color: var(--font-02);
+  cursor: pointer;
+  margin-top: 0.8rem;
+  &:hover {
+    color: var(--bright-blue);
+  }
 `;

--- a/carbonmark/components/Stats/styles.ts
+++ b/carbonmark/components/Stats/styles.ts
@@ -33,15 +33,9 @@ export const launchIcon = css`
 `;
 
 export const tooltip = css`
-  color: var(--white);
-  padding: 0.8rem;
-  background: #303030;
+  font-size: 1.4rem;
+  padding: 0.5rem;
   max-width: 30rem !important;
-  border-radius: 0.4rem;
-
-  .tippy-arrow {
-    color: #303030;
-  }
 `;
 
 export const itemWithIcon = css`

--- a/carbonmark/components/Stats/styles.ts
+++ b/carbonmark/components/Stats/styles.ts
@@ -16,10 +16,25 @@ export const textWithTooltipWrapper = css`
   display: flex;
   align-items: center;
 `;
+export const tooltipIcon = css`
+    margin-top: 0.3rem;
+    margin-left: 0.5rem;
+    fill: var(--font-02);
+    align-self: flex-start;
+    
+  }
+`;
 
 export const tooltip = css`
-  width: 20em;
-  padding: 0.3em;
+  color: var(--white);
+  padding: 0.8rem;
+  background: #303030;
+  max-width: 30rem !important;
+  border-radius: 0.4rem;
+
+  .tippy-arrow {
+    color: #303030;
+  }
 `;
 
 export const itemWithIcon = css`

--- a/carbonmark/components/TextInfoTooltip/index.tsx
+++ b/carbonmark/components/TextInfoTooltip/index.tsx
@@ -9,12 +9,17 @@ interface TooltipProps {
   tooltip: string;
   children: ReactElement;
   className?: string;
+  align?: "start" | "end";
 }
 
 export const TextInfoTooltip = (props: TooltipProps) => (
   <Tippy
     content={
-      <Text t="body1" className={styles.infoText} align="center">
+      <Text
+        t="body1"
+        className={styles.infoText}
+        align={props.align ? props.align : "center"}
+      >
         {props.tooltip}
       </Text>
     }

--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -257,6 +257,7 @@ const Page: NextPage<PageProps> = (props) => {
               totalRetired={project.totalRetired}
               allListings={allListings || []}
               activeListings={activeListings || []}
+              projectAddress={project.projectAddress}
             />
             <Activities activities={project.activities || []} />
           </div>

--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -170,6 +170,7 @@ const Page: NextPage<PageProps> = (props) => {
               {props?.project?.methodologies?.length && (
                 <TextInfoTooltip
                   className={styles.infoContent}
+                  align="start"
                   tooltip={formatList(allMethodologyNames, "short")}
                 >
                   <InfoOutlined />

--- a/carbonmark/components/pages/Project/styles.ts
+++ b/carbonmark/components/pages/Project/styles.ts
@@ -214,15 +214,9 @@ export const methodology = css`
 `;
 
 export const infoContent = css`
-  color: var(--white);
-  padding: 1.2rem;
-  background: #303030;
-  max-width: 23rem !important;
-  border-radius: 0.4rem;
-
-  .tippy-arrow {
-    color: #303030;
-  }
+  font-size: 1.4rem;
+  padding: 0.5rem;
+  max-width: 20rem !important;
 `;
 
 export const carouselWrapper = css`


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Added explanatory tooltips and link to project details page.

One style note where there was a discrepancy:

The figma tooltip design:
![Screen Shot 2023-06-19 at 1 51 30 PM](https://github.com/KlimaDAO/klimadao/assets/72105234/d9c03906-f4a7-47a5-992e-58ca2166011a)
didn't match current tooltips already on the project page:
![Screen Shot 2023-06-19 at 1 52 12 PM](https://github.com/KlimaDAO/klimadao/assets/72105234/8b5fd39b-d202-4601-aa00-25ef73e8ae07)

I matched the tooltip design to what currently exists on the project page for consistency. If that needs to be changed let me know.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #969 


## Changes

| Before  | After  |
|---------|--------|
|![Screen Shot 2023-06-19 at 12 44 05 PM](https://github.com/KlimaDAO/klimadao/assets/72105234/1bec8fa6-acf6-45f3-9047-d3d3aa602c52)
 |![Screen Shot 2023-06-19 at 12 43 17 PM](https://github.com/KlimaDAO/klimadao/assets/72105234/bfa56c86-7f42-4c78-8152-62f679b19d07)|




## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
