### PR TITLE
fix(profile): disable create new listing button if no listable assets

### DIFF
--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -16,6 +16,7 @@ import { getFeatureFlag } from "lib/getFeatureFlag";
 import { getActiveListings, getSortByUpdateListings } from "lib/listingsGetter";
 import { User } from "lib/types/carbonmark.types";
 import { notNil } from "lib/utils/functional.utils";
+import { hasListableAssets } from "lib/utils/listings.utils";
 import { FC, useRef, useState } from "react";
 import { ProfileButton } from "../ProfileButton";
 import { ProfileHeader } from "../ProfileHeader";
@@ -150,6 +151,12 @@ export const SellerConnected: FC<Props> = (props) => {
               onClick={() => {
                 setShowCreateListingModal(true);
               }}
+              disabled={
+                !hasListableAssets(
+                  carbonmarkUser.assets,
+                  carbonmarkUser.listings
+                )
+              }
             />
           ) : (
             <TextInfoTooltip tooltip="New listings are temporarily disabled while we upgrade our marketplace to a new version.">

--- a/carbonmark/lib/utils/listings.utils.ts
+++ b/carbonmark/lib/utils/listings.utils.ts
@@ -46,3 +46,8 @@ export const hasListableBalance = (
   const balance = getUnlistedBalance(asset, listings);
   return balance >= DEFAULT_MIN_LISTING_QUANTITY;
 };
+
+/** Returns true if any asset has a listable balance */
+export const hasListableAssets = (assets: Asset[], listings: Listing[]) => {
+  return assets.some((t) => hasListableBalance(t, listings));
+};


### PR DESCRIPTION
## Description

Fix #1661 

It was actually fixed in a different PR but this disables the button unless listable assets are present to prevent this from recurring.