### PR TITLE
Makka / 1692 add alignment fixes for mobile on retire screen

### DIFF
--- a/carbonmark/components/pages/Retire/FromPortfolio/styles.ts
+++ b/carbonmark/components/pages/Retire/FromPortfolio/styles.ts
@@ -5,10 +5,9 @@ export const cardsList = css`
   display: flex;
   gap: 2rem;
   flex-wrap: wrap;
-
   justify-content: center;
 
-  ${breakpoints.medium} {
+  ${breakpoints.large} {
     justify-content: flex-start;
   }
 `;

--- a/carbonmark/components/pages/Retire/styles.ts
+++ b/carbonmark/components/pages/Retire/styles.ts
@@ -58,7 +58,7 @@ export const content = css`
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  margin: 2rem 1.6rem;
+  margin: 4rem 1.6rem;
 
   ${breakpoints.large} {
     margin: 4rem 2rem;
@@ -76,18 +76,25 @@ export const featuredCard = css`
 
 export const sectionTitle = css`
   display: grid;
-  gap: 1.2rem;
+  gap: 0rem;
+
+  ${breakpoints.large} {
+    gap: 0.4rem;
+  }
 `;
 
 export const cardsHeader = css`
   display: flex;
   gap: 0.8rem;
-  align-items: baseline;
+  align-items: center;
   flex-wrap: wrap;
   justify-content: center;
+  flex-direction: column;
 
   ${breakpoints.large} {
     gap: 2.4rem;
+    align-items: baseline;
+    flex-direction: row;
   }
 
   ${breakpoints.desktop} {
@@ -101,9 +108,11 @@ export const cardsHeaderTweakAlignment = css`
   align-items: center;
   flex-wrap: wrap;
   justify-content: center;
+  flex-direction: column;
 
   ${breakpoints.large} {
     gap: 2.4rem;
+    flex-direction: row;
   }
 
   ${breakpoints.desktop} {
@@ -145,7 +154,7 @@ export const textLink = css`
 
 export const cardsDescription = css`
   text-align: center;
-  padding: 0 2rem;
+  padding: 1.6rem 2rem 0;
 
   ${breakpoints.desktop} {
     text-align: inherit;


### PR DESCRIPTION
## Description

Fixes alignment issues on mobile for /retire screen based on [figma](https://www.figma.com/file/L8DIYEw8LbYHyBhUIQa2AY/Retire?node-id=672%3A7165&mode=dev) file

## Related Ticket

Resolves #1692

## Checklist

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
