### PR TITLE
Carbonmark values format fixes

### DIFF
--- a/carbonmark-data/app/[locale]/overview/page.tsx
+++ b/carbonmark-data/app/[locale]/overview/page.tsx
@@ -30,8 +30,8 @@ export default function OverviewPage() {
             <HistoricalPriceCard></HistoricalPriceCard>
           </div>
           <div className={layout.cardRow}>
-            <DailyCarbonSupplyOverviewCard></DailyCarbonSupplyOverviewCard>
-            <DailyCarbonRetirementsCard></DailyCarbonRetirementsCard>
+            <DailyCarbonSupplyOverviewCard bottomOptionsPosition="left"></DailyCarbonSupplyOverviewCard>
+            <DailyCarbonRetirementsCard bottomOptionsPosition="left"></DailyCarbonRetirementsCard>
           </div>
         </div>
         <div className={layout.cardStackedRows}>

--- a/carbonmark-data/components/ChangeLanguageButton/index.tsx
+++ b/carbonmark-data/components/ChangeLanguageButton/index.tsx
@@ -4,6 +4,10 @@ import { t } from "@lingui/macro";
 import Language from "@mui/icons-material/Language";
 import { Button } from "@mui/material";
 import Tippy from "@tippyjs/react";
+import { locales } from "lib/i18n";
+import { usePathname } from "next-intl/client";
+import Link from "next-intl/link";
+import { useSearchParams } from "next/navigation";
 import { FC, useState } from "react";
 import styles from "./styles.module.scss";
 
@@ -11,18 +15,22 @@ export const ChangeLanguageButton: FC<{ className?: string }> = ({
   className,
 }) => {
   const [showTooltip, setShowTooltip] = useState(false);
+  const searchParams = useSearchParams();
+  let href = usePathname();
+  if (`${searchParams}`) {
+    href = `${href}?${searchParams}`;
+  }
 
   return (
     <Tippy
       className={styles.tooltip}
       content={
-        <div>
-          <div>
-            <Button onClick={() => setShowTooltip(false)}>English</Button>
-          </div>
-          <div>
-            <Button onClick={() => setShowTooltip(false)}>Deutsch</Button>
-          </div>
+        <div aria-describedby="tooltip-content">
+          {Object.keys(locales).map((localeKey) => (
+            <Link key={localeKey} locale={localeKey} href={href}>
+              <Button>{locales[localeKey].label}</Button>
+            </Link>
+          ))}
         </div>
       }
       interactive={true}

--- a/carbonmark-data/components/ChangeLanguageButton/index.tsx
+++ b/carbonmark-data/components/ChangeLanguageButton/index.tsx
@@ -28,7 +28,7 @@ export const ChangeLanguageButton: FC<{ className?: string }> = ({
         <div aria-describedby="tooltip-content">
           {Object.keys(locales).map((localeKey) => (
             <Link key={localeKey} locale={localeKey} href={href}>
-              <Button>{locales[localeKey].label}</Button>
+              {locales[localeKey].label}
             </Link>
           ))}
         </div>

--- a/carbonmark-data/components/ChangeLanguageButton/styles.module.scss
+++ b/carbonmark-data/components/ChangeLanguageButton/styles.module.scss
@@ -31,30 +31,13 @@
     }
   }
 
-  .tippy-content {
+  div[aria-describedby="tooltip-content"] {
     padding: 0.5rem 0;
+    display: flex;
+    flex-direction: column;
 
     button {
       box-shadow: none;
     }
-  }
-
-  .tippy-arrow {
-    display: none;
-  }
-}
-
-.menuItem {
-  @include body1;
-  padding: 0;
-  height: 4.4rem;
-  align-items: center;
-
-  &:hover {
-    color: var(--bright-blue);
-  }
-
-  &[data-active="true"] {
-    color: var(--bright-blue);
   }
 }

--- a/carbonmark-data/components/cards/ChartCard/index.tsx
+++ b/carbonmark-data/components/cards/ChartCard/index.tsx
@@ -10,9 +10,11 @@ import layout from "theme/layout.module.scss";
 import styles from "./styles.module.scss";
 
 export type DetailUrlPosition = "top" | "bottom" | "none";
+export type BottomOptionsPosition = "left" | "center";
 export type CardProps = {
   isDetailPage?: boolean;
   centerTitle?: boolean;
+  bottomOptionsPosition?: BottomOptionsPosition;
 };
 /**
  * A UI layout component to position content in a white card with hyperlinks and title.
@@ -24,21 +26,22 @@ export type CardProps = {
  * isDetailPage: Is this card displayed on a detail page
  * topOptions: Options to be displayed at the top of the card
  * bottomOptions: Options to be displayed at the bottom of the card
+ * bottomOptionsPosition: Position of the bottom options
  * isColumnCard: Is this card used in a column? In this case there will be no constraint on the card height.
  */
-export default function ChartCard<T extends Key, B extends Key>(props: {
-  charts?: Record<string, React.ReactNode>;
-  chart?: React.ReactNode;
-  title: string;
-  centerTitle?: boolean;
-  detailUrl?: string;
-  detailUrlPosition?: DetailUrlPosition;
-  isDetailPage?: boolean;
-  topOptions?: Options<T>;
-  bottomOptions?: Options<B>;
-  // Todo: It would be nice if the component could detect it was inside a 'ChartRow'
-  isColumnCard?: boolean;
-}) {
+export default function ChartCard<T extends Key, B extends Key>(
+  props: {
+    charts?: Record<string, React.ReactNode>;
+    chart?: React.ReactNode;
+    title: string;
+    detailUrl?: string;
+    detailUrlPosition?: DetailUrlPosition;
+    topOptions?: Options<T>;
+    bottomOptions?: Options<B>;
+    // Todo: It would be nice if the component could detect it was inside a 'ChartRow'
+    isColumnCard?: boolean;
+  } & CardProps
+) {
   const [topOptionKey, setTopOptionKey] = useState<T | undefined>(
     props.topOptions ? props.topOptions[0].value : undefined
   );
@@ -48,6 +51,7 @@ export default function ChartCard<T extends Key, B extends Key>(props: {
   const isDetailPage = props.isDetailPage || false;
   const roleDescription = isDetailPage ? "detailPage" : "mainPage";
   const detailUrlPosition = props.detailUrlPosition || "top";
+  const bottomOptionsPosition = props.bottomOptionsPosition || "center";
   let detailUrlComponent = <></>;
   if (props.detailUrl && !isDetailPage) {
     detailUrlComponent = (
@@ -88,14 +92,21 @@ export default function ChartCard<T extends Key, B extends Key>(props: {
       return props.charts[displayedKey] || props.charts["default"] || <></>;
     }
   }
-  let className = styles.cardContainer;
+  // Card class computation
+  let cardClassName = styles.cardContainer;
   if (props.isColumnCard) {
   } else {
-    className = `${className} ${styles.rowCardContainer}`;
+    cardClassName = `${cardClassName} ${styles.rowCardContainer}`;
+  }
+
+  // Footer class computation
+  let footerClassName = styles.cardFooter;
+  if (bottomOptionsPosition == "center") {
+    footerClassName = `${footerClassName} ${styles.overlapLegend}`;
   }
 
   return (
-    <div className={className} aria-roledescription={roleDescription}>
+    <div className={cardClassName} aria-roledescription={roleDescription}>
       <div className={styles.cardHeader}>
         <h2 className={cardHeaderTitleStyle}>{props.title}</h2>
         {props.topOptions && (
@@ -111,7 +122,7 @@ export default function ChartCard<T extends Key, B extends Key>(props: {
       <div className={styles.cardContent}>
         <Suspense fallback={<Skeleton />}>{displayedChart()}</Suspense>
       </div>
-      <div className={styles.cardFooter}>
+      <div className={footerClassName}>
         {props.topOptions && (
           <div className={styles.cardFooterSwitcher}>
             <OptionsSwitcher

--- a/carbonmark-data/components/cards/ChartCard/styles.module.scss
+++ b/carbonmark-data/components/cards/ChartCard/styles.module.scss
@@ -81,12 +81,14 @@
   display: flex;
   width: 100%;
   justify-content: space-between;
+}
 
+.overlapLegend {
   @include desktop {
     margin: 0;
     justify-content: center;
     position: absolute;
-    bottom: 0;
+    bottom: 1.3rem;
     left: 0;
   }
 }

--- a/carbonmark-data/components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx
+++ b/carbonmark-data/components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx
@@ -88,6 +88,7 @@ function RetiredCreditsChart(props: {
         <KPieChart
           data={data}
           configuration={configuration}
+          showTooltip={false}
           legendContent={
             <RetiredCreditsLegendContent
               retired={props.retired}

--- a/carbonmark-data/components/charts/helpers/KAreaChart/index.tsx
+++ b/carbonmark-data/components/charts/helpers/KAreaChart/index.tsx
@@ -12,7 +12,7 @@ import {
 
 /** FIXME: Refactor to KlimaAreaChart */
 export default function KAreaChart<T extends object>(props: ChartProps<T>) {
-  const LocalLegendProps =
+  const localLegendProps =
     props.LegendProps ||
     Object.assign(
       {},
@@ -26,7 +26,7 @@ export default function KAreaChart<T extends object>(props: ChartProps<T>) {
         <XAxis {...getXAxisProps(props)} />
         <YAxis {...getYAxisProps(props)} />
         <Tooltip {...getKlimaTooltipProps(props)} />
-        <Legend {...LocalLegendProps} />
+        <Legend {...localLegendProps} />
         {KlimaStackedAreas(props.configuration)}
       </AreaChart>
     </ChartWrapper>

--- a/carbonmark-data/components/charts/helpers/KAreaChart/index.tsx
+++ b/carbonmark-data/components/charts/helpers/KAreaChart/index.tsx
@@ -3,6 +3,7 @@ import { KlimaLegendProps, KlimaStackedAreas } from "components/charts/helpers";
 import { AreaChart, Legend, Tooltip, XAxis, YAxis } from "recharts";
 import ChartWrapper from "../ChartWrapper";
 import {
+  BOTTOM_LEFT_LEGEND_PROPS,
   ChartProps,
   getKlimaTooltipProps,
   getXAxisProps,
@@ -13,12 +14,11 @@ import {
 export default function KAreaChart<T extends object>(props: ChartProps<T>) {
   const LocalLegendProps =
     props.LegendProps ||
-    Object.assign({}, KlimaLegendProps(props.configuration), {
-      layout: "horizontal",
-      verticalAlign: "bottom",
-      align: "left",
-      wrapperStyle: { marginLeft: "40px", paddingTop: "20px" },
-    });
+    Object.assign(
+      {},
+      KlimaLegendProps(props.configuration),
+      BOTTOM_LEFT_LEGEND_PROPS
+    );
 
   return (
     <ChartWrapper data={props.data} noDataText={props.noDataText}>

--- a/carbonmark-data/components/charts/helpers/KBarChart/index.tsx
+++ b/carbonmark-data/components/charts/helpers/KBarChart/index.tsx
@@ -12,7 +12,7 @@ import {
 
 /** FIXME: Refactor to KlimaBarChart */
 export default function KBarChart<T extends object>(props: ChartProps<T>) {
-  const LocalLegendProps =
+  const localLegendProps =
     props.LegendProps ||
     Object.assign(
       {},
@@ -25,7 +25,7 @@ export default function KBarChart<T extends object>(props: ChartProps<T>) {
         {props.XAxis && <XAxis {...getXAxisProps(props)} />}
         {props.YAxis && <YAxis {...getYAxisProps(props)} />}
         <Tooltip {...getKlimaTooltipProps(props)} />
-        <Legend {...LocalLegendProps} />
+        <Legend {...localLegendProps} />
         {KlimaStackedBars(props.configuration)}
       </BarChart>
     </ChartWrapper>

--- a/carbonmark-data/components/charts/helpers/KBarChart/index.tsx
+++ b/carbonmark-data/components/charts/helpers/KBarChart/index.tsx
@@ -3,6 +3,7 @@ import { KlimaLegendProps, KlimaStackedBars } from "components/charts/helpers";
 import { BarChart, Legend, Tooltip, XAxis, YAxis } from "recharts";
 import ChartWrapper from "../ChartWrapper";
 import {
+  BOTTOM_LEFT_LEGEND_PROPS,
   ChartProps,
   getKlimaTooltipProps,
   getXAxisProps,
@@ -13,12 +14,11 @@ import {
 export default function KBarChart<T extends object>(props: ChartProps<T>) {
   const LocalLegendProps =
     props.LegendProps ||
-    Object.assign({}, KlimaLegendProps(props.configuration), {
-      layout: "horizontal",
-      verticalAlign: "bottom",
-      align: "left",
-      wrapperStyle: { marginLeft: "40px", paddingTop: "20px" },
-    });
+    Object.assign(
+      {},
+      KlimaLegendProps(props.configuration),
+      BOTTOM_LEFT_LEGEND_PROPS
+    );
   return (
     <ChartWrapper data={props.data} noDataText={props.noDataText}>
       <BarChart data={props.data} barCategoryGap={"5%"}>

--- a/carbonmark-data/components/charts/helpers/KLineChart/index.tsx
+++ b/carbonmark-data/components/charts/helpers/KLineChart/index.tsx
@@ -12,7 +12,7 @@ import {
 
 /** FIXME: Refactor to KlimaLineChart */
 export default function KLineChart<T extends object>(props: ChartProps<T>) {
-  const LocalLegendProps =
+  const localLegendProps =
     props.LegendProps ||
     Object.assign(
       {},
@@ -26,7 +26,7 @@ export default function KLineChart<T extends object>(props: ChartProps<T>) {
         <XAxis {...getXAxisProps(props)} />
         <YAxis {...getYAxisProps(props)} />
         <Tooltip {...getKlimaTooltipProps(props)} />
-        <Legend {...LocalLegendProps} />
+        <Legend {...localLegendProps} />
         {KlimaLines(props.configuration)}
       </LineChart>
     </ChartWrapper>

--- a/carbonmark-data/components/charts/helpers/KLineChart/index.tsx
+++ b/carbonmark-data/components/charts/helpers/KLineChart/index.tsx
@@ -3,6 +3,7 @@ import { KlimaLegendProps, KlimaLines } from "components/charts/helpers";
 import { Legend, LineChart, Tooltip, XAxis, YAxis } from "recharts";
 import ChartWrapper from "../ChartWrapper";
 import {
+  BOTTOM_LEFT_LEGEND_PROPS,
   ChartProps,
   getKlimaTooltipProps,
   getXAxisProps,
@@ -13,12 +14,11 @@ import {
 export default function KLineChart<T extends object>(props: ChartProps<T>) {
   const LocalLegendProps =
     props.LegendProps ||
-    Object.assign({}, KlimaLegendProps(props.configuration), {
-      layout: "horizontal",
-      verticalAlign: "bottom",
-      align: "left",
-      wrapperStyle: { marginLeft: "40px", paddingTop: "20px" },
-    });
+    Object.assign(
+      {},
+      KlimaLegendProps(props.configuration),
+      BOTTOM_LEFT_LEGEND_PROPS
+    );
 
   return (
     <ChartWrapper data={props.data} noDataText={props.noDataText}>

--- a/carbonmark-data/components/charts/helpers/KPieChart/index.tsx
+++ b/carbonmark-data/components/charts/helpers/KPieChart/index.tsx
@@ -17,6 +17,7 @@ interface Props<CI extends { quantity: number }, T extends object> {
   LegendProps?: Omit<LegendProps, "ref">;
   showLegend?: boolean;
   showPercentageInLegend?: boolean;
+  showTooltip?: boolean;
   legendContent?: ContentType;
   noDataText?: string;
   YAxis?: YAxisType;
@@ -55,7 +56,7 @@ export default function KPieChart<
     return record;
   });
   // Conpute legend props
-  const LocalLegendProps =
+  const localLegendProps =
     props.LegendProps ||
     Object.assign({}, KlimaLegendProps(configuration), {
       verticalAlign: "middle",
@@ -63,6 +64,8 @@ export default function KPieChart<
       layout: "vertical",
     });
   const showLegend = props.showLegend === undefined ? true : props.showLegend;
+  const showTooltip =
+    props.showTooltip === undefined ? true : props.showTooltip;
 
   // Used to programmaticaly show/Hide tooltips see: https://codesandbox.io/s/recharts-programmatically-show-tooltip-bhfnwt?file=/src/App.tsx:666-700
   const chartRef = useRef<any>();
@@ -101,7 +104,6 @@ export default function KPieChart<
       isTooltipActive: false,
     });
   };
-
   return (
     <ChartWrapper data={chartData} noDataText={props.noDataText}>
       <PieChart ref={chartRef}>
@@ -116,17 +118,19 @@ export default function KPieChart<
             <Cell key={entry.id} fill={entry.color} />
           ))}
         </Pie>
-        <Tooltip
-          {...{
-            content: KlimaTooltip({
-              yAxisFormatter: getToolTipYAxisFormatter(props.YAxis),
-            }),
-            cursor: { fill: "transparent" },
-          }}
-        />
+        {showTooltip && (
+          <Tooltip
+            {...{
+              content: KlimaTooltip({
+                yAxisFormatter: getToolTipYAxisFormatter(props.YAxis),
+              }),
+              cursor: { fill: "transparent" },
+            }}
+          />
+        )}
         {showLegend && (
           <Legend
-            {...LocalLegendProps}
+            {...localLegendProps}
             content={props.legendContent}
             onMouseOver={legendItemOnMouseOver}
             onMouseLeave={legendItemOnMouseLeave}

--- a/carbonmark-data/components/charts/helpers/KPieChart/index.tsx
+++ b/carbonmark-data/components/charts/helpers/KPieChart/index.tsx
@@ -28,15 +28,6 @@ export default function KPieChart<
 >(props: Props<CI, T>) {
   // Copy configuration because we are going to alter it
   const configuration = cloneDeep(props.configuration);
-  // Default configuration
-  const LocalLegendProps =
-    props.LegendProps ||
-    Object.assign({}, KlimaLegendProps(configuration), {
-      verticalAlign: "middle",
-      align: "center",
-      layout: "vertical",
-    });
-  const showLegend = props.showLegend === undefined ? true : props.showLegend;
   const nonZeroData = props.data.filter((item) => item.quantity > 0);
   const total = nonZeroData.reduce((previousValue, item) => {
     return previousValue + item.quantity;
@@ -63,6 +54,15 @@ export default function KPieChart<
     chartOptions.label = label;
     return record;
   });
+  // Conpute legend props
+  const LocalLegendProps =
+    props.LegendProps ||
+    Object.assign({}, KlimaLegendProps(configuration), {
+      verticalAlign: "middle",
+      align: "center",
+      layout: "vertical",
+    });
+  const showLegend = props.showLegend === undefined ? true : props.showLegend;
 
   // Used to programmaticaly show/Hide tooltips see: https://codesandbox.io/s/recharts-programmatically-show-tooltip-bhfnwt?file=/src/App.tsx:666-700
   const chartRef = useRef<any>();
@@ -70,7 +70,6 @@ export default function KPieChart<
     if (!chartRef.current) {
       return;
     }
-    console.log(chartRef.current.state);
 
     const graphicalItems = chartRef.current.state.formattedGraphicalItems[0];
     let activeItem: any = undefined;
@@ -80,13 +79,8 @@ export default function KPieChart<
         activeItem = graphicalItems.props.sectors[index];
       }
     }
-    console.log(activeItem, graphicalItems.props);
-
     if (!activeItem) {
-      console.error(
-        "check chart state! previous versions have 'formattedGraphicalItems' with two 't', or state structure changed",
-        chartRef.current.state
-      );
+      console.error("check chart state!", chartRef.current.state);
       return;
     }
 
@@ -109,14 +103,12 @@ export default function KPieChart<
   };
 
   return (
-    <ChartWrapper data={nonZeroData} noDataText={props.noDataText}>
+    <ChartWrapper data={chartData} noDataText={props.noDataText}>
       <PieChart ref={chartRef}>
         <Pie
           data={props.data}
           dataKey="quantity"
           nameKey="label"
-          cx="50%"
-          cy="50%"
           innerRadius="93%"
           outerRadius="100%"
         >

--- a/carbonmark-data/components/charts/helpers/KlimaAxis.tsx
+++ b/carbonmark-data/components/charts/helpers/KlimaAxis.tsx
@@ -1,25 +1,32 @@
 import { helpers } from "lib/charts";
 import { ChartData } from "lib/charts/types";
 import { currentLocale } from "lib/i18n";
+import { Text } from "recharts";
 import { ChartConfiguration } from "./Configuration";
-/* Base parameters for all Axis */
+/** Base parameters for all Axis Props */
 const BASE_AXIS_PROPS = {
   tickLine: false,
   tick: { fontSize: 12 },
 };
-/* Base parameters for XAxis */
+/** Base parameters for XAxis */
 const BASE_XAXIS_PROPS = Object.assign({}, BASE_AXIS_PROPS, {
   dy: 10,
   axisLine: false,
   interval: 0,
 });
-/* Base parameters for YAxis */
+/** Base parameters for YAxis */
 const BASE_YAXIS_PROPS = Object.assign({}, BASE_AXIS_PROPS, {
   dx: -10,
   axisLine: true,
 });
+/** XAxis Tick formatter that optimize anchoring for the first and last ticks */
+function XAxisTickFormatter(props:any) {
+  const textAnchor = props.index== 0 ? "begin" :
+    props.index== props.visibleTicksCount-1 ? "end" : "middle"
 
-/* XAxis props to display ticks as months */
+return <Text {...props} textAnchor={textAnchor} fontSize={props.dy}>{props.tickFormatter(props.payload.value)}</Text>
+}
+/** XAxis props to display ticks as months */
 export function KlimaXAxisMonthlyProps<T>(
   data: ChartData<T>,
   dataKey: keyof T
@@ -29,9 +36,10 @@ export function KlimaXAxisMonthlyProps<T>(
     dataKey: dataKey as string,
     tickFormatter: helpers.formatDateAsMonths,
     ticks: helpers.niceTicks(data, dataKey),
+    tick: <XAxisTickFormatter />
   });
 }
-/* XAxis props to display ticks as days */
+/** XAxis props to display ticks as days */
 export function KlimaXAxisDailyProps<T>(data: ChartData<T>, dataKey: keyof T) {
   return Object.assign({}, BASE_XAXIS_PROPS, {
     // FIXME: We should not need to hard cast here
@@ -40,7 +48,7 @@ export function KlimaXAxisDailyProps<T>(data: ChartData<T>, dataKey: keyof T) {
     ticks: helpers.niceTicks(data, dataKey),
   });
 }
-/* XAxis props to display vintage dates */
+/** XAxis props to display vintage dates */
 export function KlimaXAxisVintageProps<T>(
   data: ChartData<T>,
   dataKey: keyof T
@@ -53,7 +61,7 @@ export function KlimaXAxisVintageProps<T>(
   });
 }
 
-/* XAxis props to display methodologies */
+/** XAxis props to display methodologies */
 export function KlimaXAxisMethodologyProps<T>(
   data: ChartData<T>,
   dataKey: keyof T
@@ -68,7 +76,7 @@ export function KlimaXAxisMethodologyProps<T>(
   });
 }
 
-/* YAxis props to display quantity in an appropriate format */
+/** YAxis props to display quantity in an appropriate format */
 export function KlimaYAxisTonsProps<CI, Q, M, T>(
   data: ChartData<CI>,
   conf: ChartConfiguration<Q, M, T>
@@ -89,7 +97,7 @@ export function KlimaYAxisTonsProps<CI, Q, M, T>(
   return Object.assign({}, BASE_YAXIS_PROPS, { tickFormatter });
 }
 
-/* YAxis props to display prices in an appropriate format */
+/** YAxis props to display prices in an appropriate format */
 export function KlimaYAxisPriceProps() {
   const locale = currentLocale();
   const formatter = new Intl.NumberFormat(locale, {
@@ -99,7 +107,7 @@ export function KlimaYAxisPriceProps() {
   return Object.assign({}, BASE_YAXIS_PROPS, { tickFormatter });
 }
 
-/* YAxis props to display percentages in an appropriate format */
+/** YAxis props to display percentages in an appropriate format */
 export function KlimaYAxisPercentageProps() {
   const tickFormatter = (x: number) =>
     helpers.formatPercentage({ value: x, fractionDigits: 0 });

--- a/carbonmark-data/components/charts/helpers/KlimaAxis.tsx
+++ b/carbonmark-data/components/charts/helpers/KlimaAxis.tsx
@@ -20,11 +20,19 @@ const BASE_YAXIS_PROPS = Object.assign({}, BASE_AXIS_PROPS, {
   axisLine: true,
 });
 /** XAxis Tick formatter that optimize anchoring for the first and last ticks */
-function XAxisTickFormatter(props:any) {
-  const textAnchor = props.index== 0 ? "begin" :
-    props.index== props.visibleTicksCount-1 ? "end" : "middle"
+function XAxisTickFormatter(props: any) {
+  const textAnchor =
+    props.index == 0
+      ? "begin"
+      : props.index == props.visibleTicksCount - 1
+      ? "end"
+      : "middle";
 
-return <Text {...props} textAnchor={textAnchor} fontSize={props.dy}>{props.tickFormatter(props.payload.value)}</Text>
+  return (
+    <Text {...props} textAnchor={textAnchor} fontSize={props.dy}>
+      {props.tickFormatter(props.payload.value)}
+    </Text>
+  );
 }
 /** XAxis props to display ticks as months */
 export function KlimaXAxisMonthlyProps<T>(
@@ -36,7 +44,7 @@ export function KlimaXAxisMonthlyProps<T>(
     dataKey: dataKey as string,
     tickFormatter: helpers.formatDateAsMonths,
     ticks: helpers.niceTicks(data, dataKey),
-    tick: <XAxisTickFormatter />
+    tick: <XAxisTickFormatter />,
   });
 }
 /** XAxis props to display ticks as days */

--- a/carbonmark-data/components/charts/helpers/props.ts
+++ b/carbonmark-data/components/charts/helpers/props.ts
@@ -50,7 +50,10 @@ export type YAxisType = "tons" | "price" | "percentage" | undefined;
 export function getXAxisProps<T extends object>(props: ChartProps<T>) {
   const locale = currentLocale();
   // Default format months
-  let XAxisProps: XAxisProps = KlimaXAxisMonthlyProps<T>(props.data, props.dateField);
+  let XAxisProps: XAxisProps = KlimaXAxisMonthlyProps<T>(
+    props.data,
+    props.dateField
+  );
   if (props.XAxis == "days") {
     XAxisProps = KlimaXAxisDailyProps<T>(props.data, props.dateField);
   }
@@ -123,3 +126,10 @@ export function getKlimaTooltipProps<T extends object>(props: ChartProps<T>) {
     cursor: { fill: "transparent" },
   };
 }
+
+export const BOTTOM_LEFT_LEGEND_PROPS = {
+  layout: "horizontal",
+  verticalAlign: "bottom",
+  align: "left",
+  wrapperStyle: { marginLeft: "0.4rem", paddingTop: "0.2rem" },
+};

--- a/carbonmark-data/components/charts/helpers/props.ts
+++ b/carbonmark-data/components/charts/helpers/props.ts
@@ -13,7 +13,7 @@ import {
   Status,
 } from "lib/charts/types";
 import { currentLocale } from "lib/i18n";
-import { LegendProps } from "recharts";
+import { LegendProps, XAxisProps } from "recharts";
 import {
   KlimaXAxisMethodologyProps,
   KlimaXAxisVintageProps,
@@ -50,7 +50,7 @@ export type YAxisType = "tons" | "price" | "percentage" | undefined;
 export function getXAxisProps<T extends object>(props: ChartProps<T>) {
   const locale = currentLocale();
   // Default format months
-  let XAxisProps = KlimaXAxisMonthlyProps<T>(props.data, props.dateField);
+  let XAxisProps: XAxisProps = KlimaXAxisMonthlyProps<T>(props.data, props.dateField);
   if (props.XAxis == "days") {
     XAxisProps = KlimaXAxisDailyProps<T>(props.data, props.dateField);
   }

--- a/carbonmark-data/lib/charts/helpers.ts
+++ b/carbonmark-data/lib/charts/helpers.ts
@@ -187,7 +187,8 @@ export const formatQuantityAsTons = function (quantity: number): string {
   return `${quantity} T`;
 };
 export const formatPrice = function (price: number): string {
-  return new Intl.NumberFormat(currentLocale(), {
+  // Enforce prices formatting in english locale ($0.00)
+  return new Intl.NumberFormat("en", {
     style: "currency",
     currency: "USD",
     maximumFractionDigits: 2,


### PR DESCRIPTION
## Description

Small UI Fixes:
- Enforce US format for prices
- Fixes ticks for XAxes representing months (No ticket)
- Adds proper behaviours for language button
- Fix bottom options position on small cards

Should be reviewed after https://github.com/KlimaDAO/klimadao/pull/1583 is merged

## Related Ticket

Resolves #1504
Resolves #1467 
Resolves #1521  

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|


## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
