### PR TITLE
carbon: move detail link up for pie chart

### DIFF
--- a/carbon/components/cards/overview/TokenizedCreditsByBridgeCard/index.tsx
+++ b/carbon/components/cards/overview/TokenizedCreditsByBridgeCard/index.tsx
@@ -18,6 +18,7 @@ export default function TokenizedCreditsByBridgeCard(props: CardProps) {
       {...props}
       title={t`Tokenized credits by bridge`}
       detailUrl="/details/verra-credits-tokenized-by-bridge"
+      detailUrlPosition="top"
       chart={chart}
     />
   );


### PR DESCRIPTION
## Description

This PR moves the detail link for the tokenized credits pie chart up like with the other cards

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1701 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
