### PR TITLE
Fixed incorrect payment method on CC checkout

### DIFF
--- a/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
@@ -66,7 +66,7 @@ export const RetireForm: FC<Props> = (props) => {
     mode: "onChange",
     defaultValues: {
       projectTokenAddress: props.price.projectTokenAddress,
-      paymentMethod: "usdc",
+      paymentMethod: "fiat",
       ...inputValues,
     },
   });
@@ -162,6 +162,7 @@ export const RetireForm: FC<Props> = (props) => {
       return;
     } catch (e) {
       console.error(e);
+
       setIsRedirecting(false);
       if (e.name === "MinPurchaseRequired") {
         setCheckoutError(t`${e.message}`);


### PR DESCRIPTION
## Description

`paymentMethod` on Retire Form was recently changed to `usdc`; should be `fiat`.

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
