### PR TITLE
Retire: Quick retire from default pool projects

### DIFF
--- a/carbonmark/components/ProjectCard/index.tsx
+++ b/carbonmark/components/ProjectCard/index.tsx
@@ -17,6 +17,7 @@ import * as styles from "./styles";
 type Props = {
   project: Project;
   className?: string;
+  url?: string;
 };
 
 export const ProjectCard: FC<Props> = (props) => {
@@ -26,7 +27,7 @@ export const ProjectCard: FC<Props> = (props) => {
 
   return (
     <Link
-      href={createProjectLink(project)}
+      href={props.url || createProjectLink(project)}
       passHref
       className={cx(styles.card, props.className)}
     >

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -16,6 +16,7 @@ import * as styles from "./styles";
 
 export type PageProps = {
   featuredProjects: Project[];
+  defaultProjects: Project[];
 };
 
 export const Retire: NextPage<PageProps> = (props) => {
@@ -92,6 +93,30 @@ export const Retire: NextPage<PageProps> = (props) => {
                   project={p}
                   className={styles.featuredCard}
                 />
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.fullWhite}>
+          <div className={styles.content}>
+            <div className={styles.cardsHeader}>
+              <Text t="h4" className={styles.textWithIcon}>
+                <Trans>Quick Retire</Trans>
+              </Text>
+            </div>
+
+            <Text className={styles.cardsDescription}>
+              <Trans>
+                Don’t want to go through the trouble of searching and selecting
+                a project to retire? Here’s a list of discount retirements from
+                trusted vendors.
+              </Trans>
+            </Text>
+
+            <div className={styles.cardsList}>
+              {props.defaultProjects.map((p) => (
+                <ProjectCard key={p.id} project={p} />
               ))}
             </div>
           </div>

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -1,4 +1,8 @@
-import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
+import {
+  concatAddress,
+  getPoolNameFromAddress,
+  useWeb3,
+} from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import LocalPoliceIcon from "@mui/icons-material/LocalPolice";
 import { CopyAddressButton } from "components/CopyAddressButton";
@@ -8,6 +12,7 @@ import { PageHead } from "components/PageHead";
 import { ProjectCard } from "components/ProjectCard";
 import { Text } from "components/Text";
 import { useGetDomainFromAddress } from "hooks/useGetDomainFromAddress";
+import { createProjectPoolRetireLink } from "lib/createUrls";
 import { Project } from "lib/types/carbonmark";
 import { NextPage } from "next";
 import Link from "next/link";
@@ -115,9 +120,20 @@ export const Retire: NextPage<PageProps> = (props) => {
             </Text>
 
             <div className={styles.cardsList}>
-              {props.defaultProjects.map((p) => (
-                <ProjectCard key={p.id} project={p} />
-              ))}
+              {props.defaultProjects.map((p) => {
+                if (p.isPoolProject)
+                  return (
+                    <ProjectCard
+                      key={p.id}
+                      project={p}
+                      url={createProjectPoolRetireLink(
+                        p,
+                        getPoolNameFromAddress(p.projectAddress) || "NBO" // typeguard, THE PROJECT ADDRESS FOR NBO 'VCS-981-2014'  IS NOT CORRECT ON CARBONMARK API !!
+                      )}
+                    />
+                  );
+                return null;
+              })}
             </div>
           </div>
         </div>

--- a/carbonmark/lib/createUrls.ts
+++ b/carbonmark/lib/createUrls.ts
@@ -1,5 +1,5 @@
 import { urls } from "@klimadao/lib/constants";
-import { Project } from "lib/types/carbonmark";
+import { Price, Project } from "lib/types/carbonmark";
 
 type ProjectData = {
   key: Project["key"];
@@ -14,6 +14,11 @@ export const createProjectPurchaseLink = (
 ) => `${createProjectLink(project)}/purchase/${listingId}`;
 
 export const createSellerLink = (handle: string) => `/users/${handle}`;
+
+export const createProjectPoolRetireLink = (
+  project: ProjectData,
+  pool: Price["name"] | Lowercase<Price["name"]>
+) => `${createProjectLink(project)}/retire/pools/${pool.toLowerCase()}`;
 
 /**
  * @example

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -192,7 +192,7 @@ msgstr ""
 msgid "Carbon Pool"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:42
+#: components/pages/Retire/index.tsx:43
 msgid "Carbon Retirements"
 msgstr ""
 
@@ -318,6 +318,10 @@ msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:180
 msgid "Display name is required"
+msgstr ""
+
+#: components/pages/Retire/index.tsx:110
+msgid "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
 msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:156
@@ -662,6 +666,10 @@ msgstr ""
 msgid "Quantity purchased:"
 msgstr ""
 
+#: components/pages/Retire/index.tsx:105
+msgid "Quick Retire"
+msgstr ""
+
 #: components/pages/Project/Retire/SubmitButton.tsx:44
 msgid "RETIRE CARBON"
 msgstr ""
@@ -703,7 +711,7 @@ msgstr ""
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:70
+#: components/pages/Retire/index.tsx:71
 msgid "Retire from a featured project"
 msgstr ""
 
@@ -726,8 +734,8 @@ msgstr ""
 
 #: components/pages/Portfolio/Retire/index.tsx:75
 #: components/pages/Portfolio/Retire/index.tsx:76
-#: components/pages/Retire/index.tsx:33
 #: components/pages/Retire/index.tsx:34
+#: components/pages/Retire/index.tsx:35
 msgid "Retire | Carbonmark"
 msgstr ""
 
@@ -1024,11 +1032,11 @@ msgstr ""
 msgid "View a complete overview of the digital carbon that you own in your Retire."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:35
+#: components/pages/Retire/index.tsx:36
 msgid "View a complete overview of the digital carbon that you retired."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:75
+#: components/pages/Retire/index.tsx:76
 msgid "View all Projects"
 msgstr ""
 
@@ -1082,7 +1090,7 @@ msgstr ""
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:81
+#: components/pages/Retire/index.tsx:82
 msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 msgstr ""
 
@@ -1276,7 +1284,7 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:47
+#: components/pages/Retire/index.tsx:48
 msgid "for beneficiary"
 msgstr ""
 

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -198,7 +198,7 @@ msgstr "Cancel"
 msgid "Carbon Pool"
 msgstr "Carbon Pool"
 
-#: components/pages/Retire/index.tsx:42
+#: components/pages/Retire/index.tsx:43
 msgid "Carbon Retirements"
 msgstr "Carbon Retirements"
 
@@ -325,6 +325,10 @@ msgstr "Display name"
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:180
 msgid "Display name is required"
 msgstr "Display name is required"
+
+#: components/pages/Retire/index.tsx:110
+msgid "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
+msgstr "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
 
 #: components/pages/Users/SellerConnected/index.tsx:156
 msgid "Edit Profile"
@@ -668,6 +672,10 @@ msgstr "Quantity listed: {listedQuantity}, Quantity unlisted: {0}, Total availab
 msgid "Quantity purchased:"
 msgstr "Quantity purchased:"
 
+#: components/pages/Retire/index.tsx:105
+msgid "Quick Retire"
+msgstr "Quick Retire"
+
 #: components/pages/Project/Retire/SubmitButton.tsx:44
 msgid "RETIRE CARBON"
 msgstr "RETIRE CARBON"
@@ -709,7 +717,7 @@ msgstr "Retire"
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "Retire carbon credits for yourself, or on behalf of another person or organization."
 
-#: components/pages/Retire/index.tsx:70
+#: components/pages/Retire/index.tsx:71
 msgid "Retire from a featured project"
 msgstr "Retire from a featured project"
 
@@ -732,8 +740,8 @@ msgstr "Retire now"
 
 #: components/pages/Portfolio/Retire/index.tsx:75
 #: components/pages/Portfolio/Retire/index.tsx:76
-#: components/pages/Retire/index.tsx:33
 #: components/pages/Retire/index.tsx:34
+#: components/pages/Retire/index.tsx:35
 msgid "Retire | Carbonmark"
 msgstr "Retire | Carbonmark"
 
@@ -1030,11 +1038,11 @@ msgstr "View a complete overview of the digital carbon that you own in your Port
 msgid "View a complete overview of the digital carbon that you own in your Retire."
 msgstr "View a complete overview of the digital carbon that you own in your Retire."
 
-#: components/pages/Retire/index.tsx:35
+#: components/pages/Retire/index.tsx:36
 msgid "View a complete overview of the digital carbon that you retired."
 msgstr "View a complete overview of the digital carbon that you retired."
 
-#: components/pages/Retire/index.tsx:75
+#: components/pages/Retire/index.tsx:76
 msgid "View all Projects"
 msgstr "View all Projects"
 
@@ -1088,7 +1096,7 @@ msgstr "We are still processing your successful purchase. Please visit this page
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 msgstr "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 
-#: components/pages/Retire/index.tsx:81
+#: components/pages/Retire/index.tsx:82
 msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 msgstr "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 
@@ -1282,7 +1290,7 @@ msgstr "You will be taken to KlimaDAO.finance to complete this transaction."
 msgid "for"
 msgstr "for"
 
-#: components/pages/Retire/index.tsx:47
+#: components/pages/Retire/index.tsx:48
 msgid "for beneficiary"
 msgstr "for beneficiary"
 

--- a/carbonmark/pages/retire/index.tsx
+++ b/carbonmark/pages/retire/index.tsx
@@ -1,9 +1,11 @@
+import { defaultProjects } from "@klimadao/lib/utils";
 import { Retire } from "components/pages/Retire";
 import { getCarbonmarkProject } from "lib/carbonmark";
 import { loadTranslation } from "lib/i18n";
 import { GetStaticProps } from "next";
 
 const featuredProjectKeys = ["VCS-1577-2015", "VCS-1764-2020", "VCS-1121-2018"];
+const defaultProjectKeys = defaultProjects.map((p) => p.id);
 
 export const getStaticProps: GetStaticProps = async (ctx) => {
   try {
@@ -11,6 +13,12 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
 
     const featuredProjects = await Promise.all(
       featuredProjectKeys.map(
+        async (project) => await getCarbonmarkProject(project)
+      )
+    );
+
+    const defaultProjects = await Promise.all(
+      defaultProjectKeys.map(
         async (project) => await getCarbonmarkProject(project)
       )
     );
@@ -23,6 +31,7 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
       props: {
         translation,
         featuredProjects,
+        defaultProjects,
         fixedThemeName: "theme-light",
       },
     };

--- a/lib/utils/getDefaultProjects/index.ts
+++ b/lib/utils/getDefaultProjects/index.ts
@@ -1,3 +1,5 @@
+import { PoolToken } from "../../constants";
+
 /* Default projects
 BCT - https://www.carbonmark.com/projects/VCS-191-2008 - 0xb139c4cc9d20a3618e9a2268d73eff18c496b991
 NCT - https://www.carbonmark.com/projects/VCS-1529-2012 - 0x6362364a37f34d39a1f4993fb595dab4116daf0d
@@ -6,7 +8,13 @@ NBO - https://www.carbonmark.com/projects/VCS-981-2014 - 0xb6ea7a53fc048d6d3b80b
 */
 
 /** These are the default (oldest vintage) projects in each pool */
-export const defaultProjects = [
+
+type defaultProject = {
+  id: string;
+  address: string;
+  pool: PoolToken;
+};
+export const defaultProjects: defaultProject[] = [
   {
     id: "VCS-191-2008",
     address: "0xb139c4cc9d20a3618e9a2268d73eff18c496b991",
@@ -35,3 +43,12 @@ const knownDefaultProjects = defaultProjects
 
 export const isDefaultProjectAddress = (projectAddress: string): boolean =>
   knownDefaultProjects.includes(projectAddress.toLowerCase());
+
+export const getPoolNameFromAddress = (
+  projectAddress: string
+): PoolToken | null => {
+  if (!isDefaultProjectAddress(projectAddress)) return null;
+  return (
+    defaultProjects.find((d) => d.address === projectAddress)?.pool || null
+  );
+};

--- a/lib/utils/getDefaultProjects/index.ts
+++ b/lib/utils/getDefaultProjects/index.ts
@@ -1,0 +1,37 @@
+/* Default projects
+BCT - https://www.carbonmark.com/projects/VCS-191-2008 - 0xb139c4cc9d20a3618e9a2268d73eff18c496b991
+NCT - https://www.carbonmark.com/projects/VCS-1529-2012 - 0x6362364a37f34d39a1f4993fb595dab4116daf0d
+UBO - https://www.carbonmark.com/projects/VCS-1140-2015 - 0xd6ed6fae5b6535cae8d92f40f5ff653db807a4ea
+NBO - https://www.carbonmark.com/projects/VCS-981-2014 - 0xb6ea7a53fc048d6d3b80b968d696e39482b7e578
+*/
+
+/** These are the default (oldest vintage) projects in each pool */
+export const defaultProjects = [
+  {
+    id: "VCS-191-2008",
+    address: "0xb139c4cc9d20a3618e9a2268d73eff18c496b991",
+    pool: "bct",
+  },
+  {
+    id: "VCS-1529-2012",
+    address: "0x6362364a37f34d39a1f4993fb595dab4116daf0d",
+    pool: "nct",
+  },
+  {
+    id: "VCS-1140-2015",
+    address: "0xd6ed6fae5b6535cae8d92f40f5ff653db807a4ea",
+    pool: "ubo",
+  },
+  {
+    id: "VCS-981-2014",
+    address: "0xb6ea7a53fc048d6d3b80b968d696e39482b7e578",
+    pool: "nbo",
+  },
+];
+
+const knownDefaultProjects = defaultProjects
+  .map((p) => p.address)
+  .map((addr) => addr.toLowerCase());
+
+export const isDefaultProjectAddress = (projectAddress: string): boolean =>
+  knownDefaultProjects.includes(projectAddress.toLowerCase());

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -10,6 +10,7 @@ export {
   getTokensFromSpender,
 } from "./getAllowance";
 export { getContract } from "./getContract";
+export { defaultProjects, isDefaultProjectAddress } from "./getDefaultProjects";
 export { getEstimatedDailyRebases } from "./getEstimatedDailyRebases";
 export { getImageSizes } from "./getImageSizes";
 export { getInfuraUrl } from "./getInfuraUrl";

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -10,7 +10,11 @@ export {
   getTokensFromSpender,
 } from "./getAllowance";
 export { getContract } from "./getContract";
-export { defaultProjects, isDefaultProjectAddress } from "./getDefaultProjects";
+export {
+  defaultProjects,
+  getPoolNameFromAddress,
+  isDefaultProjectAddress,
+} from "./getDefaultProjects";
 export { getEstimatedDailyRebases } from "./getEstimatedDailyRebases";
 export { getImageSizes } from "./getImageSizes";
 export { getInfuraUrl } from "./getInfuraUrl";


### PR DESCRIPTION
## Description

### PLEASE READ FIRST:

These are the default projects:
```TS
{
    id: "VCS-191-2008",
    address: "0xb139c4cc9d20a3618e9a2268d73eff18c496b991",
    pool: "bct",
  },
  {
    id: "VCS-1529-2012",
    address: "0x6362364a37f34d39a1f4993fb595dab4116daf0d",
    pool: "nct",
  },
  {
    id: "VCS-1140-2015",
    address: "0xd6ed6fae5b6535cae8d92f40f5ff653db807a4ea",
    pool: "ubo",
  },
  {
    id: "VCS-981-2014",
    address: "0xb6ea7a53fc048d6d3b80b968d696e39482b7e578",
    pool: "nbo",
  }
```

### BUG:
When fetching the Carbonmark API for the default project for **NBO** with "VCS-981-2014":
- GET https://api.carbonmark.com/api/projects/VCS-981-2014
- RESULT: The `projectAddress` is NOT `0xb6ea7a53fc048d6d3b80b968d696e39482b7e578`
- RESULT: The `projectAddress` is `0xabfd6760151c7f9361cc5b03bbeebe2d7c0251da` (some poolTokenAddress for NCT)

**How to proceed here?**
- Either, I need to fetch the project data not from the Carbonmark API?
- Or this is a bug on the backend?
- Or I have some misunderstanding here?


## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1211

PREVIEW URL: https://carbonmark-git-lady-retire-default-projects-klimadao.vercel.app/retire

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
