### PR TITLE
Link to Retire from Pool pages

### DIFF
--- a/carbonmark/components/pages/Project/BuyOptions/PoolPrice.tsx
+++ b/carbonmark/components/pages/Project/BuyOptions/PoolPrice.tsx
@@ -5,10 +5,11 @@ import { CarbonmarkButton } from "components/CarbonmarkButton";
 import { Card } from "components/Card";
 import { ExitModal } from "components/ExitModal";
 import { Text } from "components/Text";
-import { createRedeemLink, createRetireLink } from "lib/createUrls";
+import { createProjectPoolRetireLink, createRedeemLink } from "lib/createUrls";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { LO } from "lib/luckyOrange";
 import { PriceFlagged, Project } from "lib/types/carbonmark";
+import Link from "next/link";
 import { FC, useState } from "react";
 import * as styles from "./styles";
 
@@ -42,6 +43,7 @@ export const PoolPrice: FC<Props> = (props) => {
       <div className={styles.buttons}>
         <ButtonPrimary
           label={t`Buy`}
+          renderLink={(linkProps) => <Link {...linkProps} />}
           onClick={() => {
             LO.track("Purchase - Pool: Buy Clicked");
             setIsOpen(true);
@@ -55,15 +57,13 @@ export const PoolPrice: FC<Props> = (props) => {
         />
         <CarbonmarkButton
           label={t`Retire now`}
+          href={createProjectPoolRetireLink(
+            props.project,
+            props.price.poolName
+          )}
+          renderLink={(linkProps) => <Link {...linkProps} />}
           onClick={() => {
             LO.track("Retire - Pool: Retire Button Clicked");
-            setIsOpen(true);
-            setRetireLink(
-              createRetireLink({
-                retirementToken: props.price.poolName,
-                projectTokens: props.price.projectTokenAddress,
-              })
-            );
           }}
         />
       </div>

--- a/carbonmark/components/pages/Project/Retire/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/TotalValues.tsx
@@ -1,6 +1,6 @@
 import { cx } from "@emotion/css";
 import { trimWithLocale } from "@klimadao/lib/utils";
-import { t } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import { Text } from "components/Text";
@@ -250,7 +250,7 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
               </div>
               <div className={styles.feeText}>
                 <Text t="body2">
-                  {props.price.poolName} {t`redemption Fee`}
+                  <Trans>Pool Redemption Fee</Trans>
                 </Text>
                 <Text t="body2">
                   {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}

--- a/carbonmark/lib/createUrls.ts
+++ b/carbonmark/lib/createUrls.ts
@@ -13,41 +13,12 @@ export const createProjectPurchaseLink = (
   listingId: string
 ) => `${createProjectLink(project)}/purchase/${listingId}`;
 
-export const createSellerLink = (handle: string) => `/users/${handle}`;
-
 export const createProjectPoolRetireLink = (
   project: ProjectData,
-  pool: Price["poolName"] | Lowercase<Price["poolName"]>
-) => `${createProjectLink(project)}/retire/pools/${pool}`;
+  pool: Price["poolName"]
+) => `${createProjectLink(project)}/retire/pools/${pool.toLowerCase()}`;
 
-/**
- * @example
- * https://app.klimadao.finance/#/offset?
- *   retirementToken=nct
- *   &projectTokens=0x261bef4b19ace1398c6603ed7299296d0e32cc00
- *   &quantity=123
- */
-export const createRetireLink = (params: {
-  /** Carbon pool like "nct" or address of an owned token */
-  retirementToken?: string;
-  /** Project token address for selective retirement out of pool */
-  projectTokens?: string;
-  quantity?: string;
-}) => {
-  const searchParams = new URLSearchParams();
-
-  if (params.retirementToken) {
-    searchParams.append("retirementToken", params.retirementToken);
-  }
-  if (params.projectTokens) {
-    searchParams.append("projectTokens", params.projectTokens);
-  }
-  if (params.quantity) {
-    searchParams.append("quantity", params.quantity);
-  }
-
-  return `${urls.offset}?${searchParams}`;
-};
+export const createSellerLink = (handle: string) => `/users/${handle}`;
 
 /**
  * @example


### PR DESCRIPTION
## Description

This PR links the "Retire now" button from a Project Pool Price to the correct page.

Still, this issue remains:
- A price for a project might not be correct, see [comment](https://github.com/KlimaDAO/klimadao/issues/1156#issuecomment-1581047026)
- This can result in the total costs for 1 tonne amount being lower than a single unit price per tonne.
- **Please double check** how the total costs are retrieved [here](https://github.com/KlimaDAO/klimadao/blob/staging/carbonmark/lib/actions.retire.ts#L35-L70)

E.G.:
- https://carbonmark-git-lady-link-to-retire-klimadao.vercel.app/projects/VCS-191-2008/retire/pools/bct
- https://carbonmark-git-lady-link-to-retire-klimadao.vercel.app/projects/VCS-1140-2015/retire/pools/ubo

=> the total costs are lower than a single unit price (with 1 tonne amount)

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1189

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
