### PR TITLE
fix formatUnit issue

### DIFF
--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -59,7 +59,7 @@ export const loadAppDetails = (params: { onRPCError: () => void }): Thunk => {
 
       dispatch(
         setAppState({
-          currentIndex: formatUnits(currentIndex, "gwei"),
+          currentIndex: formatUnits(BigInt(currentIndex), "gwei"),
           currentBlock,
           fiveDayRate,
           stakingAnnualPercent,


### PR DESCRIPTION
## Description

There is an issue on the RA where the rebase data is showing "loading" and some users are unable to wrap klima. I was able to reproduce the issue and it looks to be related to a recent change I introduced with ethers-v6 where the value needs to be wrapped as a `BigInt`

## Changes

| Before  | After  |
|---------|--------|
|<img width="1512" alt="Screenshot 2023-09-19 at 21 00 37" src="https://github.com/KlimaDAO/klimadao/assets/92357475/233a8350-3d33-414b-82c0-ef43109ac68e">|<img width="1512" alt="Screenshot 2023-09-19 at 20 59 04" src="https://github.com/KlimaDAO/klimadao/assets/92357475/2b37e6a6-3940-42be-ba47-02671c8820ea">|

## Checklist

- [] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
