### PR TITLE
Hide all fees from Transaction Views

### DIFF
--- a/carbonmark/components/pages/Project/FeesBreakdownListing/index.tsx
+++ b/carbonmark/components/pages/Project/FeesBreakdownListing/index.tsx
@@ -1,0 +1,49 @@
+import { cx } from "@emotion/css";
+import { t } from "@lingui/macro";
+import { Text } from "components/Text";
+import { CARBONMARK_FEE, settings } from "lib/constants";
+import { formatToPrice } from "lib/formatNumbers";
+import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
+import { CarbonmarkPaymentMethod } from "lib/types/carbonmark";
+import Image from "next/legacy/image";
+import { useRouter } from "next/router";
+import { FC } from "react";
+import * as styles from "./styles";
+
+type Props = {
+  paymentMethod: CarbonmarkPaymentMethod;
+};
+
+export const FeesBreakdownListing: FC<Props> = (props) => {
+  const showFees = settings.SHOW_FEES;
+  const { locale } = useRouter();
+
+  return (
+    <>
+      {showFees && (
+        <div className={styles.totalsText}>
+          <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
+          <div className={cx(styles.iconAndText)}>
+            <div className="icon">
+              <Image
+                src={
+                  carbonmarkPaymentMethodMap[props.paymentMethod || "usdc"].icon
+                }
+                width={20}
+                height={20}
+                alt={
+                  carbonmarkPaymentMethodMap[props.paymentMethod || "usdc"].id
+                }
+              />
+            </div>
+            <Text t="h5" className={styles.feeColor}>
+              {formatToPrice(CARBONMARK_FEE, locale, false)}
+            </Text>
+          </div>
+        </div>
+      )}
+
+      <div className={styles.divider}></div>
+    </>
+  );
+};

--- a/carbonmark/components/pages/Project/FeesBreakdownListing/styles.ts
+++ b/carbonmark/components/pages/Project/FeesBreakdownListing/styles.ts
@@ -1,0 +1,62 @@
+import { css } from "@emotion/css";
+
+export const totalsText = css`
+  display: grid;
+  gap: 0.8rem;
+`;
+
+export const divider = css`
+  height: 0.1rem;
+  background-color: var(--font-03);
+`;
+
+export const iconAndText = css`
+  display: flex;
+  gap: 0.8rem;
+
+  .icon {
+    flex-shrink: 0;
+  }
+
+  .error {
+    color: var(--warn);
+  }
+`;
+
+export const feeColor = css`
+  color: var(--bright-blue);
+`;
+
+export const withToggle = css`
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+`;
+
+export const toggleFees = css`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+`;
+
+export const fees = css`
+  background-color: var(--surface-02);
+  padding: 0.4rem;
+  display: grid;
+  gap: 0.8rem;
+  border-top: 2px solid var(--manatee);
+  border-bottom: 2px solid var(--manatee);
+`;
+
+export const feeBreakdown = css`
+  background-color: var(--surface-02);
+  display: grid;
+  padding: 0.4rem;
+`;
+
+export const feeText = css`
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+`;

--- a/carbonmark/components/pages/Project/FeesBreakdownPool/index.tsx
+++ b/carbonmark/components/pages/Project/FeesBreakdownPool/index.tsx
@@ -1,0 +1,256 @@
+import { cx } from "@emotion/css";
+import { trimWithLocale } from "@klimadao/lib/utils";
+import { t, Trans } from "@lingui/macro";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import { Text } from "components/Text";
+import { getFeeFactor } from "lib/actions.retire";
+import {
+  AGGREGATOR_FEE,
+  CARBONMARK_FEE,
+  settings,
+  SUSHI_SWAP_FEE,
+} from "lib/constants";
+import { formatToPrice } from "lib/formatNumbers";
+import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
+import { CarbonmarkPaymentMethod, Price } from "lib/types/carbonmark";
+import Image from "next/legacy/image";
+import { useRouter } from "next/router";
+import { FC, useEffect, useState } from "react";
+import * as styles from "./styles";
+
+type Props = {
+  transaction: "retire" | "redeem";
+  price: Price;
+  paymentMethod: CarbonmarkPaymentMethod;
+  costs: number | string;
+  quantity: string | number;
+  isLoading: boolean;
+};
+
+const getSwapFee = (costs: number, pool: Price["poolName"]) => {
+  const singleSwap = costs * SUSHI_SWAP_FEE;
+  if (pool === "bct") {
+    return singleSwap * 2;
+  }
+
+  return singleSwap;
+};
+
+export const FeesBreakdownPool: FC<Props> = (props) => {
+  const showFees = settings.SHOW_FEES;
+  const poolName = props.price.poolName;
+  const isPoolDefault = props.price.isPoolDefault;
+
+  // NO fees for RA if buying from pool
+  const aggregatorFeeValue =
+    props.transaction === "redeem" ? 0 : AGGREGATOR_FEE;
+
+  const { locale } = useRouter();
+  const [feesFactor, setFeesFactor] = useState(0);
+  const [isToggled, setIsToggled] = useState(false);
+
+  const isFiat = props.paymentMethod === "fiat";
+
+  const redemptionFee =
+    (!isPoolDefault && Number(props.costs || 0) * feesFactor) || 0;
+  const aggregatorFee = Number(props.quantity || 0) * aggregatorFeeValue;
+  const swapFee = getSwapFee(Number(props.costs || 0), poolName);
+  const networkFees = redemptionFee + aggregatorFee + swapFee;
+
+  const formatFees = (value: number) =>
+    isFiat ? formatToPrice(value, locale) : trimWithLocale(value, 5, locale);
+
+  useEffect(() => {
+    const selectiveFee = async () => {
+      // No fees for default retirement
+      if (isPoolDefault) {
+        setFeesFactor(0);
+        return;
+      }
+
+      const factor = await getFeeFactor(poolName);
+      setFeesFactor(factor);
+    };
+    selectiveFee();
+  }, []);
+
+  return (
+    <>
+      {showFees && (
+        <>
+          <div className={styles.totalsText}>
+            <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
+            <div className={cx(styles.iconAndText)}>
+              {!isFiat && (
+                <div className="icon">
+                  <Image
+                    src={
+                      carbonmarkPaymentMethodMap[props.paymentMethod || "usdc"]
+                        .icon
+                    }
+                    width={20}
+                    height={20}
+                    alt={
+                      carbonmarkPaymentMethodMap[props.paymentMethod || "usdc"]
+                        .id
+                    }
+                  />
+                </div>
+              )}
+              <Text t="h5" className={styles.feeColor}>
+                {formatToPrice(CARBONMARK_FEE, locale, isFiat)}
+              </Text>
+            </div>
+          </div>
+          <div className={styles.totalsText}>
+            <Text>{t`Network fees`}</Text>
+            <div className={cx(styles.iconAndText)}>
+              {!isFiat && (
+                <div className="icon">
+                  <Image
+                    src={
+                      carbonmarkPaymentMethodMap[props.paymentMethod || "usdc"]
+                        .icon
+                    }
+                    width={20}
+                    height={20}
+                    alt={
+                      carbonmarkPaymentMethodMap[props.paymentMethod || "usdc"]
+                        .id
+                    }
+                  />
+                </div>
+              )}
+              <div className={styles.withToggle}>
+                <Text t="h5">
+                  {props.isLoading ? t`Loading` : formatFees(networkFees)}
+                </Text>
+
+                <Text
+                  t="body3"
+                  color="lighter"
+                  onClick={() => setIsToggled((prev) => !prev)}
+                  className={styles.toggleFees}
+                >
+                  {isToggled ? t`Hide Details` : t`Show Details`}
+                  {isToggled ? (
+                    <KeyboardArrowUpIcon />
+                  ) : (
+                    <KeyboardArrowDownIcon />
+                  )}
+                </Text>
+              </div>
+            </div>
+            {isToggled && (
+              <div className={styles.fees}>
+                <div className={styles.feeBreakdown}>
+                  <div className={cx(styles.iconAndText)}>
+                    {!isFiat && (
+                      <div className="icon">
+                        <Image
+                          src={
+                            carbonmarkPaymentMethodMap[
+                              props.paymentMethod || "usdc"
+                            ].icon
+                          }
+                          width={20}
+                          height={20}
+                          alt={
+                            carbonmarkPaymentMethodMap[
+                              props.paymentMethod || "usdc"
+                            ].id
+                          }
+                        />
+                      </div>
+                    )}
+                    <Text t="body2">{formatFees(swapFee)}</Text>
+                  </div>
+                  <div className={styles.feeText}>
+                    <Text t="body2">SushiSwap</Text>
+                    <Text t="body2">
+                      {`(${trimWithLocale(
+                        SUSHI_SWAP_FEE * 100,
+                        2,
+                        locale
+                      )}% per swap)`}
+                    </Text>
+                  </div>
+                </div>
+
+                <div className={styles.feeBreakdown}>
+                  <div className={cx(styles.iconAndText)}>
+                    {!isFiat && (
+                      <div className="icon">
+                        <Image
+                          src={
+                            carbonmarkPaymentMethodMap[
+                              props.paymentMethod || "usdc"
+                            ].icon
+                          }
+                          width={20}
+                          height={20}
+                          alt={
+                            carbonmarkPaymentMethodMap[
+                              props.paymentMethod || "usdc"
+                            ].id
+                          }
+                        />
+                      </div>
+                    )}
+                    <Text t="body2">{formatFees(aggregatorFee)}</Text>
+                  </div>
+                  <div className={styles.feeText}>
+                    <Text t="body2">{t`KlimaDAO Contracts`}</Text>
+                    <Text t="body2">
+                      {`(${trimWithLocale(
+                        aggregatorFeeValue * 100,
+                        5,
+                        locale
+                      )}%)`}
+                    </Text>
+                  </div>
+                </div>
+
+                <div className={styles.feeBreakdown}>
+                  <div className={cx(styles.iconAndText)}>
+                    {!isFiat && (
+                      <div className="icon">
+                        <Image
+                          src={
+                            carbonmarkPaymentMethodMap[
+                              props.paymentMethod || "usdc"
+                            ].icon
+                          }
+                          width={20}
+                          height={20}
+                          alt={
+                            carbonmarkPaymentMethodMap[
+                              props.paymentMethod || "usdc"
+                            ].id
+                          }
+                        />
+                      </div>
+                    )}
+                    <Text t="body2">{formatFees(redemptionFee)}</Text>
+                  </div>
+                  <div className={styles.feeText}>
+                    <Text t="body2">
+                      {props.price.poolName.toUpperCase()}{" "}
+                      <Trans>Redemption Fee</Trans>
+                    </Text>
+                    <Text t="body2">
+                      {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
+                    </Text>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {!isToggled && <div className={styles.divider}></div>}
+    </>
+  );
+};

--- a/carbonmark/components/pages/Project/FeesBreakdownPool/index.tsx
+++ b/carbonmark/components/pages/Project/FeesBreakdownPool/index.tsx
@@ -39,16 +39,17 @@ const getSwapFee = (costs: number, pool: Price["poolName"]) => {
 
 export const FeesBreakdownPool: FC<Props> = (props) => {
   const showFees = settings.SHOW_FEES;
+
+  const { locale } = useRouter();
+  const [feesFactor, setFeesFactor] = useState(0);
+  const [isToggled, setIsToggled] = useState(false);
+
   const poolName = props.price.poolName;
   const isPoolDefault = props.price.isPoolDefault;
 
   // NO fees for RA if buying from pool
   const aggregatorFeeValue =
     props.transaction === "redeem" ? 0 : AGGREGATOR_FEE;
-
-  const { locale } = useRouter();
-  const [feesFactor, setFeesFactor] = useState(0);
-  const [isToggled, setIsToggled] = useState(false);
 
   const isFiat = props.paymentMethod === "fiat";
 
@@ -72,8 +73,12 @@ export const FeesBreakdownPool: FC<Props> = (props) => {
       const factor = await getFeeFactor(poolName);
       setFeesFactor(factor);
     };
-    selectiveFee();
+    showFees && selectiveFee();
   }, []);
+
+  if (!showFees) {
+    return <div className={styles.divider}></div>;
+  }
 
   return (
     <>

--- a/carbonmark/components/pages/Project/FeesBreakdownPool/styles.ts
+++ b/carbonmark/components/pages/Project/FeesBreakdownPool/styles.ts
@@ -1,0 +1,62 @@
+import { css } from "@emotion/css";
+
+export const totalsText = css`
+  display: grid;
+  gap: 0.8rem;
+`;
+
+export const divider = css`
+  height: 0.1rem;
+  background-color: var(--font-03);
+`;
+
+export const iconAndText = css`
+  display: flex;
+  gap: 0.8rem;
+
+  .icon {
+    flex-shrink: 0;
+  }
+
+  .error {
+    color: var(--warn);
+  }
+`;
+
+export const feeColor = css`
+  color: var(--bright-blue);
+`;
+
+export const withToggle = css`
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+`;
+
+export const toggleFees = css`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+`;
+
+export const fees = css`
+  background-color: var(--surface-02);
+  padding: 0.4rem;
+  display: grid;
+  gap: 0.8rem;
+  border-top: 2px solid var(--manatee);
+  border-bottom: 2px solid var(--manatee);
+`;
+
+export const feeBreakdown = css`
+  background-color: var(--surface-02);
+  display: grid;
+  padding: 0.4rem;
+`;
+
+export const feeText = css`
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+`;

--- a/carbonmark/components/pages/Project/Purchase/Listing/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Listing/TotalValues.tsx
@@ -1,8 +1,9 @@
 import { cx } from "@emotion/css";
 import { formatUnits } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
+import { FeesBreakdownListing } from "components/pages/Project/FeesBreakdownListing";
 import { Text } from "components/Text";
-import { CARBONMARK_FEE, settings } from "lib/constants";
+import { CARBONMARK_FEE } from "lib/constants";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
 import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
@@ -12,14 +13,12 @@ import { FC, useEffect } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import * as styles from "../styles";
 import { FormValues } from "./types";
-
 type TotalValuesProps = {
   singleUnitPrice: string;
   balance: string | null;
 };
 
 export const TotalValues: FC<TotalValuesProps> = (props) => {
-  const showFees = settings.SHOW_FEES;
   const singleUnitPrice = formatUnits(
     props.singleUnitPrice,
     getTokenDecimals("usdc")
@@ -71,26 +70,7 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
         </div>
       </div>
 
-      {showFees && (
-        <div className={styles.totalsText}>
-          <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
-          <div className={cx(styles.iconAndText)}>
-            <div className="icon">
-              <Image
-                src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
-                width={20}
-                height={20}
-                alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-              />
-            </div>
-            <Text t="h5" className={styles.feeColor}>
-              {formatToPrice(CARBONMARK_FEE, locale, false)}
-            </Text>
-          </div>
-        </div>
-      )}
-
-      <div className={styles.divider}></div>
+      <FeesBreakdownListing paymentMethod={paymentMethod} />
 
       <div className={styles.totalsText}>
         <Text color="lightest">{t`Total cost`}</Text>

--- a/carbonmark/components/pages/Project/Purchase/Listing/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Listing/TotalValues.tsx
@@ -2,7 +2,7 @@ import { cx } from "@emotion/css";
 import { formatUnits } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
 import { Text } from "components/Text";
-import { CARBONMARK_FEE } from "lib/constants";
+import { CARBONMARK_FEE, settings } from "lib/constants";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
 import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
@@ -19,6 +19,7 @@ type TotalValuesProps = {
 };
 
 export const TotalValues: FC<TotalValuesProps> = (props) => {
+  const showFees = settings.SHOW_FEES;
   const singleUnitPrice = formatUnits(
     props.singleUnitPrice,
     getTokenDecimals("usdc")
@@ -70,22 +71,24 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
         </div>
       </div>
 
-      <div className={styles.totalsText}>
-        <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
-        <div className={cx(styles.iconAndText)}>
-          <div className="icon">
-            <Image
-              src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
-              width={20}
-              height={20}
-              alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-            />
+      {showFees && (
+        <div className={styles.totalsText}>
+          <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
+          <div className={cx(styles.iconAndText)}>
+            <div className="icon">
+              <Image
+                src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
+                width={20}
+                height={20}
+                alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
+              />
+            </div>
+            <Text t="h5" className={styles.feeColor}>
+              {formatToPrice(CARBONMARK_FEE, locale, false)}
+            </Text>
           </div>
-          <Text t="h5" className={styles.feeColor}>
-            {formatToPrice(CARBONMARK_FEE, locale, false)}
-          </Text>
         </div>
-      </div>
+      )}
 
       <div className={styles.divider}></div>
 

--- a/carbonmark/components/pages/Project/Purchase/Pool/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Pool/TotalValues.tsx
@@ -141,142 +141,146 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
         </div>
       </div>
 
-      <div className={styles.totalsText}>
-        <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
-        <div className={cx(styles.iconAndText)}>
-          <div className="icon">
-            <Image
-              src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
-              width={20}
-              height={20}
-              alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-            />
-          </div>
-          <Text t="h5" className={styles.feeColor}>
-            {formatToPrice(CARBONMARK_FEE, locale, false)}
-          </Text>
-        </div>
-      </div>
-
       {showFees && (
-        <div className={styles.totalsText}>
-          <Text>{t`Network fees`}</Text>
-          <div className={cx(styles.iconAndText)}>
-            <div className="icon">
-              <Image
-                src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
-                width={20}
-                height={20}
-                alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-              />
-            </div>
-            <div className={styles.withToggle}>
-              <Text t="h5">
-                {isLoading
-                  ? t`Loading`
-                  : trimWithLocale(networkFees, 5, locale)}
-              </Text>
-              <Text
-                t="body3"
-                color="lighter"
-                onClick={() => setIsToggled((prev) => !prev)}
-                className={styles.toggleFees}
-              >
-                {isToggled ? t`Hide Details` : t`Show Details`}
-                {isToggled ? (
-                  <KeyboardArrowUpIcon />
-                ) : (
-                  <KeyboardArrowDownIcon />
-                )}
+        <>
+          <div className={styles.totalsText}>
+            <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
+            <div className={cx(styles.iconAndText)}>
+              <div className="icon">
+                <Image
+                  src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
+                  width={20}
+                  height={20}
+                  alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
+                />
+              </div>
+              <Text t="h5" className={styles.feeColor}>
+                {formatToPrice(CARBONMARK_FEE, locale, false)}
               </Text>
             </div>
           </div>
-          {isToggled && (
-            <div className={styles.fees}>
-              <div className={styles.feeBreakdown}>
-                <div className={cx(styles.iconAndText)}>
-                  <div className="icon">
-                    <Image
-                      src={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                      }
-                      width={20}
-                      height={20}
-                      alt={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
-                      }
-                    />
-                  </div>
-                  <Text t="body2">{trimWithLocale(swapFee, 5, locale)}</Text>
-                </div>
-                <div className={styles.feeText}>
-                  <Text t="body2">SushiSwap</Text>
-                  <Text t="body2">
-                    {`(${trimWithLocale(
-                      SUSHI_SWAP_FEE * 100,
-                      2,
-                      locale
-                    )}% per swap)`}
-                  </Text>
-                </div>
+          <div className={styles.totalsText}>
+            <Text>{t`Network fees`}</Text>
+            <div className={cx(styles.iconAndText)}>
+              <div className="icon">
+                <Image
+                  src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
+                  width={20}
+                  height={20}
+                  alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
+                />
               </div>
-
-              <div className={styles.feeBreakdown}>
-                <div className={cx(styles.iconAndText)}>
-                  <div className="icon">
-                    <Image
-                      src={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                      }
-                      width={20}
-                      height={20}
-                      alt={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
-                      }
-                    />
-                  </div>
-                  <Text t="body2">
-                    {trimWithLocale(aggregatorFee, 5, locale)}
-                  </Text>
-                </div>
-                <div className={styles.feeText}>
-                  <Text t="body2">{t`KlimaDAO Contracts`}</Text>
-                  <Text t="body2">
-                    {`(${trimWithLocale(AGGREGATOR_FEE * 100, 5, locale)}%)`}
-                  </Text>
-                </div>
-              </div>
-
-              <div className={styles.feeBreakdown}>
-                <div className={cx(styles.iconAndText)}>
-                  <div className="icon">
-                    <Image
-                      src={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                      }
-                      width={20}
-                      height={20}
-                      alt={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
-                      }
-                    />
-                  </div>
-                  <Text t="body2">
-                    {trimWithLocale(redemptionFee, 5, locale)}
-                  </Text>
-                </div>
-                <div className={styles.feeText}>
-                  <Text t="body2">
-                    {props.price.poolName} {t`redemption Fee`}
-                  </Text>
-                  <Text t="body2">
-                    {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
-                  </Text>
-                </div>
+              <div className={styles.withToggle}>
+                <Text t="h5">
+                  {isLoading
+                    ? t`Loading`
+                    : trimWithLocale(networkFees, 5, locale)}
+                </Text>
+                <Text
+                  t="body3"
+                  color="lighter"
+                  onClick={() => setIsToggled((prev) => !prev)}
+                  className={styles.toggleFees}
+                >
+                  {isToggled ? t`Hide Details` : t`Show Details`}
+                  {isToggled ? (
+                    <KeyboardArrowUpIcon />
+                  ) : (
+                    <KeyboardArrowDownIcon />
+                  )}
+                </Text>
               </div>
             </div>
-          )}
-        </div>
+            {isToggled && (
+              <div className={styles.fees}>
+                <div className={styles.feeBreakdown}>
+                  <div className={cx(styles.iconAndText)}>
+                    <div className="icon">
+                      <Image
+                        src={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                            .icon
+                        }
+                        width={20}
+                        height={20}
+                        alt={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
+                        }
+                      />
+                    </div>
+                    <Text t="body2">{trimWithLocale(swapFee, 5, locale)}</Text>
+                  </div>
+                  <div className={styles.feeText}>
+                    <Text t="body2">SushiSwap</Text>
+                    <Text t="body2">
+                      {`(${trimWithLocale(
+                        SUSHI_SWAP_FEE * 100,
+                        2,
+                        locale
+                      )}% per swap)`}
+                    </Text>
+                  </div>
+                </div>
+
+                <div className={styles.feeBreakdown}>
+                  <div className={cx(styles.iconAndText)}>
+                    <div className="icon">
+                      <Image
+                        src={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                            .icon
+                        }
+                        width={20}
+                        height={20}
+                        alt={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
+                        }
+                      />
+                    </div>
+                    <Text t="body2">
+                      {trimWithLocale(aggregatorFee, 5, locale)}
+                    </Text>
+                  </div>
+                  <div className={styles.feeText}>
+                    <Text t="body2">{t`KlimaDAO Contracts`}</Text>
+                    <Text t="body2">
+                      {`(${trimWithLocale(AGGREGATOR_FEE * 100, 5, locale)}%)`}
+                    </Text>
+                  </div>
+                </div>
+
+                <div className={styles.feeBreakdown}>
+                  <div className={cx(styles.iconAndText)}>
+                    <div className="icon">
+                      <Image
+                        src={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                            .icon
+                        }
+                        width={20}
+                        height={20}
+                        alt={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
+                        }
+                      />
+                    </div>
+                    <Text t="body2">
+                      {trimWithLocale(redemptionFee, 5, locale)}
+                    </Text>
+                  </div>
+                  <div className={styles.feeText}>
+                    <Text t="body2">
+                      {props.price.poolName} {t`redemption Fee`}
+                    </Text>
+                    <Text t="body2">
+                      {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
+                    </Text>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </>
       )}
       {!isToggled && <div className={styles.divider}></div>}
 

--- a/carbonmark/components/pages/Project/Purchase/Pool/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Pool/TotalValues.tsx
@@ -6,7 +6,7 @@ import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import { Text } from "components/Text";
 import { getRedeemCost } from "lib/actions.redeem";
 import { getFeeFactor } from "lib/actions.retire";
-import { CARBONMARK_FEE, SUSHI_SWAP_FEE } from "lib/constants";
+import { CARBONMARK_FEE, settings, SUSHI_SWAP_FEE } from "lib/constants";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
 import { Price } from "lib/types/carbonmark";
@@ -33,6 +33,7 @@ const getSwapFee = (costs: number, pool: Lowercase<Price["poolName"]>) => {
 };
 
 export const TotalValues: FC<TotalValuesProps> = (props) => {
+  const showFees = settings.SHOW_FEES;
   const poolName = props.price.poolName;
   const isPoolDefault = props.price.isPoolDefault;
 
@@ -157,112 +158,126 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
         </div>
       </div>
 
-      <div className={styles.totalsText}>
-        <Text>{t`Network fees`}</Text>
-        <div className={cx(styles.iconAndText)}>
-          <div className="icon">
-            <Image
-              src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
-              width={20}
-              height={20}
-              alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-            />
+      {showFees && (
+        <div className={styles.totalsText}>
+          <Text>{t`Network fees`}</Text>
+          <div className={cx(styles.iconAndText)}>
+            <div className="icon">
+              <Image
+                src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
+                width={20}
+                height={20}
+                alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
+              />
+            </div>
+            <div className={styles.withToggle}>
+              <Text t="h5">
+                {isLoading
+                  ? t`Loading`
+                  : trimWithLocale(networkFees, 5, locale)}
+              </Text>
+              <Text
+                t="body3"
+                color="lighter"
+                onClick={() => setIsToggled((prev) => !prev)}
+                className={styles.toggleFees}
+              >
+                {isToggled ? t`Hide Details` : t`Show Details`}
+                {isToggled ? (
+                  <KeyboardArrowUpIcon />
+                ) : (
+                  <KeyboardArrowDownIcon />
+                )}
+              </Text>
+            </div>
           </div>
-          <div className={styles.withToggle}>
-            <Text t="h5">
-              {isLoading ? t`Loading` : trimWithLocale(networkFees, 5, locale)}
-            </Text>
-            <Text
-              t="body3"
-              color="lighter"
-              onClick={() => setIsToggled((prev) => !prev)}
-              className={styles.toggleFees}
-            >
-              {isToggled ? t`Hide Details` : t`Show Details`}
-              {isToggled ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-            </Text>
-          </div>
+          {isToggled && (
+            <div className={styles.fees}>
+              <div className={styles.feeBreakdown}>
+                <div className={cx(styles.iconAndText)}>
+                  <div className="icon">
+                    <Image
+                      src={
+                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
+                      }
+                      width={20}
+                      height={20}
+                      alt={
+                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
+                      }
+                    />
+                  </div>
+                  <Text t="body2">{trimWithLocale(swapFee, 5, locale)}</Text>
+                </div>
+                <div className={styles.feeText}>
+                  <Text t="body2">SushiSwap</Text>
+                  <Text t="body2">
+                    {`(${trimWithLocale(
+                      SUSHI_SWAP_FEE * 100,
+                      2,
+                      locale
+                    )}% per swap)`}
+                  </Text>
+                </div>
+              </div>
+
+              <div className={styles.feeBreakdown}>
+                <div className={cx(styles.iconAndText)}>
+                  <div className="icon">
+                    <Image
+                      src={
+                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
+                      }
+                      width={20}
+                      height={20}
+                      alt={
+                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
+                      }
+                    />
+                  </div>
+                  <Text t="body2">
+                    {trimWithLocale(aggregatorFee, 5, locale)}
+                  </Text>
+                </div>
+                <div className={styles.feeText}>
+                  <Text t="body2">{t`KlimaDAO Contracts`}</Text>
+                  <Text t="body2">
+                    {`(${trimWithLocale(AGGREGATOR_FEE * 100, 5, locale)}%)`}
+                  </Text>
+                </div>
+              </div>
+
+              <div className={styles.feeBreakdown}>
+                <div className={cx(styles.iconAndText)}>
+                  <div className="icon">
+                    <Image
+                      src={
+                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
+                      }
+                      width={20}
+                      height={20}
+                      alt={
+                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
+                      }
+                    />
+                  </div>
+                  <Text t="body2">
+                    {trimWithLocale(redemptionFee, 5, locale)}
+                  </Text>
+                </div>
+                <div className={styles.feeText}>
+                  <Text t="body2">
+                    {props.price.poolName} {t`redemption Fee`}
+                  </Text>
+                  <Text t="body2">
+                    {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
+                  </Text>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
-        {isToggled && (
-          <div className={styles.fees}>
-            <div className={styles.feeBreakdown}>
-              <div className={cx(styles.iconAndText)}>
-                <div className="icon">
-                  <Image
-                    src={
-                      carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                    }
-                    width={20}
-                    height={20}
-                    alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-                  />
-                </div>
-                <Text t="body2">{trimWithLocale(swapFee, 5, locale)}</Text>
-              </div>
-              <div className={styles.feeText}>
-                <Text t="body2">SushiSwap</Text>
-                <Text t="body2">
-                  {`(${trimWithLocale(
-                    SUSHI_SWAP_FEE * 100,
-                    2,
-                    locale
-                  )}% per swap)`}
-                </Text>
-              </div>
-            </div>
-
-            <div className={styles.feeBreakdown}>
-              <div className={cx(styles.iconAndText)}>
-                <div className="icon">
-                  <Image
-                    src={
-                      carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                    }
-                    width={20}
-                    height={20}
-                    alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-                  />
-                </div>
-                <Text t="body2">
-                  {trimWithLocale(aggregatorFee, 5, locale)}
-                </Text>
-              </div>
-              <div className={styles.feeText}>
-                <Text t="body2">{t`KlimaDAO Contracts`}</Text>
-                <Text t="body2">
-                  {`(${trimWithLocale(AGGREGATOR_FEE * 100, 5, locale)}%)`}
-                </Text>
-              </div>
-            </div>
-
-            <div className={styles.feeBreakdown}>
-              <div className={cx(styles.iconAndText)}>
-                <div className="icon">
-                  <Image
-                    src={
-                      carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                    }
-                    width={20}
-                    height={20}
-                    alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-                  />
-                </div>
-                <Text t="body2">
-                  {trimWithLocale(redemptionFee, 5, locale)}
-                </Text>
-              </div>
-              <div className={styles.feeText}>
-                <Text t="body2">
-                  {props.price.poolName} {t`redemption Fee`}
-                </Text>
-                <Text t="body2">
-                  {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
-                </Text>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
+      )}
       {!isToggled && <div className={styles.divider}></div>}
 
       <div className={styles.totalsText}>

--- a/carbonmark/components/pages/Project/Purchase/styles.ts
+++ b/carbonmark/components/pages/Project/Purchase/styles.ts
@@ -212,46 +212,8 @@ export const labelWithInput = css`
   gap: 0.8rem;
 `;
 
-export const feeColor = css`
-  color: var(--bright-blue);
-`;
-
 export const breakText = css`
   overflow-wrap: anywhere;
-`;
-
-export const withToggle = css`
-  flex: 1;
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-`;
-
-export const toggleFees = css`
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-`;
-
-export const fees = css`
-  background-color: var(--surface-02);
-  padding: 0.4rem;
-  display: grid;
-  gap: 0.8rem;
-  border-top: 2px solid var(--manatee);
-  border-bottom: 2px solid var(--manatee);
-`;
-
-export const feeBreakdown = css`
-  background-color: var(--surface-02);
-  display: grid;
-  padding: 0.4rem;
-`;
-
-export const feeText = css`
-  display: flex;
-  justify-content: space-between;
-  gap: 0.8rem;
 `;
 
 export const successScreen = css`

--- a/carbonmark/components/pages/Project/Retire/Pool/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/TotalValues.tsx
@@ -5,7 +5,12 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import { Text } from "components/Text";
 import { getConsumptionCost, getFeeFactor } from "lib/actions.retire";
-import { AGGREGATOR_FEE, CARBONMARK_FEE, SUSHI_SWAP_FEE } from "lib/constants";
+import {
+  AGGREGATOR_FEE,
+  CARBONMARK_FEE,
+  settings,
+  SUSHI_SWAP_FEE,
+} from "lib/constants";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
 import { Price } from "lib/types/carbonmark";
@@ -37,6 +42,7 @@ const getStringBetween = (str: string, start: string, end: string) => {
 };
 
 export const TotalValues: FC<TotalValuesProps> = (props) => {
+  const showFees = settings.SHOW_FEES;
   const poolName = props.price.poolName;
   const isPoolDefault = props.price.isPoolDefault;
 
@@ -201,123 +207,132 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
         </div>
       </div>
 
-      <div className={styles.totalsText}>
-        <Text>{t`Network fees`}</Text>
-        <div className={cx(styles.iconAndText)}>
-          {!isFiat && (
-            <div className="icon">
-              <Image
-                src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
-                width={20}
-                height={20}
-                alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-              />
+      {showFees && (
+        <div className={styles.totalsText}>
+          <Text>{t`Network fees`}</Text>
+          <div className={cx(styles.iconAndText)}>
+            {!isFiat && (
+              <div className="icon">
+                <Image
+                  src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
+                  width={20}
+                  height={20}
+                  alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
+                />
+              </div>
+            )}
+            <div className={styles.withToggle}>
+              <Text t="h5">
+                {isLoading ? t`Loading` : formatFees(networkFees)}
+              </Text>
+
+              <Text
+                t="body3"
+                color="lighter"
+                onClick={() => setIsToggled((prev) => !prev)}
+                className={styles.toggleFees}
+              >
+                {isToggled ? t`Hide Details` : t`Show Details`}
+                {isToggled ? (
+                  <KeyboardArrowUpIcon />
+                ) : (
+                  <KeyboardArrowDownIcon />
+                )}
+              </Text>
+            </div>
+          </div>
+          {isToggled && (
+            <div className={styles.fees}>
+              <div className={styles.feeBreakdown}>
+                <div className={cx(styles.iconAndText)}>
+                  {!isFiat && (
+                    <div className="icon">
+                      <Image
+                        src={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                            .icon
+                        }
+                        width={20}
+                        height={20}
+                        alt={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
+                        }
+                      />
+                    </div>
+                  )}
+                  <Text t="body2">{formatFees(swapFee)}</Text>
+                </div>
+                <div className={styles.feeText}>
+                  <Text t="body2">SushiSwap</Text>
+                  <Text t="body2">
+                    {`(${trimWithLocale(
+                      SUSHI_SWAP_FEE * 100,
+                      2,
+                      locale
+                    )}% per swap)`}
+                  </Text>
+                </div>
+              </div>
+
+              <div className={styles.feeBreakdown}>
+                <div className={cx(styles.iconAndText)}>
+                  {!isFiat && (
+                    <div className="icon">
+                      <Image
+                        src={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                            .icon
+                        }
+                        width={20}
+                        height={20}
+                        alt={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
+                        }
+                      />
+                    </div>
+                  )}
+                  <Text t="body2">{formatFees(aggregatorFee)}</Text>
+                </div>
+                <div className={styles.feeText}>
+                  <Text t="body2">{t`KlimaDAO Contracts`}</Text>
+                  <Text t="body2">
+                    {`(${trimWithLocale(AGGREGATOR_FEE * 100, 5, locale)}%)`}
+                  </Text>
+                </div>
+              </div>
+
+              <div className={styles.feeBreakdown}>
+                <div className={cx(styles.iconAndText)}>
+                  {!isFiat && (
+                    <div className="icon">
+                      <Image
+                        src={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                            .icon
+                        }
+                        width={20}
+                        height={20}
+                        alt={
+                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
+                        }
+                      />
+                    </div>
+                  )}
+                  <Text t="body2">{formatFees(redemptionFee)}</Text>
+                </div>
+                <div className={styles.feeText}>
+                  <Text t="body2">
+                    <Trans>Pool Redemption Fee</Trans>
+                  </Text>
+                  <Text t="body2">
+                    {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
+                  </Text>
+                </div>
+              </div>
             </div>
           )}
-          <div className={styles.withToggle}>
-            <Text t="h5">
-              {isLoading ? t`Loading` : formatFees(networkFees)}
-            </Text>
-
-            <Text
-              t="body3"
-              color="lighter"
-              onClick={() => setIsToggled((prev) => !prev)}
-              className={styles.toggleFees}
-            >
-              {isToggled ? t`Hide Details` : t`Show Details`}
-              {isToggled ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-            </Text>
-          </div>
         </div>
-        {isToggled && (
-          <div className={styles.fees}>
-            <div className={styles.feeBreakdown}>
-              <div className={cx(styles.iconAndText)}>
-                {!isFiat && (
-                  <div className="icon">
-                    <Image
-                      src={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                      }
-                      width={20}
-                      height={20}
-                      alt={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
-                      }
-                    />
-                  </div>
-                )}
-                <Text t="body2">{formatFees(swapFee)}</Text>
-              </div>
-              <div className={styles.feeText}>
-                <Text t="body2">SushiSwap</Text>
-                <Text t="body2">
-                  {`(${trimWithLocale(
-                    SUSHI_SWAP_FEE * 100,
-                    2,
-                    locale
-                  )}% per swap)`}
-                </Text>
-              </div>
-            </div>
-
-            <div className={styles.feeBreakdown}>
-              <div className={cx(styles.iconAndText)}>
-                {!isFiat && (
-                  <div className="icon">
-                    <Image
-                      src={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                      }
-                      width={20}
-                      height={20}
-                      alt={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
-                      }
-                    />
-                  </div>
-                )}
-                <Text t="body2">{formatFees(aggregatorFee)}</Text>
-              </div>
-              <div className={styles.feeText}>
-                <Text t="body2">{t`KlimaDAO Contracts`}</Text>
-                <Text t="body2">
-                  {`(${trimWithLocale(AGGREGATOR_FEE * 100, 5, locale)}%)`}
-                </Text>
-              </div>
-            </div>
-
-            <div className={styles.feeBreakdown}>
-              <div className={cx(styles.iconAndText)}>
-                {!isFiat && (
-                  <div className="icon">
-                    <Image
-                      src={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                      }
-                      width={20}
-                      height={20}
-                      alt={
-                        carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
-                      }
-                    />
-                  </div>
-                )}
-                <Text t="body2">{formatFees(redemptionFee)}</Text>
-              </div>
-              <div className={styles.feeText}>
-                <Text t="body2">
-                  <Trans>Pool Redemption Fee</Trans>
-                </Text>
-                <Text t="body2">
-                  {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
-                </Text>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
+      )}
       {!isToggled && <div className={styles.divider}></div>}
 
       <div className={styles.totalsText}>

--- a/carbonmark/components/pages/Project/Retire/Pool/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/TotalValues.tsx
@@ -188,150 +188,158 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
         </div>
       </div>
 
-      <div className={styles.totalsText}>
-        <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
-        <div className={cx(styles.iconAndText)}>
-          {!isFiat && (
-            <div className="icon">
-              <Image
-                src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
-                width={20}
-                height={20}
-                alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-              />
-            </div>
-          )}
-          <Text t="h5" className={styles.feeColor}>
-            {formatToPrice(CARBONMARK_FEE, locale, isFiat)}
-          </Text>
-        </div>
-      </div>
-
       {showFees && (
-        <div className={styles.totalsText}>
-          <Text>{t`Network fees`}</Text>
-          <div className={cx(styles.iconAndText)}>
-            {!isFiat && (
-              <div className="icon">
-                <Image
-                  src={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon}
-                  width={20}
-                  height={20}
-                  alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-                />
-              </div>
-            )}
-            <div className={styles.withToggle}>
-              <Text t="h5">
-                {isLoading ? t`Loading` : formatFees(networkFees)}
-              </Text>
-
-              <Text
-                t="body3"
-                color="lighter"
-                onClick={() => setIsToggled((prev) => !prev)}
-                className={styles.toggleFees}
-              >
-                {isToggled ? t`Hide Details` : t`Show Details`}
-                {isToggled ? (
-                  <KeyboardArrowUpIcon />
-                ) : (
-                  <KeyboardArrowDownIcon />
-                )}
+        <>
+          <div className={styles.totalsText}>
+            <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
+            <div className={cx(styles.iconAndText)}>
+              {!isFiat && (
+                <div className="icon">
+                  <Image
+                    src={
+                      carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
+                    }
+                    width={20}
+                    height={20}
+                    alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
+                  />
+                </div>
+              )}
+              <Text t="h5" className={styles.feeColor}>
+                {formatToPrice(CARBONMARK_FEE, locale, isFiat)}
               </Text>
             </div>
           </div>
-          {isToggled && (
-            <div className={styles.fees}>
-              <div className={styles.feeBreakdown}>
-                <div className={cx(styles.iconAndText)}>
-                  {!isFiat && (
-                    <div className="icon">
-                      <Image
-                        src={
-                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
-                            .icon
-                        }
-                        width={20}
-                        height={20}
-                        alt={
-                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
-                        }
-                      />
-                    </div>
-                  )}
-                  <Text t="body2">{formatFees(swapFee)}</Text>
+          <div className={styles.totalsText}>
+            <Text>{t`Network fees`}</Text>
+            <div className={cx(styles.iconAndText)}>
+              {!isFiat && (
+                <div className="icon">
+                  <Image
+                    src={
+                      carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
+                    }
+                    width={20}
+                    height={20}
+                    alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
+                  />
                 </div>
-                <div className={styles.feeText}>
-                  <Text t="body2">SushiSwap</Text>
-                  <Text t="body2">
-                    {`(${trimWithLocale(
-                      SUSHI_SWAP_FEE * 100,
-                      2,
-                      locale
-                    )}% per swap)`}
-                  </Text>
-                </div>
-              </div>
+              )}
+              <div className={styles.withToggle}>
+                <Text t="h5">
+                  {isLoading ? t`Loading` : formatFees(networkFees)}
+                </Text>
 
-              <div className={styles.feeBreakdown}>
-                <div className={cx(styles.iconAndText)}>
-                  {!isFiat && (
-                    <div className="icon">
-                      <Image
-                        src={
-                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
-                            .icon
-                        }
-                        width={20}
-                        height={20}
-                        alt={
-                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
-                        }
-                      />
-                    </div>
+                <Text
+                  t="body3"
+                  color="lighter"
+                  onClick={() => setIsToggled((prev) => !prev)}
+                  className={styles.toggleFees}
+                >
+                  {isToggled ? t`Hide Details` : t`Show Details`}
+                  {isToggled ? (
+                    <KeyboardArrowUpIcon />
+                  ) : (
+                    <KeyboardArrowDownIcon />
                   )}
-                  <Text t="body2">{formatFees(aggregatorFee)}</Text>
-                </div>
-                <div className={styles.feeText}>
-                  <Text t="body2">{t`KlimaDAO Contracts`}</Text>
-                  <Text t="body2">
-                    {`(${trimWithLocale(AGGREGATOR_FEE * 100, 5, locale)}%)`}
-                  </Text>
-                </div>
-              </div>
-
-              <div className={styles.feeBreakdown}>
-                <div className={cx(styles.iconAndText)}>
-                  {!isFiat && (
-                    <div className="icon">
-                      <Image
-                        src={
-                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
-                            .icon
-                        }
-                        width={20}
-                        height={20}
-                        alt={
-                          carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id
-                        }
-                      />
-                    </div>
-                  )}
-                  <Text t="body2">{formatFees(redemptionFee)}</Text>
-                </div>
-                <div className={styles.feeText}>
-                  <Text t="body2">
-                    <Trans>Pool Redemption Fee</Trans>
-                  </Text>
-                  <Text t="body2">
-                    {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
-                  </Text>
-                </div>
+                </Text>
               </div>
             </div>
-          )}
-        </div>
+            {isToggled && (
+              <div className={styles.fees}>
+                <div className={styles.feeBreakdown}>
+                  <div className={cx(styles.iconAndText)}>
+                    {!isFiat && (
+                      <div className="icon">
+                        <Image
+                          src={
+                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                              .icon
+                          }
+                          width={20}
+                          height={20}
+                          alt={
+                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                              .id
+                          }
+                        />
+                      </div>
+                    )}
+                    <Text t="body2">{formatFees(swapFee)}</Text>
+                  </div>
+                  <div className={styles.feeText}>
+                    <Text t="body2">SushiSwap</Text>
+                    <Text t="body2">
+                      {`(${trimWithLocale(
+                        SUSHI_SWAP_FEE * 100,
+                        2,
+                        locale
+                      )}% per swap)`}
+                    </Text>
+                  </div>
+                </div>
+
+                <div className={styles.feeBreakdown}>
+                  <div className={cx(styles.iconAndText)}>
+                    {!isFiat && (
+                      <div className="icon">
+                        <Image
+                          src={
+                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                              .icon
+                          }
+                          width={20}
+                          height={20}
+                          alt={
+                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                              .id
+                          }
+                        />
+                      </div>
+                    )}
+                    <Text t="body2">{formatFees(aggregatorFee)}</Text>
+                  </div>
+                  <div className={styles.feeText}>
+                    <Text t="body2">{t`KlimaDAO Contracts`}</Text>
+                    <Text t="body2">
+                      {`(${trimWithLocale(AGGREGATOR_FEE * 100, 5, locale)}%)`}
+                    </Text>
+                  </div>
+                </div>
+
+                <div className={styles.feeBreakdown}>
+                  <div className={cx(styles.iconAndText)}>
+                    {!isFiat && (
+                      <div className="icon">
+                        <Image
+                          src={
+                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                              .icon
+                          }
+                          width={20}
+                          height={20}
+                          alt={
+                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
+                              .id
+                          }
+                        />
+                      </div>
+                    )}
+                    <Text t="body2">{formatFees(redemptionFee)}</Text>
+                  </div>
+                  <div className={styles.feeText}>
+                    <Text t="body2">
+                      <Trans>Pool Redemption Fee</Trans>
+                    </Text>
+                    <Text t="body2">
+                      {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
+                    </Text>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </>
       )}
       {!isToggled && <div className={styles.divider}></div>}
 

--- a/carbonmark/components/pages/Project/Retire/Pool/TotalValues.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/TotalValues.tsx
@@ -1,16 +1,8 @@
 import { cx } from "@emotion/css";
-import { trimWithLocale } from "@klimadao/lib/utils";
-import { t, Trans } from "@lingui/macro";
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import { t } from "@lingui/macro";
+import { FeesBreakdownPool } from "components/pages/Project/FeesBreakdownPool";
 import { Text } from "components/Text";
-import { getConsumptionCost, getFeeFactor } from "lib/actions.retire";
-import {
-  AGGREGATOR_FEE,
-  CARBONMARK_FEE,
-  settings,
-  SUSHI_SWAP_FEE,
-} from "lib/constants";
+import { getConsumptionCost } from "lib/actions.retire";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
 import { Price } from "lib/types/carbonmark";
@@ -27,22 +19,12 @@ type TotalValuesProps = {
   fiatBalance: string | null;
 };
 
-const getSwapFee = (costs: number, pool: Price["poolName"]) => {
-  const singleSwap = costs * SUSHI_SWAP_FEE;
-  if (pool === "bct") {
-    return singleSwap * 2;
-  }
-
-  return singleSwap;
-};
-
 const getStringBetween = (str: string, start: string, end: string) => {
   const result = str.match(new RegExp(start + "(.*)" + end));
   return result && result[1];
 };
 
 export const TotalValues: FC<TotalValuesProps> = (props) => {
-  const showFees = settings.SHOW_FEES;
   const poolName = props.price.poolName;
   const isPoolDefault = props.price.isPoolDefault;
 
@@ -50,37 +32,12 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
   const { formState, control, setValue } = useFormContext<FormValues>();
   const [isLoading, setIsLoading] = useState(false);
   const [costs, setCosts] = useState("");
-  const [feesFactor, setFeesFactor] = useState(0);
   const [error, setError] = useState("");
-  const [isToggled, setIsToggled] = useState(false);
 
   const amount = useWatch({ name: "quantity", control });
   const paymentMethod = useWatch({ name: "paymentMethod", control });
 
   const isFiat = paymentMethod === "fiat";
-
-  const redemptionFee =
-    (!isPoolDefault && Number(costs || 0) * feesFactor) || 0;
-  const aggregatorFee = Number(amount || 0) * AGGREGATOR_FEE;
-  const swapFee = getSwapFee(Number(costs || 0), poolName);
-  const networkFees = redemptionFee + aggregatorFee + swapFee;
-
-  const formatFees = (value: number) =>
-    isFiat ? formatToPrice(value, locale) : trimWithLocale(value, 5, locale);
-
-  useEffect(() => {
-    const selectiveFee = async () => {
-      // No fees for default retirement
-      if (isPoolDefault) {
-        setFeesFactor(0);
-        return;
-      }
-
-      const factor = await getFeeFactor(poolName);
-      setFeesFactor(factor);
-    };
-    selectiveFee();
-  }, []);
 
   useEffect(() => {
     const newCosts = async () => {
@@ -188,160 +145,14 @@ export const TotalValues: FC<TotalValuesProps> = (props) => {
         </div>
       </div>
 
-      {showFees && (
-        <>
-          <div className={styles.totalsText}>
-            <Text className={styles.feeColor}>{t`Carbonmark fee`}</Text>
-            <div className={cx(styles.iconAndText)}>
-              {!isFiat && (
-                <div className="icon">
-                  <Image
-                    src={
-                      carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                    }
-                    width={20}
-                    height={20}
-                    alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-                  />
-                </div>
-              )}
-              <Text t="h5" className={styles.feeColor}>
-                {formatToPrice(CARBONMARK_FEE, locale, isFiat)}
-              </Text>
-            </div>
-          </div>
-          <div className={styles.totalsText}>
-            <Text>{t`Network fees`}</Text>
-            <div className={cx(styles.iconAndText)}>
-              {!isFiat && (
-                <div className="icon">
-                  <Image
-                    src={
-                      carbonmarkPaymentMethodMap[paymentMethod || "usdc"].icon
-                    }
-                    width={20}
-                    height={20}
-                    alt={carbonmarkPaymentMethodMap[paymentMethod || "usdc"].id}
-                  />
-                </div>
-              )}
-              <div className={styles.withToggle}>
-                <Text t="h5">
-                  {isLoading ? t`Loading` : formatFees(networkFees)}
-                </Text>
-
-                <Text
-                  t="body3"
-                  color="lighter"
-                  onClick={() => setIsToggled((prev) => !prev)}
-                  className={styles.toggleFees}
-                >
-                  {isToggled ? t`Hide Details` : t`Show Details`}
-                  {isToggled ? (
-                    <KeyboardArrowUpIcon />
-                  ) : (
-                    <KeyboardArrowDownIcon />
-                  )}
-                </Text>
-              </div>
-            </div>
-            {isToggled && (
-              <div className={styles.fees}>
-                <div className={styles.feeBreakdown}>
-                  <div className={cx(styles.iconAndText)}>
-                    {!isFiat && (
-                      <div className="icon">
-                        <Image
-                          src={
-                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
-                              .icon
-                          }
-                          width={20}
-                          height={20}
-                          alt={
-                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
-                              .id
-                          }
-                        />
-                      </div>
-                    )}
-                    <Text t="body2">{formatFees(swapFee)}</Text>
-                  </div>
-                  <div className={styles.feeText}>
-                    <Text t="body2">SushiSwap</Text>
-                    <Text t="body2">
-                      {`(${trimWithLocale(
-                        SUSHI_SWAP_FEE * 100,
-                        2,
-                        locale
-                      )}% per swap)`}
-                    </Text>
-                  </div>
-                </div>
-
-                <div className={styles.feeBreakdown}>
-                  <div className={cx(styles.iconAndText)}>
-                    {!isFiat && (
-                      <div className="icon">
-                        <Image
-                          src={
-                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
-                              .icon
-                          }
-                          width={20}
-                          height={20}
-                          alt={
-                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
-                              .id
-                          }
-                        />
-                      </div>
-                    )}
-                    <Text t="body2">{formatFees(aggregatorFee)}</Text>
-                  </div>
-                  <div className={styles.feeText}>
-                    <Text t="body2">{t`KlimaDAO Contracts`}</Text>
-                    <Text t="body2">
-                      {`(${trimWithLocale(AGGREGATOR_FEE * 100, 5, locale)}%)`}
-                    </Text>
-                  </div>
-                </div>
-
-                <div className={styles.feeBreakdown}>
-                  <div className={cx(styles.iconAndText)}>
-                    {!isFiat && (
-                      <div className="icon">
-                        <Image
-                          src={
-                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
-                              .icon
-                          }
-                          width={20}
-                          height={20}
-                          alt={
-                            carbonmarkPaymentMethodMap[paymentMethod || "usdc"]
-                              .id
-                          }
-                        />
-                      </div>
-                    )}
-                    <Text t="body2">{formatFees(redemptionFee)}</Text>
-                  </div>
-                  <div className={styles.feeText}>
-                    <Text t="body2">
-                      <Trans>Pool Redemption Fee</Trans>
-                    </Text>
-                    <Text t="body2">
-                      {`(${trimWithLocale(feesFactor * 100, 2, locale)}%)`}
-                    </Text>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-        </>
-      )}
-      {!isToggled && <div className={styles.divider}></div>}
+      <FeesBreakdownPool
+        transaction="retire"
+        price={props.price}
+        paymentMethod={paymentMethod}
+        costs={costs}
+        quantity={amount}
+        isLoading={isLoading}
+      />
 
       <div className={styles.totalsText}>
         <Text color="lightest">{t`Total cost`}</Text>

--- a/carbonmark/components/pages/Project/Retire/Pool/styles.ts
+++ b/carbonmark/components/pages/Project/Retire/Pool/styles.ts
@@ -121,13 +121,6 @@ export const totalsText = css`
   gap: 0.8rem;
 `;
 
-export const withToggle = css`
-  flex: 1;
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-`;
-
 export const externalLink = css`
   color: var(--font-01);
   text-decoration: underline;
@@ -142,44 +135,8 @@ export const externalLink = css`
   }
 `;
 
-export const toggleFees = css`
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-`;
-
-export const fees = css`
-  background-color: var(--surface-02);
-  padding: 0.4rem;
-  display: grid;
-  gap: 0.8rem;
-  border-top: 2px solid var(--manatee);
-  border-bottom: 2px solid var(--manatee);
-`;
-
-export const feeBreakdown = css`
-  background-color: var(--surface-02);
-  display: grid;
-  padding: 0.4rem;
-`;
-
-export const feeText = css`
-  display: flex;
-  justify-content: space-between;
-  gap: 0.8rem;
-`;
-
-export const feeColor = css`
-  color: var(--bright-blue);
-`;
-
 export const breakText = css`
   overflow-wrap: anywhere;
-`;
-
-export const divider = css`
-  height: 0.1rem;
-  background-color: var(--manatee);
 `;
 
 export const iconAndText = css`

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -44,6 +44,11 @@ export const CARBONMARK_FEE = 0.0; // 0%
 export const SUSHI_SWAP_FEE = 0.003; // 0.3% per swap
 export const AGGREGATOR_FEE = 0.01; // 1% per tonnage
 
+// List of booleans to show/hide data in the UI
+export const settings = {
+  SHOW_FEES: false,
+};
+
 export const getConnectErrorStrings = () => ({
   default: t({
     message: "We had some trouble connecting. Please try again.",


### PR DESCRIPTION
## Description

As long as the discussion about the correct display of all fees is still ongoing, we discussed to hide _ALL FEES_.

This affects these views:
- Retire from Pool (see [before](https://www.carbonmark.com/projects/VCS-1718-2013/retire/pools/nct), see [after](https://carbonmark-git-lady-hide-all-fees-klimadao.vercel.app/projects/VCS-1718-2013/retire/pools/nct))
- Purchase from Pool (see [before](https://www.carbonmark.com/projects/VCS-1718-2013/purchase/pools/nct), see [after](https://carbonmark-git-lady-hide-all-fees-klimadao.vercel.app/projects/VCS-1718-2013/purchase/pools/nct))
- Purchase from Listing (currently disabled)

The "Carbonmark Fee" of 0% is hidden too.
Because it looks weird telling the user there are 0% fees but the total costs is way higher than the single price? 
Where does the difference come from when fees are 0%? 🤔 (Hidden! But the user does not know)

To enable the fees again => Just change one boolean in the constants file for Carbonmark. Easy 👍 

## Related Ticket

Belongs to https://github.com/KlimaDAO/klimadao/issues/1344


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
