### PR TITLE
Get total tonnes sold from activities

### DIFF
--- a/carbonmark/components/Stats/StatsListings.tsx
+++ b/carbonmark/components/Stats/StatsListings.tsx
@@ -4,7 +4,7 @@ import SavingsOutlinedIcon from "@mui/icons-material/SavingsOutlined";
 import SellOutlinedIcon from "@mui/icons-material/SellOutlined";
 import StoreOutlinedIcon from "@mui/icons-material/StoreOutlined";
 import { Text } from "components/Text";
-import { getTotalAmountSoldFromActivities } from "lib/activitiesGetter";
+import { getTotalTonnesSoldFromActivities } from "lib/activitiesGetter";
 import { getAmountLeftToSell, getTotalAmountSold } from "lib/listingsGetter";
 import { Listing, UserActivity } from "lib/types/carbonmark";
 import { useRouter } from "next/router";
@@ -23,7 +23,7 @@ export const StatsListings: FC<Props> = (props) => {
     ? getTotalAmountSold(props.allListings)
     : 0;
   const tonnesSoldFromActivities = !!props.activities?.length
-    ? getTotalAmountSoldFromActivities(props.activities)
+    ? getTotalTonnesSoldFromActivities(props.activities)
     : 0;
 
   const tonnesSold = tonnesSoldFromListings || tonnesSoldFromActivities;

--- a/carbonmark/components/Stats/StatsListings.tsx
+++ b/carbonmark/components/Stats/StatsListings.tsx
@@ -4,8 +4,9 @@ import SavingsOutlinedIcon from "@mui/icons-material/SavingsOutlined";
 import SellOutlinedIcon from "@mui/icons-material/SellOutlined";
 import StoreOutlinedIcon from "@mui/icons-material/StoreOutlined";
 import { Text } from "components/Text";
+import { getTotalAmountSoldFromActivities } from "lib/activitiesGetter";
 import { getAmountLeftToSell, getTotalAmountSold } from "lib/listingsGetter";
-import { Listing } from "lib/types/carbonmark";
+import { Listing, UserActivity } from "lib/types/carbonmark";
 import { useRouter } from "next/router";
 import { FC } from "react";
 import * as styles from "./styles";
@@ -13,13 +14,19 @@ import * as styles from "./styles";
 interface Props {
   allListings?: Listing[];
   activeListings?: Listing[];
+  activities?: UserActivity[];
 }
 
 export const StatsListings: FC<Props> = (props) => {
   const { locale } = useRouter();
-  const tonnesSold = !!props.allListings?.length
+  const tonnesSoldFromListings = !!props.allListings?.length
     ? getTotalAmountSold(props.allListings)
     : 0;
+  const tonnesSoldFromActivities = !!props.activities?.length
+    ? getTotalAmountSoldFromActivities(props.activities)
+    : 0;
+
+  const tonnesSold = tonnesSoldFromListings || tonnesSoldFromActivities;
 
   const tonnesOwned = !!props.activeListings?.length
     ? getAmountLeftToSell(props.activeListings)

--- a/carbonmark/components/Stats/index.tsx
+++ b/carbonmark/components/Stats/index.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/macro";
 import { Card } from "components/Card";
 import { Text } from "components/Text";
-import { Listing, Project } from "lib/types/carbonmark";
+import { Listing, Project, UserActivity } from "lib/types/carbonmark";
 import { FC } from "react";
 import { StatsBar } from "./StatsBar";
 import { StatsListings } from "./StatsListings";
@@ -13,6 +13,7 @@ interface Props {
   totalSupply?: Project["stats"]["totalSupply"];
   totalRetired?: Project["stats"]["totalRetired"];
   description: string;
+  activities?: UserActivity[];
 }
 
 export const Stats: FC<Props> = (props) => {
@@ -36,6 +37,7 @@ export const Stats: FC<Props> = (props) => {
         <StatsListings
           activeListings={props.activeListings}
           allListings={props.allListings}
+          activities={props.activities}
         />
       )}
     </Card>

--- a/carbonmark/components/pages/Portfolio/PortfolioSidebar.tsx
+++ b/carbonmark/components/pages/Portfolio/PortfolioSidebar.tsx
@@ -14,6 +14,7 @@ type Props = {
 export const PortfolioSidebar: FC<Props> = (props) => {
   const allListings = props.user && getAllListings(props.user.listings);
   const activeListings = props.user && getActiveListings(props.user.listings);
+  const activities = props.user && props.user.activities;
 
   return (
     <>
@@ -22,6 +23,7 @@ export const PortfolioSidebar: FC<Props> = (props) => {
         allListings={allListings || []}
         activeListings={activeListings || []}
         description={t`Your seller data`}
+        activities={activities || []}
       />
       <Activities
         activities={props.user?.activities || []}

--- a/carbonmark/components/pages/Users/ProfileSidebar/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileSidebar/index.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const ProfileSidebar: FC<Props> = (props) => {
   const allListings = props.user && getAllListings(props.user.listings);
   const activeListings = props.user && getActiveListings(props.user.listings);
+  const activities = props.user && props.user.activities;
 
   return (
     <>
@@ -20,6 +21,7 @@ export const ProfileSidebar: FC<Props> = (props) => {
         allListings={allListings || []}
         activeListings={activeListings || []}
         description={props.title}
+        activities={activities || []}
       />
       <Activities
         activities={props.user?.activities || []}

--- a/carbonmark/lib/activitiesGetter.ts
+++ b/carbonmark/lib/activitiesGetter.ts
@@ -1,20 +1,18 @@
 import { UserActivity } from "lib/types/carbonmark";
 
-export const getSoldSum = (activities: UserActivity[]): number =>
+export const getSoldTonnes = (activities: UserActivity[]): number =>
   activities.reduce((acc, curr) => {
-    const price = Number(curr.price);
     const amount = Number(curr.amount);
-    const total = amount * price;
-    return acc + total;
+    return acc + amount;
   }, 0);
 
 export const getActivitiesTypeSold = (activities: UserActivity[]) => {
   return activities.filter((a) => a.activityType === "Sold");
 };
 
-export const getTotalAmountSoldFromActivities = (
+export const getTotalTonnesSoldFromActivities = (
   activities: UserActivity[]
 ) => {
   const activitySold = getActivitiesTypeSold(activities);
-  return getSoldSum(activitySold);
+  return getSoldTonnes(activitySold);
 };

--- a/carbonmark/lib/activitiesGetter.ts
+++ b/carbonmark/lib/activitiesGetter.ts
@@ -1,0 +1,20 @@
+import { UserActivity } from "lib/types/carbonmark";
+
+export const getSoldSum = (activities: UserActivity[]): number =>
+  activities.reduce((acc, curr) => {
+    const price = Number(curr.price);
+    const amount = Number(curr.amount);
+    const total = amount * price;
+    return acc + total;
+  }, 0);
+
+export const getActivitiesTypeSold = (activities: UserActivity[]) => {
+  return activities.filter((a) => a.activityType === "Sold");
+};
+
+export const getTotalAmountSoldFromActivities = (
+  activities: UserActivity[]
+) => {
+  const activitySold = getActivitiesTypeSold(activities);
+  return getSoldSum(activitySold);
+};


### PR DESCRIPTION
## Description

See this comment here: https://github.com/KlimaDAO/klimadao/issues/1262#issuecomment-1625470684
Even though the listings are deleted, let's show the tonnes the user sold before when selling listings was still possible.

Problem is, that the listings value `leftToSell` was set to "0" for all listings of a user.
This value was used before to calculate the sum of all sold tonnes before.

Now, the sold amount must be retrieved by iterating over the user's activities data instead.
See comment here https://github.com/KlimaDAO/klimadao/issues/1262#issuecomment-1645503147

**See Preview:**
- [JABBY](https://carbonmark-git-lady-user-stats-klimadao.vercel.app/users/jabby)
- [ATMOS](https://carbonmark-git-lady-user-stats-klimadao.vercel.app/users/atmosfearful)
- [LADY](https://carbonmark-git-lady-user-stats-klimadao.vercel.app/users/ladsysdfsdfsdfsdfsdfsdfsfsdfsdf)

## 🔥 MERGING IS BLOCKED 🔥 

**The API limits the activity data of a user to 10 entries !** 🚒 

When summing up all SOLD activities of a user, the API needs to return ALL entries of this user.
Otherwise the total tonnes sold value is not correct.


## Related Ticket

Resolves https://github.com/KlimaDAO/klimadao/issues/1262


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
