### PR TITLE
Update the URL to fastify.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo contains 6 packages.
 `@klimadao/carbonmark` -> The NextJS project that powers the carbonmark web application at carbonmark.com.
 The backend Node.js web-service and smart contracts are located in separate repositories.
 
-`@klimadao/carbonmark-api` -> A [Fastify](https://www.fastify.io/) API acting as a Backend-for-Frontend for Carbonmark
+`@klimadao/carbonmark-api` -> A [Fastify](https://fastify.dev/) API acting as a Backend-for-Frontend for Carbonmark
 
 `@klimadao/cms` -> A Sanity CMS that powers our blog, deployed to [klimadao.sanity.studio](https://klimadao.sanity.studio). NOTE: Unlike the other packages, this one is **not** included as an NPM workspace from the root package.json. To work with the CMS you need to run `sanity install` from inside the `cms` folder.
 

--- a/carbonmark-api/README.md
+++ b/carbonmark-api/README.md
@@ -14,7 +14,7 @@
 
 ### Built With
 
-- [Fastify](https://fastify.io)
+- [Fastify](https://fastify.dev)
 - [Vercel](https://vercel.com)
 - [Firebase](https://firebase.google.com)
 - [Apollo](https://www.apollographql.com/)

--- a/carbonmark-api/plugins/README.md
+++ b/carbonmark-api/plugins/README.md
@@ -11,6 +11,6 @@ that will then be used in the rest of your application.
 
 Check out:
 
-- [The hitchhiker's guide to plugins](https://www.fastify.io/docs/latest/Guides/Plugins-Guide/)
-- [Fastify decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
-- [Fastify lifecycle](https://www.fastify.io/docs/latest/Reference/Lifecycle/).
+- [The hitchhiker's guide to plugins](https://fastify.dev/docs/latest/Guides/Plugins-Guide/)
+- [Fastify decorators](https://fastify.dev/docs/latest/Reference/Decorators/).
+- [Fastify lifecycle](https://fastify.dev/docs/latest/Reference/Lifecycle/).

--- a/carbonmark-api/plugins/open-api.js
+++ b/carbonmark-api/plugins/open-api.js
@@ -9,7 +9,7 @@ Since fastify-openapi-docs uses an onRoute hook, you have to either:
 * use `await register...`
 * wrap you routes definitions in a plugin
 
-See: https://www.fastify.io/docs/latest/Guides/Migration-Guide-V4/#synchronous-route-definitions
+See: https://fastify.dev/docs/latest/Guides/Migration-Guide-V4/#synchronous-route-definitions
 */
 module.exports = fp(async function (fastify, opts) {
   fastify.register(require("@fastify/swagger"), {

--- a/carbonmark-api/routes/README.md
+++ b/carbonmark-api/routes/README.md
@@ -7,7 +7,7 @@ to independently deploy some of those.
 In this folder you should define all the routes that define the endpoints
 of your web application.
 Each service is a [Fastify
-plugin](https://www.fastify.io/docs/latest/Reference/Plugins/), it is
+plugin](https://fastify.dev/docs/latest/Reference/Plugins/), it is
 encapsulated (it can have its own independent plugins) and it is
 typically stored in a file; be careful to group your routes logically,
 e.g. all `/users` routes in a `users.js` file. We have added
@@ -21,7 +21,7 @@ and eventually extract them.
 
 If you need to share functionality between routes, place that
 functionality into the `plugins` folder, and share it via
-[decorators](https://www.fastify.io/docs/latest/Reference/Decorators/).
+[decorators](https://fastify.dev/docs/latest/Reference/Decorators/).
 
 If you're a bit confused about using `async/await` to write routes, you would
-better take a look at [Promise resolution](https://www.fastify.io/docs/latest/Reference/Routes/#promise-resolution) for more details.
+better take a look at [Promise resolution](https://fastify.dev/docs/latest/Reference/Routes/#promise-resolution) for more details.


### PR DESCRIPTION
## Description

Fastify site URL is changed from `fastify.io` to `fastify.dev`.

https://twitter.com/fastifyjs/status/1670145210347577344

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

N/A

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
