### PR TITLE
Lazy loading of projects page map view

### DIFF
--- a/carbonmark/components/pages/Projects/GridView/GridView.tsx
+++ b/carbonmark/components/pages/Projects/GridView/GridView.tsx
@@ -9,13 +9,10 @@ import { getCategoryFromProject } from "lib/projectGetter";
 import { CategoryName, Project } from "lib/types/carbonmark.types";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import ViewProps from "../props";
 import * as styles from "./styles";
 
-type Props = {
-  projects: Array<Project>;
-};
-
-export const GridView: React.FC<Props> = ({ projects }) => {
+export const GridView: React.FC<ViewProps> = ({ projects }) => {
   const { locale } = useRouter();
 
   return (

--- a/carbonmark/components/pages/Projects/ListView/ListView.tsx
+++ b/carbonmark/components/pages/Projects/ListView/ListView.tsx
@@ -15,6 +15,7 @@ import { Project } from "lib/types/carbonmark.types";
 import { isEqual, split } from "lodash";
 import { useRouter } from "next/router";
 import { FC, useEffect, useState } from "react";
+import ViewProps from "../props";
 import * as styles from "./styles";
 
 interface Data {
@@ -66,11 +67,7 @@ const columns: readonly Column[] = [
   },
 ];
 
-type Props = {
-  projects: Array<Project>;
-};
-
-export const ListView: FC<Props> = ({ projects }) => {
+export const ListView: FC<ViewProps> = ({ projects }) => {
   const router = useRouter();
   const {
     params: { sort },

--- a/carbonmark/components/pages/Projects/MapView/LazyLoadingMapView.tsx
+++ b/carbonmark/components/pages/Projects/MapView/LazyLoadingMapView.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@mui/material";
+import dynamic from "next/dynamic";
+import ViewProps from "../props";
+
+const DynamicMap = dynamic(async () => (await import("./MapView")).MapView, {
+  loading: () => <Skeleton />,
+});
+
+export default function LazyLoadingMapView(props: ViewProps) {
+  return <DynamicMap {...props} />;
+}

--- a/carbonmark/components/pages/Projects/MapView/MapView.tsx
+++ b/carbonmark/components/pages/Projects/MapView/MapView.tsx
@@ -1,16 +1,15 @@
-import { useFetchProjects } from "hooks/useFetchProjects";
 import { Project } from "lib/types/carbonmark.types";
 import { compact } from "lodash";
 import { map as mapFn, pipe, uniqBy } from "lodash/fp";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { useEffect, useRef } from "react";
+import { FC, useEffect, useRef } from "react";
+import ViewProps from "../props";
 import * as styles from "./MapView.styles";
 import CarbonmarkMap from "./carbonmark-map";
 
-export const MapView = () => {
+export const MapView: FC<ViewProps> = ({ projects }) => {
   const mapContainer = useRef<HTMLDivElement | null>(null);
   const map = useRef<CarbonmarkMap | null>(null);
-  const { projects } = useFetchProjects();
 
   //Convert projects to GeoJSON Features
   const fn = pipe(

--- a/carbonmark/components/pages/Projects/MapView/carbonmark-map.ts
+++ b/carbonmark/components/pages/Projects/MapView/carbonmark-map.ts
@@ -2,7 +2,7 @@ import { BBox } from "@turf/helpers";
 import { NEXT_PUBLIC_MAPBOX_TOKEN } from "lib/constants";
 import { Project } from "lib/types/carbonmark.types";
 import { compact, isNil } from "lodash";
-import { default as MapBoxGL, default as mapboxgl } from "mapbox-gl";
+import MapBoxGL from "mapbox-gl";
 import Supercluster, { AnyProps, ClusterFeature } from "supercluster";
 import { DEFAULT_OPTS } from "./carbonmark-map.constants";
 import { CarbonmarkMapOpts } from "./carbonmark-map.types";
@@ -14,14 +14,14 @@ MapBoxGL.accessToken = NEXT_PUBLIC_MAPBOX_TOKEN;
 
 const BRIGHT_BLUE = "#0019ff"; // var(--bright-blue)
 
-class CarbonmarkMap extends mapboxgl.Map {
+class CarbonmarkMap extends MapBoxGL.Map {
   points?: Supercluster.PointFeature<{ project: Project }>[];
   markers: MapBoxGL.Marker[] = [];
   clusterer?: Supercluster;
 
   constructor(container: string | HTMLElement, opts?: CarbonmarkMapOpts) {
     super({ container, ...DEFAULT_OPTS, ...opts });
-    this.addControl(new mapboxgl.NavigationControl(), "bottom-left");
+    this.addControl(new MapBoxGL.NavigationControl(), "bottom-left");
     this.points = opts?.points;
     this.on("moveend", () => this.renderMarkers());
     this.on("zoomend", () => this.renderMarkers());

--- a/carbonmark/components/pages/Projects/index.tsx
+++ b/carbonmark/components/pages/Projects/index.tsx
@@ -18,14 +18,14 @@ import { useEffect } from "react";
 import { SWRConfig } from "swr";
 import { GridView } from "./GridView/GridView";
 import { ListView } from "./ListView/ListView";
-import { MapView } from "./MapView/MapView";
+import LazyLoadingMapView from "./MapView/LazyLoadingMapView";
 import ProjectsController from "./ProjectsController";
 import * as styles from "./styles";
 
 const views = {
   grid: GridView,
   list: ListView,
-  map: MapView,
+  map: LazyLoadingMapView,
 };
 
 const Page: NextPage = () => {

--- a/carbonmark/components/pages/Projects/props.ts
+++ b/carbonmark/components/pages/Projects/props.ts
@@ -1,0 +1,5 @@
+import { Project } from "lib/types/carbonmark.types";
+
+export default interface ViewProps {
+  projects: Array<Project>;
+}


### PR DESCRIPTION
## Description

Lazy loading of projects page map view

## Related Ticket

Resolves #1636 

## Changes

| Before  | After  |
|---------|--------|
|/projects                                                 300 kB          693 kB |/projects                                                 22 kB           419 kB|


## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
