### PR TITLE
Tufnel/resources not showing 1144

### DIFF
--- a/site/pages/resources/index.tsx
+++ b/site/pages/resources/index.tsx
@@ -6,10 +6,31 @@ import { GetStaticPropsContext } from "next";
 export async function getStaticProps(ctx: GetStaticPropsContext) {
   try {
     const { locale } = ctx;
-    const documents = await fetchCMSContent("allDocuments", { locale });
-    const featuredArticles = await fetchCMSContent("allFeaturedPosts", {
-      locale,
-    });
+
+    const [
+      enDocuments,
+      enFeaturedArticles,
+      localeDocuments,
+      localeFeaturedArticles,
+    ] = await Promise.all([
+      fetchCMSContent("allDocuments", { locale: "en" }),
+      fetchCMSContent("allFeaturedPosts", { locale: "en" }),
+      fetchCMSContent("allDocuments", { locale }),
+      fetchCMSContent("allFeaturedPosts", { locale }),
+    ]);
+
+    let documents, featuredArticles;
+    // if en has more documents or articles than locale, then show locale documents and articles plus en documents and articles
+    if (
+      localeDocuments.length < enDocuments.length ||
+      localeFeaturedArticles.length < enFeaturedArticles.length
+    ) {
+      documents = [...localeDocuments, ...enDocuments];
+      featuredArticles = [...localeFeaturedArticles, ...enFeaturedArticles];
+    } else {
+      documents = [...enDocuments];
+      featuredArticles = [...enFeaturedArticles];
+    }
 
     const translation = await loadTranslation(locale);
     if (!documents) {


### PR DESCRIPTION
## Description

If a language has no featuredArticles or documents translated yet, instead of showing a page with no featuredArticles or documents it will automatically redirect to the english page.

Used a client side re-route in order to keep using getStaticProps.

In Sanity, updated the languages to match production languages and made language selection required.

**NOTE: I tried to deploy the changes to Sanity but it doesn't look like I have push access even though I can now log in.**

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Issue: #1144 

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
