### PR TITLE
servers attribute on open-api response

### DIFF
--- a/carbonmark-api/src/plugins/open-api.ts
+++ b/carbonmark-api/src/plugins/open-api.ts
@@ -16,6 +16,8 @@ import { UserModel } from "../models/User.model";
 import { ImageModel } from "../models/Utility.model";
 
 const OPEN_API_OPTIONS: FastifyDynamicSwaggerOptions["openapi"] = {
+  // This enables codegen utilities to target the relevant urls
+  servers: [{ url: `https://v${packageJson.version}.api.carbonmark.com` }],
   info: {
     title: "Carbonmark REST API",
     description: `


### PR DESCRIPTION
## Description

The open api spec can return a "servers" attribute that specifies the available urls for the api. This can be necessary for code generation 