### PR TITLE
Updated locale groq queries for resources

### DIFF
--- a/site/components/pages/Resources/lib/queries.ts
+++ b/site/components/pages/Resources/lib/queries.ts
@@ -15,7 +15,7 @@ type QueryParams = {
 
 /** fetch posts and podcasts filtered by specific tag slugs, types and order */
 const filterDocumentsByTags = (params: QueryParams) => /* groq */ `
-    *[_type in ${params.types} && count((tags[]->tag.current)[@ in ${params.tags} ]) > 0 && ${baseFilters}] | order(${params.sortedBy}) {
+    *[_type in ${params.types} && count((tags[]->tag.current)[@ in ${params.tags} ]) > 0 && ${baseFilters}] | order((locale == $locale) desc, ${params.sortedBy}) {
       "type": _type,
       publishedAt, 
       title, 
@@ -30,7 +30,7 @@ const filterDocumentsByTags = (params: QueryParams) => /* groq */ `
 
 /** fetch posts and podcasts filtered by types and order */
 const filterDocumentsWithoutTags = (params: QueryParams) => /* groq */ `
-  *[_type in ${params.types} && ${baseFilters}] | order(${params.sortedBy}) {
+  *[_type in ${params.types} && ${baseFilters}] | order((locale == $locale) desc, ${params.sortedBy}) {
     "type": _type,
     publishedAt, 
     title, 

--- a/site/lib/queries.ts
+++ b/site/lib/queries.ts
@@ -13,16 +13,16 @@ const hideFromProduction = IS_PRODUCTION
 
 const isDomainKlimadao = '(domain == "klimadao" || !defined(domain))';
 
-const localeFilter =
-  '(locale == $locale || (!defined(locale) && $locale == "en"))';
+const localeFilter = `(!defined(locale) || locale == "en" || locale == $locale)`;
 
 /** these filters are typicaly used for all queries, filters the documents for locale, domain and production environment */
 export const baseFilters = `${localeFilter} && ${hideFromProduction} && ${isDomainKlimadao}`;
 
 export const queries = {
   /** fetch all blog posts and podcasts, sorted by publishedAt, limit to 20 */
+
   allDocuments: /* groq */ `
-    *[_type in ["post", "podcast"] && ${baseFilters}][0...20] | order(publishedAt desc) {
+    *[_type in ["post", "podcast"] && ${baseFilters}] | order((locale == $locale) desc, publishedAt desc)[0...20] {
       "type": _type,
       publishedAt, 
       title, 
@@ -37,7 +37,7 @@ export const queries = {
 
   /** fetch all blog posts, sorted by publishedAt */
   allPosts: /* groq */ `
-    *[_type == "post" && ${baseFilters}] | order(publishedAt desc) {
+    *[_type == "post" && ${baseFilters}] | order((locale == $locale) desc, publishedAt desc) {
       summary, 
       "slug": slug.current, 
       title, 
@@ -49,7 +49,7 @@ export const queries = {
 
   /** fetch all blog posts with isFeaturedArticle == true, limit to 20, sorted by publishedAt */
   allFeaturedPosts: /* groq */ `
-    *[_type == "post"  && isFeaturedArticle == true && ${baseFilters}][0...20] | order(publishedAt desc) {
+    *[_type == "post"  && isFeaturedArticle == true && ${baseFilters}] | order((locale == $locale) desc, publishedAt desc)[0...20] {
       summary, 
       "slug": slug.current, 
       title, 
@@ -62,7 +62,7 @@ export const queries = {
 
   /** fetch the last published post slug and title */
   latestPost: /* groq */ `
-    *[_type == "post" && ${baseFilters}] | order(publishedAt desc) {
+    *[_type == "post" && ${baseFilters}] | order((locale == $locale) desc, publishedAt desc) {
       "slug": slug.current, 
       title
     }[0]
@@ -98,7 +98,7 @@ export const queries = {
   `,
 
   allPodcasts: /* groq */ `
-  *[_type == "podcast"  && ${baseFilters}] | order(publishedAt desc) {
+  *[_type == "podcast"  && ${baseFilters}] | order((locale == $locale) desc, publishedAt desc) {
     summary, 
     "slug": slug.current, 
     title, 


### PR DESCRIPTION
## Description

1. Updated locale filters to fetch where locale === undefined || locale === "en" || locale === $locale

2. Updated ordering to include locale === $locale. When locale articles run out, then the "en" documents will fill in.

3. Changed the [0...20] slice to after ordering. Otherwise the first arbitrary 20 articles were selected  instead of the locale documents.

4. Updated filtering A-Z and newest/oldest filters in frontend to include locale === $locale. I did not modify the search by text function as that will be language specific anyway.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1144 

**When this merged, #1373 can be closed as this proposed an alternate solution to this issue.**

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
