### PR TITLE
fix #1663 don't show zero balance testnet tokens

### DIFF
--- a/carbonmark-api/src/routes/users/get.utils.ts
+++ b/carbonmark-api/src/routes/users/get.utils.ts
@@ -59,7 +59,7 @@ const fetchTestnetHoldings = async (params: {
       },
     };
   });
-  return holdings.map(formatHolding);
+  return holdings.map(formatHolding).filter((h) => Number(h.amount) > 0);
 };
 
 /** Network-aware fetcher for marketplace user data (listings and activities) */


### PR DESCRIPTION
## Description
Fix #1663

For the hardcoded testnet assets that we track, don't show them if the balance is zero