### PR TITLE
fix: Correctly filter deleted listings from API

### DIFF
--- a/carbonmark-api/src/routes/projects/get.ts
+++ b/carbonmark-api/src/routes/projects/get.ts
@@ -289,10 +289,9 @@ const handler = (fastify: FastifyInstance) =>
 
     const filteredItems = projects
       .concat(pooledProjects)
-      .filter((project) => project != null && project.price !== "0");
+      .filter((project) => Number(project?.price) !== 0);
 
     // Send the transformed projects array as a JSON string in the response
-    // return reply.send(JSON.stringify(projects));
     return reply.send(JSON.stringify(filteredItems));
   };
 


### PR DESCRIPTION
## Description

Project listings with a price of "0" were previously filtered. This broke once listing.price was correctly typed to a number. This resulted in listings with 0 price being displayed on https://carbonmark.com/projects

<img width="1177" alt="Screenshot 2023-07-06 at 5 50 22 pm" src="https://github.com/KlimaDAO/klimadao/assets/7104689/4b06f49c-caa0-4949-85df-ec74ce6ef2a9">
