### PR TITLE
[carbonmark] Enable create listing buttons

### DIFF
--- a/carbonmark/.generated/carbonmark-api.schema.ts
+++ b/carbonmark/.generated/carbonmark-api.schema.ts
@@ -2,7 +2,7 @@ export default {
   "openapi": "3.0.3",
   "info": {
     "title": "Carbonmark REST API",
-    "description": "\nWelcome to the API Reference docs for **version 2.0.0-3** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
+    "description": "\nWelcome to the API Reference docs for **version 2.0.0-4** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
     "termsOfService": "https://www.carbonmark.com/blog/terms-of-use",
     "contact": {
       "name": "Support",
@@ -12,7 +12,7 @@ export default {
       "name": "MIT",
       "url": "https://github.com/KlimaDAO/klimadao/blob/main/LICENSE"
     },
-    "version": "2.0.0-3"
+    "version": "2.0.0-4"
   },
   "components": {
     "schemas": {
@@ -262,61 +262,54 @@ export default {
                       ]
                     },
                     "seller": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "handle": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            },
-                            "username": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            },
-                            "description": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            },
-                            "profileImgUrl": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            },
-                            "id": {
+                      "type": "object",
+                      "properties": {
+                        "handle": {
+                          "anyOf": [
+                            {
                               "type": "string"
+                            },
+                            {
+                              "type": "null"
                             }
-                          },
-                          "required": [
-                            "id"
                           ]
                         },
-                        {
-                          "type": "null"
+                        "username": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "profileImgUrl": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "id": {
+                          "type": "string"
                         }
+                      },
+                      "required": [
+                        "id"
                       ]
                     },
                     "expiration": {
@@ -338,12 +331,28 @@ export default {
                         },
                         "vintage": {
                           "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "category": {
+                          "type": "string"
+                        },
+                        "country": {
+                          "type": "string"
+                        },
+                        "methodology": {
+                          "type": "string"
                         }
                       },
                       "required": [
                         "id",
                         "key",
-                        "vintage"
+                        "vintage",
+                        "name",
+                        "category",
+                        "country",
+                        "methodology"
                       ]
                     }
                   },
@@ -353,6 +362,7 @@ export default {
                     "tokenAddress",
                     "singleUnitPrice",
                     "totalAmountToSell",
+                    "seller",
                     "expiration",
                     "minFillAmount",
                     "project"
@@ -791,61 +801,54 @@ export default {
                   ]
                 },
                 "seller": {
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "handle": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "username": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "profileImgUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "id": {
+                  "type": "object",
+                  "properties": {
+                    "handle": {
+                      "anyOf": [
+                        {
                           "type": "string"
+                        },
+                        {
+                          "type": "null"
                         }
-                      },
-                      "required": [
-                        "id"
                       ]
                     },
-                    {
-                      "type": "null"
+                    "username": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "profileImgUrl": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "id": {
+                      "type": "string"
                     }
+                  },
+                  "required": [
+                    "id"
                   ]
                 },
                 "expiration": {
@@ -867,12 +870,28 @@ export default {
                     },
                     "vintage": {
                       "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "type": "string"
+                    },
+                    "country": {
+                      "type": "string"
+                    },
+                    "methodology": {
+                      "type": "string"
                     }
                   },
                   "required": [
                     "id",
                     "key",
-                    "vintage"
+                    "vintage",
+                    "name",
+                    "category",
+                    "country",
+                    "methodology"
                   ]
                 }
               },
@@ -882,6 +901,7 @@ export default {
                 "tokenAddress",
                 "singleUnitPrice",
                 "totalAmountToSell",
+                "seller",
                 "expiration",
                 "minFillAmount",
                 "project"
@@ -1275,61 +1295,54 @@ export default {
             ]
           },
           "seller": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "handle": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "username": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "description": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "profileImgUrl": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "id": {
+            "type": "object",
+            "properties": {
+              "handle": {
+                "anyOf": [
+                  {
                     "type": "string"
+                  },
+                  {
+                    "type": "null"
                   }
-                },
-                "required": [
-                  "id"
                 ]
               },
-              {
-                "type": "null"
+              "username": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "profileImgUrl": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "id": {
+                "type": "string"
               }
+            },
+            "required": [
+              "id"
             ]
           },
           "expiration": {
@@ -1351,12 +1364,28 @@ export default {
               },
               "vintage": {
                 "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "category": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              },
+              "methodology": {
+                "type": "string"
               }
             },
             "required": [
               "id",
               "key",
-              "vintage"
+              "vintage",
+              "name",
+              "category",
+              "country",
+              "methodology"
             ]
           }
         },
@@ -1366,6 +1395,7 @@ export default {
           "tokenAddress",
           "singleUnitPrice",
           "totalAmountToSell",
+          "seller",
           "expiration",
           "minFillAmount",
           "project"
@@ -1662,61 +1692,54 @@ export default {
                   ]
                 },
                 "seller": {
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "handle": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "username": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "description": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "profileImgUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "id": {
+                  "type": "object",
+                  "properties": {
+                    "handle": {
+                      "anyOf": [
+                        {
                           "type": "string"
+                        },
+                        {
+                          "type": "null"
                         }
-                      },
-                      "required": [
-                        "id"
                       ]
                     },
-                    {
-                      "type": "null"
+                    "username": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "profileImgUrl": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "id": {
+                      "type": "string"
                     }
+                  },
+                  "required": [
+                    "id"
                   ]
                 },
                 "expiration": {
@@ -1738,12 +1761,28 @@ export default {
                     },
                     "vintage": {
                       "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "type": "string"
+                    },
+                    "country": {
+                      "type": "string"
+                    },
+                    "methodology": {
+                      "type": "string"
                     }
                   },
                   "required": [
                     "id",
                     "key",
-                    "vintage"
+                    "vintage",
+                    "name",
+                    "category",
+                    "country",
+                    "methodology"
                   ]
                 }
               },
@@ -1753,6 +1792,7 @@ export default {
                 "tokenAddress",
                 "singleUnitPrice",
                 "totalAmountToSell",
+                "seller",
                 "expiration",
                 "minFillAmount",
                 "project"
@@ -2287,7 +2327,7 @@ export default {
           },
           {
             "schema": {
-              "default": "1696288898",
+              "default": "1696379549",
               "type": "string"
             },
             "example": "1620000000",
@@ -2550,61 +2590,54 @@ export default {
                                   ]
                                 },
                                 "seller": {
-                                  "anyOf": [
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "handle": {
-                                          "anyOf": [
-                                            {
-                                              "type": "string"
-                                            },
-                                            {
-                                              "type": "null"
-                                            }
-                                          ]
-                                        },
-                                        "username": {
-                                          "anyOf": [
-                                            {
-                                              "type": "string"
-                                            },
-                                            {
-                                              "type": "null"
-                                            }
-                                          ]
-                                        },
-                                        "description": {
-                                          "anyOf": [
-                                            {
-                                              "type": "string"
-                                            },
-                                            {
-                                              "type": "null"
-                                            }
-                                          ]
-                                        },
-                                        "profileImgUrl": {
-                                          "anyOf": [
-                                            {
-                                              "type": "string"
-                                            },
-                                            {
-                                              "type": "null"
-                                            }
-                                          ]
-                                        },
-                                        "id": {
+                                  "type": "object",
+                                  "properties": {
+                                    "handle": {
+                                      "anyOf": [
+                                        {
                                           "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
                                         }
-                                      },
-                                      "required": [
-                                        "id"
                                       ]
                                     },
-                                    {
-                                      "type": "null"
+                                    "username": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "description": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "profileImgUrl": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "id": {
+                                      "type": "string"
                                     }
+                                  },
+                                  "required": [
+                                    "id"
                                   ]
                                 },
                                 "expiration": {
@@ -2626,12 +2659,28 @@ export default {
                                     },
                                     "vintage": {
                                       "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "category": {
+                                      "type": "string"
+                                    },
+                                    "country": {
+                                      "type": "string"
+                                    },
+                                    "methodology": {
+                                      "type": "string"
                                     }
                                   },
                                   "required": [
                                     "id",
                                     "key",
-                                    "vintage"
+                                    "vintage",
+                                    "name",
+                                    "category",
+                                    "country",
+                                    "methodology"
                                   ]
                                 }
                               },
@@ -2641,6 +2690,7 @@ export default {
                                 "tokenAddress",
                                 "singleUnitPrice",
                                 "totalAmountToSell",
+                                "seller",
                                 "expiration",
                                 "minFillAmount",
                                 "project"
@@ -2740,7 +2790,7 @@ export default {
           },
           {
             "schema": {
-              "default": "1696288899",
+              "default": "1696379549",
               "type": "string"
             },
             "example": "1620000000",
@@ -2909,61 +2959,54 @@ export default {
                             ]
                           },
                           "seller": {
-                            "anyOf": [
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "handle": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "username": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "description": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "profileImgUrl": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "id": {
+                            "type": "object",
+                            "properties": {
+                              "handle": {
+                                "anyOf": [
+                                  {
                                     "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
                                   }
-                                },
-                                "required": [
-                                  "id"
                                 ]
                               },
-                              {
-                                "type": "null"
+                              "username": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "profileImgUrl": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "id": {
+                                "type": "string"
                               }
+                            },
+                            "required": [
+                              "id"
                             ]
                           },
                           "expiration": {
@@ -2985,12 +3028,28 @@ export default {
                               },
                               "vintage": {
                                 "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "category": {
+                                "type": "string"
+                              },
+                              "country": {
+                                "type": "string"
+                              },
+                              "methodology": {
+                                "type": "string"
                               }
                             },
                             "required": [
                               "id",
                               "key",
-                              "vintage"
+                              "vintage",
+                              "name",
+                              "category",
+                              "country",
+                              "methodology"
                             ]
                           }
                         },
@@ -3000,6 +3059,7 @@ export default {
                           "tokenAddress",
                           "singleUnitPrice",
                           "totalAmountToSell",
+                          "seller",
                           "expiration",
                           "minFillAmount",
                           "project"
@@ -3896,61 +3956,54 @@ export default {
                             ]
                           },
                           "seller": {
-                            "anyOf": [
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "handle": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "username": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "description": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "profileImgUrl": {
-                                    "anyOf": [
-                                      {
-                                        "type": "string"
-                                      },
-                                      {
-                                        "type": "null"
-                                      }
-                                    ]
-                                  },
-                                  "id": {
+                            "type": "object",
+                            "properties": {
+                              "handle": {
+                                "anyOf": [
+                                  {
                                     "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
                                   }
-                                },
-                                "required": [
-                                  "id"
                                 ]
                               },
-                              {
-                                "type": "null"
+                              "username": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "profileImgUrl": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "id": {
+                                "type": "string"
                               }
+                            },
+                            "required": [
+                              "id"
                             ]
                           },
                           "expiration": {
@@ -3972,12 +4025,28 @@ export default {
                               },
                               "vintage": {
                                 "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "category": {
+                                "type": "string"
+                              },
+                              "country": {
+                                "type": "string"
+                              },
+                              "methodology": {
+                                "type": "string"
                               }
                             },
                             "required": [
                               "id",
                               "key",
-                              "vintage"
+                              "vintage",
+                              "name",
+                              "category",
+                              "country",
+                              "methodology"
                             ]
                           }
                         },
@@ -3987,6 +4056,7 @@ export default {
                           "tokenAddress",
                           "singleUnitPrice",
                           "totalAmountToSell",
+                          "seller",
                           "expiration",
                           "minFillAmount",
                           "project"

--- a/carbonmark/.generated/carbonmark-api.schema.ts
+++ b/carbonmark/.generated/carbonmark-api.schema.ts
@@ -2,7 +2,7 @@ export default {
   "openapi": "3.0.3",
   "info": {
     "title": "Carbonmark REST API",
-    "description": "\nWelcome to the API Reference docs for **version 2.0.0-4** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
+    "description": "\nWelcome to the API Reference docs for **version 2.0.0-5** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
     "termsOfService": "https://www.carbonmark.com/blog/terms-of-use",
     "contact": {
       "name": "Support",
@@ -12,7 +12,7 @@ export default {
       "name": "MIT",
       "url": "https://github.com/KlimaDAO/klimadao/blob/main/LICENSE"
     },
-    "version": "2.0.0-4"
+    "version": "2.0.0-5"
   },
   "components": {
     "schemas": {
@@ -2327,7 +2327,7 @@ export default {
           },
           {
             "schema": {
-              "default": "1696379549",
+              "default": "1696438740",
               "type": "string"
             },
             "example": "1620000000",
@@ -2790,7 +2790,7 @@ export default {
           },
           {
             "schema": {
-              "default": "1696379549",
+              "default": "1696438740",
               "type": "string"
             },
             "example": "1620000000",

--- a/carbonmark/.generated/carbonmark-api.schema.ts
+++ b/carbonmark/.generated/carbonmark-api.schema.ts
@@ -2,7 +2,7 @@ export default {
   "openapi": "3.0.3",
   "info": {
     "title": "Carbonmark REST API",
-    "description": "\nWelcome to the API Reference docs for **version 2.0.0-5** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
+    "description": "\nWelcome to the API Reference docs for **version 2.0.0-6** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
     "termsOfService": "https://www.carbonmark.com/blog/terms-of-use",
     "contact": {
       "name": "Support",
@@ -12,7 +12,7 @@ export default {
       "name": "MIT",
       "url": "https://github.com/KlimaDAO/klimadao/blob/main/LICENSE"
     },
-    "version": "2.0.0-5"
+    "version": "2.0.0-6"
   },
   "components": {
     "schemas": {
@@ -2327,7 +2327,6 @@ export default {
           },
           {
             "schema": {
-              "default": "1696438740",
               "type": "string"
             },
             "example": "1620000000",
@@ -2790,7 +2789,6 @@ export default {
           },
           {
             "schema": {
-              "default": "1696438740",
               "type": "string"
             },
             "example": "1620000000",

--- a/carbonmark/.generated/carbonmark-api.schema.ts
+++ b/carbonmark/.generated/carbonmark-api.schema.ts
@@ -2,7 +2,7 @@ export default {
   "openapi": "3.0.3",
   "info": {
     "title": "Carbonmark REST API",
-    "description": "\nWelcome to the API Reference docs for **version 2.0.0-1** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
+    "description": "\nWelcome to the API Reference docs for **version 2.0.0-3** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
     "termsOfService": "https://www.carbonmark.com/blog/terms-of-use",
     "contact": {
       "name": "Support",
@@ -12,7 +12,7 @@ export default {
       "name": "MIT",
       "url": "https://github.com/KlimaDAO/klimadao/blob/main/LICENSE"
     },
-    "version": "2.0.0-1"
+    "version": "2.0.0-3"
   },
   "components": {
     "schemas": {
@@ -336,57 +336,6 @@ export default {
                         "key": {
                           "type": "string"
                         },
-                        "name": {
-                          "type": "string"
-                        },
-                        "category": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "id"
-                              ]
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "country": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "id"
-                              ]
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "methodology": {
-                          "type": "string"
-                        },
-                        "projectAddress": {
-                          "type": "string"
-                        },
-                        "projectID": {
-                          "type": "string"
-                        },
-                        "registry": {
-                          "type": "string"
-                        },
                         "vintage": {
                           "type": "string"
                         }
@@ -394,11 +343,6 @@ export default {
                       "required": [
                         "id",
                         "key",
-                        "name",
-                        "methodology",
-                        "projectAddress",
-                        "projectID",
-                        "registry",
                         "vintage"
                       ]
                     }
@@ -921,57 +865,6 @@ export default {
                     "key": {
                       "type": "string"
                     },
-                    "name": {
-                      "type": "string"
-                    },
-                    "category": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "id"
-                          ]
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "country": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "id"
-                          ]
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "methodology": {
-                      "type": "string"
-                    },
-                    "projectAddress": {
-                      "type": "string"
-                    },
-                    "projectID": {
-                      "type": "string"
-                    },
-                    "registry": {
-                      "type": "string"
-                    },
                     "vintage": {
                       "type": "string"
                     }
@@ -979,11 +872,6 @@ export default {
                   "required": [
                     "id",
                     "key",
-                    "name",
-                    "methodology",
-                    "projectAddress",
-                    "projectID",
-                    "registry",
                     "vintage"
                   ]
                 }
@@ -1461,57 +1349,6 @@ export default {
               "key": {
                 "type": "string"
               },
-              "name": {
-                "type": "string"
-              },
-              "category": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "id"
-                    ]
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "country": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "id"
-                    ]
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "methodology": {
-                "type": "string"
-              },
-              "projectAddress": {
-                "type": "string"
-              },
-              "projectID": {
-                "type": "string"
-              },
-              "registry": {
-                "type": "string"
-              },
               "vintage": {
                 "type": "string"
               }
@@ -1519,11 +1356,6 @@ export default {
             "required": [
               "id",
               "key",
-              "name",
-              "methodology",
-              "projectAddress",
-              "projectID",
-              "registry",
               "vintage"
             ]
           }
@@ -1607,9 +1439,9 @@ export default {
             "type": "string"
           },
           "amount": {
-            "description": "Stringified 18 decimal BigNumber",
+            "description": "Quantity of credits purchased",
             "examples": [
-              "1000000000000000000"
+              "1.0"
             ],
             "type": "string"
           },
@@ -1679,9 +1511,9 @@ export default {
             ]
           },
           "price": {
-            "description": "Stringified 6 decimal BigNumber",
+            "description": "Total purchase price (USDC)",
             "examples": [
-              "1000000"
+              "5.0"
             ],
             "type": "string"
           }
@@ -1904,57 +1736,6 @@ export default {
                     "key": {
                       "type": "string"
                     },
-                    "name": {
-                      "type": "string"
-                    },
-                    "category": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "id"
-                          ]
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "country": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "id"
-                          ]
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "methodology": {
-                      "type": "string"
-                    },
-                    "projectAddress": {
-                      "type": "string"
-                    },
-                    "projectID": {
-                      "type": "string"
-                    },
-                    "registry": {
-                      "type": "string"
-                    },
                     "vintage": {
                       "type": "string"
                     }
@@ -1962,11 +1743,6 @@ export default {
                   "required": [
                     "id",
                     "key",
-                    "name",
-                    "methodology",
-                    "projectAddress",
-                    "projectID",
-                    "registry",
                     "vintage"
                   ]
                 }
@@ -2350,48 +2126,6 @@ export default {
     }
   },
   "paths": {
-    "/countries": {
-      "get": {
-        "summary": "Countries",
-        "description": "Retrieve an array containing the countries that carbon projects originate from",
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "id"
-                    ]
-                  }
-                },
-                "examples": [
-                  [
-                    {
-                      "id": "Brazil"
-                    },
-                    {
-                      "id": "Bulgaria"
-                    },
-                    {
-                      "id": "China"
-                    }
-                  ]
-                ]
-              }
-            }
-          }
-        }
-      }
-    },
     "/categories": {
       "get": {
         "summary": "Categories",
@@ -2425,6 +2159,48 @@ export default {
                     },
                     {
                       "id": "Other"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/countries": {
+      "get": {
+        "summary": "Countries",
+        "description": "Retrieve an array containing the countries that carbon projects originate from",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id"
+                    ]
+                  }
+                },
+                "examples": [
+                  [
+                    {
+                      "id": "Brazil"
+                    },
+                    {
+                      "id": "Bulgaria"
+                    },
+                    {
+                      "id": "China"
                     }
                   ]
                 ]
@@ -2511,7 +2287,7 @@ export default {
           },
           {
             "schema": {
-              "default": "1696209839",
+              "default": "1696288898",
               "type": "string"
             },
             "example": "1620000000",
@@ -2848,57 +2624,6 @@ export default {
                                     "key": {
                                       "type": "string"
                                     },
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "category": {
-                                      "anyOf": [
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "id": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "id"
-                                          ]
-                                        },
-                                        {
-                                          "type": "null"
-                                        }
-                                      ]
-                                    },
-                                    "country": {
-                                      "anyOf": [
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "id": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "id"
-                                          ]
-                                        },
-                                        {
-                                          "type": "null"
-                                        }
-                                      ]
-                                    },
-                                    "methodology": {
-                                      "type": "string"
-                                    },
-                                    "projectAddress": {
-                                      "type": "string"
-                                    },
-                                    "projectID": {
-                                      "type": "string"
-                                    },
-                                    "registry": {
-                                      "type": "string"
-                                    },
                                     "vintage": {
                                       "type": "string"
                                     }
@@ -2906,11 +2631,6 @@ export default {
                                   "required": [
                                     "id",
                                     "key",
-                                    "name",
-                                    "methodology",
-                                    "projectAddress",
-                                    "projectID",
-                                    "registry",
                                     "vintage"
                                   ]
                                 }
@@ -3020,7 +2740,7 @@ export default {
           },
           {
             "schema": {
-              "default": "1696209839",
+              "default": "1696288899",
               "type": "string"
             },
             "example": "1620000000",
@@ -3263,57 +2983,6 @@ export default {
                               "key": {
                                 "type": "string"
                               },
-                              "name": {
-                                "type": "string"
-                              },
-                              "category": {
-                                "anyOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "id"
-                                    ]
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "country": {
-                                "anyOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "id"
-                                    ]
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "methodology": {
-                                "type": "string"
-                              },
-                              "projectAddress": {
-                                "type": "string"
-                              },
-                              "projectID": {
-                                "type": "string"
-                              },
-                              "registry": {
-                                "type": "string"
-                              },
                               "vintage": {
                                 "type": "string"
                               }
@@ -3321,11 +2990,6 @@ export default {
                             "required": [
                               "id",
                               "key",
-                              "name",
-                              "methodology",
-                              "projectAddress",
-                              "projectID",
-                              "registry",
                               "vintage"
                             ]
                           }
@@ -4306,57 +3970,6 @@ export default {
                               "key": {
                                 "type": "string"
                               },
-                              "name": {
-                                "type": "string"
-                              },
-                              "category": {
-                                "anyOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "id"
-                                    ]
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "country": {
-                                "anyOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "id"
-                                    ]
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "methodology": {
-                                "type": "string"
-                              },
-                              "projectAddress": {
-                                "type": "string"
-                              },
-                              "projectID": {
-                                "type": "string"
-                              },
-                              "registry": {
-                                "type": "string"
-                              },
                               "vintage": {
                                 "type": "string"
                               }
@@ -4364,11 +3977,6 @@ export default {
                             "required": [
                               "id",
                               "key",
-                              "name",
-                              "methodology",
-                              "projectAddress",
-                              "projectID",
-                              "registry",
                               "vintage"
                             ]
                           }
@@ -4579,7 +4187,7 @@ export default {
             "schema": {
               "type": "string"
             },
-            "example": "0xcad9383fba33aaad6256304ef7b103f3f00b21afbaffbbff14423bf074b699e8",
+            "example": "0x2821a317b0166e40eff697c209c4534bbfa1c1fbd418255b2be24443b146a60f",
             "in": "path",
             "name": "id",
             "required": true,
@@ -4602,9 +4210,9 @@ export default {
                       "type": "string"
                     },
                     "amount": {
-                      "description": "Stringified 18 decimal BigNumber",
+                      "description": "Quantity of credits purchased",
                       "examples": [
-                        "1000000000000000000"
+                        "1.0"
                       ],
                       "type": "string"
                     },
@@ -4674,9 +4282,9 @@ export default {
                       ]
                     },
                     "price": {
-                      "description": "Stringified 6 decimal BigNumber",
+                      "description": "Total purchase price (USDC)",
                       "examples": [
-                        "1000000"
+                        "5.0"
                       ],
                       "type": "string"
                     }

--- a/carbonmark/components/CreateListing/Form/index.tsx
+++ b/carbonmark/components/CreateListing/Form/index.tsx
@@ -6,17 +6,14 @@ import { MINIMUM_TONNE_PRICE } from "lib/constants";
 import { AssetForListing } from "lib/types/carbonmark.types";
 import { useRouter } from "next/router";
 import { FC } from "react";
-import { SubmitHandler, useForm, useWatch } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { ProjectTokenDropDown } from "./ProjectTokenDropDown";
 import * as styles from "./styles";
 
 export type FormValues = {
+  amount: string;
+  unitPrice: string;
   tokenAddress: string;
-  totalAmountToSell: string;
-  singleUnitPrice: string;
-  tokenType: "1" | "2";
-  batches?: string;
-  batchPrices?: string;
 };
 
 type Props = {
@@ -25,33 +22,27 @@ type Props = {
   values: null | FormValues;
 };
 
-const defaultValues = {
+const defaultValues: FormValues = {
   tokenAddress: "",
-  totalAmountToSell: "",
-  singleUnitPrice: "",
-  tokenType: "",
+  amount: "",
+  unitPrice: "",
 };
 
 export const CreateListingForm: FC<Props> = (props) => {
   const { locale } = useRouter();
 
-  const { register, handleSubmit, formState, control, setValue } =
+  const { register, handleSubmit, formState, setValue, getValues } =
     useForm<FormValues>({
       defaultValues: {
         ...defaultValues,
         ...props.values,
         tokenAddress:
           props.values?.tokenAddress || props.assets[0].tokenAddress,
-        tokenType: props.values?.tokenType || props.assets[0].tokenType,
       },
     });
 
-  const selectedTokenAddress = useWatch({
-    name: "tokenAddress",
-    control,
-  });
   const selectedAsset =
-    props.assets.find((t) => t.tokenAddress === selectedTokenAddress) ||
+    props.assets.find((t) => t.tokenAddress === getValues("tokenAddress")) ||
     props.assets[0];
 
   const onSubmit: SubmitHandler<FormValues> = (values: FormValues) => {
@@ -62,14 +53,11 @@ export const CreateListingForm: FC<Props> = (props) => {
     <div className={styles.formContainer}>
       <div className={styles.inputsContainer}>
         <Text t="body1">
-          <Trans id="user.listing.form.input.select_project.label">
-            Select Project:
-          </Trans>
+          <Trans>Select asset:</Trans>
         </Text>
         <ProjectTokenDropDown
           onTokenSelect={(asset) => {
             setValue("tokenAddress", asset.tokenAddress);
-            setValue("tokenType", asset.tokenType);
           }}
           assets={props.assets}
           selectedAsset={selectedAsset}
@@ -78,24 +66,6 @@ export const CreateListingForm: FC<Props> = (props) => {
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className={styles.inputsContainer}>
           <InputField
-            id="tokenAddress"
-            inputProps={{
-              type: "hidden",
-              ...register("tokenAddress"),
-            }}
-            label={"token address"}
-            hideLabel
-          />
-          <InputField
-            id="tokenType"
-            inputProps={{
-              type: "hidden",
-              ...register("tokenType"),
-            }}
-            label={"Token Type"}
-            hideLabel
-          />
-          <InputField
             id="totalAmountToSell"
             inputProps={{
               placeholder: t({
@@ -103,7 +73,7 @@ export const CreateListingForm: FC<Props> = (props) => {
                 message: "How many do you want to sell",
               }),
               type: "number",
-              ...register("totalAmountToSell", {
+              ...register("amount", {
                 required: {
                   value: true,
                   message: t({
@@ -131,7 +101,7 @@ export const CreateListingForm: FC<Props> = (props) => {
               id: "user.edit.form.input.totalAmountToSell.label",
               message: `Total Amount`,
             })}
-            errorMessage={formState.errors.totalAmountToSell?.message}
+            errorMessage={formState.errors.amount?.message}
           />
           <Text t="body3" className={styles.availableAmount}>
             Available: {selectedAsset.balance}
@@ -139,18 +109,12 @@ export const CreateListingForm: FC<Props> = (props) => {
           <InputField
             id="singleUnitPrice"
             inputProps={{
-              placeholder: t({
-                id: "user.edit.form.input.singleUnitPrice.placeholder",
-                message: "USDC per ton",
-              }),
+              placeholder: t`USDC per unit (tonne)`,
               type: "number",
-              ...register("singleUnitPrice", {
+              ...register("unitPrice", {
                 required: {
                   value: true,
-                  message: t({
-                    id: "user.listing.form.input.singleUnitPrice.required",
-                    message: "Single Price is required",
-                  }),
+                  message: t`Unit price is required`,
                 },
                 pattern: {
                   // https://stackoverflow.com/questions/354044/what-is-the-best-u-s-currency-regex#:~:text=Number%3A%20Currency%20amount%20(cents%20optional)%20Optional%20thousands%20separators%3B%20optional%20two%2Ddigit%20fraction
@@ -172,7 +136,7 @@ export const CreateListingForm: FC<Props> = (props) => {
               id: "user.edit.form.input.singleUnitPrice.label",
               message: "Single Unit Price",
             })}
-            errorMessage={formState.errors.singleUnitPrice?.message}
+            errorMessage={formState.errors.unitPrice?.message}
           />
 
           <ButtonPrimary

--- a/carbonmark/components/CreateListing/styles.ts
+++ b/carbonmark/components/CreateListing/styles.ts
@@ -8,7 +8,6 @@ export const centerContent = css`
 `;
 
 export const formatParagraph = css`
-  p {
-    margin-bottom: 1em;
-  }
+  display: grid;
+  gap: 1.6rem;
 `;

--- a/carbonmark/components/Transaction/index.tsx
+++ b/carbonmark/components/Transaction/index.tsx
@@ -58,7 +58,6 @@ export const Transaction: FC<Props> = (props) => {
       {view === "approve" && (
         <Approve
           amount={props.approvalValue || props.amount}
-          price={props.price}
           description={props.approvalText}
           spenderAddress={props.spenderAddress}
           onApproval={props.onApproval}

--- a/carbonmark/components/pages/Portfolio/AssetProject/index.tsx
+++ b/carbonmark/components/pages/Portfolio/AssetProject/index.tsx
@@ -10,6 +10,7 @@ import { TextInfoTooltip } from "components/TextInfoTooltip";
 import { Vintage } from "components/Vintage";
 import { createProjectLink } from "lib/createUrls";
 import { formatToTonnes } from "lib/formatNumbers";
+import { getFeatureFlag } from "lib/getFeatureFlag";
 import { LO } from "lib/luckyOrange";
 import { AssetForListing } from "lib/types/carbonmark.types";
 import Link from "next/link";
@@ -68,15 +69,22 @@ export const AssetProject: FC<Props> = (props) => {
             LO.track("Retire: Retire Button Clicked");
           }}
         />
-        <TextInfoTooltip tooltip="New listings are temporarily disabled while we upgrade our marketplace to a new version.">
-          <div>
-            <CarbonmarkButton
-              label={<Trans>Sell</Trans>}
-              onClick={props.onSell}
-              disabled={true}
-            />
-          </div>
-        </TextInfoTooltip>
+        {getFeatureFlag("createListing") ? (
+          <CarbonmarkButton
+            label={<Trans>Sell</Trans>}
+            onClick={props.onSell}
+          />
+        ) : (
+          <TextInfoTooltip tooltip="New listings are temporarily disabled while we upgrade our marketplace to a new version.">
+            <div>
+              <CarbonmarkButton
+                label={<Trans>Sell</Trans>}
+                onClick={props.onSell}
+                disabled={true}
+              />
+            </div>
+          </TextInfoTooltip>
+        )}
       </div>
     </Card>
   );

--- a/carbonmark/components/pages/Purchases/index.tsx
+++ b/carbonmark/components/pages/Purchases/index.tsx
@@ -8,7 +8,7 @@ import { PageHead } from "components/PageHead";
 import { Text } from "components/Text";
 import { urls } from "lib/constants";
 import { createProjectLink } from "lib/createUrls";
-import { formatBigToPrice, formatBigToTonnes } from "lib/formatNumbers";
+import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { Purchase } from "lib/types/carbonmark.types";
 import { NextPage } from "next";
 import Link from "next/link";
@@ -23,7 +23,7 @@ export type PageProps = {
 export const PurchaseReceipt: NextPage<PageProps> = (props) => {
   const { locale } = useRouter();
   const amount =
-    props.purchase?.amount && formatBigToTonnes(props.purchase.amount, locale);
+    props.purchase?.amount && formatToTonnes(props.purchase.amount, locale);
   const metaDescription = props.purchase
     ? t`${amount} tonnes were purchased for project ${props.purchase?.listing?.project?.key}`
     : t`View the project details and other info for this purchase.`;
@@ -103,7 +103,7 @@ export const PurchaseReceipt: NextPage<PageProps> = (props) => {
                             <Trans>Quantity purchased:</Trans>
                           </Text>
                           <Text t="body1">
-                            {formatBigToTonnes(props.purchase.amount, locale)}
+                            {formatToTonnes(props.purchase.amount, locale)}
                           </Text>
                         </div>
 
@@ -112,7 +112,7 @@ export const PurchaseReceipt: NextPage<PageProps> = (props) => {
                             <Trans>Final price</Trans>
                           </Text>
                           <Text t="body1">
-                            {formatBigToPrice(props.purchase.price, locale)}
+                            {formatToPrice(props.purchase.price, locale)}
                           </Text>
                         </div>
                       </div>

--- a/carbonmark/components/pages/Users/Listing/index.tsx
+++ b/carbonmark/components/pages/Users/Listing/index.tsx
@@ -33,12 +33,12 @@ export const Listing: FC<Props> = (props) => {
       </div>
       <Link href={createProjectLink(project)}>
         <Text t="h4" className={styles.link}>
-          {project.name}
+          {project.name || `${project.key}-${project.vintage}`}
         </Text>
       </Link>
       <div className={styles.image}>
         <Link href={createProjectLink(project)}>
-          <ProjectImage category={category} />
+          <ProjectImage category={category || "Other"} />
         </Link>
       </div>
       <div className={styles.amounts}>

--- a/carbonmark/components/pages/Users/Listing/index.tsx
+++ b/carbonmark/components/pages/Users/Listing/index.tsx
@@ -22,7 +22,7 @@ type Props = {
 export const Listing: FC<Props> = (props) => {
   const { locale } = useRouter();
   const project = props.listing.project;
-  const category = project?.category?.id as CategoryName;
+  const category = project?.category as CategoryName;
 
   return (
     <Card>

--- a/carbonmark/components/pages/Users/Listing/index.tsx
+++ b/carbonmark/components/pages/Users/Listing/index.tsx
@@ -6,7 +6,7 @@ import { ProjectKey } from "components/ProjectKey";
 import { Text } from "components/Text";
 import { Vintage } from "components/Vintage";
 import { createProjectLink } from "lib/createUrls";
-import { formatBigToPrice, formatBigToTonnes } from "lib/formatNumbers";
+import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { CategoryName, Listing as ListingT } from "lib/types/carbonmark.types";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -43,13 +43,13 @@ export const Listing: FC<Props> = (props) => {
       </div>
       <div className={styles.amounts}>
         <Text t="h4">
-          {formatBigToPrice(props.listing.singleUnitPrice, locale)}
+          {formatToPrice(props.listing.singleUnitPrice, locale)}
         </Text>
         <Text t="body1">
           <Trans id="seller.listing.quantity_available">
             Quantity Available:
           </Trans>{" "}
-          {formatBigToTonnes(props.listing.leftToSell, locale)}
+          {formatToTonnes(props.listing.leftToSell, locale)}
         </Text>
       </div>
       {props.children}

--- a/carbonmark/components/pages/Users/SellerConnected/Forms/EditListing.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/Forms/EditListing.tsx
@@ -1,10 +1,9 @@
-import { formatTonnes, formatUnits } from "@klimadao/lib/utils";
+import { formatTonnes } from "@klimadao/lib/utils";
 import { Trans, t } from "@lingui/macro";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { Text } from "components/Text";
 import { InputField } from "components/shared/Form/InputField";
 import { MINIMUM_TONNE_PRICE } from "lib/constants";
-import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
 import { Listing } from "lib/types/carbonmark.types";
 import { useRouter } from "next/router";
 import { FC } from "react";
@@ -35,7 +34,7 @@ export const EditListing: FC<Props> = (props) => {
   const locale = router.locale || "en";
 
   const listedQuantity = formatTonnes({
-    amount: formatUnits(props.listing.leftToSell),
+    amount: props.listing.leftToSell,
     locale,
   });
   const totalAvailableQuantity = formatTonnes({
@@ -46,11 +45,8 @@ export const EditListing: FC<Props> = (props) => {
   const { register, handleSubmit, formState } = useForm<FormValues>({
     defaultValues: {
       tokenAddress: props.listing.tokenAddress,
-      newQuantity: formatUnits(props.listing.leftToSell),
-      newSingleUnitPrice: formatUnits(
-        props.listing.singleUnitPrice,
-        getTokenDecimals("usdc")
-      ),
+      newQuantity: props.listing.leftToSell,
+      newSingleUnitPrice: props.listing.singleUnitPrice,
       ...props.values,
     },
   });

--- a/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
@@ -5,8 +5,6 @@ import { Modal } from "components/shared/Modal";
 import { Spinner } from "components/shared/Spinner";
 import { Text } from "components/Text";
 import { Transaction } from "components/Transaction";
-import { parseUnits } from "ethers-v6";
-import { formatUnits } from "ethers/lib/utils";
 import {
   approveTokenSpend,
   deleteListingTransaction,
@@ -52,12 +50,9 @@ export const ListingEditable: FC<Props> = (props) => {
   const [allowanceValue, setAllowanceValue] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const existingQuantityBN = BigInt(listingToEdit?.leftToSell || "0");
-  const newQuantityBN = parseUnits(inputValues?.newQuantity || "1", 18);
-  const newQuantityDelta = formatUnits(
-    BigInt(newQuantityBN) - BigInt(existingQuantityBN),
-    18
-  );
+  const existingQuantityBN = Number(listingToEdit?.leftToSell || "0");
+  const newQuantityBN = Number(inputValues?.newQuantity || "1");
+  const newQuantityDelta = newQuantityBN - existingQuantityBN;
 
   const isPending =
     status?.statusType === "userConfirmation" ||
@@ -96,7 +91,7 @@ export const ListingEditable: FC<Props> = (props) => {
   };
 
   const hasApproval = () => {
-    if (Number(newQuantityDelta) <= 0) {
+    if (newQuantityDelta <= 0) {
       // we only need an approval when tonnes are being added
       return true;
     }
@@ -115,7 +110,7 @@ export const ListingEditable: FC<Props> = (props) => {
         tokenAddress: inputValues.tokenAddress,
         spender: "carbonmark",
         signer: provider.getSigner(),
-        value: newQuantityDelta,
+        value: newQuantityDelta.toString(),
         onStatus: onUpdateStatus,
       });
     } catch (e) {

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -1,3 +1,4 @@
+import { useWeb3 } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import AddIcon from "@mui/icons-material/Add";
 import { CarbonmarkButton } from "components/CarbonmarkButton";
@@ -32,8 +33,11 @@ type Props = {
 
 export const SellerConnected: FC<Props> = (props) => {
   const scrollToRef = useRef<null | HTMLDivElement>(null);
-
-  const { carbonmarkUser, isLoading, mutate } = useFetchUser(props.userAddress);
+  const { networkLabel } = useWeb3();
+  const { carbonmarkUser, isLoading, mutate } = useFetchUser(
+    props.userAddress,
+    { network: networkLabel }
+  );
   const [isPending, setIsPending] = useState(false);
 
   const [assetsData, setAssetsData] = useState<AssetForListing[] | null>(null);

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -13,6 +13,7 @@ import { useFetchUser } from "hooks/useFetchUser";
 import { addProjectsToAssets } from "lib/actions";
 import { activityIsAdded, getUser, getUserUntil } from "lib/api";
 import { getAssetsWithProjectTokens } from "lib/getAssetsData";
+import { getFeatureFlag } from "lib/getFeatureFlag";
 import { getActiveListings, getSortByUpdateListings } from "lib/listingsGetter";
 import { AssetForListing, User } from "lib/types/carbonmark.types";
 import { notNil } from "lib/utils/functional.utils";
@@ -177,28 +178,42 @@ export const SellerConnected: FC<Props> = (props) => {
             </Text>
           )}
         </div>
-        {isCarbonmarkUser && (
-          <TextInfoTooltip tooltip="New listings are temporarily disabled while we upgrade our marketplace to a new version.">
-            <div>
-              <CarbonmarkButton
-                label={
-                  <>
-                    <span className={styles.addListingButtonText}>
-                      <Trans>Create New Listing</Trans>
-                    </span>
-                    <span className={styles.addListingButtonIcon}>
-                      <AddIcon />
-                    </span>
-                  </>
-                }
-                disabled={true} // disabled until carbonmark V2
-                onClick={() => {
-                  // setShowCreateListingModal(true)
-                }}
-              />
-            </div>
-          </TextInfoTooltip>
-        )}
+        {isCarbonmarkUser &&
+          (getFeatureFlag("createListing") ? (
+            <CarbonmarkButton
+              label={
+                <>
+                  <span className={styles.addListingButtonText}>
+                    <Trans>Create New Listing</Trans>
+                  </span>
+                  <span className={styles.addListingButtonIcon}>
+                    <AddIcon />
+                  </span>
+                </>
+              }
+              onClick={() => {
+                setShowCreateListingModal(true);
+              }}
+            />
+          ) : (
+            <TextInfoTooltip tooltip="New listings are temporarily disabled while we upgrade our marketplace to a new version.">
+              <div>
+                <CarbonmarkButton
+                  label={
+                    <>
+                      <span className={styles.addListingButtonText}>
+                        <Trans>Create New Listing</Trans>
+                      </span>
+                      <span className={styles.addListingButtonIcon}>
+                        <AddIcon />
+                      </span>
+                    </>
+                  }
+                  disabled={true} // disabled until carbonmark V2
+                />
+              </div>
+            </TextInfoTooltip>
+          ))}
       </div>
 
       <TwoColLayout>

--- a/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
@@ -19,8 +19,10 @@ type Props = {
 };
 
 export const SellerUnconnected: FC<Props> = (props) => {
-  const { address, isConnected, toggleModal } = useWeb3();
-  const { carbonmarkUser } = useFetchUser(props.userAddress);
+  const { address, isConnected, toggleModal, networkLabel } = useWeb3();
+  const { carbonmarkUser } = useFetchUser(props.userAddress, {
+    network: networkLabel,
+  });
 
   const activeListings = getActiveListings(carbonmarkUser?.listings ?? []);
   const hasListings = !!activeListings.length;

--- a/carbonmark/lib/actions.ts
+++ b/carbonmark/lib/actions.ts
@@ -337,7 +337,7 @@ export const addProjectsToAssets = async (params: {
         resolvedAssets.push({
           tokenAddress: asset.token.id,
           tokenName: asset.token.name,
-          balance: ethersFormatUnits(asset.amount, asset.token.decimals),
+          balance: asset.amount,
           tokenType: getTokenType(asset),
           project,
         });
@@ -366,7 +366,7 @@ export const createCompositeAsset = (
 
   const compositeAsset: AssetForRetirement = {
     tokenName: asset.token.name,
-    balance: ethersFormatUnits(asset.amount, asset.token.decimals),
+    balance: asset.amount,
     tokenType: getTokenType(asset),
     tokenSymbol: asset.token.symbol,
     project,

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -26,7 +26,7 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-export const API_PROD_URL = "https://v2.0.0-1.api.carbonmark.com";
+export const API_PROD_URL = "https://v2.0.0-3.api.carbonmark.com";
 
 /**
  * Optional preview URL can be provided via env var.

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -56,6 +56,10 @@ export const MINIMUM_TONNE_PRICE = 0.1;
 export const CARBONMARK_FEE = 0.0; // 0%
 /** No special chars */
 export const VALID_HANDLE_REGEX = /^[a-zA-Z0-9]+$/;
+/** Default number of days until a listing expires */
+export const DEFAULT_EXPIRATION_DAYS = 90;
+/** Default minimum fill for a listing */
+export const DEFAULT_MIN_FILL_AMOUNT = 1;
 
 export const getConnectErrorStrings = () => ({
   default: t({

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -45,7 +45,7 @@ const API_PREVIEW_URL = process.env.NEXT_PUBLIC_USE_PREVIEW_CARBONMARK_API
 const API_DEVELOPMENT_URL =
   process.env.NEXT_PUBLIC_CARBONMARK_API_URL ?? API_PREVIEW_URL;
 
-const ENVIRONMENT: Environment =
+export const ENVIRONMENT: Environment =
   new LogicTable({
     production: IS_PRODUCTION,
     development: IS_LOCAL_DEVELOPMENT,
@@ -74,10 +74,19 @@ export const getConnectErrorStrings = () => ({
 });
 
 export const config = {
+  // todo, deprecate in favor of networks e.g. "mumbai", "polygon"
   networks: {
     production: "mainnet",
     preview: "mainnet",
     development: "mainnet",
+  },
+  featureFlags: {
+    /** Ability to create listings from assets in portfolio */
+    createListing: {
+      production: false,
+      preview: true,
+      development: true,
+    },
   },
   urls: {
     baseUrl: {

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -26,7 +26,7 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-export const API_PROD_URL = "https://v2.0.0-5.api.carbonmark.com";
+export const API_PROD_URL = "https://v2.0.0-6.api.carbonmark.com";
 
 /**
  * Optional preview URL can be provided via env var.

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -26,7 +26,7 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-export const API_PROD_URL = "https://v2.0.0-3.api.carbonmark.com";
+export const API_PROD_URL = "https://v2.0.0-4.api.carbonmark.com";
 
 /**
  * Optional preview URL can be provided via env var.

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -26,7 +26,7 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-export const API_PROD_URL = "https://v2.0.0-4.api.carbonmark.com";
+export const API_PROD_URL = "https://v2.0.0-5.api.carbonmark.com";
 
 /**
  * Optional preview URL can be provided via env var.

--- a/carbonmark/lib/formatNumbers.ts
+++ b/carbonmark/lib/formatNumbers.ts
@@ -1,12 +1,4 @@
-import { formatUnits, trimWithLocale } from "@klimadao/lib/utils";
-import { BigNumberish } from "ethers";
-import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
-
-/** USDC only */
-export const formatBigToPrice = (value: BigNumberish, locale = "en") => {
-  const toNumber = Number(formatUnits(value, getTokenDecimals("usdc")));
-  return formatToPrice(toNumber, locale);
-};
+import { trimWithLocale } from "@klimadao/lib/utils";
 
 export const formatToPrice = (
   value: string | number,
@@ -31,11 +23,6 @@ export const formatToPrice = (
     maximumFractionDigits: currencyFractionDigits,
     minimumFractionDigits: 2,
   });
-};
-
-export const formatBigToTonnes = (value: BigNumberish, locale = "en") => {
-  const toNumber = formatUnits(value, 18);
-  return formatToTonnes(toNumber, locale);
 };
 
 export const formatToTonnes = (

--- a/carbonmark/lib/getFeatureFlag.ts
+++ b/carbonmark/lib/getFeatureFlag.ts
@@ -1,0 +1,11 @@
+import { config, ENVIRONMENT } from "lib/constants";
+
+type Flag = keyof typeof config.featureFlags;
+
+/**
+ * Returns a boolean for a given feature flag, using current build environment
+ * Feature flags are defined in the application config (currently in lib/constants.ts)
+ */
+export const getFeatureFlag = (flag: Flag): boolean => {
+  return config.featureFlags[flag][ENVIRONMENT];
+};


### PR DESCRIPTION
## Description

- Add featureFlags to app config object
  - Add createListing as a feature flag, disabled on production
  - The Create Listing buttons on /portfolio and /user pages both respect the feature flag.
- Fix createListing plumbing in the frontend to support testnet and use the new ABI. I successfully created a testnet listing from my portfolio 🚀 🎉 
- Change some variable names in CreateListing modal to match those defined in the Carbonmark v2 ABI.json spec
- Update modal text to be more concise.
- Remove "price" from the "approve" step because price has nothing to do with approval.

## Related Ticket
Part of #1494

## Changes
### New modal text
![image](https://github.com/KlimaDAO/klimadao/assets/88635679/6a2fc815-1f8f-4203-98a8-c5127e8c6f2f)|
![image](https://github.com/KlimaDAO/klimadao/assets/88635679/3456fd9e-7df5-4edb-845e-3c1c963d142a)|
