### PR TITLE
fix button layout on off-vs-on page

### DIFF
--- a/carbonmark-data/components/pages/offVsOnChain/OffVsOnChainClientWrapper/index.tsx
+++ b/carbonmark-data/components/pages/offVsOnChain/OffVsOnChainClientWrapper/index.tsx
@@ -3,6 +3,7 @@ import OptionsSwitcher from "components/OptionsSwitcher";
 import { getCreditsStatusOptions } from "lib/charts/options";
 import { Status } from "lib/charts/types";
 import { ReactNode, useState } from "react";
+import styles from "./styles.module.scss";
 /**
  * A UI layout component to position Retirement Trends pages content
  */
@@ -25,6 +26,7 @@ export default function OffVsOnChainClientWrapper(props: {
   return (
     <>
       <OptionsSwitcher
+        className={styles.centered}
         options={getCreditsStatusOptions()}
         onSelectionChange={setOptionKey}
       ></OptionsSwitcher>

--- a/carbonmark-data/components/pages/offVsOnChain/OffVsOnChainClientWrapper/styles.module.scss
+++ b/carbonmark-data/components/pages/offVsOnChain/OffVsOnChainClientWrapper/styles.module.scss
@@ -1,0 +1,4 @@
+.centered {
+  display: flex;
+  margin: 1rem auto 2rem auto;
+}


### PR DESCRIPTION
## Description

This PR centers the segmented button on the off-vs-on chain carbon page

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
