### PR TITLE
Fix local api setup and README instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ yarn-error.log*
 
 # sanity
 .sanity/
+.env*.local

--- a/carbonmark-api/README.md
+++ b/carbonmark-api/README.md
@@ -1,24 +1,37 @@
 <!-- PROJECT LOGO -->
+ver
 <br />
-<div align="center">
-  <a href="https://github.com/github_username/repo_name">
-    <img src="./assets/logo.png" alt="Logo" width="80" height="80">
-  </a>
 
-<h2 align="center">Carbonmark Api</h2>
+<div  align="center">
 
-  <p align="center">
-    A BFF API for Carbonmark
-    <br />
-  </p>
+<a  href="https://github.com/github_username/repo_name">
+
+<img  src="./assets/logo.png"  alt="Logo"  width="80"  height="80">
+
+</a>
+
+<h2  align="center">Carbonmark Api</h2>
+
+<p  align="center">
+
+A BFF API for Carbonmark
+
+<br />
+
+</p>
+
 </div>
 
 ### Built With
 
 - [Fastify](https://fastify.io)
+
 - [Vercel](https://vercel.com)
+
 - [Firebase](https://firebase.google.com)
+
 - [Apollo](https://www.apollographql.com/)
+
 - [Ethers](https://docs.ethers.org/)
 
 <br />
@@ -30,46 +43,74 @@
 You will need to be authenticated to the following in order to run the project:
 
 - Vercel - https://vercel.com/klimadao/carbonmark-api
+
 - Firebase - https://console.firebase.google.com/project/klimadao-staging
 
-**Note all vercel commands should be run from within the root klimadao (monorepo) directory, all others should be run from within the carbonmark-api folder **
+\*\*Note all `vercel` commands should be run from within the root klimadao (monorepo) directory.
+
+\*\*All others should be run from within the `carbonmark-api` folder
 
 ### Link your local copy of the project with vercel
 
+1. You must be a member of the KlimaDAO project in Vercel.
+2. Say `Y`es when prompted to link the project to an existing project.
+3. Existing project name is `carbonmark-api`.
+
+- run from root
+
 ```sh
-vercel link
+vercel  link
 ```
 
 ### Environment Variables
 
-The vercel config is where all environment variables required for the project are defined and can be pulled down via the `vercel-cli`
+The vercel config is where all environment variables required for the project are defined and can be pulled down via the `vercel-cli`.
+
+Using the below command, the newest version of vercel cli will create a `.vercel`folder in the root and install the env variables in `.vercel/.env.development.local`.
+
+Previous versions created and stored in an `.env.local` in the root.
+
+Ensure you have updated vercel cli to the latest version (31.0.4 as of this doc)
+
+### **Note:** You will need to manually remove the beginning and trailing quotation marks on the `FIREBASE_ADMIN_CERT` env var in `.vercel/env.development.local` otherwise you will receive a _SyntaxError: Unexpected token_ error when trying to run the project
+
+- run from root
 
 ```sh
-vercel env pull --environment development
+vercel  env  pull  --environment  development
 ```
 
 or
 
 ```sh
-vercel env pull --environment production
+vercel  env  pull  --environment  production
 ```
 
 ### Install dependencies
 
+- run from root
+
 ```sh
-cd carbonmark-api && npm ci
+cd  carbonmark-api && npm  ci
 ```
 
-**Note:** You will need to manually remove the beginning and trailing quotation marks on the `FIREBASE_ADMIN_CERT` env var otherwise you will receive a _SyntaxError: Unexpected token_ error when trying to run the project
+## Coming from previous version
+
+In `carbonmark-api/`:
+
+Delete the current `dist` folder if it exists
+
+Run `npm run build` to create a new `dist` folder with the correct path
 
 <!-- USAGE EXAMPLES -->
 
 ## Usage
 
-### `vercel dev`
+### `vercel dev` or `npm run dev-carbonmark-api`
 
-To start the app in dev mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+To start the app in dev mode.
+
+Open [http://localhost:3003](http://localhost:3003) to view it in the browser.
 
 ### `npm start`
 
@@ -84,6 +125,7 @@ Run the test cases.
 Run the test cases via postman
 
 <!-- TODO Add description about deployment process -->
+
 <!-- TODO Add description of available endpoints -->
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+<p  align="right">(<a  href="#readme-top">back to top</a>)</p>

--- a/carbonmark-api/README.md
+++ b/carbonmark-api/README.md
@@ -1,5 +1,4 @@
 <!-- PROJECT LOGO -->
-ver
 <br />
 
 <div  align="center">

--- a/carbonmark-api/src/app.ts
+++ b/carbonmark-api/src/app.ts
@@ -2,9 +2,10 @@ import AutoLoad, { AutoloadPluginOptions } from "@fastify/autoload";
 import * as dotenv from "dotenv";
 import { FastifyPluginAsync } from "fastify";
 import { join } from "path";
+import { LOCAL_ENV_PATH } from "./utils/helpers/utils.constants";
 
 // This is not pretty but we need to reference the env file at the root of the monorepo
-const result = dotenv.config({ path: "../.env.local" });
+const result = dotenv.config({ path: LOCAL_ENV_PATH });
 
 if (result.error) {
   console.error("Error loading .env file", result.error);

--- a/carbonmark-api/src/utils/helpers/utils.constants.ts
+++ b/carbonmark-api/src/utils/helpers/utils.constants.ts
@@ -29,3 +29,5 @@ export type TokenPool = (typeof TOKEN_POOLS)[number];
 
 /** The value by which to truncate token prices */
 export const POOL_PRICE_DECIMALS = 1e6;
+
+export const LOCAL_ENV_PATH = "../.vercel/.env.development.local";

--- a/package-lock.json
+++ b/package-lock.json
@@ -364,6 +364,7 @@
       "license": "MIT"
     },
     "cms": {
+      "name": "@klimadao/cms",
       "version": "1.0.0",
       "dependencies": {
         "@sanity/vision": "^3.2.4",


### PR DESCRIPTION
## Description

Updated readme for updating to the newest vercel version, linking to the carbonmark-api vercel project, pulling the env variables, upgrading from previous version and running carbonmark-api locally in dev mode.

Updated path to the folder and variables created by the newest vercel cli.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1338 

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`