### PR TITLE
chore: Remove /api prefix from api

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -9,7 +9,7 @@
     "test": "jest --coverage",
     "lint": "eslint . --ext .ts && tsc --noEmit",
     "start:test": "npm run build && fastify start -l info dist/app.js --port 3003",
-    "test:postman": "npm:start:test && ./postman_tests.sh",
+    "test:postman": "./postman_tests.sh",
     "generate:types": "rm -rf ./.generated/types && rm -rf ./.generated/mocks && graphql-codegen --config src/graphql/codegen.ts"
   },
   "keywords": [],

--- a/carbonmark-api/postman_collection.json
+++ b/carbonmark-api/postman_collection.json
@@ -25,9 +25,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{url}}/api/categories",
+          "raw": "{{url}}/categories",
           "host": ["{{url}}"],
-          "path": ["api", "categories"]
+          "path": ["categories"]
         }
       },
       "response": []
@@ -51,9 +51,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{url}}/api/countries",
+          "raw": "{{url}}/countries",
           "host": ["{{url}}"],
-          "path": ["api", "countries"]
+          "path": ["countries"]
         }
       },
       "response": []
@@ -77,9 +77,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{url}}/api/vintages",
+          "raw": "{{url}}/vintages",
           "host": ["{{url}}"],
-          "path": ["api", "vintages"]
+          "path": ["vintages"]
         }
       },
       "response": []
@@ -103,9 +103,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{url}}/api/purchases/:purchaseId",
+          "raw": "{{url}}/purchases/:purchaseId",
           "host": ["{{url}}"],
-          "path": ["api", "purchases", ":purchaseId"],
+          "path": ["purchases", ":purchaseId"],
           "variable": [
             {
               "key": "purchaseId",
@@ -135,9 +135,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{url}}/api/projects",
+          "raw": "{{url}}/projects",
           "host": ["{{url}}"],
-          "path": ["api", "projects"]
+          "path": ["projects"]
         }
       },
       "response": []
@@ -161,9 +161,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{url}}/api/projects?search=Dayingjiang&vintage=2008",
+          "raw": "{{url}}/projects?search=Dayingjiang&vintage=2008",
           "host": ["{{url}}"],
-          "path": ["api", "projects"],
+          "path": ["projects"],
           "query": [
             {
               "key": "search",
@@ -197,9 +197,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{url}}/api/projects/:id",
+          "raw": "{{url}}/projects/:id",
           "host": ["{{url}}"],
-          "path": ["api", "projects", ":id"],
+          "path": ["projects", ":id"],
           "variable": [
             {
               "key": "id",
@@ -229,9 +229,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{url}}/api/users/:walletid?type=wallet",
+          "raw": "{{url}}/users/:walletid?type=wallet",
           "host": ["{{url}}"],
-          "path": ["api", "users", ":walletid"],
+          "path": ["users", ":walletid"],
           "query": [
             {
               "key": "type",
@@ -267,9 +267,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{url}}/api/users/:handle",
+          "raw": "{{url}}/users/:handle",
           "host": ["{{url}}"],
-          "path": ["api", "users", ":handle"],
+          "path": ["users", ":handle"],
           "query": [
             {
               "key": "type",
@@ -322,9 +322,9 @@
           }
         },
         "url": {
-          "raw": "{{url}}/api/users",
+          "raw": "{{url}}/users",
           "host": ["{{url}}"],
-          "path": ["api", "users"]
+          "path": ["users"]
         }
       },
       "response": []
@@ -364,9 +364,9 @@
           }
         },
         "url": {
-          "raw": "{{url}}/api/users/login",
+          "raw": "{{url}}/users/login",
           "host": ["{{url}}"],
-          "path": ["api", "users", "login"]
+          "path": ["users", "login"]
         }
       },
       "response": []
@@ -406,9 +406,9 @@
           }
         },
         "url": {
-          "raw": "{{url}}/api/users/login/verify",
+          "raw": "{{url}}/users/login/verify",
           "host": ["{{url}}"],
-          "path": ["api", "users", "login", "verify"]
+          "path": ["users", "login", "verify"]
         }
       },
       "response": []

--- a/carbonmark-api/postman_tests.sh
+++ b/carbonmark-api/postman_tests.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 # Start the server in the background
-npm run start:test &
+npm run dev &
 
 # Get the process ID of the server
 server_pid=$!
 
 # Wait for the server to be available
-while ! curl -s http://localhost:3000 > /dev/null; do
-  sleep 1
+while ! curl -s http://localhost:3003 > /dev/null; do
+    sleep 1
 done
 
 # Run the Newman tests
-npx newman run postman_collection.json
+npx newman run postman_collection.json --env-var url=http://localhost:3003
 
 # Store the exit code of the Newman tests
 newman_exit_code=$?

--- a/carbonmark-api/src/app.ts
+++ b/carbonmark-api/src/app.ts
@@ -1,7 +1,6 @@
 import AutoLoad, { AutoloadPluginOptions } from "@fastify/autoload";
 import * as dotenv from "dotenv";
 import { FastifyPluginAsync } from "fastify";
-import fs from "fs";
 import path, { join } from "path";
 import { commonSchema } from "./routes/common.schema";
 
@@ -38,45 +37,6 @@ const app: FastifyPluginAsync<AppOptions> = async (
     options: opts,
     dirNameRoutePrefix: false,
   }));
-
-  // We add /openapi.json by hand as we don't want it to have the /api/ prefix
-  fastify.route({
-    method: "GET",
-    url: "/openapi.json",
-    schema: {
-      hide: true, // hide from docs
-    },
-    handler: (_req, res) => {
-      try {
-        const json = fastify.swagger();
-        return res.status(200).send(json);
-      } catch (error) {
-        console.error(error);
-        return res.status(502).send(error?.message);
-      }
-    },
-  });
-
-  // Render stoplight docs to the root
-  fastify.route({
-    method: "GET",
-    url: "/",
-    schema: {
-      hide: true, // hidden from docs
-    },
-    handler: (_req, reply) => {
-      try {
-        const html = fs.readFileSync(
-          path.resolve(__dirname, "referenceDocs.html"),
-          "utf8"
-        );
-        return reply.status(200).type("text/html").send(html);
-      } catch (error) {
-        console.error(error);
-        return reply.status(502).send(error?.message);
-      }
-    },
-  });
 
   void (await fastify.setErrorHandler((error, request, reply) => {
     fastify.log.error(error); // Log the error

--- a/carbonmark-api/src/app.ts
+++ b/carbonmark-api/src/app.ts
@@ -35,7 +35,7 @@ const app: FastifyPluginAsync<AppOptions> = async (
 
   void (await fastify.register(AutoLoad, {
     dir: join(__dirname, "routes"),
-    options: { ...opts, prefix: "/api" },
+    options: opts,
     dirNameRoutePrefix: false,
   }));
 

--- a/carbonmark-api/src/plugins/open-api.ts
+++ b/carbonmark-api/src/plugins/open-api.ts
@@ -11,7 +11,7 @@ Welcome to the API Reference docs for **version ${packageJson.version}** of the 
 ⚠️Be sure to prefix a version number, otherwise your application will be exposed to breaking changes.
 
 ~~~ts
-const res = await fetch("https://v1.api.carbonmark.com/api/projects");
+const res = await fetch("https://v1.api.carbonmark.com/projects");
 const projects = await res.json();
 ~~~
 

--- a/carbonmark-api/src/routes/openapi.ts
+++ b/carbonmark-api/src/routes/openapi.ts
@@ -1,0 +1,23 @@
+import { FastifyInstance, RouteHandlerMethod } from "fastify";
+
+const handler =
+  (fastify: FastifyInstance): RouteHandlerMethod =>
+  (_, res) => {
+    try {
+      const json = fastify.swagger();
+      return res.status(200).send(json);
+    } catch (error) {
+      console.error(error);
+      return res.status(502).send(error?.message);
+    }
+  };
+
+export default async (fastify: FastifyInstance) =>
+  await fastify.route({
+    method: "GET",
+    url: "/openapi.json",
+    handler: handler(fastify),
+    schema: {
+      hide: true, // hide from docs
+    },
+  });

--- a/carbonmark-api/src/routes/root.ts
+++ b/carbonmark-api/src/routes/root.ts
@@ -1,0 +1,27 @@
+import { FastifyInstance, RouteHandlerMethod } from "fastify";
+import fs from "fs";
+import path from "path";
+
+const handler: RouteHandlerMethod = (_req, reply) => {
+  try {
+    const html = fs.readFileSync(
+      path.resolve(__dirname, "../referenceDocs.html"),
+      "utf8"
+    );
+    return reply.status(200).type("text/html").send(html);
+  } catch (error) {
+    console.error(error);
+    return reply.status(502).send(error?.message);
+  }
+};
+
+// Render stoplight docs to the root
+export default async (fastify: FastifyInstance) =>
+  await fastify.route({
+    method: "GET",
+    url: "/",
+    handler,
+    schema: {
+      hide: true, // hidden from docs
+    },
+  });

--- a/carbonmark-api/test/regression.test.ts
+++ b/carbonmark-api/test/regression.test.ts
@@ -4,9 +4,9 @@ import { isArray, isObject, mapValues, sortBy } from "lodash";
 import { curry, map } from "lodash/fp";
 import fetch from "node-fetch";
 import { build } from "./helper";
-const DEV_URL = "http://localhost:3003/api";
-// const STAGING_URL = "https://staging-api.carbonmark.com/api";
-const PRODUCTION_URL = "https://api.carbonmark.com/api";
+const DEV_URL = "http://localhost:3003";
+// const STAGING_URL = "https://staging-api.carbonmark.com";
+const PRODUCTION_URL = "https://api.carbonmark.com";
 
 // A longer than usual timeout because the APIs are slooow
 const TIMEOUT = 1000 * 100;

--- a/carbonmark-api/test/test.constants.ts
+++ b/carbonmark-api/test/test.constants.ts
@@ -1,1 +1,1 @@
-export const DEV_URL = "http://localhost:3003/api";
+export const DEV_URL = "http://localhost:3003";

--- a/carbonmark-data/.env.example
+++ b/carbonmark-data/.env.example
@@ -1,3 +1,3 @@
 
 # Create a file called .env.local and provide these keys.
-# NEXT_PUBLIC_DATA_API_URL=http://localhost:8051/api/v1
+# NEXT_PUBLIC_DATA_API_URL=http://localhost:8051/v1

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -25,7 +25,7 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-const API_PROD_URL = "https://v1.1.0.api.carbonmark.com";
+const API_PROD_URL = "https://v1.1.0.api.carbonmark.com/api";
 
 /**
  * Optional preview URL can be provided via env var.

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -28,12 +28,12 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 const API_PROD_URL = "https://v1.1.0.api.carbonmark.com";
 
 /**
- * Use the aliased carbonmark-api deployment for the current commit if set manually in the CLI
+ * Optional preview URL can be provided via env var.
+ * Testnet data can be accessed via `network=mumbai` query param
  */
 const API_PREVIEW_URL = process.env.NEXT_PUBLIC_USE_PREVIEW_CARBONMARK_API
   ? `https://carbonmark-api-${SHORT_COMMIT_HASH}-klimadao.vercel.app`
-  : "https://staging-api.carbonmark.com";
-
+  : API_PROD_URL;
 const ENVIRONMENT: Environment =
   new LogicTable({
     production: IS_PRODUCTION,
@@ -80,10 +80,7 @@ export const config = {
     api: {
       production: API_PROD_URL,
       preview: API_PREVIEW_URL,
-      //Allow the developer to set the carbonmark api url to point to their local instance if necessary
-      development:
-        process.env.NEXT_PUBLIC_CARBONMARK_API_URL ??
-        "https://staging-api.carbonmark.com",
+      development: API_PREVIEW_URL,
     },
     fiat: {
       production: "https://checkout.offsetra.com/api",

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -25,14 +25,14 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-const API_PROD_URL = "https://v1.1.0.api.carbonmark.com/api";
+const API_PROD_URL = "https://v1.1.0.api.carbonmark.com";
 
 /**
  * Use the aliased carbonmark-api deployment for the current commit if set manually in the CLI
  */
 const API_PREVIEW_URL = process.env.NEXT_PUBLIC_USE_PREVIEW_CARBONMARK_API
-  ? `https://carbonmark-api-${SHORT_COMMIT_HASH}-klimadao.vercel.app/api`
-  : "https://staging-api.carbonmark.com/api";
+  ? `https://carbonmark-api-${SHORT_COMMIT_HASH}-klimadao.vercel.app`
+  : "https://staging-api.carbonmark.com";
 
 const ENVIRONMENT: Environment =
   new LogicTable({
@@ -83,7 +83,7 @@ export const config = {
       //Allow the developer to set the carbonmark api url to point to their local instance if necessary
       development:
         process.env.NEXT_PUBLIC_CARBONMARK_API_URL ??
-        "https://staging-api.carbonmark.com/api",
+        "https://staging-api.carbonmark.com",
     },
     fiat: {
       production: "https://checkout.offsetra.com/api",

--- a/examples/nextjs-typescript-integration/utils/fetchProjectInfo.ts
+++ b/examples/nextjs-typescript-integration/utils/fetchProjectInfo.ts
@@ -58,9 +58,7 @@ export async function fetchProjectInfo(
    * */
   project_key: string
 ): Promise<ProjectInfo> {
-  const res = await fetch(
-    `https://api.carbonmark.com/api/projects/${project_key}`
-  );
+  const res = await fetch(`https://api.carbonmark.com/projects/${project_key}`);
   const data = await res.json();
   return data;
 }


### PR DESCRIPTION
## Description

- Removes the `/api` prefix for all routes
- moves extra routes out of `app.ts`

