### PR TITLE
fetchIsNewHandle to use response status instead of error message

### DIFF
--- a/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
@@ -147,23 +147,23 @@ export const EditProfile: FC<Props> = (props) => {
               "handle",
               !isExistingUser // validate only if handle can be changed
                 ? {
-                  required: {
-                    value: true,
-                    message: t`Handle is required`,
-                  },
-                  pattern: {
-                    value: VALID_HANDLE_REGEX, // no special characters!
-                    message: t`Handle should not contain any special characters`,
-                  },
-                  validate: {
-                    isAddress: (v) =>
-                      !isAddress(v) || // do not allow polygon addresses
-                      t`Handle should not be an address`,
-                    isNewHandle: async (v) =>
-                      (await fetchIsNewHandle(v)) || // ensure unique handles
-                      t`Sorry, this handle already exists`,
-                  },
-                }
+                    required: {
+                      value: true,
+                      message: t`Handle is required`,
+                    },
+                    pattern: {
+                      value: VALID_HANDLE_REGEX, // no special characters!
+                      message: t`Handle should not contain any special characters`,
+                    },
+                    validate: {
+                      isAddress: (v) =>
+                        !isAddress(v) || // do not allow polygon addresses
+                        t`Handle should not be an address`,
+                      isNewHandle: async (v) =>
+                        (await fetchIsNewHandle(v)) || // ensure unique handles
+                        t`Sorry, this handle already exists`,
+                    },
+                  }
                 : undefined
             ),
           }}

--- a/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
@@ -60,7 +60,7 @@ export const EditProfile: FC<Props> = (props) => {
       return apiHandle.toLowerCase() !== handle.toLowerCase();
     } catch (error) {
       console.error(error);
-      if (error.message === "Not Found") {
+      if (error.status === 404) {
         return true;
       }
       return false;
@@ -147,23 +147,23 @@ export const EditProfile: FC<Props> = (props) => {
               "handle",
               !isExistingUser // validate only if handle can be changed
                 ? {
-                    required: {
-                      value: true,
-                      message: t`Handle is required`,
-                    },
-                    pattern: {
-                      value: VALID_HANDLE_REGEX, // no special characters!
-                      message: t`Handle should not contain any special characters`,
-                    },
-                    validate: {
-                      isAddress: (v) =>
-                        !isAddress(v) || // do not allow polygon addresses
-                        t`Handle should not be an address`,
-                      isNewHandle: async (v) =>
-                        (await fetchIsNewHandle(v)) || // ensure unique handles
-                        t`Sorry, this handle already exists`,
-                    },
-                  }
+                  required: {
+                    value: true,
+                    message: t`Handle is required`,
+                  },
+                  pattern: {
+                    value: VALID_HANDLE_REGEX, // no special characters!
+                    message: t`Handle should not contain any special characters`,
+                  },
+                  validate: {
+                    isAddress: (v) =>
+                      !isAddress(v) || // do not allow polygon addresses
+                      t`Handle should not be an address`,
+                    isNewHandle: async (v) =>
+                      (await fetchIsNewHandle(v)) || // ensure unique handles
+                      t`Sorry, this handle already exists`,
+                  },
+                }
                 : undefined
             ),
           }}

--- a/carbonmark/lib/api/client.ts
+++ b/carbonmark/lib/api/client.ts
@@ -12,11 +12,24 @@ export const client = createClient<NormalizeOAS<typeof schema>>({
     // If the status code is not in the range 200-299,
     // we still try to parse and throw it.
     if (!res.ok) {
-      throw new Error((await res.json()).message);
+      throw new FetchError((await res.json()).message, res.status);
     }
 
     return res;
   },
 });
+/** Extend Error to allow network status to be returned */
+class FetchError extends Error {
+  constructor(
+    public message: string,
+    public status: number
+  ) {
+    super(message);
+    // Ensure the name of this error is the same as the class name
+    this.name = this.constructor.name;
+    // This clips the constructor invocation from the stack trace.
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
 
 export type ClientT = typeof client;


### PR DESCRIPTION
## Description

`fetchIsNewHandle` was using the error message returned rather than the error status. 

* Added FetchError
*Check for error status 404 instead of string compare