### PR TITLE
Link to Purchase from Pool pages

### DIFF
--- a/carbonmark/components/pages/Project/BuyOptions/PoolPrice.tsx
+++ b/carbonmark/components/pages/Project/BuyOptions/PoolPrice.tsx
@@ -3,14 +3,16 @@ import { t, Trans } from "@lingui/macro";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { CarbonmarkButton } from "components/CarbonmarkButton";
 import { Card } from "components/Card";
-import { ExitModal } from "components/ExitModal";
 import { Text } from "components/Text";
-import { createProjectPoolRetireLink, createRedeemLink } from "lib/createUrls";
+import {
+  createProjectPoolPurchaseLink,
+  createProjectPoolRetireLink,
+} from "lib/createUrls";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { LO } from "lib/luckyOrange";
 import { PriceFlagged, Project } from "lib/types/carbonmark";
 import Link from "next/link";
-import { FC, useState } from "react";
+import { FC } from "react";
 import * as styles from "./styles";
 
 type Props = {
@@ -20,8 +22,6 @@ type Props = {
 };
 
 export const PoolPrice: FC<Props> = (props) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [retireLink, setRetireLink] = useState("");
   return (
     <Card>
       <div className={styles.sellerInfo}>
@@ -46,14 +46,11 @@ export const PoolPrice: FC<Props> = (props) => {
           renderLink={(linkProps) => <Link {...linkProps} />}
           onClick={() => {
             LO.track("Purchase - Pool: Buy Clicked");
-            setIsOpen(true);
-            setRetireLink(
-              createRedeemLink({
-                projectTokenAddress: props.price.projectTokenAddress,
-                poolName: props.price.poolName,
-              })
-            );
           }}
+          href={createProjectPoolPurchaseLink(
+            props.project,
+            props.price.poolName
+          )}
         />
         <CarbonmarkButton
           label={t`Retire now`}
@@ -67,12 +64,6 @@ export const PoolPrice: FC<Props> = (props) => {
           }}
         />
       </div>
-      <ExitModal
-        showModal={isOpen}
-        title={t`Leaving Carbonmark`}
-        retireLink={retireLink}
-        onToggleModal={() => setIsOpen(false)}
-      />
     </Card>
   );
 };

--- a/carbonmark/lib/createUrls.ts
+++ b/carbonmark/lib/createUrls.ts
@@ -1,4 +1,3 @@
-import { urls } from "@klimadao/lib/constants";
 import { Price, Project } from "lib/types/carbonmark";
 
 type ProjectData = {
@@ -20,24 +19,7 @@ export const createProjectPoolRetireLink = (
 
 export const createSellerLink = (handle: string) => `/users/${handle}`;
 
-/**
- * @example
- * https://app.klimadao.finance/#/redeem?
- *   pool=nct
- *   &projectTokenAddress=0x261bef4b19ace1398c6603ed7299296d0e32cc00
- */
-export const createRedeemLink = (params: {
-  poolName?: string;
-  projectTokenAddress?: string;
-}) => {
-  const searchParams = new URLSearchParams();
-
-  if (params.poolName) {
-    searchParams.append("pool", params.poolName);
-  }
-  if (params.projectTokenAddress) {
-    searchParams.append("projectTokenAddress", params.projectTokenAddress);
-  }
-
-  return `${urls.redeem}?${searchParams}`;
-};
+export const createProjectPoolPurchaseLink = (
+  project: ProjectData,
+  pool: Price["poolName"]
+) => `${createProjectLink(project)}/purchase/pools/${pool}`;


### PR DESCRIPTION
## Description

This PR links the "Buy" button from a Project Pool Price to the correct page.

Still, this issue remains:
- A price for a project might not be correct, see [comment](https://github.com/KlimaDAO/klimadao/issues/1156#issuecomment-1581047026)
- This can result in the total costs for 1 tonne amount being lower than a single unit price per tonne.
- **Please double check** how the total costs for redeem are retrieved [here](https://github.com/KlimaDAO/klimadao/blob/staging/carbonmark/lib/actions.redeem.ts#L119-L160)

E.G.:
- https://carbonmark-git-lady-link-to-redeem-klimadao.vercel.app/projects/VCS-191-2008/purchase/pools/bct
- https://carbonmark-git-lady-link-to-redeem-klimadao.vercel.app/projects/VCS-1140-2015/purchase/pools/ubo
- https://carbonmark-git-lady-link-to-redeem-klimadao.vercel.app/projects/VCS-981-2014/purchase/pools/nct

=> the total costs are lower than a single unit price (with 1 tonne amount)

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1219


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
