### PR TITLE
make more sidebars sticky

### DIFF
--- a/carbonmark/components/pages/Project/Purchase/Pool/PurchaseForm.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Pool/PurchaseForm.tsx
@@ -181,12 +181,14 @@ export const PurchaseForm: FC<Props> = (props) => {
           </Card>
         </Col>
         <Col>
-          <Card>
-            <TotalValues balance={balance} price={props.price} />
-          </Card>
-          <Card>
-            <AssetDetails price={props.price} project={props.project} />
-          </Card>
+          <div className={styles.stickyContentWrapper}>
+            <Card>
+              <TotalValues balance={balance} price={props.price} />
+            </Card>
+            <Card>
+              <AssetDetails price={props.price} project={props.project} />
+            </Card>
+          </div>
           <SubmitButton
             onSubmit={onContinue}
             isLoading={isLoadingAllowance}

--- a/carbonmark/components/pages/Project/Purchase/styles.ts
+++ b/carbonmark/components/pages/Project/Purchase/styles.ts
@@ -253,3 +253,10 @@ export const externalLink = css`
     text-decoration: none;
   }
 `;
+
+export const stickyContentWrapper = css`
+  display: grid;
+  gap: 2.4rem;
+  position: sticky;
+  top: 1rem;
+`;


### PR DESCRIPTION
## Description

This PR makes the side panel for pool listings sticky on scroll.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->
fixes #1352 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
