### PR TITLE
Add dotenv to carbonmark

### DIFF
--- a/carbonmark/next.config.js
+++ b/carbonmark/next.config.js
@@ -4,6 +4,11 @@ const withBundleAnalyzer = require("@next/bundle-analyzer");
 
 const IS_PRODUCTION = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
 
+// For local development we need to source envs
+if (!IS_PRODUCTION) {
+  require("dotenv").config({ path: "../.env.local" });
+}
+
 module.exports = async (phase, { defaultConfig }) => {
   const getLocales = (await import("../lib/out/utils/getLocales/index.js"))
     .getLocales;


### PR DESCRIPTION
## Description

.env.local was required to be copied in to `/carbonmark` this should no longer require that