### PR TITLE
fix: resource sort by tippy dropdown styling

### DIFF
--- a/carbonmark/components/pages/Resources/SortyByDropDown/index.tsx
+++ b/carbonmark/components/pages/Resources/SortyByDropDown/index.tsx
@@ -38,7 +38,7 @@ export const SortyByDropDown: FC<Props> = (props) => {
     <div className={styles.tippyContainer}>
       <Tippy
         content={
-          <div className={styles.dropDownMenu}>
+          <>
             {getSortedByQueries().map((option) => (
               <SortByButton
                 key={option.id}
@@ -47,13 +47,14 @@ export const SortyByDropDown: FC<Props> = (props) => {
                 active={sortedBy === option.value}
               />
             ))}
-          </div>
+          </>
         }
         interactive={true}
         onClickOutside={onToggle}
         visible={isOpen}
         placement="bottom-end"
         appendTo="parent"
+        arrow={false}
       >
         <button
           onClick={onToggle}

--- a/carbonmark/components/pages/Resources/SortyByDropDown/styles.ts
+++ b/carbonmark/components/pages/Resources/SortyByDropDown/styles.ts
@@ -20,14 +20,16 @@ export const dropdownHeader = css`
 `;
 
 export const tippyContainer = css`
-  .tippy-box {
-    margin-top: 0rem;
+  .tippy-content {
+    background-color: var(--surface-01);
+    border-radius: 1rem;
+    padding: 1rem;
+    font-size: 1.6rem;
   }
-`;
 
-export const dropDownMenu = css`
-  background-color: var(--surface-01);
-  border-radius: 1rem;
-  padding: 1rem;
-  box-shadow: var(--shadow-03);
+  .tippy-box {
+    border-radius: 1rem;
+    background-color: var(--surface-01);
+    box-shadow: var(--shadow-03);
+  }
 `;


### PR DESCRIPTION
## Description

Realign resources sort dropdown styling to match intended design. 
Fixes:
- Removes black background around dropdown content
- Bumps the font size to match page
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

Half of #1403 


## Changes

| Before  | After  |
|---------|--------|
| ![image](https://github.com/KlimaDAO/klimadao/assets/97446324/3738d194-1a49-4f4f-80fb-9bbce061e401) |![image](https://github.com/KlimaDAO/klimadao/assets/97446324/fd98f083-746b-492f-8e0f-c353817bd1be) |


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
