### PR TITLE
Improve empty state for unconnected users

### DIFF
--- a/carbonmark/components/pages/Users/ProfileHeader/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileHeader/index.tsx
@@ -43,7 +43,7 @@ export const ProfileHeader: FC<Props> = (props) => {
         )}
         {!isCarbonmarkUser && isUnconnectedUser && (
           <Text t="body1">
-            <Trans>This user has not yet created a carbonmark profile</Trans>
+            <Trans>This user has not yet created a carbonmark profile.</Trans>
           </Text>
         )}
 
@@ -52,7 +52,7 @@ export const ProfileHeader: FC<Props> = (props) => {
           !props.carbonmarkUser?.description && (
             <Text t="body1">
               <Trans id="profile.edit_your_profile">
-                Edit your profile to add a description
+                Edit your profile to add a description.
               </Trans>
             </Text>
           )}

--- a/carbonmark/components/pages/Users/ProfileHeader/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileHeader/index.tsx
@@ -1,6 +1,7 @@
 import { Trans } from "@lingui/macro";
 import { ProfileLogo } from "components/pages/Users/ProfileLogo";
 import { Text } from "components/Text";
+import { useConnectedUser } from "hooks/useConnectedUser";
 import { User } from "lib/types/carbonmark";
 import { FC } from "react";
 import * as styles from "./styles";
@@ -8,10 +9,14 @@ import * as styles from "./styles";
 type Props = {
   carbonmarkUser: User | null;
   userName: string;
+  userAddress: string;
 };
 
 export const ProfileHeader: FC<Props> = (props) => {
   const isCarbonmarkUser = !!props.carbonmarkUser;
+  const { isConnectedUser, isUnconnectedUser } = useConnectedUser(
+    props.userAddress
+  );
 
   return (
     <div className={styles.profileHeader}>
@@ -28,22 +33,29 @@ export const ProfileHeader: FC<Props> = (props) => {
             </Text>
           )}
         </div>
-        {!isCarbonmarkUser && (
+        {!isCarbonmarkUser && isConnectedUser && (
           <Text t="body1">
-            <Trans id="profile.create_your_profile">
-              To start selling you need to create your profile, click the
-              'create profile' button above to get started.
+            <Trans>
+              Click the 'create profile' button to customize this page and get
+              started.
             </Trans>
+          </Text>
+        )}
+        {!isCarbonmarkUser && isUnconnectedUser && (
+          <Text t="body1">
+            <Trans>This user has not yet created a carbonmark profile</Trans>
           </Text>
         )}
 
-        {isCarbonmarkUser && !props.carbonmarkUser?.description && (
-          <Text t="body1">
-            <Trans id="profile.edit_your_profile">
-              Edit your profile to add a description
-            </Trans>
-          </Text>
-        )}
+        {isCarbonmarkUser &&
+          isConnectedUser &&
+          !props.carbonmarkUser?.description && (
+            <Text t="body1">
+              <Trans id="profile.edit_your_profile">
+                Edit your profile to add a description
+              </Trans>
+            </Text>
+          )}
 
         {isCarbonmarkUser && props.carbonmarkUser?.description && (
           <Text t="body1">{props.carbonmarkUser.description}</Text>

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -163,6 +163,7 @@ export const SellerConnected: FC<Props> = (props) => {
         <ProfileHeader
           carbonmarkUser={carbonmarkUser}
           userName={props.userName}
+          userAddress={props.userAddress}
         />
       </div>
       <div className={styles.listings}>

--- a/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
@@ -39,6 +39,7 @@ export const SellerUnconnected: FC<Props> = (props) => {
         <ProfileHeader
           carbonmarkUser={carbonmarkUser}
           userName={props.userName}
+          userAddress={props.userAddress}
         />
       </div>
       <div className={styles.listings}>

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -269,6 +269,10 @@ msgstr ""
 msgid "Clear Filters"
 msgstr ""
 
+#: components/pages/Users/ProfileHeader/index.tsx:38
+msgid "Click the 'create profile' button to customize this page and get started."
+msgstr ""
+
 #: components/Dropdown/index.tsx:133
 msgid "Coming soon"
 msgstr ""
@@ -307,7 +311,7 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:187
+#: components/pages/Users/SellerConnected/index.tsx:188
 msgid "Create New Listing"
 msgstr ""
 
@@ -354,7 +358,7 @@ msgid "Data for this project and vintage"
 msgstr ""
 
 #: components/pages/Users/Login/index.tsx:47
-#: components/pages/Users/SellerUnconnected/index.tsx:91
+#: components/pages/Users/SellerUnconnected/index.tsx:92
 msgid "Data for this seller"
 msgstr ""
 
@@ -544,8 +548,8 @@ msgstr ""
 msgid "List your projects for sale in just a few clicks"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:171
-#: components/pages/Users/SellerUnconnected/index.tsx:47
+#: components/pages/Users/SellerConnected/index.tsx:172
+#: components/pages/Users/SellerUnconnected/index.tsx:48
 msgid "Listings"
 msgstr ""
 
@@ -624,8 +628,8 @@ msgstr ""
 msgid "No Activity to show."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:214
-#: components/pages/Users/SellerUnconnected/index.tsx:83
+#: components/pages/Users/SellerConnected/index.tsx:215
+#: components/pages/Users/SellerUnconnected/index.tsx:84
 msgid "No active listings."
 msgstr ""
 
@@ -1141,6 +1145,10 @@ msgstr ""
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr ""
 
+#: components/pages/Users/ProfileHeader/index.tsx:46
+msgid "This user has not yet created a carbonmark profile."
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr ""
@@ -1238,7 +1246,7 @@ msgstr ""
 msgid "Updated:"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:208
+#: components/pages/Users/SellerConnected/index.tsx:209
 msgid "Updating your data..."
 msgstr ""
 
@@ -1405,7 +1413,7 @@ msgid "Your purchase has not been completed yet. To finalize your purchase, veri
 msgstr ""
 
 #: components/pages/Portfolio/PortfolioSidebar.tsx:24
-#: components/pages/Users/SellerConnected/index.tsx:232
+#: components/pages/Users/SellerConnected/index.tsx:233
 msgid "Your seller data"
 msgstr ""
 
@@ -1616,10 +1624,6 @@ msgstr ""
 msgid "profile.addListing_modal.submit"
 msgstr ""
 
-#: components/pages/Users/ProfileHeader/index.tsx:33
-msgid "profile.create_your_profile"
-msgstr ""
-
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:151
 msgid "profile.editListing_modal.submit"
 msgstr ""
@@ -1628,11 +1632,11 @@ msgstr ""
 msgid "profile.edit_modal.submit"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:238
+#: components/pages/Users/SellerConnected/index.tsx:239
 msgid "profile.edit_profile.title"
 msgstr ""
 
-#: components/pages/Users/ProfileHeader/index.tsx:42
+#: components/pages/Users/ProfileHeader/index.tsx:54
 msgid "profile.edit_your_profile"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgstr ""
 msgid "seller.edit_listing.title"
 msgstr ""
 
-#: components/pages/Users/SellerUnconnected/index.tsx:70
+#: components/pages/Users/SellerUnconnected/index.tsx:71
 msgid "seller.listing.buy"
 msgstr ""
 
@@ -1974,7 +1978,7 @@ msgid "shared.approve"
 msgstr ""
 
 #: components/pages/Project/BuyOptions/SellerListing.tsx:95
-#: components/pages/Users/SellerUnconnected/index.tsx:60
+#: components/pages/Users/SellerUnconnected/index.tsx:61
 msgid "shared.connect_to_buy"
 msgstr ""
 

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -275,6 +275,10 @@ msgstr "Choose from over 20 million verified digital carbon credits from hundred
 msgid "Clear Filters"
 msgstr "Clear Filters"
 
+#: components/pages/Users/ProfileHeader/index.tsx:38
+msgid "Click the 'create profile' button to customize this page and get started."
+msgstr "Click the 'create profile' button to customize this page and get started."
+
 #: components/Dropdown/index.tsx:133
 msgid "Coming soon"
 msgstr "Coming soon"
@@ -313,7 +317,7 @@ msgstr "Could not calculate Total Cost"
 msgid "Country"
 msgstr "Country"
 
-#: components/pages/Users/SellerConnected/index.tsx:187
+#: components/pages/Users/SellerConnected/index.tsx:188
 msgid "Create New Listing"
 msgstr "Create New Listing"
 
@@ -360,7 +364,7 @@ msgid "Data for this project and vintage"
 msgstr "Data for this project and vintage"
 
 #: components/pages/Users/Login/index.tsx:47
-#: components/pages/Users/SellerUnconnected/index.tsx:91
+#: components/pages/Users/SellerUnconnected/index.tsx:92
 msgid "Data for this seller"
 msgstr "Data for this seller"
 
@@ -550,8 +554,8 @@ msgstr "List and sell for free"
 msgid "List your projects for sale in just a few clicks"
 msgstr "List your projects for sale in just a few clicks"
 
-#: components/pages/Users/SellerConnected/index.tsx:171
-#: components/pages/Users/SellerUnconnected/index.tsx:47
+#: components/pages/Users/SellerConnected/index.tsx:172
+#: components/pages/Users/SellerUnconnected/index.tsx:48
 msgid "Listings"
 msgstr "Listings"
 
@@ -630,8 +634,8 @@ msgstr "New Unit Price (USDC)"
 msgid "No Activity to show."
 msgstr "No Activity to show."
 
-#: components/pages/Users/SellerConnected/index.tsx:214
-#: components/pages/Users/SellerUnconnected/index.tsx:83
+#: components/pages/Users/SellerConnected/index.tsx:215
+#: components/pages/Users/SellerUnconnected/index.tsx:84
 msgid "No active listings."
 msgstr "No active listings."
 
@@ -1147,6 +1151,10 @@ msgstr "This offer no longer exists."
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr "This product is still in Beta and audits have not been completed yet."
 
+#: components/pages/Users/ProfileHeader/index.tsx:46
+msgid "This user has not yet created a carbonmark profile."
+msgstr "This user has not yet created a carbonmark profile."
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
@@ -1244,7 +1252,7 @@ msgstr "Unprecedented transparency across the digital carbon market."
 msgid "Updated:"
 msgstr "Updated:"
 
-#: components/pages/Users/SellerConnected/index.tsx:208
+#: components/pages/Users/SellerConnected/index.tsx:209
 msgid "Updating your data..."
 msgstr "Updating your data..."
 
@@ -1411,7 +1419,7 @@ msgid "Your purchase has not been completed yet. To finalize your purchase, veri
 msgstr "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 
 #: components/pages/Portfolio/PortfolioSidebar.tsx:24
-#: components/pages/Users/SellerConnected/index.tsx:232
+#: components/pages/Users/SellerConnected/index.tsx:233
 msgid "Your seller data"
 msgstr "Your seller data"
 
@@ -1622,10 +1630,6 @@ msgstr "Balances"
 msgid "profile.addListing_modal.submit"
 msgstr "Create Listing"
 
-#: components/pages/Users/ProfileHeader/index.tsx:33
-msgid "profile.create_your_profile"
-msgstr "To start selling you need to create your profile, click the 'create profile' button above to get started."
-
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:151
 msgid "profile.editListing_modal.submit"
 msgstr "Update Listing"
@@ -1634,13 +1638,13 @@ msgstr "Update Listing"
 msgid "profile.edit_modal.submit"
 msgstr "Save Changes"
 
-#: components/pages/Users/SellerConnected/index.tsx:238
+#: components/pages/Users/SellerConnected/index.tsx:239
 msgid "profile.edit_profile.title"
 msgstr "Your Profile"
 
-#: components/pages/Users/ProfileHeader/index.tsx:42
+#: components/pages/Users/ProfileHeader/index.tsx:54
 msgid "profile.edit_your_profile"
-msgstr "Edit your profile to add a description"
+msgstr "Edit your profile to add a description."
 
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:164
 msgid "profile.listing.delete.error"
@@ -1967,7 +1971,7 @@ msgstr "Total Retirement Transactions"
 msgid "seller.edit_listing.title"
 msgstr "Edit Listing"
 
-#: components/pages/Users/SellerUnconnected/index.tsx:70
+#: components/pages/Users/SellerUnconnected/index.tsx:71
 msgid "seller.listing.buy"
 msgstr "Buy"
 
@@ -1980,7 +1984,7 @@ msgid "shared.approve"
 msgstr "Approve"
 
 #: components/pages/Project/BuyOptions/SellerListing.tsx:95
-#: components/pages/Users/SellerUnconnected/index.tsx:60
+#: components/pages/Users/SellerUnconnected/index.tsx:61
 msgid "shared.connect_to_buy"
 msgstr "Sign In / Connect To Buy"
 


### PR DESCRIPTION
## Description

**Better empty state texts**

Viewing someones profile URL who is not yet registered:
"This user has not yet created a carbonmark profile."

Viewing owns profile URL and still not registered:
"Click the 'create profile' button to customize this page and get started."

## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1164

## Changes

| Logged In  | Not Logged In  |
|---------|--------|
|<img width="1245" alt="Bildschirmfoto 2023-07-21 um 13 51 00" src="https://github.com/KlimaDAO/klimadao/assets/95881624/4a081457-a5ab-4044-8ea2-1b6b44c8a5ce"> |<img width="1249" alt="Bildschirmfoto 2023-07-21 um 13 51 17" src="https://github.com/KlimaDAO/klimadao/assets/95881624/e2d8ced2-8a5f-45b6-9377-6676640b5384">|




## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
