### PR TITLE
[api] include project data in Listings model

### DIFF
--- a/carbonmark-api/src/.generated/types/marketplace.types.ts
+++ b/carbonmark-api/src/.generated/types/marketplace.types.ts
@@ -1346,9 +1346,9 @@ export enum _SubgraphErrorPolicy_ {
   Deny = 'deny'
 }
 
-export type ListingFragmentFragment = { __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string } };
+export type ListingFragmentFragment = { __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, category: { __typename?: 'Category', id: string } | null, country: { __typename?: 'Country', id: string } | null } };
 
-export type ProjectFragmentFragment = { __typename?: 'Project', id: string, key: string, vintage: string };
+export type ProjectFragmentFragment = { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, category: { __typename?: 'Category', id: string } | null, country: { __typename?: 'Country', id: string } | null };
 
 export type ActivityFragmentFragment = { __typename?: 'Activity', id: string, amount: string | null, previousAmount: string | null, price: string | null, previousPrice: string | null, timeStamp: string | null, activityType: ActivityType, project: { __typename?: 'Project', key: string, vintage: string }, buyer: { __typename?: 'User', id: any } | null, seller: { __typename?: 'User', id: any } };
 
@@ -1372,7 +1372,7 @@ export type GetPurchaseByIdQueryVariables = Exact<{
 }>;
 
 
-export type GetPurchaseByIdQuery = { __typename?: 'Query', purchase: { __typename?: 'Purchase', id: any, amount: string, price: string, listing: { __typename?: 'Listing', id: string, project: { __typename?: 'Project', id: string, key: string, vintage: string } } } | null };
+export type GetPurchaseByIdQuery = { __typename?: 'Query', purchase: { __typename?: 'Purchase', id: any, amount: string, price: string, listing: { __typename?: 'Listing', id: string, project: { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, category: { __typename?: 'Category', id: string } | null, country: { __typename?: 'Country', id: string } | null } } } | null };
 
 export type GetUserByWalletQueryVariables = Exact<{
   wallet: InputMaybe<Scalars['Bytes']>;
@@ -1380,7 +1380,7 @@ export type GetUserByWalletQueryVariables = Exact<{
 }>;
 
 
-export type GetUserByWalletQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', listings: Array<{ __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string } }> | null, activities: Array<{ __typename?: 'Activity', id: string, amount: string | null, previousAmount: string | null, price: string | null, previousPrice: string | null, timeStamp: string | null, activityType: ActivityType, project: { __typename?: 'Project', key: string, vintage: string }, buyer: { __typename?: 'User', id: any } | null, seller: { __typename?: 'User', id: any } }> | null }> };
+export type GetUserByWalletQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', listings: Array<{ __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, category: { __typename?: 'Category', id: string } | null, country: { __typename?: 'Country', id: string } | null } }> | null, activities: Array<{ __typename?: 'Activity', id: string, amount: string | null, previousAmount: string | null, price: string | null, previousPrice: string | null, timeStamp: string | null, activityType: ActivityType, project: { __typename?: 'Project', key: string, vintage: string }, buyer: { __typename?: 'User', id: any } | null, seller: { __typename?: 'User', id: any } }> | null }> };
 
 export type GetProjectsQueryVariables = Exact<{
   search: InputMaybe<Scalars['String']>;
@@ -1389,7 +1389,7 @@ export type GetProjectsQueryVariables = Exact<{
 }>;
 
 
-export type GetProjectsQuery = { __typename?: 'Query', projects: Array<{ __typename?: 'Project', id: string, key: string, vintage: string, listings: Array<{ __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string } }> | null }> };
+export type GetProjectsQuery = { __typename?: 'Query', projects: Array<{ __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, listings: Array<{ __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, category: { __typename?: 'Category', id: string } | null, country: { __typename?: 'Country', id: string } | null } }> | null, category: { __typename?: 'Category', id: string } | null, country: { __typename?: 'Country', id: string } | null }> };
 
 export type GetProjectByIdQueryVariables = Exact<{
   projectId: Scalars['ID'];
@@ -1397,13 +1397,21 @@ export type GetProjectByIdQueryVariables = Exact<{
 }>;
 
 
-export type GetProjectByIdQuery = { __typename?: 'Query', project: { __typename?: 'Project', id: string, key: string, vintage: string, listings: Array<{ __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string } }> | null, activities: Array<{ __typename?: 'Activity', id: string, amount: string | null, previousAmount: string | null, price: string | null, previousPrice: string | null, timeStamp: string | null, activityType: ActivityType, project: { __typename?: 'Project', key: string, vintage: string }, buyer: { __typename?: 'User', id: any } | null, seller: { __typename?: 'User', id: any } }> | null } | null };
+export type GetProjectByIdQuery = { __typename?: 'Query', project: { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, listings: Array<{ __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, category: { __typename?: 'Category', id: string } | null, country: { __typename?: 'Country', id: string } | null } }> | null, activities: Array<{ __typename?: 'Activity', id: string, amount: string | null, previousAmount: string | null, price: string | null, previousPrice: string | null, timeStamp: string | null, activityType: ActivityType, project: { __typename?: 'Project', key: string, vintage: string }, buyer: { __typename?: 'User', id: any } | null, seller: { __typename?: 'User', id: any } }> | null, category: { __typename?: 'Category', id: string } | null, country: { __typename?: 'Country', id: string } | null } | null };
 
 export const ProjectFragmentFragmentDoc = gql`
     fragment ProjectFragment on Project {
   id
   key
   vintage
+  name
+  category {
+    id
+  }
+  country {
+    id
+  }
+  methodology
 }
     `;
 export const ListingFragmentFragmentDoc = gql`

--- a/carbonmark-api/src/graphql/marketplace.fragments.gql
+++ b/carbonmark-api/src/graphql/marketplace.fragments.gql
@@ -22,6 +22,14 @@ fragment ProjectFragment on Project {
   id
   key
   vintage
+  name
+  category {
+    id
+  }
+  country {
+    id
+  }
+  methodology
 }
 
 fragment ActivityFragment on Activity {

--- a/carbonmark-api/src/models/Listing.model.ts
+++ b/carbonmark-api/src/models/Listing.model.ts
@@ -32,7 +32,7 @@ export const ListingModel = Type.Object(
     batchPrices: Nullable(Type.Array(Type.String())),
     createdAt: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     updatedAt: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    seller: Nullable(ListingSeller),
+    seller: ListingSeller,
     expiration: Type.String({
       description: "Unix Timestamp (seconds) when the listing expires.",
     }),
@@ -43,6 +43,10 @@ export const ListingModel = Type.Object(
       id: Type.String(),
       key: Type.String(),
       vintage: Type.String(),
+      name: Type.String(),
+      category: Type.String(),
+      country: Type.String(),
+      methodology: Type.String(),
     }),
   },
   {

--- a/carbonmark-api/src/routes/projects/get.utils.ts
+++ b/carbonmark-api/src/routes/projects/get.utils.ts
@@ -24,6 +24,7 @@ import {
   getAllCountries,
   getAllVintages,
 } from "../../utils/helpers/utils";
+import { formatListing } from "../../utils/marketplace.utils";
 import { POOL_INFO } from "./get.constants";
 
 /**
@@ -140,9 +141,9 @@ export const isActiveListing = (l: {
  * Returns true if project has >=1 tonne in any active, unexpired listing
  * */
 export const isValidMarketplaceProject = (
-  project: Pick<Project, "listings">
+  project: GetProjectsQuery["projects"][number]
 ) => {
-  if (!project.listings) return false;
+  if (!project?.listings) return false;
   const validProjects = project.listings.filter(isActiveListing);
   return !!validProjects.length;
 };
@@ -234,7 +235,7 @@ export const composeProjectEntries = (
       projectAddress: pool?.tokenAddress ?? "",
       updatedAt: pickUpdatedAt(data),
       price: pickBestPrice(data, poolPrices),
-      listings: market?.listings || null,
+      listings: market?.listings?.map(formatListing) || null,
     };
 
     entries.push(entry);

--- a/carbonmark-api/src/routes/users/get.ts
+++ b/carbonmark-api/src/routes/users/get.ts
@@ -1,13 +1,13 @@
 import { Static } from "@sinclair/typebox";
 import { utils } from "ethers";
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import { Listing } from "../../models/Listing.model";
 import { User } from "../../models/User.model";
 import {
   getProfileByAddress,
   getProfileByHandle,
   getUserProfilesByIds,
 } from "../../utils/helpers/users.utils";
+import { formatListing } from "../../utils/marketplace.utils";
 import { Params, QueryString, schema } from "./get.schema";
 import {
   getHoldingsByWallet,
@@ -81,16 +81,7 @@ const handler = (fastify: FastifyInstance) =>
         };
       }) || [];
 
-    const listings =
-      user?.listings?.map(
-        (l): Listing => ({
-          ...l,
-          minFillAmount: utils.formatUnits(l.minFillAmount, 18),
-          leftToSell: utils.formatUnits(l.leftToSell, 18),
-          singleUnitPrice: utils.formatUnits(l.singleUnitPrice, 6),
-          totalAmountToSell: utils.formatUnits(l.totalAmountToSell),
-        })
-      ) || [];
+    const listings = user?.listings?.map(formatListing) || [];
 
     const response: User = {
       createdAt: profile?.createdAt || 0,

--- a/carbonmark-api/src/routes/users/get.utils.ts
+++ b/carbonmark-api/src/routes/users/get.utils.ts
@@ -1,4 +1,4 @@
-import { Contract, providers } from "ethers";
+import { Contract, providers, utils } from "ethers";
 import { compact, sortBy, sortedUniq } from "lodash";
 import { pipe } from "lodash/fp";
 import ERC20 from "../../abis/ERC20.json";
@@ -6,6 +6,13 @@ import { RPC_URLS } from "../../app.constants";
 import { NetworkParam } from "../../models/NetworkParam.model";
 import { Holding } from "../../types/assets.types";
 import { gql_sdk } from "../../utils/gqlSdk";
+
+const formatHolding = (h: Holding): Holding => {
+  return {
+    ...h,
+    amount: utils.formatUnits(h.amount, h.token.decimals),
+  };
+};
 
 /** Hacky Mumbai simulation for known testnet assets
  *  until we get a testnet version of polygon-digital-carbon */
@@ -52,7 +59,7 @@ const fetchTestnetHoldings = async (params: {
       },
     };
   });
-  return holdings;
+  return holdings.map(formatHolding);
 };
 
 /** Network-aware fetcher for marketplace user data (listings and activities) */
@@ -87,7 +94,7 @@ export const getHoldingsByWallet = async (params: {
   const { accounts } = await sdk.assets.getHoldingsByWallet({
     wallet: params.address,
   });
-  return accounts.at(0)?.holdings ?? [];
+  return accounts.at(0)?.holdings.map(formatHolding) ?? [];
 };
 
 /** Reduce an array of activities into a deduplicated sorted array of buyer and seller address strings. */

--- a/carbonmark-api/src/utils/helpers/fetchMarketplaceListings.ts
+++ b/carbonmark-api/src/utils/helpers/fetchMarketplaceListings.ts
@@ -5,6 +5,7 @@ import { Activity } from "../../models/Activity.model";
 import { Listing } from "../../models/Listing.model";
 import { isActiveListing } from "../../routes/projects/get.utils";
 import { GQL_SDK } from "../gqlSdk";
+import { formatListing } from "../marketplace.utils";
 import { getUserProfilesByIds } from "./users.utils";
 
 type Params = {
@@ -53,14 +54,7 @@ export const fetchMarketplaceListings = async (
   const filteredActivities =
     project?.activities?.filter(filterUnsoldActivity) || [];
 
-  // TODO abstract to util and share logic with User.listings and DetailedProject.listings
-  const formattedListings = filteredListings.map((listing) => ({
-    ...listing,
-    minFillAmount: utils.formatUnits(listing.minFillAmount, 18),
-    singleUnitPrice: utils.formatUnits(listing.singleUnitPrice, 6),
-    leftToSell: utils.formatUnits(listing.leftToSell, 18),
-    totalAmountToSell: utils.formatUnits(listing.totalAmountToSell, 18),
-  }));
+  const formattedListings = filteredListings.map(formatListing);
 
   const formattedActivities = filteredActivities.map((activity) => ({
     ...activity,

--- a/carbonmark-api/src/utils/marketplace.utils.ts
+++ b/carbonmark-api/src/utils/marketplace.utils.ts
@@ -1,4 +1,4 @@
-import { formatUnits } from "ethers-v6";
+import { utils } from "ethers";
 import {
   GetProjectsQuery,
   Listing,
@@ -34,10 +34,10 @@ type GetProjectListing = NonNullable<
 export const formatListing = (listing: GetProjectListing): ListingModel => {
   return {
     ...listing,
-    leftToSell: formatUnits(listing.leftToSell, 18),
-    singleUnitPrice: formatUnits(listing.singleUnitPrice, 6),
-    minFillAmount: formatUnits(listing.minFillAmount, 18),
-    totalAmountToSell: formatUnits(listing.totalAmountToSell, 18),
+    leftToSell: utils.formatUnits(listing.leftToSell, 18),
+    singleUnitPrice: utils.formatUnits(listing.singleUnitPrice, 6),
+    minFillAmount: utils.formatUnits(listing.minFillAmount, 18),
+    totalAmountToSell: utils.formatUnits(listing.totalAmountToSell, 18),
     project: {
       ...listing.project,
       category: listing.project.category?.id || "",

--- a/carbonmark-api/src/utils/marketplace.utils.ts
+++ b/carbonmark-api/src/utils/marketplace.utils.ts
@@ -1,4 +1,9 @@
-import { Listing } from "../.generated/types/marketplace.types";
+import { formatUnits } from "ethers-v6";
+import {
+  GetProjectsQuery,
+  Listing,
+} from "../.generated/types/marketplace.types";
+import { Listing as ListingModel } from "../models/Listing.model";
 import { notNil } from "./functional.utils";
 
 export const isListingActive = (listing: Partial<Listing>) =>
@@ -18,5 +23,25 @@ export const deconstructListingId = (str: string) => {
   return {
     key,
     vintage,
+  };
+};
+
+type GetProjectListing = NonNullable<
+  GetProjectsQuery["projects"][number]["listings"]
+>[number];
+
+/** Formats a gql.marketplace listing to match Listing.model, and formats integers */
+export const formatListing = (listing: GetProjectListing): ListingModel => {
+  return {
+    ...listing,
+    leftToSell: formatUnits(listing.leftToSell, 18),
+    singleUnitPrice: formatUnits(listing.singleUnitPrice, 6),
+    minFillAmount: formatUnits(listing.minFillAmount, 18),
+    totalAmountToSell: formatUnits(listing.totalAmountToSell, 18),
+    project: {
+      ...listing.project,
+      category: listing.project.category?.id || "",
+      country: listing.project.country?.id || "",
+    },
   };
 };

--- a/carbonmark-api/test/fixtures/marketplace.ts
+++ b/carbonmark-api/test/fixtures/marketplace.ts
@@ -6,6 +6,8 @@ import { GetPurchaseByIdQuery } from "../../src/.generated/types/marketplace.typ
 
 const listing = aListing({
   singleUnitPrice: "99000000",
+  minFillAmount: "100000000000000000000",
+  totalAmountToSell: "100000000000000000000",
   leftToSell: "100000000000000000000",
   updatedAt: "1234",
 });
@@ -29,6 +31,10 @@ const purchase: GetPurchaseByIdQuery["purchase"] = {
       id: "VCS-191-2008",
       key: "VCS-191",
       vintage: "2008",
+      category: { id: "Renewable Energy" },
+      country: { id: "United States" },
+      methodology: "VM0006",
+      name: "Hydroelectric Fixture",
     },
   },
 };

--- a/carbonmark-api/test/routes/projects/get.test.ts
+++ b/carbonmark-api/test/routes/projects/get.test.ts
@@ -192,12 +192,9 @@ describe("GET /projects", () => {
             "batches",
             "createdAt",
             "deleted",
-            "totalAmountToSell",
             "updatedAt",
             "id",
-            "leftToSell",
             "tokenAddress",
-            "singleUnitPrice",
           ]),
         ],
         location: {


### PR DESCRIPTION
# Description

Brings back the marketplace project query as a temporary workaround, passes this data down to the listing.project entity. Changes affect /projects, /projects/:id, and /users/:id

Eliminates more bignumber strings from API responses.

Creates a shared formatting util for formatting Listings.