### PR TITLE
Retirement: render receipt with fallback data

### DIFF
--- a/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
@@ -94,59 +94,63 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
       <Navigation activePage="Home" />
       <Section className={styles.section}>
         <div className={styles.gridLayout}>
-          {retirement.pending && (
-            <div className={styles.pending}>
-              <div className="spinnerTitle">
-                <Spinner />
-                <Text>
-                  <Trans>Processing data...</Trans>
-                </Text>
-              </div>
-              <Text t="button" align="center">
-                <Trans>
-                  We haven't finished processing the blockchain data for this
-                  retirement. This usually takes a few seconds, but might take
-                  longer if the network is congested.
-                </Trans>
-              </Text>
-              <RetirementHeader formattedAmount={formattedAmount} />
-              <BeneficiaryDetails
-                beneficiary={retirement.beneficiary}
-                beneficiaryAddress={props.beneficiaryAddress}
-              />
-              {retirement.retirementMessage && (
-                <RetirementMessage message={retirement.retirementMessage} />
-              )}
-            </div>
-          )}
-          {!retirement.pending && tokenData && (
-            <Col className="column">
-              <RetirementDate timestamp={retirement.timestamp} />
-              <RetirementHeader formattedAmount={formattedAmount} />
-              {retirement.beneficiary && props.beneficiaryAddress && (
+          <Col className="column">
+            {retirement.pending && (
+              <>
+                <div className={styles.pending}>
+                  <div className="spinnerTitle">
+                    <Spinner />
+                    <Text>
+                      <Trans>Processing data...</Trans>
+                    </Text>
+                  </div>
+                  <Text t="button" align="center">
+                    <Trans>
+                      We haven't finished processing the blockchain data for
+                      this retirement. This usually takes a few seconds, but
+                      might take longer if the network is congested.
+                    </Trans>
+                  </Text>
+                </div>
+                <RetirementHeader formattedAmount={formattedAmount} />
                 <BeneficiaryDetails
                   beneficiary={retirement.beneficiary}
                   beneficiaryAddress={props.beneficiaryAddress}
                 />
-              )}
-              {retirement.retirementMessage && (
-                <RetirementMessage message={retirement.retirementMessage} />
-              )}
-              <ShareDetails
-                retiree={retiree}
-                formattedAmount={formattedAmount}
-                beneficiaryName={retirement.beneficiary}
-                retirementIndex={props.retirementIndex}
-                beneficiaryAddress={props.beneficiaryAddress}
-              />
-              <div className={styles.visibleDesktop}>
-                <TransactionDetails
-                  tokenData={tokenData}
-                  retirement={retirement}
+                {retirement.retirementMessage && (
+                  <RetirementMessage message={retirement.retirementMessage} />
+                )}
+              </>
+            )}
+            {!retirement.pending && tokenData && (
+              <>
+                <RetirementDate timestamp={retirement.timestamp} />
+                <RetirementHeader formattedAmount={formattedAmount} />
+                {retirement.beneficiary && props.beneficiaryAddress && (
+                  <BeneficiaryDetails
+                    beneficiary={retirement.beneficiary}
+                    beneficiaryAddress={props.beneficiaryAddress}
+                  />
+                )}
+                {retirement.retirementMessage && (
+                  <RetirementMessage message={retirement.retirementMessage} />
+                )}
+                <ShareDetails
+                  retiree={retiree}
+                  formattedAmount={formattedAmount}
+                  beneficiaryName={retirement.beneficiary}
+                  retirementIndex={props.retirementIndex}
+                  beneficiaryAddress={props.beneficiaryAddress}
                 />
-              </div>
-            </Col>
-          )}
+                <div className={styles.visibleDesktop}>
+                  <TransactionDetails
+                    tokenData={tokenData}
+                    retirement={retirement}
+                  />
+                </div>
+              </>
+            )}
+          </Col>
           <Col className="column">
             <ProjectDetails
               retirement={retirement}

--- a/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
@@ -109,6 +109,14 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
                   longer if the network is congested.
                 </Trans>
               </Text>
+              <RetirementHeader formattedAmount={formattedAmount} />
+              <BeneficiaryDetails
+                beneficiary={retirement.beneficiary}
+                beneficiaryAddress={props.beneficiaryAddress}
+              />
+              {retirement.retirementMessage && (
+                <RetirementMessage message={retirement.retirementMessage} />
+              )}
             </div>
           )}
           {!retirement.pending && tokenData && (

--- a/carbonmark/components/pages/Retirements/SingleRetirement/styles.ts
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/styles.ts
@@ -4,9 +4,8 @@ import breakpoints from "@klimadao/lib/theme/breakpoints";
 export const section = css`
   padding-bottom: 3.6rem;
   ${breakpoints.desktop} {
-      padding-top: 6.8rem;
-      padding-bottom: 4rem;
-    }
+    padding-top: 6.8rem;
+    padding-bottom: 4rem;
   }
 `;
 
@@ -86,12 +85,13 @@ export const pending = css`
   border-radius: 0.8rem;
   padding: 1.6rem;
   display: grid;
-  gap: 0.8rem;
+  gap: 2.4rem;
   justify-items: center;
 
   .spinnerTitle {
     display: flex;
     gap: 1.6rem;
+    align-items: center;
   }
 `;
 

--- a/carbonmark/pages/retirements/[beneficiary]/[retirement_index].tsx
+++ b/carbonmark/pages/retirements/[beneficiary]/[retirement_index].tsx
@@ -104,9 +104,11 @@ export const getStaticProps: GetStaticProps<
       throw new Error("No translation found");
     }
 
-    const project = await getCarbonmarkProject(
-      `${retirement.offset.projectID}-${retirement.offset.vintageYear}`
-    );
+    const project =
+      !!subgraphData &&
+      (await getCarbonmarkProject(
+        `${retirement.offset.projectID}-${retirement.offset.vintageYear}`
+      ));
 
     return {
       props: {


### PR DESCRIPTION
## Description

A quick fix to render a receipt page even though the subgraph can not find it.

Not beautiful, but something.

- Compare with this working [link](https://carbonmark-git-lady-fix-receipt-klimadao.vercel.app/retirements/0x6476edf98bdc5ee62f9d4e4bf8932d69ed685483/28) with subgraph data
- How the page would look like without subgraph data:

<img width="1279" alt="Bildschirmfoto 2023-07-14 um 18 10 55" src="https://github.com/KlimaDAO/klimadao/assets/95881624/e8ea41a4-cdc5-40f7-a244-846e040c44b9">


## Related Ticket

Part of https://github.com/KlimaDAO/klimadao/issues/1290


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
