### PR TITLE
fix:1357 User wallet added to /GET response

### DIFF
--- a/carbonmark-api/src/routes/users/get.ts
+++ b/carbonmark-api/src/routes/users/get.ts
@@ -137,12 +137,15 @@ const handler = (fastify: FastifyInstance) =>
 
     const { accounts } = await gqlSdk.assets.getHoldingsByWallet({ wallet });
 
-    return reply.send({
+    const response: ResponseType = {
       ...firebaseUser,
       listings: listingsWithSellerData,
       activities: activitiesWithUserData,
       assets: accounts.at(0)?.holdings,
-    });
+      wallet,
+    };
+
+    return reply.send(response);
   };
 
 export default async (fastify: FastifyInstance) =>


### PR DESCRIPTION
## Description

Add missing `wallet` attribute from the GET `/user` requests.

Previously this was added in the middle of the route:

<img width="607" alt="image" src="https://github.com/KlimaDAO/klimadao/assets/7104689/4082b47a-059c-4bdb-b51b-f1007cdd3d54">

It seems to have been lost during refactor. Tests for response content will be added in forthcoming PR 

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #13557

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->


