### PR TITLE
fix receipt urls for when retiring on behalf

### DIFF
--- a/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
@@ -372,6 +372,7 @@ export const RetireForm: FC<Props> = (props) => {
             transactionHash={transactionHash}
             paymentMethod={inputValues?.paymentMethod}
             address={address}
+            beneficiary={inputValues?.beneficiaryAddress || address}
             retirementIndex={retirementIndex}
             subgraphIndexStatus={subgraphIndexStatus}
           />

--- a/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
@@ -367,12 +367,10 @@ export const RetireForm: FC<Props> = (props) => {
         onResetStatus={() => setStatus(null)}
         successScreen={
           <SuccessScreen
-            project={props.project}
             totalPrice={inputValues?.totalPrice}
             transactionHash={transactionHash}
             paymentMethod={inputValues?.paymentMethod}
-            address={address}
-            beneficiary={inputValues?.beneficiaryAddress || address}
+            beneficiaryAddress={inputValues?.beneficiaryAddress || address}
             retirementIndex={retirementIndex}
             subgraphIndexStatus={subgraphIndexStatus}
           />

--- a/carbonmark/components/pages/Project/Retire/Pool/SuccessScreen.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/SuccessScreen.tsx
@@ -5,19 +5,17 @@ import { CarbonmarkButton } from "components/CarbonmarkButton";
 import { Text } from "components/Text";
 import { urls } from "lib/constants";
 import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
-import { CarbonmarkPaymentMethod, Project } from "lib/types/carbonmark";
+import { CarbonmarkPaymentMethod } from "lib/types/carbonmark";
 import Image from "next/legacy/image";
 import Link from "next/link";
 import { FC } from "react";
 import * as styles from "./styles";
 
 type Props = {
-  project: Project;
   totalPrice?: string;
   transactionHash: string | null;
   paymentMethod?: CarbonmarkPaymentMethod;
-  address?: string;
-  beneficiary?: string;
+  beneficiaryAddress?: string;
   retirementIndex: number | null;
   subgraphIndexStatus: "indexed" | "pending" | "timeout";
 };
@@ -34,11 +32,14 @@ export const SuccessScreen: FC<Props> = (props) => {
             </Trans>
           </Text>
           <Text t="body5">
-            <Trans id="offset.successModal.body3">
-              Your transaction has been successfully processed but is taking
-              longer than normal to index. It will appear in your{" "}
-              <Link target="_blank" href={`/retirements/${props.address}`}>
-                retirements
+            <Trans>
+              Our system is taking longer than expected. The retirement should
+              appear in your
+              <Link
+                target="_blank"
+                href={`/retirements/${props.beneficiaryAddress}`}
+              >
+                retirement history
               </Link>{" "}
               soon.
             </Trans>
@@ -60,7 +61,6 @@ export const SuccessScreen: FC<Props> = (props) => {
         </>
       ) : (
         <>
-          {" "}
           <Text t="h5" className="headline">
             <CelebrationOutlinedIcon fontSize="inherit" />
             <Trans>Thank you for supporting the planet!</Trans>
@@ -100,7 +100,7 @@ export const SuccessScreen: FC<Props> = (props) => {
               </div>
             </div>
             <ButtonPrimary
-              href={`/retirements/${props.beneficiary}/${props.retirementIndex}`}
+              href={`/retirements/${props.beneficiaryAddress}/${props.retirementIndex}`}
               label={<Trans>See your retirement receipt</Trans>}
               renderLink={(linkProps) => <Link {...linkProps} />}
               target="_blank"

--- a/carbonmark/components/pages/Project/Retire/Pool/SuccessScreen.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/SuccessScreen.tsx
@@ -17,6 +17,7 @@ type Props = {
   transactionHash: string | null;
   paymentMethod?: CarbonmarkPaymentMethod;
   address?: string;
+  beneficiary?: string;
   retirementIndex: number | null;
   subgraphIndexStatus: "indexed" | "pending" | "timeout";
 };
@@ -99,7 +100,7 @@ export const SuccessScreen: FC<Props> = (props) => {
               </div>
             </div>
             <ButtonPrimary
-              href={`/retirements/${props.address}/${props.retirementIndex}`}
+              href={`/retirements/${props.beneficiary}/${props.retirementIndex}`}
               label={<Trans>See your retirement receipt</Trans>}
               renderLink={(linkProps) => <Link {...linkProps} />}
               target="_blank"

--- a/carbonmark/components/pages/Projects/ProjectView/GridView.tsx
+++ b/carbonmark/components/pages/Projects/ProjectView/GridView.tsx
@@ -31,7 +31,9 @@ export const GridView: React.FC<Props> = ({ projects }) => {
           </div>
           <div className={styles.cardContent}>
             <Text t="h4">{formatToPrice(project.price, locale)}</Text>
-            <Text t="h5" className={styles.cardTitle}>{project.name || "! MISSING PROJECT NAME !"}</Text>
+            <Text t="h5" className={styles.cardTitle}>
+              {project.name || "! MISSING PROJECT NAME !"}
+            </Text>
             <Text t="body1" className={styles.cardDescription}>
               {project.short_description ||
                 project.description ||


### PR DESCRIPTION
## Description

We were using the wallet address of the current user for receipt URLs before. This PR makes it so that we use the beneficiary address if it is provided in the retirement form.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1370 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
