### PR TITLE
Tufnel/integrate digital carbon graph into get.ts

### DIFF
--- a/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
+++ b/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
@@ -4196,10 +4196,10 @@ export type GetProjectCreditsQueryVariables = Exact<{
 export type GetProjectCreditsQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', registry: Registry, region: string, projectID: string, name: string, methodologies: string, id: string, country: string, category: string, carbonCredits: Array<{ __typename?: 'CarbonCredit', vintage: number, currentSupply: string, id: any, crossChainSupply: string, bridgeProtocol: BridgeProtocol, bridged: string, retired: string, poolBalances: Array<{ __typename?: 'CarbonPoolCreditBalance', balance: string, id: any, deposited: string, redeemed: string, pool: { __typename?: 'CarbonPool', name: string, supply: string, id: any, decimals: number, dailySnapshots: Array<{ __typename?: 'CarbonPoolDailySnapshot', lastUpdateTimestamp: string }> } }> }> }> };
 
 export type FindDigitalCarbonProjectsQueryVariables = Exact<{
-  category: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
   country: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
-  vintage: InputMaybe<Array<Scalars['Int']> | Scalars['Int']>;
+  category: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
   search: InputMaybe<Scalars['String']>;
+  vintage: InputMaybe<Array<Scalars['Int']> | Scalars['Int']>;
 }>;
 
 
@@ -4268,7 +4268,7 @@ export const GetProjectCreditsDocument = gql`
 }
     `;
 export const FindDigitalCarbonProjectsDocument = gql`
-    query findDigitalCarbonProjects($category: [String!], $country: [String!], $vintage: [Int!], $search: String) {
+    query findDigitalCarbonProjects($country: [String!], $category: [String!], $search: String, $vintage: [Int!]) {
   carbonProjects(
     first: 1000
     where: {and: [{category_in: $category}, {country_in: $country}, {carbonCredits_: {vintage_in: $vintage}}, {or: [{name_contains_nocase: $search}, {projectID_contains_nocase: $search}]}]}

--- a/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
+++ b/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
@@ -4172,6 +4172,14 @@ export enum _SubgraphErrorPolicy_ {
   Deny = 'deny'
 }
 
+export type DigitalCarbonProjectFragmentFragment = { __typename?: 'CarbonProject', id: string, name: string, projectID: string, methodologies: string, country: string, category: string, registry: Registry, region: string };
+
+export type CarbonCreditFragmentFragment = { __typename?: 'CarbonCredit', vintage: number, currentSupply: string, id: any, crossChainSupply: string, bridgeProtocol: BridgeProtocol, bridged: string, retired: string };
+
+export type PoolBalancesFragmentFragment = { __typename?: 'CarbonPoolCreditBalance', balance: string, id: any, deposited: string, redeemed: string, pool: { __typename?: 'CarbonPool', name: string, supply: string, id: any, decimals: number, dailySnapshots: Array<{ __typename?: 'CarbonPoolDailySnapshot', lastUpdateTimestamp: string }> } };
+
+export type PoolFragmentFragment = { __typename?: 'CarbonPool', name: string, supply: string, id: any, decimals: number, dailySnapshots: Array<{ __typename?: 'CarbonPoolDailySnapshot', lastUpdateTimestamp: string }> };
+
 export type GetDigitalCarbonProjectsVintagesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -4193,7 +4201,7 @@ export type GetProjectCreditsQueryVariables = Exact<{
 }>;
 
 
-export type GetProjectCreditsQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', registry: Registry, region: string, projectID: string, name: string, methodologies: string, id: string, country: string, category: string, carbonCredits: Array<{ __typename?: 'CarbonCredit', vintage: number, currentSupply: string, id: any, crossChainSupply: string, bridgeProtocol: BridgeProtocol, bridged: string, retired: string, poolBalances: Array<{ __typename?: 'CarbonPoolCreditBalance', balance: string, id: any, deposited: string, redeemed: string, pool: { __typename?: 'CarbonPool', name: string, supply: string, id: any, decimals: number, dailySnapshots: Array<{ __typename?: 'CarbonPoolDailySnapshot', lastUpdateTimestamp: string }> } }> }> }> };
+export type GetProjectCreditsQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', id: string, name: string, projectID: string, methodologies: string, country: string, category: string, registry: Registry, region: string, carbonCredits: Array<{ __typename?: 'CarbonCredit', vintage: number, currentSupply: string, id: any, crossChainSupply: string, bridgeProtocol: BridgeProtocol, bridged: string, retired: string, poolBalances: Array<{ __typename?: 'CarbonPoolCreditBalance', balance: string, id: any, deposited: string, redeemed: string, pool: { __typename?: 'CarbonPool', name: string, supply: string, id: any, decimals: number, dailySnapshots: Array<{ __typename?: 'CarbonPoolDailySnapshot', lastUpdateTimestamp: string }> } }> }> }> };
 
 export type FindDigitalCarbonProjectsQueryVariables = Exact<{
   country: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
@@ -4205,7 +4213,57 @@ export type FindDigitalCarbonProjectsQueryVariables = Exact<{
 
 export type FindDigitalCarbonProjectsQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', id: string, name: string, projectID: string, methodologies: string, country: string, category: string, registry: Registry, region: string, carbonCredits: Array<{ __typename?: 'CarbonCredit', vintage: number, currentSupply: string, id: any, crossChainSupply: string, bridgeProtocol: BridgeProtocol, bridged: string, retired: string, poolBalances: Array<{ __typename?: 'CarbonPoolCreditBalance', balance: string, id: any, deposited: string, redeemed: string, pool: { __typename?: 'CarbonPool', name: string, supply: string, id: any, decimals: number, dailySnapshots: Array<{ __typename?: 'CarbonPoolDailySnapshot', lastUpdateTimestamp: string }> } }> }> }> };
 
-
+export const DigitalCarbonProjectFragmentFragmentDoc = gql`
+    fragment DigitalCarbonProjectFragment on CarbonProject {
+  id
+  name
+  projectID
+  methodologies
+  country
+  category
+  registry
+  region
+}
+    `;
+export const CarbonCreditFragmentFragmentDoc = gql`
+    fragment CarbonCreditFragment on CarbonCredit {
+  vintage
+  currentSupply
+  id
+  crossChainSupply
+  bridgeProtocol
+  bridged
+  retired
+}
+    `;
+export const PoolBalancesFragmentFragmentDoc = gql`
+    fragment PoolBalancesFragment on CarbonPoolCreditBalance {
+  balance
+  id
+  deposited
+  redeemed
+  pool {
+    name
+    supply
+    id
+    decimals
+    dailySnapshots {
+      lastUpdateTimestamp
+    }
+  }
+}
+    `;
+export const PoolFragmentFragmentDoc = gql`
+    fragment PoolFragment on CarbonPool {
+  name
+  supply
+  id
+  decimals
+  dailySnapshots {
+    lastUpdateTimestamp
+  }
+}
+    `;
 export const GetDigitalCarbonProjectsVintagesDocument = gql`
     query getDigitalCarbonProjectsVintages {
   carbonProjects(first: 1000) {
@@ -4232,82 +4290,40 @@ export const GetDigitalCarbonProjectsCountriesDocument = gql`
 export const GetProjectCreditsDocument = gql`
     query getProjectCredits($projectID: String!, $vintage: Int) {
   carbonProjects(where: {projectID: $projectID}) {
-    registry
-    region
-    projectID
-    name
-    methodologies
-    id
-    country
-    category
+    ...DigitalCarbonProjectFragment
     carbonCredits(where: {vintage: $vintage}) {
-      vintage
-      currentSupply
+      ...CarbonCreditFragment
       poolBalances {
-        balance
-        id
-        deposited
-        redeemed
-        pool {
-          name
-          supply
-          id
-          decimals
-          dailySnapshots {
-            lastUpdateTimestamp
-          }
-        }
+        ...PoolBalancesFragment
       }
-      id
-      crossChainSupply
-      bridgeProtocol
-      bridged
-      retired
     }
   }
 }
-    `;
+    ${DigitalCarbonProjectFragmentFragmentDoc}
+${CarbonCreditFragmentFragmentDoc}
+${PoolBalancesFragmentFragmentDoc}`;
 export const FindDigitalCarbonProjectsDocument = gql`
     query findDigitalCarbonProjects($country: [String!], $category: [String!], $search: String, $vintage: [Int!]) {
   carbonProjects(
     first: 1000
     where: {and: [{category_in: $category}, {country_in: $country}, {carbonCredits_: {vintage_in: $vintage}}, {or: [{name_contains_nocase: $search}, {projectID_contains_nocase: $search}]}]}
   ) {
-    id
-    name
-    projectID
-    methodologies
-    country
-    category
-    registry
-    region
+    ...DigitalCarbonProjectFragment
     carbonCredits {
-      vintage
-      currentSupply
-      id
-      crossChainSupply
-      bridgeProtocol
-      bridged
-      retired
+      ...CarbonCreditFragment
       poolBalances {
-        balance
-        id
-        deposited
-        redeemed
+        ...PoolBalancesFragment
         pool {
-          name
-          supply
-          id
-          decimals
-          dailySnapshots {
-            lastUpdateTimestamp
-          }
+          ...PoolFragment
         }
       }
     }
   }
 }
-    `;
+    ${DigitalCarbonProjectFragmentFragmentDoc}
+${CarbonCreditFragmentFragmentDoc}
+${PoolBalancesFragmentFragmentDoc}
+${PoolFragmentFragmentDoc}`;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 

--- a/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
+++ b/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
@@ -4172,15 +4172,63 @@ export enum _SubgraphErrorPolicy_ {
   Deny = 'deny'
 }
 
+export type GetDigitalCarbonProjectsVintagesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetDigitalCarbonProjectsVintagesQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', carbonCredits: Array<{ __typename?: 'CarbonCredit', vintage: number }> }> };
+
+export type GetDigitalCarbonProjectsCategoriesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetDigitalCarbonProjectsCategoriesQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', category: string }> };
+
+export type GetDigitalCarbonProjectsCountriesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetDigitalCarbonProjectsCountriesQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', country: string }> };
+
 export type GetProjectCreditsQueryVariables = Exact<{
   projectID: Scalars['String'];
   vintage: InputMaybe<Scalars['Int']>;
 }>;
 
 
-export type GetProjectCreditsQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', registry: Registry, region: string, projectID: string, name: string, methodologies: string, id: string, country: string, category: string, carbonCredits: Array<{ __typename?: 'CarbonCredit', vintage: number, currentSupply: string, id: any, crossChainSupply: string, bridgeProtocol: BridgeProtocol, bridged: string, retired: string, poolBalances: Array<{ __typename?: 'CarbonPoolCreditBalance', balance: string, id: any, deposited: string, redeemed: string, pool: { __typename?: 'CarbonPool', name: string, supply: string, id: any, decimals: number } }> }> }> };
+export type GetProjectCreditsQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', registry: Registry, region: string, projectID: string, name: string, methodologies: string, id: string, country: string, category: string, carbonCredits: Array<{ __typename?: 'CarbonCredit', vintage: number, currentSupply: string, id: any, crossChainSupply: string, bridgeProtocol: BridgeProtocol, bridged: string, retired: string, poolBalances: Array<{ __typename?: 'CarbonPoolCreditBalance', balance: string, id: any, deposited: string, redeemed: string, pool: { __typename?: 'CarbonPool', name: string, supply: string, id: any, decimals: number, dailySnapshots: Array<{ __typename?: 'CarbonPoolDailySnapshot', lastUpdateTimestamp: string }> } }> }> }> };
+
+export type FindDigitalCarbonProjectsQueryVariables = Exact<{
+  category: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
+  country: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
+  vintage: InputMaybe<Array<Scalars['Int']> | Scalars['Int']>;
+  search: InputMaybe<Scalars['String']>;
+}>;
 
 
+export type FindDigitalCarbonProjectsQuery = { __typename?: 'Query', carbonProjects: Array<{ __typename?: 'CarbonProject', id: string, name: string, projectID: string, methodologies: string, country: string, category: string, registry: Registry, region: string, carbonCredits: Array<{ __typename?: 'CarbonCredit', vintage: number, currentSupply: string, id: any, crossChainSupply: string, bridgeProtocol: BridgeProtocol, bridged: string, retired: string, poolBalances: Array<{ __typename?: 'CarbonPoolCreditBalance', balance: string, id: any, deposited: string, redeemed: string, pool: { __typename?: 'CarbonPool', name: string, supply: string, id: any, decimals: number, dailySnapshots: Array<{ __typename?: 'CarbonPoolDailySnapshot', lastUpdateTimestamp: string }> } }> }> }> };
+
+
+export const GetDigitalCarbonProjectsVintagesDocument = gql`
+    query getDigitalCarbonProjectsVintages {
+  carbonProjects(first: 1000) {
+    carbonCredits {
+      vintage
+    }
+  }
+}
+    `;
+export const GetDigitalCarbonProjectsCategoriesDocument = gql`
+    query getDigitalCarbonProjectsCategories {
+  carbonProjects(first: 1000) {
+    category
+  }
+}
+    `;
+export const GetDigitalCarbonProjectsCountriesDocument = gql`
+    query getDigitalCarbonProjectsCountries {
+  carbonProjects(first: 1000) {
+    country
+  }
+}
+    `;
 export const GetProjectCreditsDocument = gql`
     query getProjectCredits($projectID: String!, $vintage: Int) {
   carbonProjects(where: {projectID: $projectID}) {
@@ -4205,6 +4253,9 @@ export const GetProjectCreditsDocument = gql`
           supply
           id
           decimals
+          dailySnapshots {
+            lastUpdateTimestamp
+          }
         }
       }
       id
@@ -4212,6 +4263,47 @@ export const GetProjectCreditsDocument = gql`
       bridgeProtocol
       bridged
       retired
+    }
+  }
+}
+    `;
+export const FindDigitalCarbonProjectsDocument = gql`
+    query findDigitalCarbonProjects($category: [String!], $country: [String!], $vintage: [Int!], $search: String) {
+  carbonProjects(
+    first: 1000
+    where: {and: [{category_in: $category}, {country_in: $country}, {carbonCredits_: {vintage_in: $vintage}}, {or: [{name_contains_nocase: $search}, {projectID_contains_nocase: $search}]}]}
+  ) {
+    id
+    name
+    projectID
+    methodologies
+    country
+    category
+    registry
+    region
+    carbonCredits {
+      vintage
+      currentSupply
+      id
+      crossChainSupply
+      bridgeProtocol
+      bridged
+      retired
+      poolBalances {
+        balance
+        id
+        deposited
+        redeemed
+        pool {
+          name
+          supply
+          id
+          decimals
+          dailySnapshots {
+            lastUpdateTimestamp
+          }
+        }
+      }
     }
   }
 }
@@ -4224,8 +4316,20 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
+    getDigitalCarbonProjectsVintages(variables?: GetDigitalCarbonProjectsVintagesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetDigitalCarbonProjectsVintagesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetDigitalCarbonProjectsVintagesQuery>(GetDigitalCarbonProjectsVintagesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getDigitalCarbonProjectsVintages', 'query');
+    },
+    getDigitalCarbonProjectsCategories(variables?: GetDigitalCarbonProjectsCategoriesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetDigitalCarbonProjectsCategoriesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetDigitalCarbonProjectsCategoriesQuery>(GetDigitalCarbonProjectsCategoriesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getDigitalCarbonProjectsCategories', 'query');
+    },
+    getDigitalCarbonProjectsCountries(variables?: GetDigitalCarbonProjectsCountriesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetDigitalCarbonProjectsCountriesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetDigitalCarbonProjectsCountriesQuery>(GetDigitalCarbonProjectsCountriesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getDigitalCarbonProjectsCountries', 'query');
+    },
     getProjectCredits(variables: GetProjectCreditsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectCreditsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetProjectCreditsQuery>(GetProjectCreditsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProjectCredits', 'query');
+    },
+    findDigitalCarbonProjects(variables?: FindDigitalCarbonProjectsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FindDigitalCarbonProjectsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<FindDigitalCarbonProjectsQuery>(FindDigitalCarbonProjectsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'findDigitalCarbonProjects', 'query');
     }
   };
 }

--- a/carbonmark-api/src/graphql/digitalCarbon.fragments.gql
+++ b/carbonmark-api/src/graphql/digitalCarbon.fragments.gql
@@ -1,0 +1,46 @@
+fragment DigitalCarbonProjectFragment on CarbonProject {
+  id
+  name
+  projectID
+  methodologies
+  country
+  category
+  registry
+  region
+}
+
+fragment CarbonCreditFragment on CarbonCredit {
+  vintage
+  currentSupply
+  id
+  crossChainSupply
+  bridgeProtocol
+  bridged
+  retired
+}
+
+fragment PoolBalancesFragment on CarbonPoolCreditBalance {
+  balance
+  id
+  deposited
+  redeemed
+  pool {
+    name
+    supply
+    id
+    decimals
+    dailySnapshots {
+      lastUpdateTimestamp
+    }
+  }
+}
+
+fragment PoolFragment on CarbonPool {
+  name
+  supply
+  id
+  decimals
+  dailySnapshots {
+    lastUpdateTimestamp
+  }
+}

--- a/carbonmark-api/src/graphql/digitalCarbon.gql
+++ b/carbonmark-api/src/graphql/digitalCarbon.gql
@@ -56,10 +56,10 @@ query getProjectCredits($projectID: String!, $vintage: Int) {
 }
 
 query findDigitalCarbonProjects(
-  $category: [String!]
   $country: [String!]
-  $vintage: [Int!]
+  $category: [String!]
   $search: String
+  $vintage: [Int!]
 ) {
   carbonProjects(
     first: 1000

--- a/carbonmark-api/src/graphql/digitalCarbon.gql
+++ b/carbonmark-api/src/graphql/digitalCarbon.gql
@@ -20,37 +20,12 @@ query getDigitalCarbonProjectsCountries {
 
 query getProjectCredits($projectID: String!, $vintage: Int) {
   carbonProjects(where: { projectID: $projectID }) {
-    registry
-    region
-    projectID
-    name
-    methodologies
-    id
-    country
-    category
+    ...DigitalCarbonProjectFragment
     carbonCredits(where: { vintage: $vintage }) {
-      vintage
-      currentSupply
+      ...CarbonCreditFragment
       poolBalances {
-        balance
-        id
-        deposited
-        redeemed
-        pool {
-          name
-          supply
-          id
-          decimals
-          dailySnapshots {
-            lastUpdateTimestamp
-          }
-        }
+        ...PoolBalancesFragment
       }
-      id
-      crossChainSupply
-      bridgeProtocol
-      bridged
-      retired
     }
   }
 }
@@ -77,35 +52,13 @@ query findDigitalCarbonProjects(
       ]
     }
   ) {
-    id
-    name
-    projectID
-    methodologies
-    country
-    category
-    registry
-    region
+    ...DigitalCarbonProjectFragment
     carbonCredits {
-      vintage
-      currentSupply
-      id
-      crossChainSupply
-      bridgeProtocol
-      bridged
-      retired
+      ...CarbonCreditFragment
       poolBalances {
-        balance
-        id
-        deposited
-        redeemed
+        ...PoolBalancesFragment
         pool {
-          name
-          supply
-          id
-          decimals
-          dailySnapshots {
-            lastUpdateTimestamp
-          }
+          ...PoolFragment
         }
       }
     }

--- a/carbonmark-api/src/graphql/digitalCarbon.gql
+++ b/carbonmark-api/src/graphql/digitalCarbon.gql
@@ -1,3 +1,23 @@
+query getDigitalCarbonProjectsVintages {
+  carbonProjects(first: 1000) {
+    carbonCredits {
+      vintage
+    }
+  }
+}
+
+query getDigitalCarbonProjectsCategories {
+  carbonProjects(first: 1000) {
+    category
+  }
+}
+
+query getDigitalCarbonProjectsCountries {
+  carbonProjects(first: 1000) {
+    country
+  }
+}
+
 query getProjectCredits($projectID: String!, $vintage: Int) {
   carbonProjects(where: { projectID: $projectID }) {
     registry
@@ -21,6 +41,9 @@ query getProjectCredits($projectID: String!, $vintage: Int) {
           supply
           id
           decimals
+          dailySnapshots {
+            lastUpdateTimestamp
+          }
         }
       }
       id
@@ -28,6 +51,63 @@ query getProjectCredits($projectID: String!, $vintage: Int) {
       bridgeProtocol
       bridged
       retired
+    }
+  }
+}
+
+query findDigitalCarbonProjects(
+  $category: [String!]
+  $country: [String!]
+  $vintage: [Int!]
+  $search: String
+) {
+  carbonProjects(
+    first: 1000
+    where: {
+      and: [
+        { category_in: $category }
+        { country_in: $country }
+        { carbonCredits_: { vintage_in: $vintage } }
+        {
+          or: [
+            { name_contains_nocase: $search }
+            { projectID_contains_nocase: $search }
+          ]
+        }
+      ]
+    }
+  ) {
+    id
+    name
+    projectID
+    methodologies
+    country
+    category
+    registry
+    region
+    carbonCredits {
+      vintage
+      currentSupply
+      id
+      crossChainSupply
+      bridgeProtocol
+      bridged
+      retired
+      poolBalances {
+        balance
+        id
+        deposited
+        redeemed
+        pool {
+          name
+          supply
+          id
+          decimals
+          dailySnapshots {
+            lastUpdateTimestamp
+          }
+        }
+      }
     }
   }
 }

--- a/carbonmark-api/src/models/Project.model.ts
+++ b/carbonmark-api/src/models/Project.model.ts
@@ -14,7 +14,7 @@ export const ProjectModel = Type.Object({
     description: "A GeoJSON Point feature.",
   }),
   vintage: Type.String(),
-  projectAddress: Type.String(),
+  creditTokenAddress: Type.String(),
   registry: Type.String(),
   updatedAt: Type.String(),
   country: Type.Object({ id: Type.String() }),

--- a/carbonmark-api/src/routes/projects/get.constants.ts
+++ b/carbonmark-api/src/routes/projects/get.constants.ts
@@ -3,7 +3,6 @@ export const DEFAULT_POOL_PROJECT_TOKENS = {
   ubo: "0xd6ed6fae5b6535cae8d92f40f5ff653db807a4ea",
   bct: "0xb139c4cc9d20a3618e9a2268d73eff18c496b991",
   nct: "0x6362364a37f34d39a1f4993fb595dab4116daf0d",
-  mco2: "0x0000000000000000000000000000000000000000",
 };
 
 const POOL_ADDRESSES = {
@@ -11,7 +10,6 @@ const POOL_ADDRESSES = {
   ubo: "0x2B3eCb0991AF0498ECE9135bcD04013d7993110c",
   bct: "0x2f800db0fdb5223b3c3f354886d907a671414a7f",
   nct: "0xD838290e877E0188a4A44700463419ED96c16107",
-  mco2: "0xaa7dbd1598251f856c12f63557a4c4397c253cea",
 };
 
 const LP_ADDRESSES = {
@@ -19,7 +17,6 @@ const LP_ADDRESSES = {
   nbo: "0x251ca6a70cbd93ccd7039b6b708d4cb9683c266c",
   bct: "0x9803c7ae526049210a1725f7487af26fe2c24614",
   nct: "0xdb995f975f1bfc3b2157495c47e4efb31196b2ca",
-  mco2: "0x64a3b8cA5A7e406A78e660AE10c7563D9153a739",
 };
 
 export type PoolInfo = {
@@ -77,13 +74,5 @@ export const POOL_INFO: Record<string, PoolInfo> = {
     poolFeeRatio: toucanPoolFee(0.1),
     assetSwapFeeRatio: 0.003,
     retirementServiceFeeRatio: 0.01,
-  },
-  mco2: {
-    defaultProjectTokenAddress: DEFAULT_POOL_PROJECT_TOKENS["mco2"],
-    poolAddress: POOL_ADDRESSES["mco2"],
-    lpAddress: LP_ADDRESSES["mco2"],
-    poolName: "mco2",
-    feeAdd: false,
-    fee: 0.1,
   },
 };

--- a/carbonmark-api/src/routes/projects/get.constants.ts
+++ b/carbonmark-api/src/routes/projects/get.constants.ts
@@ -3,6 +3,7 @@ export const DEFAULT_POOL_PROJECT_TOKENS = {
   ubo: "0xd6ed6fae5b6535cae8d92f40f5ff653db807a4ea",
   bct: "0xb139c4cc9d20a3618e9a2268d73eff18c496b991",
   nct: "0x6362364a37f34d39a1f4993fb595dab4116daf0d",
+  mco2: "0x0000000000000000000000000000000000000000",
 };
 
 const POOL_ADDRESSES = {
@@ -10,6 +11,7 @@ const POOL_ADDRESSES = {
   ubo: "0x2B3eCb0991AF0498ECE9135bcD04013d7993110c",
   bct: "0x2f800db0fdb5223b3c3f354886d907a671414a7f",
   nct: "0xD838290e877E0188a4A44700463419ED96c16107",
+  mco2: "0xaa7dbd1598251f856c12f63557a4c4397c253cea",
 };
 
 const LP_ADDRESSES = {
@@ -17,6 +19,7 @@ const LP_ADDRESSES = {
   nbo: "0x251ca6a70cbd93ccd7039b6b708d4cb9683c266c",
   bct: "0x9803c7ae526049210a1725f7487af26fe2c24614",
   nct: "0xdb995f975f1bfc3b2157495c47e4efb31196b2ca",
+  mco2: "0x64a3b8cA5A7e406A78e660AE10c7563D9153a739",
 };
 
 export type PoolInfo = {
@@ -74,5 +77,13 @@ export const POOL_INFO: Record<string, PoolInfo> = {
     poolFeeRatio: toucanPoolFee(0.1),
     assetSwapFeeRatio: 0.003,
     retirementServiceFeeRatio: 0.01,
+  },
+  mco2: {
+    defaultProjectTokenAddress: DEFAULT_POOL_PROJECT_TOKENS["mco2"],
+    poolAddress: POOL_ADDRESSES["mco2"],
+    lpAddress: LP_ADDRESSES["mco2"],
+    poolName: "mco2",
+    feeAdd: false,
+    fee: 0.1,
   },
 };

--- a/carbonmark-api/src/routes/projects/get.ts
+++ b/carbonmark-api/src/routes/projects/get.ts
@@ -53,10 +53,10 @@ const handler = (fastify: FastifyInstance) =>
           search: request.query.search ?? "",
           expiresAfter: request.query.expiresAfter ?? allOptions.expiresAfter,
         }),
-        sdk.offsets.findCarbonOffsets({
+        sdk.digital_carbon.findDigitalCarbonProjects({
           category: args.category ?? allOptions.category,
           country: args.country ?? allOptions.country,
-          vintage: args.vintage ?? allOptions.vintage,
+          vintage: (args.vintage ?? allOptions.vintage).map(Number),
           search: request.query.search ?? "",
         }),
         fetchAllCarbonProjects(sdk),
@@ -73,7 +73,7 @@ const handler = (fastify: FastifyInstance) =>
     });
 
     /** Assign valid pool projects to map */
-    poolProjectsData.carbonOffsets.forEach((project) => {
+    poolProjectsData.carbonProjects.forEach((project) => {
       if (!isValidPoolProject(project)) {
         console.debug(
           `Project with id ${JSON.stringify(
@@ -92,7 +92,7 @@ const handler = (fastify: FastifyInstance) =>
       const { creditId: key } = new CreditId({
         standard,
         registryProjectId,
-        vintage: project.vintageYear,
+        vintage: project.carbonCredits[0].vintage.toString(),
       });
       ProjectMap.set(key, { poolProjectData: project, key });
     });

--- a/carbonmark-api/src/routes/projects/get.utils.ts
+++ b/carbonmark-api/src/routes/projects/get.utils.ts
@@ -61,7 +61,7 @@ export const getDefaultQueryArgs = async (
  */
 type ProjectBalances = Record<
   string,
-  { balance: string; projectAddress: string }
+  { balance: string; creditTokenAddress: string }
 >;
 
 export const getDigitalCarbonTokenPrices = (
@@ -75,11 +75,11 @@ export const getDigitalCarbonTokenPrices = (
   }
 
   const tokenBalances: ProjectBalances = {
-    nbo: { balance: "0", projectAddress: "" },
-    ubo: { balance: "0", projectAddress: "" },
-    bct: { balance: "0", projectAddress: "" },
-    nct: { balance: "0", projectAddress: "" },
-    mco2: { balance: "0", projectAddress: "" },
+    nbo: { balance: "0", creditTokenAddress: "" },
+    ubo: { balance: "0", creditTokenAddress: "" },
+    bct: { balance: "0", creditTokenAddress: "" },
+    nct: { balance: "0", creditTokenAddress: "" },
+    mco2: { balance: "0", creditTokenAddress: "" },
   };
 
   /**
@@ -97,7 +97,7 @@ export const getDigitalCarbonTokenPrices = (
 
       tokenBalances[key] = {
         balance: poolBalance.balance,
-        projectAddress: credit.id, // should this be this be credit.id or poolBalance.pool.id ?
+        creditTokenAddress: credit.id,
       };
     }
   }
@@ -106,28 +106,28 @@ export const getDigitalCarbonTokenPrices = (
   if (parseFloat(tokenBalances["ubo"].balance) >= 1) {
     const isDefault =
       POOL_INFO.ubo.defaultProjectTokenAddress.toLowerCase() ===
-      tokenBalances["ubo"].projectAddress.toLowerCase();
+      tokenBalances["ubo"].creditTokenAddress.toLowerCase();
     const priceKey = isDefault ? "defaultPrice" : "selectiveRedeemPrice";
     prices.push(poolPrices.ubo[priceKey]);
   }
   if (parseFloat(tokenBalances["nbo"].balance) >= 1) {
     const isDefault =
       POOL_INFO.nbo.defaultProjectTokenAddress.toLowerCase() ===
-      tokenBalances["nbo"].projectAddress.toLowerCase();
+      tokenBalances["nbo"].creditTokenAddress.toLowerCase();
     const priceKey = isDefault ? "defaultPrice" : "selectiveRedeemPrice";
     prices.push(poolPrices.nbo[priceKey]);
   }
   if (parseFloat(tokenBalances["nct"].balance) >= 1) {
     const isDefault =
       POOL_INFO.nct.defaultProjectTokenAddress.toLowerCase() ===
-      tokenBalances["nct"].projectAddress.toLowerCase();
+      tokenBalances["nct"].creditTokenAddress.toLowerCase();
     const priceKey = isDefault ? "defaultPrice" : "selectiveRedeemPrice";
     prices.push(poolPrices.nct[priceKey]);
   }
   if (parseFloat(tokenBalances["bct"].balance) >= 1) {
     const isDefault =
       POOL_INFO.bct.defaultProjectTokenAddress.toLowerCase() ===
-      tokenBalances["bct"].projectAddress.toLowerCase();
+      tokenBalances["bct"].creditTokenAddress.toLowerCase();
     const priceKey = isDefault ? "defaultPrice" : "selectiveRedeemPrice";
     prices.push(poolPrices.bct[priceKey]);
   }
@@ -284,7 +284,7 @@ export const composeProjectEntries = (
         poolBalances?.carbonCredits[0].vintage.toString() ??
         market?.vintage ??
         "",
-      projectAddress: poolBalances?.carbonCredits?.[0].id ?? "",
+      creditTokenAddress: poolBalances?.carbonCredits?.[0].id ?? "",
       updatedAt: pickUpdatedAt(data),
       price: pickBestPrice(data, poolPrices),
       listings: market?.listings?.map(formatListing) || null,

--- a/carbonmark-api/src/utils/helpers/utils.ts
+++ b/carbonmark-api/src/utils/helpers/utils.ts
@@ -31,18 +31,25 @@ export async function getAllVintages(
     return cachedResult;
   }
 
-  const [{ projects }, { carbonOffsets }] = await Promise.all([
-    sdk.marketplace.getVintages(),
-    sdk.offsets.getCarbonOffsetsVintages(),
-  ]);
+  const [{ projects }, { carbonProjects: digitalCarbonProjects }] =
+    await Promise.all([
+      sdk.marketplace.getVintages(),
+      sdk.digital_carbon.getDigitalCarbonProjectsVintages(),
+    ]);
 
   /** Handle invalid responses */
-  if (!isArray(projects) || !isArray(carbonOffsets)) {
+  if (!isArray(projects) || !isArray(digitalCarbonProjects)) {
     throw new Error("Response from server did not match schema definition");
   }
 
   projects.forEach((item) => uniqueValues.add(item.vintage));
-  carbonOffsets.forEach((item) => uniqueValues.add(item.vintageYear));
+  digitalCarbonProjects.forEach((project) => {
+    project.carbonCredits.forEach((credit) => {
+      if (credit.vintage) {
+        uniqueValues.add(credit.vintage.toString());
+      }
+    });
+  });
 
   const result = Array.from(uniqueValues).sort().filter(notEmptyOrNil);
 
@@ -68,20 +75,21 @@ export async function getAllCategories(sdk: GQL_SDK, fastify: FastifyInstance) {
   }
 
   // Fetch categories from the marketplace & carbon offsets categories
-  const [{ categories }, { carbonOffsets }] = await Promise.all([
-    sdk.marketplace.getCategories(),
-    sdk.offsets.getCarbonOffsetsCategories(),
-  ]);
+  const [{ categories }, { carbonProjects: digitalCarbonProjects }] =
+    await Promise.all([
+      sdk.marketplace.getCategories(),
+      sdk.digital_carbon.getDigitalCarbonProjectsCategories(),
+    ]);
 
   /** Handle invalid responses */
-  if (!isArray(categories) || !isArray(carbonOffsets)) {
+  if (!isArray(categories) || !isArray(digitalCarbonProjects)) {
     throw new Error("Response from server did not match schema definition");
   }
 
   // Extract the required values from the fetched data
   const values = [
     categories?.map(extract("id")),
-    carbonOffsets?.map(extract("methodologyCategory")),
+    digitalCarbonProjects?.map(extract("category")),
   ];
 
   // This function pipeline combines and deduplicates categories from different sources
@@ -116,13 +124,14 @@ export async function getAllCountries(sdk: GQL_SDK, fastify: FastifyInstance) {
     return cachedResult;
   }
 
-  const [{ countries }, { carbonOffsets }] = await Promise.all([
-    sdk.marketplace.getCountries(),
-    sdk.offsets.getCarbonOffsetsCountries(),
-  ]);
+  const [{ countries }, { carbonProjects: digitalCarbonProjects }] =
+    await Promise.all([
+      sdk.marketplace.getCountries(),
+      sdk.digital_carbon.getDigitalCarbonProjectsCountries(),
+    ]);
 
   /** Handle invalid responses */
-  if (!isArray(countries) || !isArray(carbonOffsets)) {
+  if (!isArray(countries) || !isArray(digitalCarbonProjects)) {
     throw new Error("Response from server did not match schema definition");
   }
 
@@ -136,7 +145,7 @@ export async function getAllCountries(sdk: GQL_SDK, fastify: FastifyInstance) {
 
   const result: Country[] = fn([
     countries?.map(extract("id")),
-    carbonOffsets.map(extract("country")),
+    digitalCarbonProjects.map(extract("country")),
   ]);
 
   await fastify.lcache.set(cacheKey, { payload: result });

--- a/carbonmark-api/test/fixtures/digitalCarbon.ts
+++ b/carbonmark-api/test/fixtures/digitalCarbon.ts
@@ -1,90 +1,133 @@
 import {
-  aCarbonCredit,
-  aCarbonPool,
-  aCarbonPoolCreditBalance,
-  aCarbonProject,
-} from "../../src/.generated/mocks/digitalCarbon.mocks";
-import { POOL_INFO } from "../../src/routes/projects/get.constants";
+  BridgeProtocol,
+  CarbonCredit,
+  CarbonPool,
+  CarbonPoolCreditBalance,
+  CarbonPoolDailySnapshot,
+  Registry,
+} from "../../src/.generated/types/digitalCarbon.types";
 
-const TCO2_VCS_981_2017 = "0xeaa9938076748d7edd4df0721b3e3fe4077349d3";
-const C3T_VCS_981_2017 = "0x7dbeebf8c2356ff8c53e41928c9575054a6f331b";
+import { aCarbonProject } from "../../src/.generated/mocks/digitalCarbon.mocks";
 
-const uboPool = aCarbonPool({
-  id: POOL_INFO.nbo.poolAddress,
-  decimals: 18,
-  name: "Universal Basic Offset",
-  supply: "21202280666164910248664",
-});
-const nboPool = aCarbonPool({
-  id: POOL_INFO.nbo.poolAddress,
-  decimals: 18,
-  name: "Nature Based Offset",
-  supply: "31202280666164910248664",
-});
-const nctPool = aCarbonPool({
-  id: POOL_INFO.nct.poolAddress,
-  name: "Toucan Protocol: Nature Carbon Tonne",
-  supply: "1604659955808874505539565",
-  decimals: 18,
-});
-const bctPool = aCarbonPool({
-  id: POOL_INFO.bct.poolAddress,
-  name: "Toucan Protocol: Base Carbon Tonne",
-  supply: "18545844499823544157213608",
-  decimals: 18,
-});
-const poolBalance_NBO = aCarbonPoolCreditBalance({
-  balance: "26202320013669175484739",
-  pool: nboPool,
-  deposited: "28903000000000000000000",
-  redeemed: "2700679986330824515261",
-});
-const poolBalance_NCT = aCarbonPoolCreditBalance({
-  balance: "137168659539439210",
-  pool: nctPool,
-  deposited: "19048774113647802186879",
-  redeemed: "17724636944988262747669",
-});
-const poolBalance_BCT = aCarbonPoolCreditBalance({
-  balance: "0", // all redeemed and moved to TCO2
-  pool: bctPool,
-  deposited: "142330703112744844598983",
-  redeemed: "142330703112744844598983",
-});
-const carbonCredit_C3T = aCarbonCredit({
-  vintage: 2017,
-  bridged: "28903000000000000000000",
-  retired: "2645744986330824515261",
-  currentSupply: "26257255013669175484739",
-  poolBalances: [poolBalance_NBO],
-  id: C3T_VCS_981_2017,
-});
-const carbonCredit_TCO2 = aCarbonCredit({
-  vintage: 2017,
-  bridged: "73794000000000000000000",
-  retired: "6709707416786222240581",
-  currentSupply: "62876512583213777759419",
-  poolBalances: [poolBalance_BCT, poolBalance_NCT],
-  id: TCO2_VCS_981_2017,
-});
-/** A project with two pool prices (1 empty pool) */
-const carbonProject = aCarbonProject({
-  projectID: "VCS-981",
-  name: "Pacajai REDD+ Project",
-  methodologies: "VM0015",
-  id: "VCS-981",
-  country: "Brazil",
-  category: "Forestry",
-  carbonCredits: [carbonCredit_TCO2, carbonCredit_C3T],
+type PartialCarbonPoolCreditBalance = Partial<CarbonPoolCreditBalance>;
+
+type PartialCarbonPoolDailySnapshot = Partial<CarbonPoolDailySnapshot>;
+
+// /** Fixtures for the polygon-bridged-carbon subgraph */
+
+const creditBalance: PartialCarbonPoolCreditBalance = {
+  id: "0xb0d34b2ec3b47ba1f27c9d4e8520f8fa38ef538d",
+};
+
+const dailySnapshot: PartialCarbonPoolDailySnapshot = {
+  // Note: You did not provide a new value for this id, so it remains the same.
+  id: "0xaa7dbd1598251f856c12f63557a4c4397c253cea014b0000",
+  lastUpdateTimestamp: "1628582400",
+};
+
+const poolBalance: PartialCarbonPoolCreditBalance = {
+  balance: "320307910491148199345054",
+  id: "0x2f800db0fdb5223b3c3f354886d907a671414a7fb0d34b2ec3b47ba1f27c9d4e8520f8fa38ef538d",
+  deposited: "320308000000000000000000",
+  redeemed: "89508851800654946",
+  pool: {
+    name: "Toucan Protocol: Base Carbon Tonne",
+    supply: "18546102526284342155938612",
+    id: "0x2f800db0fdb5223b3c3f354886d907a671414a7f",
+    decimals: 18,
+    creditBalances: [creditBalance as CarbonPoolCreditBalance],
+    crossChainSupply: "0",
+    dailySnapshots: [dailySnapshot as CarbonPoolDailySnapshot],
+  } as CarbonPool,
+};
+
+type PartialCarbonCredit = Partial<CarbonCredit>;
+
+const carbonCredit: PartialCarbonCredit = {
+  vintage: 2011,
+  currentSupply: "320308000000000000000000",
+  id: "0xb0d34b2ec3b47ba1f27c9d4e8520f8fa38ef538d",
+  crossChainSupply: "0",
+  bridgeProtocol: BridgeProtocol.Toucan,
+  bridged: "320308000000000000000000",
+  retired: "0",
+  poolBalances: [poolBalance as CarbonPoolCreditBalance],
+};
+
+// const carbonProject = aCarbonProject({
+//   id: "VCS-191",
+//   name: "4×50 MW Dayingjiang- 3 Hydropower Project Phases 1&2",
+//   projectID: "VCS-191",
+//   methodologies: "ACM0002",
+//   country: "China",
+//   category: "Renewable Energy",
+//   registry: Registry.Verra,
+//   region: "",
+//   carbonCredits: [carbonCredit as CarbonCredit],
+// });
+
+const digitalCarbonProject = aCarbonProject({
+  id: "VCS-191",
+  name: "Grid-connected electricity generation from renewable sources",
+  projectID: "VCS-191",
+  methodologies: "ACM0002",
+  country: "China",
+  category: "Renewable Energy",
+  registry: Registry.Verra,
+  region: "Asia",
+  carbonCredits: [carbonCredit as CarbonCredit],
 });
 
-/** Fixtures for the polygon-bridged-carbon subgraph */
+const countries = {
+  data: {
+    carbonProjects: [
+      {
+        country: "",
+      },
+      {
+        country: "",
+      },
+      {
+        country: "Brazil",
+      },
+      {
+        country: "India",
+      },
+      {
+        country: "India",
+      },
+      {
+        country: "China",
+      },
+      {
+        country: "China",
+      },
+      {
+        country: "Congo",
+      },
+      {
+        country: "",
+      },
+      {
+        country: "India",
+      },
+      {
+        country: "Brazil",
+      },
+    ],
+  },
+};
+
+const empty_countries = {
+  data: {
+    carbonProjects: [],
+  },
+};
+
 const fixtures = {
-  carbonProject,
-  bctPool,
-  nctPool,
-  uboPool,
-  nboPool,
+  countries,
+  empty_countries,
+  digitalCarbonProject,
 };
 
 export default fixtures;

--- a/carbonmark-api/test/fixtures/digitalCarbon.ts
+++ b/carbonmark-api/test/fixtures/digitalCarbon.ts
@@ -13,14 +13,13 @@ type PartialCarbonPoolCreditBalance = Partial<CarbonPoolCreditBalance>;
 
 type PartialCarbonPoolDailySnapshot = Partial<CarbonPoolDailySnapshot>;
 
-// /** Fixtures for the polygon-bridged-carbon subgraph */
+// /** Fixtures for the polygon-digital-carbon subgraph */
 
 const creditBalance: PartialCarbonPoolCreditBalance = {
   id: "0xb0d34b2ec3b47ba1f27c9d4e8520f8fa38ef538d",
 };
 
 const dailySnapshot: PartialCarbonPoolDailySnapshot = {
-  // Note: You did not provide a new value for this id, so it remains the same.
   id: "0xaa7dbd1598251f856c12f63557a4c4397c253cea014b0000",
   lastUpdateTimestamp: "1628582400",
 };
@@ -54,18 +53,6 @@ const carbonCredit: PartialCarbonCredit = {
   poolBalances: [poolBalance as CarbonPoolCreditBalance],
 };
 
-// const carbonProject = aCarbonProject({
-//   id: "VCS-191",
-//   name: "4×50 MW Dayingjiang- 3 Hydropower Project Phases 1&2",
-//   projectID: "VCS-191",
-//   methodologies: "ACM0002",
-//   country: "China",
-//   category: "Renewable Energy",
-//   registry: Registry.Verra,
-//   region: "",
-//   carbonCredits: [carbonCredit as CarbonCredit],
-// });
-
 const digitalCarbonProject = aCarbonProject({
   id: "VCS-191",
   name: "Grid-connected electricity generation from renewable sources",
@@ -78,46 +65,6 @@ const digitalCarbonProject = aCarbonProject({
   carbonCredits: [carbonCredit as CarbonCredit],
 });
 
-const countries = {
-  data: {
-    carbonProjects: [
-      {
-        country: "",
-      },
-      {
-        country: "",
-      },
-      {
-        country: "Brazil",
-      },
-      {
-        country: "India",
-      },
-      {
-        country: "India",
-      },
-      {
-        country: "China",
-      },
-      {
-        country: "China",
-      },
-      {
-        country: "Congo",
-      },
-      {
-        country: "",
-      },
-      {
-        country: "India",
-      },
-      {
-        country: "Brazil",
-      },
-    ],
-  },
-};
-
 const empty_countries = {
   data: {
     carbonProjects: [],
@@ -125,7 +72,6 @@ const empty_countries = {
 };
 
 const fixtures = {
-  countries,
   empty_countries,
   digitalCarbonProject,
 };

--- a/carbonmark-api/test/fixtures/digitalCarbon.ts
+++ b/carbonmark-api/test/fixtures/digitalCarbon.ts
@@ -16,7 +16,7 @@ type PartialCarbonPoolDailySnapshot = Partial<CarbonPoolDailySnapshot>;
 // /** Fixtures for the polygon-digital-carbon subgraph */
 
 const creditBalance: PartialCarbonPoolCreditBalance = {
-  id: "0xb0d34b2ec3b47ba1f27c9d4e8520f8fa38ef538d",
+  id: "0xb139c4cc9d20a3618e9a2268d73eff18c496b991",
 };
 
 const dailySnapshot: PartialCarbonPoolDailySnapshot = {
@@ -26,7 +26,7 @@ const dailySnapshot: PartialCarbonPoolDailySnapshot = {
 
 const poolBalance: PartialCarbonPoolCreditBalance = {
   balance: "320307910491148199345054",
-  id: "0x2f800db0fdb5223b3c3f354886d907a671414a7fb0d34b2ec3b47ba1f27c9d4e8520f8fa38ef538d",
+  id: "0x2f800db0fdb5223b3c3f354886d907a671414a7fb139c4cc9d20a3618e9a2268d73eff18c496b99",
   deposited: "320308000000000000000000",
   redeemed: "89508851800654946",
   pool: {
@@ -45,7 +45,7 @@ type PartialCarbonCredit = Partial<CarbonCredit>;
 const carbonCredit: PartialCarbonCredit = {
   vintage: 2011,
   currentSupply: "320308000000000000000000",
-  id: "0xb0d34b2ec3b47ba1f27c9d4e8520f8fa38ef538d",
+  id: "0xb139c4cc9d20a3618e9a2268d73eff18c496b991",
   crossChainSupply: "0",
   bridgeProtocol: BridgeProtocol.Toucan,
   bridged: "320308000000000000000000",

--- a/carbonmark-api/test/plugins/rate-limit.test.ts
+++ b/carbonmark-api/test/plugins/rate-limit.test.ts
@@ -15,9 +15,9 @@ describe("Rate Limiter", () => {
 
   test("should limit requests", async () => {
     for (let i = 0; i < 100 + 1; i++) {
-      nock(GRAPH_URLS["polygon"].offsets)
+      nock(GRAPH_URLS["polygon"].digitalCarbon)
         .post("")
-        .reply(200, { data: { carbonOffsets: [] } });
+        .reply(200, { data: { carbonProjects: [] } });
 
       nock(GRAPH_URLS["polygon"].marketplace)
         .post("")

--- a/carbonmark-api/test/routes/categories/get.test.ts
+++ b/carbonmark-api/test/routes/categories/get.test.ts
@@ -12,11 +12,11 @@ describe("GET /categories", () => {
     fastify = await build();
   });
 
-  /** A default response for offsets */
+  /** A default response for digital-carbon */
   beforeEach(() =>
-    nock(GRAPH_URLS["polygon"].offsets)
+    nock(GRAPH_URLS["polygon"].digitalCarbon)
       .post("")
-      .reply(200, { data: { carbonOffsets: [] } })
+      .reply(200, { data: { carbonProjects: [] } })
   );
 
   /** The happy path */

--- a/carbonmark-api/test/routes/countries/get.test.ts
+++ b/carbonmark-api/test/routes/countries/get.test.ts
@@ -15,9 +15,9 @@ describe("GET /countries", () => {
 
   /** A default response for offsets */
   beforeEach(() =>
-    nock(GRAPH_URLS["polygon"].offsets)
+    nock(GRAPH_URLS["polygon"].digitalCarbon)
       .post("")
-      .reply(200, { data: { carbonOffsets: COUNTRIES } })
+      .reply(200, { data: { carbonProjects: COUNTRIES } })
   );
 
   /** The happy path */
@@ -25,6 +25,10 @@ describe("GET /countries", () => {
     nock(GRAPH_URLS["polygon"].marketplace)
       .post("")
       .reply(200, { data: { countries: COUNTRIES } });
+
+    nock(GRAPH_URLS["polygon"].digitalCarbon)
+      .post("")
+      .reply(200, { data: { carbonProjects: COUNTRIES } });
 
     const response = await fastify.inject({
       method: "GET",
@@ -45,6 +49,8 @@ describe("GET /countries", () => {
         errors: [ERROR],
       });
 
+    nock(GRAPH_URLS["polygon"].digitalCarbon).post("").reply(200, []);
+
     const response = await fastify.inject({
       method: "GET",
       url: `${DEV_URL}/countries`,
@@ -58,6 +64,10 @@ describe("GET /countries", () => {
     nock(GRAPH_URLS["polygon"].marketplace)
       .post("")
       .reply(200, { data: { countries: [] } });
+
+    nock(GRAPH_URLS["polygon"].digitalCarbon)
+      .post("")
+      .reply(200, { data: { carbonProjects: [] } });
 
     const response = await fastify.inject({
       method: "GET",
@@ -73,6 +83,10 @@ describe("GET /countries", () => {
     nock(GRAPH_URLS["polygon"].marketplace)
       .post("")
       .reply(200, { data: { categories: "invalid data" } });
+
+    nock(GRAPH_URLS["polygon"].digitalCarbon)
+      .post("")
+      .reply(200, { data: { carbonProjects: "invalid data" } });
 
     const response = await fastify.inject({
       method: "GET",

--- a/carbonmark-api/test/routes/projects/[id]/get.test.ts
+++ b/carbonmark-api/test/routes/projects/[id]/get.test.ts
@@ -82,9 +82,9 @@ describe("GET /projects/:id", () => {
     });
     const project = await response.json();
     expect(response.statusCode).toEqual(200);
-    expect(project.prices).toHaveLength(2);
-    expect(project.prices[0].singleUnitBuyPrice).toBe("0.681502");
-    expect(project.prices[0].singleUnitSellPrice).toBe("0.688131");
+    expect(project.prices).toHaveLength(1);
+    expect(project.prices[0].singleUnitBuyPrice).toBe("0.358940");
+    expect(project.prices[0].singleUnitSellPrice).toBe("0.361620");
   });
 
   test("Empty network param default is polygon", async () => {

--- a/carbonmark-api/test/routes/projects/[id]/get.test.ts
+++ b/carbonmark-api/test/routes/projects/[id]/get.test.ts
@@ -69,7 +69,7 @@ describe("GET /projects/:id", () => {
       .post("")
       .reply(200, {
         data: {
-          carbonProjects: [digitalCarbon.carbonProject],
+          carbonProjects: [digitalCarbon.digitalCarbonProject],
         },
       });
     nock(GRAPH_URLS["polygon"].offsets).post("").reply(200, { data: {} });
@@ -104,7 +104,7 @@ describe("GET /projects/:id", () => {
       .post("")
       .reply(200, {
         data: {
-          carbonProjects: [digitalCarbon.carbonProject],
+          carbonProjects: [digitalCarbon.digitalCarbonProject],
         },
       });
     nock(GRAPH_URLS["polygon"].offsets).post("").reply(200, { data: {} });
@@ -117,6 +117,6 @@ describe("GET /projects/:id", () => {
     });
     const project = await response.json();
     expect(response.statusCode).toEqual(200);
-    expect(project.prices).toHaveLength(2);
+    expect(project.prices).toHaveLength(1);
   });
 });

--- a/carbonmark-api/test/routes/projects/get.test.ts
+++ b/carbonmark-api/test/routes/projects/get.test.ts
@@ -136,7 +136,8 @@ describe("GET /projects", () => {
         projectID: digitalCarbon.digitalCarbonProject.projectID.split("-")[1],
         vintage:
           digitalCarbon.digitalCarbonProject.carbonCredits[0].vintage.toString(),
-        projectAddress: digitalCarbon.digitalCarbonProject.carbonCredits[0].id,
+        creditTokenAddress:
+          digitalCarbon.digitalCarbonProject.carbonCredits[0].id,
         // Takes registry tag
         registry: digitalCarbon.digitalCarbonProject.id.split("-")[0],
         updatedAt:

--- a/carbonmark-api/test/routes/vintages/get.test.ts
+++ b/carbonmark-api/test/routes/vintages/get.test.ts
@@ -13,11 +13,11 @@ describe("GET /vintages", () => {
     fastify = await build();
   });
 
-  /** A default response for offsets */
+  /** A default response for digital-carbon */
   beforeEach(() =>
-    nock(GRAPH_URLS["polygon"].offsets)
+    nock(GRAPH_URLS["polygon"].digitalCarbon)
       .post("")
-      .reply(200, { data: { carbonOffsets: [] } })
+      .reply(200, { data: { carbonProjects: [] } })
   );
 
   /** The happy path */


### PR DESCRIPTION
## Description

Integrates the `digital-carbon` subgraph into `get.ts`, so the `/projects` endpoint uses the new subgraph.

One question [HERE](https://github.com/KlimaDAO/klimadao/compare/tufnel/digital-carbon-subgraph-in-fetchPoolPrices-1168...tufnel/integrate-digital-carbon-graph-into-get.ts?expand=1#diff-cc0d13d9fea158c1b9164a577fc190aaf13ee604e8eacf9e5e30e910f6a8890dR142). 
--> Should this compare the project token balance or the pool balance?

This replaces all the instances of the bridged-carbon subgraph that are used.

Update: This PR incorporates all the changes from #1543, so that can PR can almost definitely be closed

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1168 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
