### PR TITLE
[api] hide mumbai listings from /users endpoint (temp fix)

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "2.0.0-4",
+  "version": "2.0.0-5",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/carbonmark-api/src/routes/users/get.ts
+++ b/carbonmark-api/src/routes/users/get.ts
@@ -1,6 +1,7 @@
 import { Static } from "@sinclair/typebox";
 import { utils } from "ethers";
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { Listing } from "../../models/Listing.model";
 import { User } from "../../models/User.model";
 import {
   getProfileByAddress,
@@ -81,7 +82,14 @@ const handler = (fastify: FastifyInstance) =>
         };
       }) || [];
 
-    const listings = user?.listings?.map(formatListing) || [];
+    let listings = user?.listings?.map(formatListing) || [];
+
+    // TEMP HOTFIX until we have a mainnet graph url
+    // https://github.com/KlimaDAO/klimadao/issues/1604
+    if (listings.length && request.query.network !== "mumbai") {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- temp fix
+      listings = [] as Listing[];
+    }
 
     const response: User = {
       createdAt: profile?.createdAt || 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,7 +349,7 @@
     },
     "carbonmark-api": {
       "name": "@klimadao/carbonmark-api",
-      "version": "2.0.0-4",
+      "version": "2.0.0-5",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",


### PR DESCRIPTION
## Description

Until we have a mainnet graph

Increment to v2.0.0-5

No ticket, I just noticed this.

## Checklist

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`