### PR TITLE
Retire: do not continue when costs is invalid

### DIFF
--- a/carbonmark/components/pages/Project/Retire/Pool/RetireInputs.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/RetireInputs.tsx
@@ -335,6 +335,7 @@ export const RetireInputs: FC<Props> = (props) => {
               message: t`Could not calculate Total Cost`,
             },
             validate: {
+              moreThanZero: (v) => Number(v) > 0 || t`Total Cost is required`,
               lessThanMax: (v) =>
                 parseInt(v) < getValidations().totalPrice.max.value ||
                 getValidations().totalPrice.max.message,

--- a/carbonmark/components/pages/Project/Retire/Pool/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/TotalValues.tsx
@@ -122,6 +122,7 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
           );
         } else {
           setError(t`There was an error loading the total cost.`);
+          setCosts("0");
         }
       } finally {
         setIsLoading(false);
@@ -343,7 +344,7 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
         </div>
       </div>
 
-      {formState.errors.totalPrice?.message && !error && (
+      {formState.errors.totalPrice?.message && (
         <Text t="body1" className={styles.errorMessagePrice}>
           {formState.errors.totalPrice?.message}
         </Text>


### PR DESCRIPTION
## Description

When the costs could not be calculated, the former value of the total costs was not resetted.
Therefore the user could continue with a false total cost value.

Now, the total costs are set to "0" when the API for the total costs calculation throws.
And the form is invalid.

## Related Ticket

none

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
