### PR TITLE
0xMakka/1175 add error message styling

### DIFF
--- a/carbonmark/components/pages/Portfolio/Retire/RetireForm/index.tsx
+++ b/carbonmark/components/pages/Portfolio/Retire/RetireForm/index.tsx
@@ -267,19 +267,15 @@ export const RetireForm = (props: RetireFormProps) => {
                         value: retirement.beneficiaryAddress,
                       }}
                       label={"beneficiaryAddress"}
+                      errorMessage={
+                        retirement.beneficiaryAddress &&
+                        !ethers.utils.isAddress(retirement.beneficiaryAddress)
+                          ? "Please enter a valid wallet address"
+                          : ""
+                      }
                       hideLabel
                     />
                   </div>
-                  {retirement.beneficiaryAddress &&
-                    !ethers.utils.isAddress(retirement.beneficiaryAddress) && (
-                      <Text
-                        t="caption"
-                        color="lighter"
-                        className={styles.warningText}
-                      >
-                        Please enter a valid wallet address
-                      </Text>
-                    )}
                   <Text
                     t="body8"
                     color="lightest"


### PR DESCRIPTION
## Description

Adds an error message to the beneficiary wallet address field. 

@Atmosfearful & @jabby09 I've added a quick fix here to address the beneficiary wallet address but I think it's worth investing some time in refactoring this component to use react-hook-form like the Retire & Buy forms. Let me know if you guys want me to tackle it as part of this ticket, or roll out with this quick fix and pick up in another ticket.

## Related Ticket

Resolves #1175

## Checklist

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
