### PR TITLE
Remove test branch from api release workflow

### DIFF
--- a/.github/workflows/release_carbonmark_api.yml
+++ b/.github/workflows/release_carbonmark_api.yml
@@ -7,8 +7,6 @@ on:
     # Run on changes made to package.json
     branches:
       - staging
-      # Temporarily for testing
-      - emc/chore/carbonmark-api-package-version-release
     paths:
       - "carbonmark-api/package.json"
     # Run on pushed carbonmark-api tags


### PR DESCRIPTION
## Description

Removes the test branch from the `release_crabonmark_api` workflow