### PR TITLE
Remove automatic preview config

### DIFF
--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -23,8 +23,11 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
   0,
   7
 );
-
-const API_PREVIEW_URL = SHORT_COMMIT_HASH
+/**
+ * Use the aliased carbonmark-api deployment for the current commit if set manually in the CLI
+ * @todo remove this once carbonmark is built via github actions
+ */
+const API_PREVIEW_URL = process.env.NEXT_PUBLIC_USE_PREVIEW_CARBONMARK_API
   ? `https://carbonmark-api-${SHORT_COMMIT_HASH}-klimadao.vercel.app/api`
   : "https://staging-api.carbonmark.com/api";
 


### PR DESCRIPTION
## Description

Removes the configuration to point to the pr preview carbonmark api url by default.

This is a temporary solution until we can deploy carbonmark via github action and remove the race condition.

