### PR TITLE
fix: align search input field styles

### DIFF
--- a/carbonmark/components/Dropdown/index.tsx
+++ b/carbonmark/components/Dropdown/index.tsx
@@ -52,7 +52,7 @@ export function Dropdown<V, T extends FieldValues = FieldValues>(
     <div className={cx(styles.tippyContainer, className)}>
       <Tippy
         content={
-          <div className={styles.dropDownMenu}>
+          <>
             {options.map((option) => (
               <DropdownButton
                 key={option.id}
@@ -63,7 +63,7 @@ export function Dropdown<V, T extends FieldValues = FieldValues>(
                 disabled={option.disabled}
               />
             ))}
-          </div>
+          </>
         }
         disabled={disableToggle}
         arrow={false}

--- a/carbonmark/components/Dropdown/styles.ts
+++ b/carbonmark/components/Dropdown/styles.ts
@@ -28,16 +28,12 @@ export const dropdownHeader = css`
 
 export const tippyContainer = css`
   .tippy-box {
+    background-color: var(--surface-01);
+    border-radius: 1rem;
+    box-shadow: var(--shadow-03);
     margin-top: 0rem;
-    background: none;
+    font-size: 1.6rem;
   }
-`;
-
-export const dropDownMenu = css`
-  background-color: var(--surface-02);
-  border-radius: 1rem;
-  padding: 1rem;
-  box-shadow: var(--shadow-03);
 `;
 
 export const dropdownButton = css`

--- a/carbonmark/components/pages/Resources/ResourcesList/index.tsx
+++ b/carbonmark/components/pages/Resources/ResourcesList/index.tsx
@@ -158,7 +158,6 @@ export const ResourcesList: FC<Props> = (props) => {
             <div className={styles.searchInputContainer}>
               <InputField
                 id="search"
-                icon={<SearchIcon fontSize="large" />}
                 inputProps={{
                   placeholder: t({
                     id: "resources.form.input.search.placeholder",
@@ -174,6 +173,11 @@ export const ResourcesList: FC<Props> = (props) => {
                   message: "Search",
                 })}
                 hideLabel
+              />
+              <ButtonPrimary
+                className={styles.searchInputButton}
+                icon={<SearchIcon />}
+                onClick={handleSubmit(onSearchSubmit)}
               />
             </div>
           </form>

--- a/carbonmark/components/pages/Resources/ResourcesList/styles.ts
+++ b/carbonmark/components/pages/Resources/ResourcesList/styles.ts
@@ -30,10 +30,11 @@ export const searchInputContainer = css`
 `;
 
 export const searchInput = css`
+  width: 24rem;
   background-color: var(--surface-01);
   -webkit-appearance: none; // remove default border radius for iOS
-  border-radius: 1rem;
   border: 0.175rem solid var(--surface-01);
+  border-radius: var(--border-radius) 0 0 var(--border-radius);
 
   &:focus,
   &:hover {
@@ -48,6 +49,17 @@ export const searchInput = css`
     -webkit-appearance: none;
   }
 `;
+
+export const searchInputButton = css`
+  padding: 1.4rem;
+  border-radius: 0 var(--border-radius) var(--border-radius) 0;
+  color: white;
+  background-color: var(--manatee) !important;
+  
+  svg {
+    font-size: 2rem;
+  }
+`
 
 export const showOnSmallScreens = css`
   ${breakpoints.large} {

--- a/carbonmark/components/pages/Resources/ResourcesList/styles.ts
+++ b/carbonmark/components/pages/Resources/ResourcesList/styles.ts
@@ -55,11 +55,11 @@ export const searchInputButton = css`
   border-radius: 0 var(--border-radius) var(--border-radius) 0;
   color: white;
   background-color: var(--manatee) !important;
-  
+
   svg {
     font-size: 2rem;
   }
-`
+`;
 
 export const showOnSmallScreens = css`
   ${breakpoints.large} {


### PR DESCRIPTION
## Description

- Align resources search input field styles to the marketplace input field styles
- Fix dropdown box alignment with parent element (marketplace sort by filters)
  - Also bumps font size

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1403 


## Changes

| Before  | After  |
|---------|--------|
|![image](https://github.com/KlimaDAO/klimadao/assets/97446324/b26e0467-8e1a-450e-8957-103347e14a38)|![image](https://github.com/KlimaDAO/klimadao/assets/97446324/ca93f758-59d4-4625-a713-6ab982379f78)|
|![image](https://github.com/KlimaDAO/klimadao/assets/97446324/647affe9-2fff-48ac-b380-f335f380cc67)|![image](https://github.com/KlimaDAO/klimadao/assets/97446324/639a687c-4293-410e-b8da-239a8016b992)|


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
