### PR TITLE
Carbon: Improve selective fee presentation

### DIFF
--- a/carbon/app/[locale]/details/price-of-digital-carbon/page.tsx
+++ b/carbon/app/[locale]/details/price-of-digital-carbon/page.tsx
@@ -14,7 +14,7 @@ export default function PriceOfDigitalCarbonPage() {
           <TokensPriceCard isDetailPage={true}></TokensPriceCard>
         </div>
       }
-      overview={t`The prices of various digital carbon pool tokens and their selective fees charged by bridges to redeem or retire a specific underlying digital carbon credit token. Note: The chart shows MCO2 price data from the KLIMA/MCO2 pool launched in January 2022.`}
+      overview={t`The prices of various digital carbon pool tokens and their selective costs charged by bridges to redeem or retire a specific underlying digital carbon credit token. Note: The chart shows MCO2 price data from the KLIMA/MCO2 pool launched in January 2022.`}
     />
   );
 }

--- a/carbon/components/cards/overview/TokensPriceCard/index.tsx
+++ b/carbon/components/cards/overview/TokensPriceCard/index.tsx
@@ -90,7 +90,7 @@ async function TokenPricesChart(props: { layout: CoinTilesLayout }) {
           {
             label: (
               <span className={styles.selectiveFee}>
-                <span>{t`Selective fee`}</span>
+                <span>{t`Selective cost`}</span>
                 <span
                   className={styles.selectiveFeeIcon}
                   title={selectiveFeeDescription}

--- a/carbon/components/cards/overview/TokensPriceCard/index.tsx
+++ b/carbon/components/cards/overview/TokensPriceCard/index.tsx
@@ -1,6 +1,7 @@
 import { formatTonnes } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
 import { ArrowDropDown, ArrowDropUp, InfoOutlined } from "@mui/icons-material";
+import { Tooltip } from "@mui/material";
 import PercentageChange from "components/PercentageChage";
 import ChartCard, { CardProps } from "components/cards/ChartCard";
 import {
@@ -91,12 +92,17 @@ async function TokenPricesChart(props: { layout: CoinTilesLayout }) {
             label: (
               <span className={styles.selectiveFee}>
                 <span>{t`Selective cost`}</span>
-                <span
-                  className={styles.selectiveFeeIcon}
-                  title={selectiveFeeDescription}
+                <Tooltip
+                  title={
+                    <span className={styles.tooltipText}>
+                      {selectiveFeeDescription}
+                    </span>
+                  }
                 >
-                  <InfoOutlined fontSize={"inherit"} />
-                </span>
+                  <span className={styles.selectiveFeeIcon}>
+                    <InfoOutlined fontSize={"inherit"} />
+                  </span>
+                </Tooltip>
               </span>
             ),
             value: selectiveCostInfo,

--- a/carbon/components/cards/overview/TokensPriceCard/styles.module.scss
+++ b/carbon/components/cards/overview/TokensPriceCard/styles.module.scss
@@ -9,4 +9,10 @@
 }
 .selectiveFeeIcon {
   font-size: 10px;
+  &:hover {
+    color: var(--brand-blue);
+  }
+}
+.tooltipText {
+  font-size: 12px;
 }

--- a/carbon/lib/tokens.tsx
+++ b/carbon/lib/tokens.tsx
@@ -28,7 +28,7 @@ export function getTokenIcon(token: Token) {
   return <OverviewCardIcon icon={icon} alt={token} />;
 }
 
-/** Returns the helper text of the selective fee for the given Token */
+/** Returns the helper text of the selective cost for the given Token */
 export async function getTokenSelectiveFeeDescription(token: Token) {
   const tokenInfo = await queryTokenInfo(token);
   if (tokenInfo == undefined) return "";


### PR DESCRIPTION
## Description

- Rename selective fee into selective cost
- Render selective cost tooltip using material UI

## Related Ticket

Resolves #1700

## Changes

| Before  | After  |
|---------|--------|
|![image](https://github.com/KlimaDAO/klimadao/assets/11857992/d342d194-162c-448a-82eb-6955315e35d9)|![image](https://github.com/KlimaDAO/klimadao/assets/11857992/a6aacec7-2439-41b2-8fe1-ae86ce0ad7d9)|

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
