### PR TITLE
Tufnel/Retirements enhancements # 1018

### DIFF
--- a/carbonmark/pages/retirements/[beneficiary]/[retirement_index].tsx
+++ b/carbonmark/pages/retirements/[beneficiary]/[retirement_index].tsx
@@ -1,16 +1,12 @@
 import { urls } from "@klimadao/lib/constants";
 import { KlimaRetire, PendingKlimaRetire } from "@klimadao/lib/types/subgraph";
-import {
-  getRetirementDetails,
-  queryKlimaRetireByIndex,
-} from "@klimadao/lib/utils";
+import { queryKlimaRetireByIndex } from "@klimadao/lib/utils";
 import { SingleRetirementPage } from "components/pages/Retirements/SingleRetirement";
 import { utils } from "ethers";
 import { getCarbonmarkProject } from "lib/carbonmark";
 import { loadTranslation } from "lib/i18n";
 import { getAddressByDomain } from "lib/shared/getAddressByDomain";
 import { getIsDomainInURL } from "lib/shared/getIsDomainInURL";
-import { INFURA_ID } from "lib/shared/secrets";
 import { Project } from "lib/types/carbonmark";
 import { GetStaticProps } from "next";
 import { ParsedUrlQuery } from "querystring";
@@ -69,7 +65,7 @@ export const getStaticProps: GetStaticProps<
 
     const retirementIndex = Number(params.retirement_index) - 1; // totals does not include index 0
 
-    let retirement: KlimaRetire | PendingKlimaRetire | any; // @todo - fix types & remove any (offset not being picked up in types)
+    let retirement: KlimaRetire | null;
     const [subgraphData, translation] = await Promise.all([
       queryKlimaRetireByIndex(beneficiaryAddress, retirementIndex),
       loadTranslation(locale),
@@ -78,25 +74,9 @@ export const getStaticProps: GetStaticProps<
     if (subgraphData) {
       retirement = subgraphData;
     } else {
-      // if the subgraph is slow to index, try grabbing the retirement directly from the storage contract
-      const fallbackData = await getRetirementDetails({
-        beneficiaryAddress,
-        index: retirementIndex,
-        infuraId: INFURA_ID,
-      });
-      if (!fallbackData) {
-        // if no fallback data and no subgraph data, it probably never existed, return page 404
-        throw new Error(
-          `No retirement found for address ${beneficiaryAddress} at index ${retirementIndex}`
-        );
-      }
-      // construct PendingKlimaRetire
-      retirement = {
-        pending: true,
-        amount: fallbackData.amount,
-        beneficiary: fallbackData.beneficiary,
-        beneficiaryAddress,
-        retirementMessage: fallbackData.retirementMessage,
+      return {
+        notFound: true,
+        revalidate: 1,
       };
     }
 
@@ -121,13 +101,13 @@ export const getStaticProps: GetStaticProps<
         translation,
         fixedThemeName: "theme-light",
       },
-      revalidate: retirement.pending ? 4 : 240,
+      revalidate: retirement.pending ? 4 : 86400,
     };
   } catch (e) {
     console.error("Failed to generate", e);
     return {
       notFound: true,
-      revalidate: 240,
+      revalidate: 1,
     };
   }
 };

--- a/carbonmark/pages/retirements/[beneficiary]/index.tsx
+++ b/carbonmark/pages/retirements/[beneficiary]/index.tsx
@@ -54,15 +54,19 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (ctx) => {
     ]);
 
     if (Array.isArray(klimaRetires)) {
-      let total = 0;
       totalRetirements = klimaRetires.length;
 
-      klimaRetires.forEach((retirement) => {
-        total += parseFloat(retirement.amount);
-      });
-      totalCarbonRetired = total.toString();
+      try {
+        totalCarbonRetired = klimaRetires
+          .reduce((acc, retirement) => acc + parseFloat(retirement.amount), 0)
+          .toString();
+      } catch (e) {
+        throw new Error(
+          `Invalid retirement.amount in the array klimaRetires: ${e}`
+        );
+      }
     } else {
-      console.log("klimaRetires is not an array");
+      console.error("klimaRetires is not an array");
     }
 
     if (!translation) {

--- a/carbonmark/pages/retirements/[beneficiary]/index.tsx
+++ b/carbonmark/pages/retirements/[beneficiary]/index.tsx
@@ -90,7 +90,7 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (ctx) => {
     console.error("Failed to generate", e);
     return {
       notFound: true,
-      revalidate: 30,
+      revalidate: 1,
     };
   }
 };


### PR DESCRIPTION
## Description

`/retirements`:

Removed RPC calls for totalRetirements and totalCarbonRetired and using the return from the subgraph instead to get the necessary data. 

Promise.all w/ rpc calls: 800ms to 1.2s
Subgraph only: ~200ms

shortened revalidation to 30 seconds if not found.

`/retirements/[index]`

Removed RPC fallback for subgraph. If no subgraph data exists, directs to a 404.

Changed revalidation times. If the subgraph data exists, revalidates every 24 hours. If no subgraph data, revalidates every second.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1018 



## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
