### PR TITLE
Add limit:1000 to all country, category, vintage queries

### DIFF
--- a/carbonmark-api/src/.generated/types/marketplace.types.ts
+++ b/carbonmark-api/src/.generated/types/marketplace.types.ts
@@ -1417,21 +1417,21 @@ export const ActivityFragmentFragmentDoc = gql`
     `;
 export const GetCategoriesDocument = gql`
     query getCategories {
-  categories {
+  categories(first: 1000) {
     id
   }
 }
     `;
 export const GetCountriesDocument = gql`
     query getCountries {
-  countries {
+  countries(first: 1000) {
     id
   }
 }
     `;
 export const GetVintagesDocument = gql`
     query getVintages {
-  projects {
+  projects(first: 1000) {
     vintage
   }
 }

--- a/carbonmark-api/src/.generated/types/offsets.types.ts
+++ b/carbonmark-api/src/.generated/types/offsets.types.ts
@@ -2863,21 +2863,21 @@ export type FindCarbonOffsetsQuery = { __typename?: 'Query', carbonOffsets: Arra
 
 export const GetCarbonOffsetsCategoriesDocument = gql`
     query getCarbonOffsetsCategories {
-  carbonOffsets {
+  carbonOffsets(first: 1000) {
     methodologyCategory
   }
 }
     `;
 export const GetCarbonOffsetsCountriesDocument = gql`
     query getCarbonOffsetsCountries {
-  carbonOffsets {
+  carbonOffsets(first: 1000) {
     country
   }
 }
     `;
 export const GetCarbonOffsetsVintagesDocument = gql`
     query getCarbonOffsetsVintages {
-  carbonOffsets {
+  carbonOffsets(first: 1000) {
     vintageYear
   }
 }

--- a/carbonmark-api/src/graphql/codegen.ts
+++ b/carbonmark-api/src/graphql/codegen.ts
@@ -52,7 +52,6 @@ const config = {
   generates,
   config: {
     scalars: { BigInt: "string", ID: "string" },
-    // skipTypename: true,
   },
 };
 

--- a/carbonmark-api/src/graphql/marketplace.gql
+++ b/carbonmark-api/src/graphql/marketplace.gql
@@ -1,3 +1,6 @@
+# @todo these "first:1000" will possibly miss results if there are more than 1000
+# this will cause a silent error. GQL Resolver needs to be updated to allow null search params
+# to return all possible values
 query getCategories {
   categories(first: 1000) {
     id

--- a/carbonmark-api/src/graphql/marketplace.gql
+++ b/carbonmark-api/src/graphql/marketplace.gql
@@ -1,17 +1,17 @@
 query getCategories {
-  categories {
+  categories(first: 1000) {
     id
   }
 }
 
 query getCountries {
-  countries {
+  countries(first: 1000) {
     id
   }
 }
 
 query getVintages {
-  projects {
+  projects(first: 1000) {
     vintage
   }
 }

--- a/carbonmark-api/src/graphql/offsets.gql
+++ b/carbonmark-api/src/graphql/offsets.gql
@@ -1,17 +1,17 @@
 query getCarbonOffsetsCategories {
-  carbonOffsets {
+  carbonOffsets(first: 1000) {
     methodologyCategory
   }
 }
 
 query getCarbonOffsetsCountries {
-  carbonOffsets {
+  carbonOffsets(first: 1000) {
     country
   }
 }
 
 query getCarbonOffsetsVintages {
-  carbonOffsets {
+  carbonOffsets(first: 1000) {
     vintageYear
   }
 }

--- a/carbonmark-api/src/routes/projects/projects.utils.ts
+++ b/carbonmark-api/src/routes/projects/projects.utils.ts
@@ -31,6 +31,7 @@ export const getDefaultQueryArgs = async (
     getAllCountries(fastify).then(map(extract("id"))),
     getAllVintages(fastify),
   ]);
+
   return {
     category,
     country,

--- a/carbonmark-api/src/routes/projects/projects.utils.ts
+++ b/carbonmark-api/src/routes/projects/projects.utils.ts
@@ -21,6 +21,10 @@ import {
  * via findProjects
  * @param fastify
  * @returns
+ *
+ * # @todo these "first:1000" will possibly miss results if there are more than 1000
+ * # this will cause a silent error. GQL Resolver needs to be updated to allow null search params
+ * # to return all possible values
  */
 export const getDefaultQueryArgs = async (
   fastify: FastifyInstance

--- a/carbonmark-api/src/utils/helpers/utils.ts
+++ b/carbonmark-api/src/utils/helpers/utils.ts
@@ -8,7 +8,7 @@ import {
 } from "../../.generated/types/marketplace.types";
 import { CarbonOffset } from "../../.generated/types/offsets.types";
 
-import { extract, notNil } from "../functional.utils";
+import { extract, notEmptyOrNil } from "../functional.utils";
 import { gqlSdk } from "../gqlSdk";
 
 // This function retrieves all vintages from two different sources (marketplace and carbon offsets),
@@ -37,7 +37,7 @@ export async function getAllVintages(
   projects.forEach((item) => uniqueValues.add(item.vintage));
   carbonOffsets.forEach((item) => uniqueValues.add(item.vintageYear));
 
-  const result = Array.from(uniqueValues).sort();
+  const result = Array.from(uniqueValues).sort().filter(notEmptyOrNil);
 
   await fastify.lcache.set(cacheKey, { payload: result });
 
@@ -86,7 +86,8 @@ export async function getAllCategories(fastify: FastifyInstance) {
     map(trim),
     uniq,
     compact,
-    map((id: Category) => ({ id }))
+    map((id: Category) => ({ id })),
+    filter(notEmptyOrNil)
   );
 
   // Apply the function pipeline to the extracted values
@@ -122,7 +123,7 @@ export async function getAllCountries(fastify: FastifyInstance) {
     concat,
     flatten,
     uniq,
-    filter(notNil),
+    filter(notEmptyOrNil),
     map((id: Country) => ({ id }))
   );
 


### PR DESCRIPTION
## Description

Some countries were being missed when fetching all countries for each project. This is because the default response limit seems to be 100 and "Belize" was in the 100nth+ project.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1372 


This is a temporary fix, this error could arise again until the gql resolver is updated to allow null values for searches on `findProjects` query.

See related ticket: https://github.com/KlimaDAO/klimadao/issues/1401
