### PR TITLE
Retire: Show Assets from Portfolio

### DIFF
--- a/carbonmark/components/pages/Retire/FromPortfolio/AssetProject/index.tsx
+++ b/carbonmark/components/pages/Retire/FromPortfolio/AssetProject/index.tsx
@@ -43,8 +43,8 @@ export const AssetProject: FC<Props> = (props) => {
         </div>
 
         <Text t="body1">
-          <Trans>Quantity Available:</Trans>{" "}
-          {formatToTonnes(props.asset.balance, locale)}
+          <Trans>Available Tonnes:</Trans>{" "}
+          <b>{formatToTonnes(props.asset.balance, locale)}</b>
         </Text>
       </div>
     </Link>

--- a/carbonmark/components/pages/Retire/FromPortfolio/AssetProject/index.tsx
+++ b/carbonmark/components/pages/Retire/FromPortfolio/AssetProject/index.tsx
@@ -1,0 +1,52 @@
+import { Trans } from "@lingui/macro";
+import { Category } from "components/Category";
+import { ProjectImage } from "components/ProjectImage";
+import { ProjectKey } from "components/ProjectKey";
+import { Text } from "components/Text";
+import { Vintage } from "components/Vintage";
+import { formatToTonnes } from "lib/formatNumbers";
+import { AssetForListing } from "lib/types/carbonmark";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { FC } from "react";
+import * as styles from "./styles";
+
+interface Props {
+  asset: AssetForListing;
+}
+
+export const AssetProject: FC<Props> = (props) => {
+  const { locale } = useRouter();
+
+  // typeguard
+  if (!props.asset.project) {
+    return null;
+  }
+
+  return (
+    <Link
+      href={`/portfolio/${props.asset.tokenAddress}/retire`}
+      passHref
+      className={styles.card}
+    >
+      <div className={styles.tags}>
+        <Category category={props.asset.project.category} />
+        <Vintage vintage={props.asset.project.vintage} />
+        <ProjectKey projectKey={props.asset.project.key} />
+      </div>
+
+      <Text t="h4">{props.asset.project?.name || props.asset.tokenName}</Text>
+
+      <div className={styles.belowHeadline}>
+        <div className={styles.image}>
+          <ProjectImage category={props.asset.project?.category} />
+        </div>
+
+        <Text t="body1">
+          <Trans>Quantity Available:</Trans>{" "}
+          {formatToTonnes(props.asset.balance, locale)}
+        </Text>
+      </div>
+    </Link>
+  );
+};

--- a/carbonmark/components/pages/Retire/FromPortfolio/AssetProject/styles.ts
+++ b/carbonmark/components/pages/Retire/FromPortfolio/AssetProject/styles.ts
@@ -1,0 +1,46 @@
+import { css } from "@emotion/css";
+import breakpoints from "@klimadao/lib/theme/breakpoints";
+
+export const card = css`
+  box-shadow: var(--shadow-01);
+  width: 100%;
+  line-height: 1.15;
+  transition: 0.25s ease-in-out;
+  background-color: var(--surface-01);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-01);
+  padding: 1.6rem;
+  display: flex;
+  gap: 1.6rem;
+  flex-direction: column;
+
+  ${breakpoints.medium} {
+    max-width: 33rem;
+  }
+  ${breakpoints.large} {
+    transition: all 0.2s ease 0s;
+    &:hover {
+      transform: scale(0.98);
+      box-shadow: var(--shadow-02);
+    }
+  }
+`;
+
+export const image = css`
+  position: relative;
+  overflow: hidden;
+
+  min-height: 12rem;
+`;
+
+export const tags = css`
+  display: flex;
+  gap: 1.6rem;
+  flex-direction: row;
+`;
+
+export const belowHeadline = css`
+  display: grid;
+  gap: 1rem;
+  margin-top: auto;
+`;

--- a/carbonmark/components/pages/Retire/FromPortfolio/AssetProject/styles.ts
+++ b/carbonmark/components/pages/Retire/FromPortfolio/AssetProject/styles.ts
@@ -35,7 +35,7 @@ export const image = css`
 
 export const tags = css`
   display: flex;
-  gap: 1.6rem;
+  gap: 0.8rem;
   flex-direction: row;
 `;
 

--- a/carbonmark/components/pages/Retire/FromPortfolio/index.tsx
+++ b/carbonmark/components/pages/Retire/FromPortfolio/index.tsx
@@ -24,8 +24,10 @@ export const RetireFromPortfolio: FC<Props> = (props) => {
     !!carbonmarkUser?.assets?.length &&
     getAssetsWithProjectTokens(carbonmarkUser.assets);
 
-  const emptyAssets = !isLoadingAssets && !assetsData?.length;
-  const hasAssets = !isLoadingAssets && !!assetWithProjectTokens;
+  const emptyAssets =
+    !!carbonmarkUser && !isLoadingAssets && !assetsData?.length;
+  const hasAssets =
+    !!carbonmarkUser && !isLoadingAssets && !!assetWithProjectTokens;
   const isUnregistered = props.address && !isLoading && carbonmarkUser === null;
 
   // load Assets on carbonmarkUser

--- a/carbonmark/components/pages/Retire/FromPortfolio/index.tsx
+++ b/carbonmark/components/pages/Retire/FromPortfolio/index.tsx
@@ -1,0 +1,102 @@
+import { t, Trans } from "@lingui/macro";
+import { SpinnerWithLabel } from "components/SpinnerWithLabel";
+import { Text } from "components/Text";
+import { useFetchUser } from "hooks/useFetchUser";
+import { addProjectsToAssets } from "lib/actions";
+import { getAssetsWithProjectTokens } from "lib/getAssetsData";
+import { AssetForListing } from "lib/types/carbonmark";
+import Link from "next/link";
+import { FC, useEffect, useState } from "react";
+import { AssetProject } from "./AssetProject";
+import * as styles from "./styles";
+
+export type Props = {
+  address: string;
+};
+
+export const RetireFromPortfolio: FC<Props> = (props) => {
+  const { carbonmarkUser, isLoading } = useFetchUser(props.address);
+
+  const [isLoadingAssets, setIsLoadingAssets] = useState(false);
+  const [assetsData, setAssetsData] = useState<AssetForListing[] | null>(null);
+
+  const assetWithProjectTokens =
+    !!carbonmarkUser?.assets?.length &&
+    getAssetsWithProjectTokens(carbonmarkUser.assets);
+
+  const emptyAssets = !isLoadingAssets && !assetsData?.length;
+  const hasAssets = !isLoadingAssets && !!assetWithProjectTokens;
+  const isUnregistered = props.address && !isLoading && carbonmarkUser === null;
+
+  // load Assets on carbonmarkUser
+  useEffect(() => {
+    if (hasAssets) {
+      const getAssetsData = async () => {
+        try {
+          setIsLoadingAssets(true);
+
+          if (assetWithProjectTokens) {
+            const assetsWithProject = await addProjectsToAssets({
+              assets: assetWithProjectTokens,
+            });
+
+            // TODO: filter assets with balance > 0
+            // this will be unnecessary as soon as bezos switched to mainnet
+            const assetsWithBalance = assetsWithProject.filter(
+              (a) => Number(a.balance) > 0
+            );
+
+            setAssetsData(assetsWithBalance);
+          }
+        } catch (e) {
+          console.error(e);
+        } finally {
+          setIsLoadingAssets(false);
+        }
+      };
+
+      getAssetsData();
+    }
+  }, [carbonmarkUser]);
+
+  return (
+    <>
+      {isLoadingAssets && <SpinnerWithLabel label={t`Loading your assets`} />}
+
+      <div className={styles.cardsList}>
+        {!!assetsData &&
+          assetsData.map((a) => (
+            <AssetProject asset={a} key={a.tokenAddress} />
+          ))}
+      </div>
+
+      {emptyAssets && (
+        <Text>
+          <i>
+            <Trans>No listable assets found.</Trans>
+          </i>
+        </Text>
+      )}
+
+      {isUnregistered && (
+        <>
+          <Text>
+            <i>
+              <Trans>
+                Sorry. We could not find any data on Carbonmark for your user.
+              </Trans>
+            </i>
+          </Text>
+          <Text>
+            <i>
+              <Trans>
+                Have you already created your Carbonmark{" "}
+                <Link href={`/users/${props.address}`}>Profile</Link>?
+              </Trans>
+            </i>
+          </Text>
+        </>
+      )}
+    </>
+  );
+};

--- a/carbonmark/components/pages/Retire/FromPortfolio/styles.ts
+++ b/carbonmark/components/pages/Retire/FromPortfolio/styles.ts
@@ -1,0 +1,14 @@
+import { css } from "@emotion/css";
+import breakpoints from "@klimadao/lib/theme/breakpoints";
+
+export const cardsList = css`
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+
+  justify-content: center;
+
+  ${breakpoints.medium} {
+    justify-content: space-evenly;
+  }
+`;

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -15,6 +15,7 @@ import { Project } from "lib/types/carbonmark";
 import { NextPage } from "next";
 import Link from "next/link";
 import { RetireActivity } from "./Activity";
+import { RetireFromPortfolio } from "./FromPortfolio";
 import * as styles from "./styles";
 
 export type PageProps = {
@@ -101,6 +102,28 @@ export const Retire: NextPage<PageProps> = (props) => {
             </div>
           </div>
         </div>
+
+        {isConnectedUser && (
+          <div className={styles.content}>
+            <div className={styles.cardsHeader}>
+              <Text t="h4">
+                <Trans>Retire from your portfolio</Trans>
+              </Text>
+              <Link href="/portfolio">
+                <Text t="body4" className={styles.textLink}>
+                  <Trans>View all Portfolio items</Trans>
+                </Text>
+              </Link>
+            </div>
+            <Text className={styles.cardsDescription}>
+              <Trans>
+                You can also retire any carbon asset in your wallet.
+              </Trans>
+            </Text>
+
+            <RetireFromPortfolio address={address} />
+          </div>
+        )}
 
         <div
           className={cx(styles.fullWidth, {

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -70,26 +70,27 @@ export const Retire: NextPage<PageProps> = (props) => {
 
         <div className={cx(styles.fullWidth, "whiteBG")}>
           <div className={styles.content}>
-            <div className={styles.cardsHeader}>
-              <Text t="h4" className={styles.textWithIcon}>
-                <LocalPoliceIcon className="featured" fontSize="inherit" />
-                <Trans>Retire from a featured project</Trans>
-              </Text>
-
-              <Link href="/projects">
-                <Text t="body4" className={styles.textLink}>
-                  <Trans>View all Projects</Trans>
+            <div className={styles.sectionTitle}>
+              <div className={styles.cardsHeader}>
+                <Text t="h4" className={styles.textWithIcon}>
+                  <LocalPoliceIcon className="featured" fontSize="inherit" />
+                  <Trans>Retire from a featured project</Trans>
                 </Text>
-              </Link>
-            </div>
 
-            <Text className={styles.cardsDescription}>
-              <Trans>
-                We’ve hand-curated some of the best projects based on strict
-                criteria, such as price, veracity, and global environmental
-                impact.
-              </Trans>
-            </Text>
+                <Link href="/projects">
+                  <Text t="body4" className={styles.textLink}>
+                    <Trans>View all Projects</Trans>
+                  </Text>
+                </Link>
+              </div>
+              <Text className={styles.cardsDescription}>
+                <Trans>
+                  We’ve hand-curated some of the best projects based on strict
+                  criteria, such as price, veracity, and global environmental
+                  impact.
+                </Trans>
+              </Text>
+            </div>
 
             <div className={styles.cardsList}>
               {props.featuredProjects.map((p) => (
@@ -105,22 +106,23 @@ export const Retire: NextPage<PageProps> = (props) => {
 
         {isConnectedUser && (
           <div className={styles.content}>
-            <div className={styles.cardsHeader}>
-              <Text t="h4">
-                <Trans>Retire from your portfolio</Trans>
-              </Text>
-              <Link href="/portfolio">
-                <Text t="body4" className={styles.textLink}>
-                  <Trans>View all Portfolio items</Trans>
+            <div className={styles.sectionTitle}>
+              <div className={styles.cardsHeader}>
+                <Text t="h4">
+                  <Trans>Retire from your portfolio</Trans>
                 </Text>
-              </Link>
+                <Link href="/portfolio">
+                  <Text t="body4" className={styles.textLink}>
+                    <Trans>View all Portfolio items</Trans>
+                  </Text>
+                </Link>
+              </div>
+              <Text className={styles.cardsDescription}>
+                <Trans>
+                  You can also retire any carbon asset in your wallet.
+                </Trans>
+              </Text>
             </div>
-            <Text className={styles.cardsDescription}>
-              <Trans>
-                You can also retire any carbon asset in your wallet.
-              </Trans>
-            </Text>
-
             <RetireFromPortfolio address={address} />
           </div>
         )}
@@ -131,19 +133,21 @@ export const Retire: NextPage<PageProps> = (props) => {
           })}
         >
           <div className={styles.content}>
-            <div className={styles.cardsHeader}>
-              <Text t="h4" className={styles.textWithIcon}>
-                <Trans>Quick Retire</Trans>
+            <div className={styles.sectionTitle}>
+              <div className={styles.cardsHeader}>
+                <Text t="h4" className={styles.textWithIcon}>
+                  <Trans>Quick Retire</Trans>
+                </Text>
+              </div>
+
+              <Text className={styles.cardsDescription}>
+                <Trans>
+                  Don’t want to go through the trouble of searching and
+                  selecting a project to retire? Here’s a list of discount
+                  retirements from trusted vendors.
+                </Trans>
               </Text>
             </div>
-
-            <Text className={styles.cardsDescription}>
-              <Trans>
-                Don’t want to go through the trouble of searching and selecting
-                a project to retire? Here’s a list of discount retirements from
-                trusted vendors.
-              </Trans>
-            </Text>
 
             <div className={styles.cardsList}>
               {props.defaultProjects.map((p) => {

--- a/carbonmark/components/pages/Retire/styles.ts
+++ b/carbonmark/components/pages/Retire/styles.ts
@@ -73,6 +73,11 @@ export const featuredCard = css`
   border: 2px solid var(--yellow);
 `;
 
+export const sectionTitle = css`
+  display: grid;
+  gap: 0.8rem;
+`;
+
 export const cardsHeader = css`
   display: flex;
   gap: 0.8rem;

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -102,6 +102,7 @@ msgid "Asset ID"
 msgstr ""
 
 #: components/ProjectCard/index.tsx:43
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:46
 msgid "Available Tonnes:"
 msgstr ""
 
@@ -370,7 +371,7 @@ msgstr ""
 msgid "Display name is required"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:141
+#: components/pages/Retire/index.tsx:144
 msgid "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
 msgstr ""
 
@@ -776,7 +777,6 @@ msgstr ""
 #: components/pages/Portfolio/AssetProject/index.tsx:58
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:41
 #: components/pages/Project/BuyOptions/SellerListing.tsx:79
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:46
 msgid "Quantity Available:"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Quantity purchased:"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:136
+#: components/pages/Retire/index.tsx:139
 msgid "Quick Retire"
 msgstr ""
 
@@ -858,11 +858,11 @@ msgstr ""
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:76
+#: components/pages/Retire/index.tsx:77
 msgid "Retire from a featured project"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:110
+#: components/pages/Retire/index.tsx:112
 msgid "Retire from your portfolio"
 msgstr ""
 
@@ -1228,11 +1228,11 @@ msgstr ""
 msgid "View a complete overview of the digital carbon that you retired."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:114
+#: components/pages/Retire/index.tsx:116
 msgid "View all Portfolio items"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:81
+#: components/pages/Retire/index.tsx:82
 msgid "View all Projects"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "You are about to retire a carbon asset."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:119
+#: components/pages/Retire/index.tsx:121
 msgid "You can also retire any carbon asset in your wallet."
 msgstr ""
 

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Carbon Pool"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:47
+#: components/pages/Retire/index.tsx:48
 msgid "Carbon Retirements"
 msgstr ""
 
@@ -370,7 +370,7 @@ msgstr ""
 msgid "Display name is required"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:118
+#: components/pages/Retire/index.tsx:141
 msgid "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
 msgstr ""
 
@@ -432,6 +432,7 @@ msgstr ""
 
 #: components/pages/Portfolio/Retire/index.tsx:102
 #: components/pages/Portfolio/index.tsx:111
+#: components/pages/Retire/FromPortfolio/index.tsx:94
 msgid "Have you already created your Carbonmark <0>Profile</0>?"
 msgstr ""
 
@@ -525,6 +526,7 @@ msgid "Loading"
 msgstr ""
 
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:67
+#: components/pages/Retire/FromPortfolio/index.tsx:66
 msgid "Loading your assets"
 msgstr ""
 
@@ -611,6 +613,7 @@ msgid "No data to show"
 msgstr ""
 
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:104
+#: components/pages/Retire/FromPortfolio/index.tsx:78
 msgid "No listable assets found."
 msgstr ""
 
@@ -773,6 +776,7 @@ msgstr ""
 #: components/pages/Portfolio/AssetProject/index.tsx:58
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:41
 #: components/pages/Project/BuyOptions/SellerListing.tsx:79
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:46
 msgid "Quantity Available:"
 msgstr ""
 
@@ -788,7 +792,7 @@ msgstr ""
 msgid "Quantity purchased:"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:113
+#: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr ""
 
@@ -854,8 +858,12 @@ msgstr ""
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:75
+#: components/pages/Retire/index.tsx:76
 msgid "Retire from a featured project"
+msgstr ""
+
+#: components/pages/Retire/index.tsx:110
+msgid "Retire from your portfolio"
 msgstr ""
 
 #: components/pages/Project/Retire/index.tsx:24
@@ -885,8 +893,8 @@ msgstr ""
 
 #: components/pages/Portfolio/Retire/index.tsx:75
 #: components/pages/Portfolio/Retire/index.tsx:76
-#: components/pages/Retire/index.tsx:38
 #: components/pages/Retire/index.tsx:39
+#: components/pages/Retire/index.tsx:40
 msgid "Retire | Carbonmark"
 msgstr ""
 
@@ -976,6 +984,7 @@ msgstr ""
 
 #: components/pages/Portfolio/Retire/index.tsx:97
 #: components/pages/Portfolio/index.tsx:105
+#: components/pages/Retire/FromPortfolio/index.tsx:87
 msgid "Sorry. We could not find any data on Carbonmark for your user."
 msgstr ""
 
@@ -1215,11 +1224,15 @@ msgstr ""
 msgid "View a complete overview of the digital carbon that you own in your Retire."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:40
+#: components/pages/Retire/index.tsx:41
 msgid "View a complete overview of the digital carbon that you retired."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:80
+#: components/pages/Retire/index.tsx:114
+msgid "View all Portfolio items"
+msgstr ""
+
+#: components/pages/Retire/index.tsx:81
 msgid "View all Projects"
 msgstr ""
 
@@ -1269,7 +1282,7 @@ msgstr ""
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:86
+#: components/pages/Retire/index.tsx:87
 msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 msgstr ""
 
@@ -1298,6 +1311,10 @@ msgstr ""
 
 #: components/pages/Project/Retire/RetireModal.tsx:38
 msgid "You are about to retire a carbon asset."
+msgstr ""
+
+#: components/pages/Retire/index.tsx:119
+msgid "You can also retire any carbon asset in your wallet."
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:107
@@ -1471,7 +1488,7 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:52
+#: components/pages/Retire/index.tsx:53
 msgid "for beneficiary"
 msgstr ""
 

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -213,7 +213,7 @@ msgstr "Cancel"
 msgid "Carbon Pool"
 msgstr "Carbon Pool"
 
-#: components/pages/Retire/index.tsx:47
+#: components/pages/Retire/index.tsx:48
 msgid "Carbon Retirements"
 msgstr "Carbon Retirements"
 
@@ -376,7 +376,7 @@ msgstr "Display name"
 msgid "Display name is required"
 msgstr "Display name is required"
 
-#: components/pages/Retire/index.tsx:118
+#: components/pages/Retire/index.tsx:141
 msgid "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
 msgstr "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
 
@@ -438,6 +438,7 @@ msgstr "Handle should not contain any special characters"
 
 #: components/pages/Portfolio/Retire/index.tsx:102
 #: components/pages/Portfolio/index.tsx:111
+#: components/pages/Retire/FromPortfolio/index.tsx:94
 msgid "Have you already created your Carbonmark <0>Profile</0>?"
 msgstr "Have you already created your Carbonmark <0>Profile</0>?"
 
@@ -531,6 +532,7 @@ msgid "Loading"
 msgstr "Loading"
 
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:67
+#: components/pages/Retire/FromPortfolio/index.tsx:66
 msgid "Loading your assets"
 msgstr "Loading your assets"
 
@@ -617,6 +619,7 @@ msgid "No data to show"
 msgstr "No data to show"
 
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:104
+#: components/pages/Retire/FromPortfolio/index.tsx:78
 msgid "No listable assets found."
 msgstr "No listable assets found."
 
@@ -779,6 +782,7 @@ msgstr "QTY"
 #: components/pages/Portfolio/AssetProject/index.tsx:58
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:41
 #: components/pages/Project/BuyOptions/SellerListing.tsx:79
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:46
 msgid "Quantity Available:"
 msgstr "Quantity Available:"
 
@@ -794,7 +798,7 @@ msgstr "Quantity listed: {listedQuantity}, Quantity unlisted: {0}, Total availab
 msgid "Quantity purchased:"
 msgstr "Quantity purchased:"
 
-#: components/pages/Retire/index.tsx:113
+#: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr "Quick Retire"
 
@@ -860,9 +864,13 @@ msgstr "Retire"
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "Retire carbon credits for yourself, or on behalf of another person or organization."
 
-#: components/pages/Retire/index.tsx:75
+#: components/pages/Retire/index.tsx:76
 msgid "Retire from a featured project"
 msgstr "Retire from a featured project"
+
+#: components/pages/Retire/index.tsx:110
+msgid "Retire from your portfolio"
+msgstr "Retire from your portfolio"
 
 #: components/pages/Project/Retire/index.tsx:24
 #: components/pages/Project/Retire/index.tsx:25
@@ -891,8 +899,8 @@ msgstr "Retire now, or acquire carbon to retire later - you decide what to do wh
 
 #: components/pages/Portfolio/Retire/index.tsx:75
 #: components/pages/Portfolio/Retire/index.tsx:76
-#: components/pages/Retire/index.tsx:38
 #: components/pages/Retire/index.tsx:39
+#: components/pages/Retire/index.tsx:40
 msgid "Retire | Carbonmark"
 msgstr "Retire | Carbonmark"
 
@@ -982,6 +990,7 @@ msgstr "Sorry, this handle already exists"
 
 #: components/pages/Portfolio/Retire/index.tsx:97
 #: components/pages/Portfolio/index.tsx:105
+#: components/pages/Retire/FromPortfolio/index.tsx:87
 msgid "Sorry. We could not find any data on Carbonmark for your user."
 msgstr "Sorry. We could not find any data on Carbonmark for your user."
 
@@ -1221,11 +1230,15 @@ msgstr "View a complete overview of the digital carbon that you own in your Port
 msgid "View a complete overview of the digital carbon that you own in your Retire."
 msgstr "View a complete overview of the digital carbon that you own in your Retire."
 
-#: components/pages/Retire/index.tsx:40
+#: components/pages/Retire/index.tsx:41
 msgid "View a complete overview of the digital carbon that you retired."
 msgstr "View a complete overview of the digital carbon that you retired."
 
-#: components/pages/Retire/index.tsx:80
+#: components/pages/Retire/index.tsx:114
+msgid "View all Portfolio items"
+msgstr "View all Portfolio items"
+
+#: components/pages/Retire/index.tsx:81
 msgid "View all Projects"
 msgstr "View all Projects"
 
@@ -1275,7 +1288,7 @@ msgstr "We are still processing your successful purchase. Please visit this page
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 msgstr "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 
-#: components/pages/Retire/index.tsx:86
+#: components/pages/Retire/index.tsx:87
 msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 msgstr "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 
@@ -1305,6 +1318,10 @@ msgstr "You are about to purchase a carbon asset."
 #: components/pages/Project/Retire/RetireModal.tsx:38
 msgid "You are about to retire a carbon asset."
 msgstr "You are about to retire a carbon asset."
+
+#: components/pages/Retire/index.tsx:119
+msgid "You can also retire any carbon asset in your wallet."
+msgstr "You can also retire any carbon asset in your wallet."
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:107
 msgid "You chose to reject the transaction."
@@ -1477,7 +1494,7 @@ msgstr "You will be taken to KlimaDAO.finance to complete this transaction."
 msgid "for"
 msgstr "for"
 
-#: components/pages/Retire/index.tsx:52
+#: components/pages/Retire/index.tsx:53
 msgid "for beneficiary"
 msgstr "for beneficiary"
 

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -108,6 +108,7 @@ msgid "Asset ID"
 msgstr "Asset ID"
 
 #: components/ProjectCard/index.tsx:43
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:46
 msgid "Available Tonnes:"
 msgstr "Available Tonnes:"
 
@@ -376,7 +377,7 @@ msgstr "Display name"
 msgid "Display name is required"
 msgstr "Display name is required"
 
-#: components/pages/Retire/index.tsx:141
+#: components/pages/Retire/index.tsx:144
 msgid "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
 msgstr "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
 
@@ -782,7 +783,6 @@ msgstr "QTY"
 #: components/pages/Portfolio/AssetProject/index.tsx:58
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:41
 #: components/pages/Project/BuyOptions/SellerListing.tsx:79
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:46
 msgid "Quantity Available:"
 msgstr "Quantity Available:"
 
@@ -798,7 +798,7 @@ msgstr "Quantity listed: {listedQuantity}, Quantity unlisted: {0}, Total availab
 msgid "Quantity purchased:"
 msgstr "Quantity purchased:"
 
-#: components/pages/Retire/index.tsx:136
+#: components/pages/Retire/index.tsx:139
 msgid "Quick Retire"
 msgstr "Quick Retire"
 
@@ -864,11 +864,11 @@ msgstr "Retire"
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "Retire carbon credits for yourself, or on behalf of another person or organization."
 
-#: components/pages/Retire/index.tsx:76
+#: components/pages/Retire/index.tsx:77
 msgid "Retire from a featured project"
 msgstr "Retire from a featured project"
 
-#: components/pages/Retire/index.tsx:110
+#: components/pages/Retire/index.tsx:112
 msgid "Retire from your portfolio"
 msgstr "Retire from your portfolio"
 
@@ -1234,11 +1234,11 @@ msgstr "View a complete overview of the digital carbon that you own in your Reti
 msgid "View a complete overview of the digital carbon that you retired."
 msgstr "View a complete overview of the digital carbon that you retired."
 
-#: components/pages/Retire/index.tsx:114
+#: components/pages/Retire/index.tsx:116
 msgid "View all Portfolio items"
 msgstr "View all Portfolio items"
 
-#: components/pages/Retire/index.tsx:81
+#: components/pages/Retire/index.tsx:82
 msgid "View all Projects"
 msgstr "View all Projects"
 
@@ -1319,7 +1319,7 @@ msgstr "You are about to purchase a carbon asset."
 msgid "You are about to retire a carbon asset."
 msgstr "You are about to retire a carbon asset."
 
-#: components/pages/Retire/index.tsx:119
+#: components/pages/Retire/index.tsx:121
 msgid "You can also retire any carbon asset in your wallet."
 msgstr "You can also retire any carbon asset in your wallet."
 


### PR DESCRIPTION
## Description

This PR renders available assets a carbonmark user owns.

Including all states:
- hide when not connected
- loading spinner when connected
- empty state when no assets
- empty state when not a carbonmark user
- render assets with project data
- link to form

When clicking on an asset, the user is taken to the page "retire from portfolio".
This page is a subpage of the Portfolio page (not of the retire page). 

Preview link: https://carbonmark-git-lady-retire-portfolio-klimadao.vercel.app/retire

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1210

## Screenshots

<img width="650" alt="Bildschirmfoto 2023-06-29 um 13 20 58" src="https://github.com/KlimaDAO/klimadao/assets/95881624/48477540-bb98-49b7-a24e-9103a83102d3">

---

<img width="650" alt="Bildschirmfoto 2023-06-29 um 13 20 27" src="https://github.com/KlimaDAO/klimadao/assets/95881624/87aaade8-f496-462a-868c-145fae84dc43">




## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
