### PR TITLE
[api] premajor release v2.0.0-0

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "1.1.0",
+  "version": "2.0.0-0",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,7 @@
     },
     "carbonmark-api": {
       "name": "@klimadao/carbonmark-api",
-      "version": "1.1.0",
+      "version": "2.0.0-0",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",


### PR DESCRIPTION
## Description
`npm version premajor`
Prerelease because it does not support mainnet Carbonmark data