### PR TITLE
fix:1300 Token Pool Prices to use 1e6 decimals always

### DIFF
--- a/carbonmark-api/src/utils/helpers/utils.constants.ts
+++ b/carbonmark-api/src/utils/helpers/utils.constants.ts
@@ -26,3 +26,6 @@ export const TOKEN_POOLS = [
 ] as const;
 
 export type TokenPool = (typeof TOKEN_POOLS)[number];
+
+/** The value by which to truncate token prices */
+export const POOL_PRICE_DECIMALS = 1e6;

--- a/carbonmark-api/src/utils/helpers/utils.ts
+++ b/carbonmark-api/src/utils/helpers/utils.ts
@@ -11,7 +11,7 @@ import { CarbonOffset } from "../../.generated/types/offsets.types";
 import { GetPairQuery } from "../../.generated/types/tokens.types";
 import { extract, notNil } from "../functional.utils";
 import { gqlSdk } from "../gqlSdk";
-import { TOKEN_POOLS, TokenPool } from "./utils.constants";
+import { POOL_PRICE_DECIMALS, TokenPool, TOKEN_POOLS } from "./utils.constants";
 
 // This function retrieves all vintages from two different sources (marketplace and carbon offsets),
 // combines them, removes duplicates, and returns the result as a sorted array of strings.
@@ -220,20 +220,11 @@ const getPoolPrice = async (
 
 /** @todo refactor this */
 export async function calculatePoolPrices(fastify: FastifyInstance) {
-  let decimals: number;
-  if (process.env.VERCEL_ENV == "production") {
-    decimals = 1e6;
-  } else {
-    decimals = 1e18;
-  }
+  const resultsPromises = TOKEN_POOLS.map((pool) =>
+    getPoolPrice(pool, POOL_PRICE_DECIMALS, fastify)
+  );
 
-  const resultsPromises = TOKEN_POOLS.map((pool) => {
-    return getPoolPrice(pool, decimals, fastify);
-  });
-
-  const results = await Promise.all(resultsPromises);
-
-  return results;
+  return await Promise.all(resultsPromises);
 }
 
 export function findProjectWithRegistryIdAndRegistry(


### PR DESCRIPTION
## Description

Removes the check for PRODUCTION in order to use 1e6 decimals in all cases.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1300 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

