### PR TITLE
fix: reload receipt page on subgraph data

### DIFF
--- a/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
@@ -52,7 +52,7 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
       // check if its available yet
       const result = await queryKlimaRetireByIndex(
         props.beneficiaryAddress,
-        parseInt(props.retirementIndex)
+        Number(props.retirementIndex) - 1 // totals does not include index 0
       );
       if (result) {
         return window.location.reload();


### PR DESCRIPTION
## Description

Fix:
The receipt page should enforce the browser to reload the page as soon as the subgraph data exists.

## TBD
This PR and the [one before](https://github.com/KlimaDAO/klimadao/pull/1323) are just fixing the code which already exists.
The processing spinner as well as the browser reload must have been decided before hand.
**Suggestion:**
Instead of reloading the page => the data can also be added to the client. WDYT?

## Related Ticket

Part of https://github.com/KlimaDAO/klimadao/issues/1290

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
