### PR TITLE
Duplicate projects on /projects page

### DIFF
--- a/carbonmark/hooks/useFetchProjects.ts
+++ b/carbonmark/hooks/useFetchProjects.ts
@@ -18,28 +18,31 @@ export const useFetchProjects = () => {
   const allProjects = data?.filter(negate(isNil)) ?? [];
 
   // group projects by key and vintage to find same projects with multiple prices
-    const groupedProjects = allProjects.reduce<{ [key: string]: Project[] }>((grouped, project) => {
+  const groupedProjects = allProjects.reduce<{ [key: string]: Project[] }>(
+    (grouped, project) => {
       const key = `${project.key}-${project.vintage}`;
       if (!grouped[key]) {
         grouped[key] = [];
       }
       grouped[key].push(project);
       return grouped;
-    }, {});
+    },
+    {}
+  );
 
-    // find the lowest price project for each key and vintage
-    const projects = Object.values(groupedProjects).map((projects) => {
-      if (projects.length > 1) {
-        return projects.reduce((lowest, project) => {
-          if (project.price < lowest.price) {
-            return project;
-          }
-          return lowest;
-        });
-      } else {
-        return projects[0];
-      }
-    });
+  // find the lowest price project for each key and vintage
+  const projects = Object.values(groupedProjects).map((projects) => {
+    if (projects.length > 1) {
+      return projects.reduce((lowest, project) => {
+        if (project.price < lowest.price) {
+          return project;
+        }
+        return lowest;
+      });
+    } else {
+      return projects[0];
+    }
+  });
 
   return { projects, ...rest };
 };

--- a/carbonmark/hooks/useFetchProjects.ts
+++ b/carbonmark/hooks/useFetchProjects.ts
@@ -15,6 +15,31 @@ export const useFetchProjects = () => {
     revalidateOnMount: false,
   });
   /** Remove any null or undefined projects */
-  const projects = data?.filter(negate(isNil)) ?? [];
+  const allProjects = data?.filter(negate(isNil)) ?? [];
+
+  // group projects by key and vintage to find same projects with multiple prices
+    const groupedProjects = allProjects.reduce<{ [key: string]: Project[] }>((grouped, project) => {
+      const key = `${project.key}-${project.vintage}`;
+      if (!grouped[key]) {
+        grouped[key] = [];
+      }
+      grouped[key].push(project);
+      return grouped;
+    }, {});
+
+    // find the lowest price project for each key and vintage
+    const projects = Object.values(groupedProjects).map((projects) => {
+      if (projects.length > 1) {
+        return projects.reduce((lowest, project) => {
+          if (project.price < lowest.price) {
+            return project;
+          }
+          return lowest;
+        });
+      } else {
+        return projects[0];
+      }
+    });
+
   return { projects, ...rest };
 };


### PR DESCRIPTION
## Description

Duplicate projects showed on the `/projects` page. The cause seemed to be multiple tokens and prices; one project would show per token/price.

In this solution, the fetched projects are filtered to find multiple instances of the same project-key+vintage, and then select only the lowest priced option to display on the `/projects` page. 

When the user navigates to the individual project page they'll still see both the lowest priced option as well as any others.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1161

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
