### PR TITLE
stop truncating project descriptions

### DIFF
--- a/carbonmark-api/src/routes/projects/get.ts
+++ b/carbonmark-api/src/routes/projects/get.ts
@@ -127,7 +127,7 @@ const handler = (fastify: FastifyInstance) =>
         const indexes = pooledProjectsData.carbonOffsets
           .map((item, idx) =>
             item.projectID === project.registry + "-" + project.projectID &&
-            item.vintageYear === project.vintage
+              item.vintageYear === project.vintage
               ? idx
               : ""
           )
@@ -198,8 +198,8 @@ const handler = (fastify: FastifyInstance) =>
 
         const lowestPrice = uniqueValues.length
           ? uniqueValues.reduce((a, b) =>
-              a.length < b.length ? a : a.length === b.length && a < b ? a : b
-            )
+            a.length < b.length ? a : a.length === b.length && a < b ? a : b
+          )
           : "0";
         price = lowestPrice;
       }
@@ -209,13 +209,13 @@ const handler = (fastify: FastifyInstance) =>
         project.registry
       );
       project.description = cmsData
-        ? cmsData.description.slice(0, 200)
+        ? cmsData.description
         : undefined;
       project.name = cmsData ? cmsData.name : project.name;
       project.methodologies = cmsData ? cmsData.methodologies : [];
 
       project.short_description = cmsData?.projectContent
-        ? cmsData.projectContent.shortDescription.slice(0, 200)
+        ? cmsData.projectContent.shortDescription
         : undefined;
       project.long_description = cmsData?.projectContent
         ? cmsData.projectContent.longDescription
@@ -248,9 +248,7 @@ const handler = (fastify: FastifyInstance) =>
       }
 
       const country = project.country.length
-        ? {
-            id: project.country,
-          }
+        ? { id: project.country }
         : null;
 
       const cmsData = findProjectWithRegistryIdAndRegistry(
@@ -262,7 +260,7 @@ const handler = (fastify: FastifyInstance) =>
       const singleProject = {
         id: project.id,
         isPoolProject: true,
-        description: cmsData ? cmsData.description.slice(0, 200) : undefined,
+        description: cmsData ? cmsData.description : undefined,
         key: project.projectID,
         projectID: project.projectID.split("-")[1],
         name: cmsData ? cmsData.name : project.name,
@@ -277,8 +275,8 @@ const handler = (fastify: FastifyInstance) =>
         country: country,
         price: uniqueValues.length
           ? uniqueValues.reduce((a, b) =>
-              a.length < b.length ? a : a.length === b.length && a < b ? a : b
-            )
+            a.length < b.length ? a : a.length === b.length && a < b ? a : b
+          )
           : "0",
         activities: null,
         listings: null,

--- a/carbonmark-api/src/routes/projects/get.ts
+++ b/carbonmark-api/src/routes/projects/get.ts
@@ -127,7 +127,7 @@ const handler = (fastify: FastifyInstance) =>
         const indexes = pooledProjectsData.carbonOffsets
           .map((item, idx) =>
             item.projectID === project.registry + "-" + project.projectID &&
-              item.vintageYear === project.vintage
+            item.vintageYear === project.vintage
               ? idx
               : ""
           )
@@ -198,8 +198,8 @@ const handler = (fastify: FastifyInstance) =>
 
         const lowestPrice = uniqueValues.length
           ? uniqueValues.reduce((a, b) =>
-            a.length < b.length ? a : a.length === b.length && a < b ? a : b
-          )
+              a.length < b.length ? a : a.length === b.length && a < b ? a : b
+            )
           : "0";
         price = lowestPrice;
       }
@@ -208,9 +208,7 @@ const handler = (fastify: FastifyInstance) =>
         project.projectID,
         project.registry
       );
-      project.description = cmsData
-        ? cmsData.description
-        : undefined;
+      project.description = cmsData ? cmsData.description : undefined;
       project.name = cmsData ? cmsData.name : project.name;
       project.methodologies = cmsData ? cmsData.methodologies : [];
 
@@ -247,9 +245,7 @@ const handler = (fastify: FastifyInstance) =>
         uniqueValues.push(poolPrices.find((obj) => obj.name === "btc").price);
       }
 
-      const country = project.country.length
-        ? { id: project.country }
-        : null;
+      const country = project.country.length ? { id: project.country } : null;
 
       const cmsData = findProjectWithRegistryIdAndRegistry(
         projectsCmsData,
@@ -275,8 +271,8 @@ const handler = (fastify: FastifyInstance) =>
         country: country,
         price: uniqueValues.length
           ? uniqueValues.reduce((a, b) =>
-            a.length < b.length ? a : a.length === b.length && a < b ? a : b
-          )
+              a.length < b.length ? a : a.length === b.length && a < b ? a : b
+            )
           : "0",
         activities: null,
         listings: null,

--- a/carbonmark-api/src/routes/projects/get.ts
+++ b/carbonmark-api/src/routes/projects/get.ts
@@ -257,6 +257,9 @@ const handler = (fastify: FastifyInstance) =>
         id: project.id,
         isPoolProject: true,
         description: cmsData ? cmsData.description : undefined,
+        short_description: cmsData?.projectContent
+          ? cmsData.projectContent.shortDescription
+          : undefined,
         key: project.projectID,
         projectID: project.projectID.split("-")[1],
         name: cmsData ? cmsData.name : project.name,


### PR DESCRIPTION
## Description

This PR removes the truncating logic for project descriptions. It also adds short_descriptions to pooled products, which were missing that field before.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #967 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
