### PR TITLE
Retire: Add menu link

### DIFF
--- a/carbonmark/components/Layout/NavMenu/index.tsx
+++ b/carbonmark/components/Layout/NavMenu/index.tsx
@@ -1,5 +1,6 @@
 import { Domain } from "@klimadao/lib/types/domains";
 import { Trans } from "@lingui/macro";
+import ParkIcon from "@mui/icons-material/Park";
 import PermIdentityIcon from "@mui/icons-material/PermIdentity";
 import StoreIcon from "@mui/icons-material/Store";
 import ViewQuiltOutlinedIcon from "@mui/icons-material/ViewQuiltOutlined";
@@ -32,6 +33,13 @@ export const NavMenu: React.FC<Props> = (props) => {
         icon={<StoreIcon />}
       >
         <Trans id="menu.marketplace">Marketplace</Trans>
+      </MenuButton>
+      <MenuButton
+        isActive={pathname.startsWith(`/retire`)}
+        href={"/retire"}
+        icon={<ParkIcon />}
+      >
+        <Trans id="menu.retire">Retire</Trans>
       </MenuButton>
       <MenuButton
         isActive={pathname.startsWith(`/users/login`) || isConnectedUser}

--- a/carbonmark/components/ProjectCard/styles.ts
+++ b/carbonmark/components/ProjectCard/styles.ts
@@ -44,6 +44,7 @@ export const cardImage = css`
 `;
 
 export const cardContent = css`
+  background-color: var(--surface-01);
   padding: 2rem;
   display: grid;
   gap: 1rem;

--- a/carbonmark/components/ProjectCard/styles.ts
+++ b/carbonmark/components/ProjectCard/styles.ts
@@ -31,6 +31,8 @@ export const cardDescription = css`
   background-clip: text;
   overflow: hidden;
   height: 12rem;
+
+  margin-top: auto;
 `;
 
 export const cardImage = css`

--- a/carbonmark/components/pages/Retire/Activity/Quotes.tsx
+++ b/carbonmark/components/pages/Retire/Activity/Quotes.tsx
@@ -78,7 +78,7 @@ export const ActivityQuotes: FC<Props> = (props) => {
 
       {props.hasRetirements && (
         <Link target="_blank" href={`/retirements/${props.address}`}>
-          <Text className={styles.externalLink} t="body4">
+          <Text className={styles.externalLink} t="button">
             {t`View all Retirements`} <LaunchIcon />
           </Text>
         </Link>

--- a/carbonmark/components/pages/Retire/Activity/Table.tsx
+++ b/carbonmark/components/pages/Retire/Activity/Table.tsx
@@ -62,7 +62,7 @@ export const ActivityTable: FC<Props> = (props) => {
 
       {props.hasRetirements && (
         <Link target="_blank" href={`/retirements/${props.address}`}>
-          <Text className={styles.externalLink} t="body4">
+          <Text className={styles.externalLink} t="button">
             {t`View all Retirements`} <LaunchIcon />
           </Text>
         </Link>

--- a/carbonmark/components/pages/Retire/Activity/Table.tsx
+++ b/carbonmark/components/pages/Retire/Activity/Table.tsx
@@ -37,7 +37,7 @@ export const ActivityTable: FC<Props> = (props) => {
   return (
     <div className={cx(styles.list, props.className)}>
       <div className={styles.listHeader}>
-        <Text t="body4">{t`PROJECTS`}</Text>
+        <Text t="body4">{t`PROJECT`}</Text>
         <Text align="end" t="body4">{t`QTY`}</Text>
         <Text t="body4">{t`DATE`}</Text>
       </div>

--- a/carbonmark/components/pages/Retire/Activity/styles.ts
+++ b/carbonmark/components/pages/Retire/Activity/styles.ts
@@ -69,7 +69,7 @@ export const totalsText = css`
 `;
 
 export const externalLink = css`
-  text-decoration: underline;
+  text-decoration: none;
   display: flex;
   gap: 0.4rem;
   align-items: center;
@@ -80,7 +80,7 @@ export const externalLink = css`
 
   &:hover,
   &:visited {
-    text-decoration: none;
+    text-decoration: underline;
   }
 `;
 

--- a/carbonmark/components/pages/Retire/FromPortfolio/index.tsx
+++ b/carbonmark/components/pages/Retire/FromPortfolio/index.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from "@lingui/macro";
+import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { SpinnerWithLabel } from "components/SpinnerWithLabel";
 import { Text } from "components/Text";
 import { useFetchUser } from "hooks/useFetchUser";
@@ -73,11 +74,18 @@ export const RetireFromPortfolio: FC<Props> = (props) => {
       </div>
 
       {emptyAssets && (
-        <Text>
-          <i>
-            <Trans>No listable assets found.</Trans>
-          </i>
-        </Text>
+        <>
+          <Text>
+            <i>
+              <Trans>We couldn't find any assets in your portfolio.</Trans>
+            </i>
+          </Text>
+          <ButtonPrimary
+            href={"/projects"}
+            label={t`Purchase Carbon`}
+            className={styles.buttonEmptyState}
+          />
+        </>
       )}
 
       {isUnregistered && (

--- a/carbonmark/components/pages/Retire/FromPortfolio/styles.ts
+++ b/carbonmark/components/pages/Retire/FromPortfolio/styles.ts
@@ -9,6 +9,10 @@ export const cardsList = css`
   justify-content: center;
 
   ${breakpoints.medium} {
-    justify-content: space-evenly;
+    justify-content: flex-start;
   }
+`;
+
+export const buttonEmptyState = css`
+  align-self: flex-start;
 `;

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -144,9 +144,8 @@ export const Retire: NextPage<PageProps> = (props) => {
 
               <Text className={styles.cardsDescription}>
                 <Trans>
-                  Don’t want to go through the trouble of searching and
-                  selecting a project to retire? Here’s a list of discount
-                  retirements from trusted vendors.
+                  Here’s a list of readily available, discounted carbon tokens
+                  to retire quickly and easily.
                 </Trans>
               </Text>
             </div>

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -71,15 +71,17 @@ export const Retire: NextPage<PageProps> = (props) => {
         <div className={cx(styles.fullWidth, "whiteBG")}>
           <div className={styles.content}>
             <div className={styles.sectionTitle}>
-              <div className={styles.cardsHeader}>
+              <div className={styles.cardsHeaderTweakAlignment}>
                 <Text t="h4" className={styles.textWithIcon}>
-                  <LocalPoliceIcon className="featured" fontSize="inherit" />
+                  <LocalPoliceIcon className="featured" fontSize="large" />
                   <Trans>Retire from a featured project</Trans>
                 </Text>
 
                 <Link href="/projects">
-                    <Trans>View all Projects</Trans>
                   <Text t="button" className={styles.textLink}>
+                    <span>
+                      <Trans>View all Projects</Trans>
+                    </span>
                   </Text>
                 </Link>
               </div>

--- a/carbonmark/components/pages/Retire/index.tsx
+++ b/carbonmark/components/pages/Retire/index.tsx
@@ -49,7 +49,7 @@ export const Retire: NextPage<PageProps> = (props) => {
             </Text>
             {isConnectedUser && (
               <div className={styles.beneficiary}>
-                <Text t="body4">
+                <Text t="h5">
                   <Trans>for beneficiary</Trans>{" "}
                   <span className="highlight">{displayName}</span>
                 </Text>
@@ -78,8 +78,8 @@ export const Retire: NextPage<PageProps> = (props) => {
                 </Text>
 
                 <Link href="/projects">
-                  <Text t="body4" className={styles.textLink}>
                     <Trans>View all Projects</Trans>
+                  <Text t="button" className={styles.textLink}>
                   </Text>
                 </Link>
               </div>
@@ -112,7 +112,7 @@ export const Retire: NextPage<PageProps> = (props) => {
                   <Trans>Retire from your portfolio</Trans>
                 </Text>
                 <Link href="/portfolio">
-                  <Text t="body4" className={styles.textLink}>
+                  <Text t="button" className={styles.textLink}>
                     <Trans>View all Portfolio items</Trans>
                   </Text>
                 </Link>
@@ -135,7 +135,7 @@ export const Retire: NextPage<PageProps> = (props) => {
           <div className={styles.content}>
             <div className={styles.sectionTitle}>
               <div className={styles.cardsHeader}>
-                <Text t="h4" className={styles.textWithIcon}>
+                <Text t="h4">
                   <Trans>Quick Retire</Trans>
                 </Text>
               </div>

--- a/carbonmark/components/pages/Retire/styles.ts
+++ b/carbonmark/components/pages/Retire/styles.ts
@@ -70,15 +70,32 @@ export const content = css`
 `;
 
 export const featuredCard = css`
-  border: 2px solid var(--yellow);
+  background-color: var(--yellow);
+  padding: 0.4rem;
 `;
 
 export const sectionTitle = css`
   display: grid;
-  gap: 0.8rem;
+  gap: 1.2rem;
 `;
 
 export const cardsHeader = css`
+  display: flex;
+  gap: 0.8rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  ${breakpoints.large} {
+    gap: 2.4rem;
+  }
+
+  ${breakpoints.desktop} {
+    justify-content: space-between;
+  }
+`;
+
+export const cardsHeaderTweakAlignment = css`
   display: flex;
   gap: 0.8rem;
   align-items: center;
@@ -92,6 +109,10 @@ export const cardsHeader = css`
   ${breakpoints.desktop} {
     justify-content: space-between;
   }
+
+  span {
+    margin-top: 5px;
+  }
 `;
 
 export const textWithIcon = css`
@@ -100,6 +121,9 @@ export const textWithIcon = css`
   align-items: center;
 
   .featured {
+    height: 3rem;
+    width: 3rem;
+    bottom: -4px;
     path {
       fill: var(--yellow);
     }

--- a/carbonmark/components/pages/Retire/styles.ts
+++ b/carbonmark/components/pages/Retire/styles.ts
@@ -161,6 +161,6 @@ export const cardsList = css`
   justify-content: center;
 
   ${breakpoints.desktop} {
-    justify-content: flex-start;
+    justify-content: space-between;
   }
 `;

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -372,10 +372,6 @@ msgstr ""
 msgid "Display name is required"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:144
-msgid "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
-msgstr ""
-
 #: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:37
 msgid "Download PDF"
 msgstr ""
@@ -442,7 +438,7 @@ msgstr ""
 
 #: components/pages/Portfolio/Retire/index.tsx:102
 #: components/pages/Portfolio/index.tsx:111
-#: components/pages/Retire/FromPortfolio/index.tsx:94
+#: components/pages/Retire/FromPortfolio/index.tsx:102
 msgid "Have you already created your Carbonmark <0>Profile</0>?"
 msgstr ""
 
@@ -451,6 +447,10 @@ msgstr ""
 #: components/shared/Navigation/index.tsx:87
 #: components/shared/Navigation/index.tsx:124
 msgid "Help"
+msgstr ""
+
+#: components/pages/Retire/index.tsx:146
+msgid "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:181
@@ -536,7 +536,7 @@ msgid "Loading"
 msgstr ""
 
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:67
-#: components/pages/Retire/FromPortfolio/index.tsx:66
+#: components/pages/Retire/FromPortfolio/index.tsx:67
 msgid "Loading your assets"
 msgstr ""
 
@@ -623,7 +623,6 @@ msgid "No data to show"
 msgstr ""
 
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:104
-#: components/pages/Retire/FromPortfolio/index.tsx:78
 msgid "No listable assets found."
 msgstr ""
 
@@ -669,7 +668,7 @@ msgid "Over 20 million verified digital carbon credits from hundreds of projects
 msgstr ""
 
 #: components/pages/Retire/Activity/Table.tsx:40
-msgid "PROJECTS"
+msgid "PROJECT"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:99
@@ -756,6 +755,10 @@ msgstr ""
 msgid "Project"
 msgstr ""
 
+#: components/pages/Retire/FromPortfolio/index.tsx:85
+msgid "Purchase Carbon"
+msgstr ""
+
 #: components/pages/Purchases/index.tsx:35
 #: components/pages/Purchases/index.tsx:36
 msgid "Purchase Receipt | Carbonmark"
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Quantity purchased:"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:139
+#: components/pages/Retire/index.tsx:141
 msgid "Quick Retire"
 msgstr ""
 
@@ -870,7 +873,7 @@ msgstr ""
 msgid "Retire from a featured project"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:112
+#: components/pages/Retire/index.tsx:114
 msgid "Retire from your portfolio"
 msgstr ""
 
@@ -992,7 +995,7 @@ msgstr ""
 
 #: components/pages/Portfolio/Retire/index.tsx:97
 #: components/pages/Portfolio/index.tsx:105
-#: components/pages/Retire/FromPortfolio/index.tsx:87
+#: components/pages/Retire/FromPortfolio/index.tsx:95
 msgid "Sorry. We could not find any data on Carbonmark for your user."
 msgstr ""
 
@@ -1236,11 +1239,11 @@ msgstr ""
 msgid "View a complete overview of the digital carbon that you retired."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:116
+#: components/pages/Retire/index.tsx:118
 msgid "View all Portfolio items"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:82
+#: components/pages/Retire/index.tsx:83
 msgid "View all Projects"
 msgstr ""
 
@@ -1286,11 +1289,15 @@ msgstr ""
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
 msgstr ""
 
+#: components/pages/Retire/FromPortfolio/index.tsx:80
+msgid "We couldn't find any assets in your portfolio."
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/index.tsx:106
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:87
+#: components/pages/Retire/index.tsx:89
 msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 msgstr ""
 
@@ -1321,7 +1328,7 @@ msgstr ""
 msgid "You are about to retire a carbon asset."
 msgstr ""
 
-#: components/pages/Retire/index.tsx:121
+#: components/pages/Retire/index.tsx:123
 msgid "You can also retire any carbon asset in your wallet."
 msgstr ""
 

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -1500,16 +1500,20 @@ msgstr ""
 msgid "for beneficiary"
 msgstr ""
 
-#: components/Layout/NavMenu/index.tsx:34
+#: components/Layout/NavMenu/index.tsx:35
 msgid "menu.marketplace"
 msgstr ""
 
-#: components/Layout/NavMenu/index.tsx:48
+#: components/Layout/NavMenu/index.tsx:56
 msgid "menu.portfolio"
 msgstr ""
 
-#: components/Layout/NavMenu/index.tsx:41
+#: components/Layout/NavMenu/index.tsx:49
 msgid "menu.profile"
+msgstr ""
+
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
 msgstr ""
 
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:192

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -378,10 +378,6 @@ msgstr "Display name"
 msgid "Display name is required"
 msgstr "Display name is required"
 
-#: components/pages/Retire/index.tsx:144
-msgid "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
-msgstr "Don’t want to go through the trouble of searching and selecting a project to retire? Here’s a list of discount retirements from trusted vendors."
-
 #: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:37
 msgid "Download PDF"
 msgstr "Download PDF"
@@ -448,7 +444,7 @@ msgstr "Handle should not contain any special characters"
 
 #: components/pages/Portfolio/Retire/index.tsx:102
 #: components/pages/Portfolio/index.tsx:111
-#: components/pages/Retire/FromPortfolio/index.tsx:94
+#: components/pages/Retire/FromPortfolio/index.tsx:102
 msgid "Have you already created your Carbonmark <0>Profile</0>?"
 msgstr "Have you already created your Carbonmark <0>Profile</0>?"
 
@@ -458,6 +454,10 @@ msgstr "Have you already created your Carbonmark <0>Profile</0>?"
 #: components/shared/Navigation/index.tsx:124
 msgid "Help"
 msgstr "Help"
+
+#: components/pages/Retire/index.tsx:146
+msgid "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
+msgstr "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
 
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:181
 #: components/pages/Project/Retire/TotalValues.tsx:178
@@ -542,7 +542,7 @@ msgid "Loading"
 msgstr "Loading"
 
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:67
-#: components/pages/Retire/FromPortfolio/index.tsx:66
+#: components/pages/Retire/FromPortfolio/index.tsx:67
 msgid "Loading your assets"
 msgstr "Loading your assets"
 
@@ -629,7 +629,6 @@ msgid "No data to show"
 msgstr "No data to show"
 
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:104
-#: components/pages/Retire/FromPortfolio/index.tsx:78
 msgid "No listable assets found."
 msgstr "No listable assets found."
 
@@ -675,8 +674,8 @@ msgid "Over 20 million verified digital carbon credits from hundreds of projects
 msgstr "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 
 #: components/pages/Retire/Activity/Table.tsx:40
-msgid "PROJECTS"
-msgstr "PROJECTS"
+msgid "PROJECT"
+msgstr "PROJECT"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:99
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:100
@@ -762,6 +761,10 @@ msgstr "Profile picture"
 msgid "Project"
 msgstr "Project"
 
+#: components/pages/Retire/FromPortfolio/index.tsx:85
+msgid "Purchase Carbon"
+msgstr "Purchase Carbon"
+
 #: components/pages/Purchases/index.tsx:35
 #: components/pages/Purchases/index.tsx:36
 msgid "Purchase Receipt | Carbonmark"
@@ -806,7 +809,7 @@ msgstr "Quantity listed: {listedQuantity}, Quantity unlisted: {0}, Total availab
 msgid "Quantity purchased:"
 msgstr "Quantity purchased:"
 
-#: components/pages/Retire/index.tsx:139
+#: components/pages/Retire/index.tsx:141
 msgid "Quick Retire"
 msgstr "Quick Retire"
 
@@ -876,7 +879,7 @@ msgstr "Retire carbon credits for yourself, or on behalf of another person or or
 msgid "Retire from a featured project"
 msgstr "Retire from a featured project"
 
-#: components/pages/Retire/index.tsx:112
+#: components/pages/Retire/index.tsx:114
 msgid "Retire from your portfolio"
 msgstr "Retire from your portfolio"
 
@@ -998,7 +1001,7 @@ msgstr "Sorry, this handle already exists"
 
 #: components/pages/Portfolio/Retire/index.tsx:97
 #: components/pages/Portfolio/index.tsx:105
-#: components/pages/Retire/FromPortfolio/index.tsx:87
+#: components/pages/Retire/FromPortfolio/index.tsx:95
 msgid "Sorry. We could not find any data on Carbonmark for your user."
 msgstr "Sorry. We could not find any data on Carbonmark for your user."
 
@@ -1242,11 +1245,11 @@ msgstr "View a complete overview of the digital carbon that you own in your Reti
 msgid "View a complete overview of the digital carbon that you retired."
 msgstr "View a complete overview of the digital carbon that you retired."
 
-#: components/pages/Retire/index.tsx:116
+#: components/pages/Retire/index.tsx:118
 msgid "View all Portfolio items"
 msgstr "View all Portfolio items"
 
-#: components/pages/Retire/index.tsx:82
+#: components/pages/Retire/index.tsx:83
 msgid "View all Projects"
 msgstr "View all Projects"
 
@@ -1292,11 +1295,15 @@ msgstr "Vintage Oldest"
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
 msgstr "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
 
+#: components/pages/Retire/FromPortfolio/index.tsx:80
+msgid "We couldn't find any assets in your portfolio."
+msgstr "We couldn't find any assets in your portfolio."
+
 #: components/pages/Retirements/SingleRetirement/index.tsx:106
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 msgstr "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 
-#: components/pages/Retire/index.tsx:87
+#: components/pages/Retire/index.tsx:89
 msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 msgstr "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
 
@@ -1327,7 +1334,7 @@ msgstr "You are about to purchase a carbon asset."
 msgid "You are about to retire a carbon asset."
 msgstr "You are about to retire a carbon asset."
 
-#: components/pages/Retire/index.tsx:121
+#: components/pages/Retire/index.tsx:123
 msgid "You can also retire any carbon asset in your wallet."
 msgstr "You can also retire any carbon asset in your wallet."
 

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -1506,17 +1506,21 @@ msgstr "for"
 msgid "for beneficiary"
 msgstr "for beneficiary"
 
-#: components/Layout/NavMenu/index.tsx:34
+#: components/Layout/NavMenu/index.tsx:35
 msgid "menu.marketplace"
 msgstr "Marketplace"
 
-#: components/Layout/NavMenu/index.tsx:48
+#: components/Layout/NavMenu/index.tsx:56
 msgid "menu.portfolio"
 msgstr "Portfolio"
 
-#: components/Layout/NavMenu/index.tsx:41
+#: components/Layout/NavMenu/index.tsx:49
 msgid "menu.profile"
 msgstr "Profile"
+
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr "Retire"
 
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:192
 msgid "offset.amount_in_tonnes"

--- a/carbonmark/pages/retire/index.tsx
+++ b/carbonmark/pages/retire/index.tsx
@@ -4,7 +4,7 @@ import { getCarbonmarkProject } from "lib/carbonmark";
 import { loadTranslation } from "lib/i18n";
 import { GetStaticProps } from "next";
 
-const featuredProjectKeys = ["VCS-1577-2015", "VCS-1764-2020", "VCS-1121-2018"];
+const featuredProjectKeys = ["VCS-674-2014", "VCS-292-2020", "VCS-981-2017"];
 const defaultProjectKeys = defaultProjects.map((p) => p.id);
 
 export const getStaticProps: GetStaticProps = async (ctx) => {


### PR DESCRIPTION
## Description

This is the last step of the "Retire" epic: Add the menu link for the Retire page

The former closed PRs with discussions to each section have been:
- https://github.com/KlimaDAO/klimadao/pull/1224
- https://github.com/KlimaDAO/klimadao/pull/1238
- https://github.com/KlimaDAO/klimadao/pull/1241
- https://github.com/KlimaDAO/klimadao/pull/1244

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1248

Preview Link: https://carbonmark-git-lady-link-retire-klimadao.vercel.app/retire

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
