### PR TITLE
Retire: Add featured Projects

### DIFF
--- a/carbonmark/components/Layout/index.tsx
+++ b/carbonmark/components/Layout/index.tsx
@@ -24,6 +24,7 @@ import * as styles from "./styles";
 type Props = {
   userAddress?: string;
   children: ReactNode;
+  fullContentWidth?: boolean;
 };
 
 /** App layout for desktop side-panel and mobile navigation */
@@ -66,7 +67,13 @@ export const Layout: FC<Props> = (props: Props) => {
             className={styles.menuButton}
           />
         </div>
-        <div className={styles.layoutChildrenContainer}>{props.children}</div>
+        <div
+          className={cx(styles.layoutChildrenContainer, {
+            fullContentWidth: props.fullContentWidth,
+          })}
+        >
+          {props.children}
+        </div>
         <Footer />
       </main>
       <InvalidNetworkModal />

--- a/carbonmark/components/Layout/styles.ts
+++ b/carbonmark/components/Layout/styles.ts
@@ -97,6 +97,10 @@ export const layoutChildrenContainer = css`
     gap: 2rem 0rem;
     padding: 4rem;
   }
+
+  &.fullContentWidth {
+    padding: 0;
+  }
 `;
 
 export const cardGrid = css`

--- a/carbonmark/components/ProjectCard/index.tsx
+++ b/carbonmark/components/ProjectCard/index.tsx
@@ -1,4 +1,5 @@
-import { t } from "@lingui/macro";
+import { trimWithLocale } from "@klimadao/lib/utils";
+import { t, Trans } from "@lingui/macro";
 import { Category } from "components/Category";
 import { ProjectImage } from "components/ProjectImage";
 import { Text } from "components/Text";
@@ -27,7 +28,22 @@ export const ProjectCard: FC<Props> = (props) => {
         <ProjectImage category={getCategoryFromProject(project)} />
       </div>
       <div className={styles.cardContent}>
-        <Text t="h4">{formatBigToPrice(project.price, locale)}</Text>
+        <div className={styles.price}>
+          <Text t="h4">{formatBigToPrice(project.price, locale)}</Text>
+          {project.currentSupply && (
+            <div className={styles.supply}>
+              <Text t="body2" color="lighter" align="end">
+                <Trans>Available Tonnes:</Trans>
+                <br />
+                {trimWithLocale(
+                  Number(project.currentSupply),
+                  2,
+                  locale || "en"
+                )}
+              </Text>
+            </div>
+          )}
+        </div>
         <Text t="h5">{project.name || "! MISSING PROJECT NAME !"}</Text>
         <Text t="body1" className={styles.cardDescription}>
           {project.short_description ||

--- a/carbonmark/components/ProjectCard/index.tsx
+++ b/carbonmark/components/ProjectCard/index.tsx
@@ -1,3 +1,4 @@
+import { cx } from "@emotion/css";
 import { trimWithLocale } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import { Category } from "components/Category";
@@ -15,6 +16,7 @@ import * as styles from "./styles";
 
 type Props = {
   project: Project;
+  className?: string;
 };
 
 export const ProjectCard: FC<Props> = (props) => {
@@ -23,7 +25,11 @@ export const ProjectCard: FC<Props> = (props) => {
   const { project } = props;
 
   return (
-    <Link href={createProjectLink(project)} passHref className={styles.card}>
+    <Link
+      href={createProjectLink(project)}
+      passHref
+      className={cx(styles.card, props.className)}
+    >
       <div className={styles.cardImage}>
         <ProjectImage category={getCategoryFromProject(project)} />
       </div>

--- a/carbonmark/components/ProjectCard/index.tsx
+++ b/carbonmark/components/ProjectCard/index.tsx
@@ -1,0 +1,53 @@
+import { t } from "@lingui/macro";
+import { Category } from "components/Category";
+import { ProjectImage } from "components/ProjectImage";
+import { Text } from "components/Text";
+import { Vintage } from "components/Vintage";
+import { createProjectLink } from "lib/createUrls";
+import { formatBigToPrice } from "lib/formatNumbers";
+import { getCategoryFromProject } from "lib/projectGetter";
+import { CategoryName, Methodology, Project } from "lib/types/carbonmark";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { FC } from "react";
+import * as styles from "./styles";
+
+type Props = {
+  project: Project;
+};
+
+export const ProjectCard: FC<Props> = (props) => {
+  const { locale } = useRouter();
+
+  const { project } = props;
+
+  return (
+    <Link href={createProjectLink(project)} passHref className={styles.card}>
+      <div className={styles.cardImage}>
+        <ProjectImage category={getCategoryFromProject(project)} />
+      </div>
+      <div className={styles.cardContent}>
+        <Text t="h4">{formatBigToPrice(project.price, locale)}</Text>
+        <Text t="h5">{project.name || "! MISSING PROJECT NAME !"}</Text>
+        <Text t="body1" className={styles.cardDescription}>
+          {project.short_description ||
+            project.description ||
+            t`No project description found`}
+        </Text>
+        <div className={styles.tags}>
+          <Vintage vintage={project.vintage} />
+          {project?.methodologies?.length > 1 ? (
+            project.methodologies.map((methodology: Methodology, index) => (
+              <Category
+                key={`${methodology?.id}-${index}`}
+                category={methodology?.category as CategoryName}
+              />
+            ))
+          ) : (
+            <Category category={getCategoryFromProject(project)} />
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+};

--- a/carbonmark/components/ProjectCard/styles.ts
+++ b/carbonmark/components/ProjectCard/styles.ts
@@ -14,7 +14,7 @@ export const card = css`
   ${breakpoints.large} {
     transition: all 0.2s ease 0s;
     &:hover {
-      transform: scale(1.02);
+      transform: scale(0.98);
       box-shadow: var(--shadow-02);
     }
   }
@@ -30,6 +30,7 @@ export const cardDescription = css`
   -webkit-text-fill-color: transparent;
   background-clip: text;
   overflow: hidden;
+  height: 12rem;
 `;
 
 export const cardImage = css`
@@ -43,7 +44,7 @@ export const cardImage = css`
 export const cardContent = css`
   padding: 2rem;
   display: grid;
-  gap: 0.8rem;
+  gap: 1rem;
   grid-template-rows: auto auto 1fr;
 `;
 

--- a/carbonmark/components/ProjectCard/styles.ts
+++ b/carbonmark/components/ProjectCard/styles.ts
@@ -1,0 +1,62 @@
+import { css } from "@emotion/css";
+import breakpoints from "@klimadao/lib/theme/breakpoints";
+
+export const card = css`
+  background-color: var(--surface-01);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-01);
+  width: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  ${breakpoints.medium} {
+    max-width: 32rem;
+  }
+  ${breakpoints.large} {
+    transition: all 0.2s ease 0s;
+    &:hover {
+      transform: scale(1.02);
+      box-shadow: var(--shadow-02);
+    }
+  }
+`;
+
+export const cardDescription = css`
+  background: linear-gradient(
+    180deg,
+    var(--font-01) 43.44%,
+    rgba(49, 49, 49, 0) 92.91%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  overflow: hidden;
+`;
+
+export const cardImage = css`
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 12rem;
+  border-radius: var(--border-radius) var(--border-radius) 0 0;
+`;
+
+export const cardContent = css`
+  padding: 2rem;
+  display: grid;
+  gap: 0.8rem;
+  grid-template-rows: auto auto 1fr;
+`;
+
+export const tags = css`
+  display: flex;
+  gap: 0.8rem;
+  flex-direction: row;
+  margin-top: auto;
+  align-items: center;
+  overflow-x: auto;
+  ::-webkit-scrollbar {
+    display: none; /* Hide scrollbar for Chrome, Safari and Opera */
+  }
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+`;

--- a/carbonmark/components/ProjectCard/styles.ts
+++ b/carbonmark/components/ProjectCard/styles.ts
@@ -60,3 +60,12 @@ export const tags = css`
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 `;
+
+export const price = css`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const supply = css`
+  text-align: right;
+`;

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -88,7 +88,11 @@ export const Retire: NextPage<PageProps> = (props) => {
 
             <div className={styles.cardsList}>
               {props.featuredProjects.map((p) => (
-                <ProjectCard key={p.id} project={p} />
+                <ProjectCard
+                  key={p.id}
+                  project={p}
+                  className={styles.featuredCard}
+                />
               ))}
             </div>
           </div>

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -6,11 +6,16 @@ import { LoginButton } from "components/LoginButton";
 import { PageHead } from "components/PageHead";
 import { Text } from "components/Text";
 import { useGetDomainFromAddress } from "hooks/useGetDomainFromAddress";
+import { Project } from "lib/types/carbonmark";
 import { NextPage } from "next";
 import { RetireActivity } from "./Activity";
 import * as styles from "./styles";
 
-export const Retire: NextPage = () => {
+export type PageProps = {
+  featuredProjects: Project[];
+};
+
+export const Retire: NextPage<PageProps> = (props) => {
   const { isConnected, address } = useWeb3();
   // collect nameserviceDomain Data if connected and domain is in URL
   const connectedDomain = useGetDomainFromAddress(address);

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -1,13 +1,16 @@
 import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
+import LocalPoliceIcon from "@mui/icons-material/LocalPolice";
 import { CopyAddressButton } from "components/CopyAddressButton";
 import { Layout } from "components/Layout";
 import { LoginButton } from "components/LoginButton";
 import { PageHead } from "components/PageHead";
+import { ProjectCard } from "components/ProjectCard";
 import { Text } from "components/Text";
 import { useGetDomainFromAddress } from "hooks/useGetDomainFromAddress";
 import { Project } from "lib/types/carbonmark";
 import { NextPage } from "next";
+import Link from "next/link";
 import { RetireActivity } from "./Activity";
 import * as styles from "./styles";
 
@@ -16,6 +19,7 @@ export type PageProps = {
 };
 
 export const Retire: NextPage<PageProps> = (props) => {
+  console.log("props", props);
   const { isConnected, address } = useWeb3();
   // collect nameserviceDomain Data if connected and domain is in URL
   const connectedDomain = useGetDomainFromAddress(address);
@@ -57,6 +61,37 @@ export const Retire: NextPage<PageProps> = (props) => {
           </div>
 
           <RetireActivity />
+        </div>
+
+        <div className={styles.fullWhite}>
+          <div className={styles.content}>
+            <div className={styles.cardsHeader}>
+              <Text t="h4" className={styles.textWithIcon}>
+                <LocalPoliceIcon className="featured" fontSize="inherit" />
+                <Trans>Retire from a featured project</Trans>
+              </Text>
+
+              <Link href="/projects">
+                <Text t="body4" className={styles.textLink}>
+                  <Trans>View all Projects</Trans>
+                </Text>
+              </Link>
+            </div>
+
+            <Text className={styles.cardsDescription}>
+              <Trans>
+                We’ve hand-curated some of the best projects based on strict
+                criteria, such as price, veracity, and global environmental
+                impact.
+              </Trans>
+            </Text>
+
+            <div className={styles.cardsList}>
+              {props.featuredProjects.map((p) => (
+                <ProjectCard key={p.id} project={p} />
+              ))}
+            </div>
+          </div>
         </div>
       </Layout>
     </>

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -19,7 +19,6 @@ export type PageProps = {
 };
 
 export const Retire: NextPage<PageProps> = (props) => {
-  console.log("props", props);
   const { isConnected, address } = useWeb3();
   // collect nameserviceDomain Data if connected and domain is in URL
   const connectedDomain = useGetDomainFromAddress(address);

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -32,7 +32,7 @@ export const Retire: NextPage<PageProps> = (props) => {
         metaDescription={t`View a complete overview of the digital carbon that you retired. `}
       />
 
-      <Layout>
+      <Layout fullContentWidth>
         <div className={styles.container}>
           <div>
             <Text t="h2">

--- a/carbonmark/components/pages/Retire/styles.ts
+++ b/carbonmark/components/pages/Retire/styles.ts
@@ -66,6 +66,10 @@ export const content = css`
   }
 `;
 
+export const featuredCard = css`
+  border: 2px solid var(--yellow);
+`;
+
 export const cardsHeader = css`
   display: flex;
   gap: 0.8rem;

--- a/carbonmark/components/pages/Retire/styles.ts
+++ b/carbonmark/components/pages/Retire/styles.ts
@@ -24,13 +24,6 @@ export const retireControls = css`
   }
 `;
 
-export const spinnerContainer = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-`;
-
 export const beneficiary = css`
   display: flex;
   gap: 0.8rem;

--- a/carbonmark/components/pages/Retire/styles.ts
+++ b/carbonmark/components/pages/Retire/styles.ts
@@ -6,6 +6,12 @@ export const container = css`
   display: grid;
   grid-template-rows: auto auto 1fr;
   gap: 2.4rem;
+
+  margin: 1.6rem;
+
+  ${breakpoints.desktop} {
+    margin: 4rem;
+  }
 `;
 
 export const retireControls = css`

--- a/carbonmark/components/pages/Retire/styles.ts
+++ b/carbonmark/components/pages/Retire/styles.ts
@@ -124,4 +124,11 @@ export const cardsDescription = css`
 export const cardsList = css`
   display: flex;
   gap: 2rem;
+  flex-wrap: wrap;
+
+  justify-content: center;
+
+  ${breakpoints.desktop} {
+    justify-content: flex-start;
+  }
 `;

--- a/carbonmark/components/pages/Retire/styles.ts
+++ b/carbonmark/components/pages/Retire/styles.ts
@@ -41,3 +41,83 @@ export const beneficiary = css`
     }
   }
 `;
+
+export const fullWhite = css`
+  grid-column: full;
+
+  display: grid;
+  grid-template-columns: inherit;
+  background-color: var(--white);
+`;
+
+export const content = css`
+  grid-column: main;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin: 2rem 1.6rem;
+
+  ${breakpoints.large} {
+    margin: 4rem 2rem;
+  }
+
+  ${breakpoints.desktop} {
+    margin: 4rem;
+  }
+`;
+
+export const cardsHeader = css`
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  ${breakpoints.large} {
+    gap: 2.4rem;
+  }
+
+  ${breakpoints.desktop} {
+    justify-content: space-between;
+  }
+`;
+
+export const textWithIcon = css`
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+
+  .featured {
+    path {
+      fill: var(--yellow);
+    }
+  }
+`;
+
+export const textLink = css`
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  color: var(--bright-blue);
+  text-transform: uppercase;
+
+  &:hover,
+  &:visited {
+    text-decoration: underline;
+  }
+`;
+
+export const cardsDescription = css`
+  text-align: center;
+  padding: 0 2rem;
+
+  ${breakpoints.desktop} {
+    text-align: inherit;
+    padding: 0;
+  }
+`;
+
+export const cardsList = css`
+  display: flex;
+  gap: 2rem;
+`;

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -85,6 +85,10 @@ msgstr ""
 msgid "Asset ID"
 msgstr ""
 
+#: components/ProjectCard/index.tsx:42
+msgid "Available Tonnes:"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:106
 msgid "Available balance exceeded"
 msgstr ""
@@ -180,7 +184,7 @@ msgstr ""
 msgid "Carbon Pool"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:34
+#: components/pages/Retire/index.tsx:42
 msgid "Carbon Retirements"
 msgstr ""
 
@@ -492,6 +496,7 @@ msgstr ""
 msgid "No listings found for this project."
 msgstr ""
 
+#: components/ProjectCard/index.tsx:57
 #: components/pages/Projects/index.tsx:76
 msgid "No project description found"
 msgstr ""
@@ -686,6 +691,10 @@ msgstr ""
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr ""
 
+#: components/pages/Retire/index.tsx:70
+msgid "Retire from a featured project"
+msgstr ""
+
 #: components/pages/Project/Retire/index.tsx:24
 #: components/pages/Project/Retire/index.tsx:25
 msgid "Retire from {fullProjectid} | Carbonmark"
@@ -705,8 +714,8 @@ msgstr ""
 
 #: components/pages/Portfolio/Retire/index.tsx:75
 #: components/pages/Portfolio/Retire/index.tsx:76
-#: components/pages/Retire/index.tsx:25
-#: components/pages/Retire/index.tsx:26
+#: components/pages/Retire/index.tsx:33
+#: components/pages/Retire/index.tsx:34
 msgid "Retire | Carbonmark"
 msgstr ""
 
@@ -1003,8 +1012,12 @@ msgstr ""
 msgid "View a complete overview of the digital carbon that you own in your Retire."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:27
+#: components/pages/Retire/index.tsx:35
 msgid "View a complete overview of the digital carbon that you retired."
+msgstr ""
+
+#: components/pages/Retire/index.tsx:75
+msgid "View all Projects"
 msgstr ""
 
 #: components/pages/Retire/Activity/Quotes.tsx:82
@@ -1051,6 +1064,10 @@ msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:106
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
+msgstr ""
+
+#: components/pages/Retire/index.tsx:81
+msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 msgstr ""
 
 #: components/pages/Project/Retire/RetireInputs.tsx:100
@@ -1141,19 +1158,19 @@ msgstr ""
 msgid "buy"
 msgstr ""
 
-#: components/Layout/index.tsx:84
+#: components/Layout/index.tsx:91
 msgid "connectModal.institutional"
 msgstr ""
 
-#: components/Layout/index.tsx:76
+#: components/Layout/index.tsx:83
 msgid "connectModal.torus"
 msgstr ""
 
-#: components/Layout/index.tsx:80
+#: components/Layout/index.tsx:87
 msgid "connectModal.wallet"
 msgstr ""
 
-#: components/Layout/index.tsx:93
+#: components/Layout/index.tsx:100
 msgid "connect_modal.connecting"
 msgstr ""
 
@@ -1169,7 +1186,7 @@ msgstr ""
 msgid "connect_modal.error_processing"
 msgstr ""
 
-#: components/Layout/index.tsx:97
+#: components/Layout/index.tsx:104
 msgid "connect_modal.error_title"
 msgstr ""
 
@@ -1243,7 +1260,7 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:39
+#: components/pages/Retire/index.tsx:47
 msgid "for beneficiary"
 msgstr ""
 
@@ -1687,7 +1704,7 @@ msgstr ""
 msgid "shared.head.description"
 msgstr ""
 
-#: components/Layout/index.tsx:89
+#: components/Layout/index.tsx:96
 msgid "shared.login"
 msgstr ""
 

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -91,6 +91,10 @@ msgstr "Asset Details"
 msgid "Asset ID"
 msgstr "Asset ID"
 
+#: components/ProjectCard/index.tsx:42
+msgid "Available Tonnes:"
+msgstr "Available Tonnes:"
+
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:106
 msgid "Available balance exceeded"
 msgstr "Available balance exceeded"
@@ -186,7 +190,7 @@ msgstr "Cancel"
 msgid "Carbon Pool"
 msgstr "Carbon Pool"
 
-#: components/pages/Retire/index.tsx:34
+#: components/pages/Retire/index.tsx:42
 msgid "Carbon Retirements"
 msgstr "Carbon Retirements"
 
@@ -498,6 +502,7 @@ msgstr "No listable assets found."
 msgid "No listings found for this project."
 msgstr "No listings found for this project."
 
+#: components/ProjectCard/index.tsx:57
 #: components/pages/Projects/index.tsx:76
 msgid "No project description found"
 msgstr "No project description found"
@@ -692,6 +697,10 @@ msgstr "Retire"
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "Retire carbon credits for yourself, or on behalf of another person or organization."
 
+#: components/pages/Retire/index.tsx:70
+msgid "Retire from a featured project"
+msgstr "Retire from a featured project"
+
 #: components/pages/Project/Retire/index.tsx:24
 #: components/pages/Project/Retire/index.tsx:25
 msgid "Retire from {fullProjectid} | Carbonmark"
@@ -711,8 +720,8 @@ msgstr "Retire now"
 
 #: components/pages/Portfolio/Retire/index.tsx:75
 #: components/pages/Portfolio/Retire/index.tsx:76
-#: components/pages/Retire/index.tsx:25
-#: components/pages/Retire/index.tsx:26
+#: components/pages/Retire/index.tsx:33
+#: components/pages/Retire/index.tsx:34
 msgid "Retire | Carbonmark"
 msgstr "Retire | Carbonmark"
 
@@ -1009,9 +1018,13 @@ msgstr "View a complete overview of the digital carbon that you own in your Port
 msgid "View a complete overview of the digital carbon that you own in your Retire."
 msgstr "View a complete overview of the digital carbon that you own in your Retire."
 
-#: components/pages/Retire/index.tsx:27
+#: components/pages/Retire/index.tsx:35
 msgid "View a complete overview of the digital carbon that you retired."
 msgstr "View a complete overview of the digital carbon that you retired."
+
+#: components/pages/Retire/index.tsx:75
+msgid "View all Projects"
+msgstr "View all Projects"
 
 #: components/pages/Retire/Activity/Quotes.tsx:82
 #: components/pages/Retire/Activity/Table.tsx:66
@@ -1058,6 +1071,10 @@ msgstr "We are still processing your successful purchase. Please visit this page
 #: components/pages/Retirements/SingleRetirement/index.tsx:106
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 msgstr "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
+
+#: components/pages/Retire/index.tsx:81
+msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
+msgstr "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 
 #: components/pages/Project/Retire/RetireInputs.tsx:100
 #: components/pages/Project/Retire/RetireInputs.tsx:107
@@ -1147,19 +1164,19 @@ msgstr "bought from"
 msgid "buy"
 msgstr "Buy"
 
-#: components/Layout/index.tsx:84
+#: components/Layout/index.tsx:91
 msgid "connectModal.institutional"
 msgstr "institutional"
 
-#: components/Layout/index.tsx:76
+#: components/Layout/index.tsx:83
 msgid "connectModal.torus"
 msgstr "social or email"
 
-#: components/Layout/index.tsx:80
+#: components/Layout/index.tsx:87
 msgid "connectModal.wallet"
 msgstr "connect a wallet"
 
-#: components/Layout/index.tsx:93
+#: components/Layout/index.tsx:100
 msgid "connect_modal.connecting"
 msgstr "Connecting..."
 
@@ -1175,7 +1192,7 @@ msgstr "User refused connection."
 msgid "connect_modal.error_processing"
 msgstr "Request already processing. Please open your wallet and complete the request."
 
-#: components/Layout/index.tsx:97
+#: components/Layout/index.tsx:104
 msgid "connect_modal.error_title"
 msgstr "Connection Error"
 
@@ -1249,7 +1266,7 @@ msgstr "You will be taken to KlimaDAO.finance to complete this transaction."
 msgid "for"
 msgstr "for"
 
-#: components/pages/Retire/index.tsx:39
+#: components/pages/Retire/index.tsx:47
 msgid "for beneficiary"
 msgstr "for beneficiary"
 
@@ -1693,7 +1710,7 @@ msgstr "Sign In / Connect To Buy"
 msgid "shared.head.description"
 msgstr "Drive climate action and earn rewards with a carbon-backed digital currency."
 
-#: components/Layout/index.tsx:89
+#: components/Layout/index.tsx:96
 msgid "shared.login"
 msgstr "Login"
 

--- a/carbonmark/pages/retire/index.tsx
+++ b/carbonmark/pages/retire/index.tsx
@@ -1,10 +1,19 @@
 import { Retire } from "components/pages/Retire";
+import { getCarbonmarkProject } from "lib/carbonmark";
 import { loadTranslation } from "lib/i18n";
 import { GetStaticProps } from "next";
+
+const featuredProjectKeys = ["VCS-1577-2015", "VCS-1764-2020", "VCS-1121-2018"];
 
 export const getStaticProps: GetStaticProps = async (ctx) => {
   try {
     const translation = await loadTranslation(ctx.locale);
+
+    const featuredProjects = await Promise.all(
+      featuredProjectKeys.map(
+        async (project) => await getCarbonmarkProject(project)
+      )
+    );
 
     if (!translation) {
       throw new Error("No translation found");
@@ -13,6 +22,7 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
     return {
       props: {
         translation,
+        featuredProjects,
         fixedThemeName: "theme-light",
       },
     };


### PR DESCRIPTION
## Description

~**🔥 ~MERGE IS BLOCKED BY THIS [PR](https://github.com/KlimaDAO/klimadao/pull/1224)~ 🔥** ~ ✔️ 

This PR adds hardcoded featured projects to the Retire view.

## Design Changes

- The link "View all Projects" is moved to the right as it was hard to properly align this link with the main headline which breaks on smaller screens (and breaks into centered or left alignment depending on the browser size)
- The project description height is fixed which doesn't work well with the super long project title of the second project as now the description is cut off differently
- => maybe change/shorten the project title of the second project (in CMS??) 


Preview URL: https://carbonmark-git-lady-retire-featured-projects-klimadao.vercel.app/retire

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1209


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
