### PR TITLE
carbon: fix what is digital carbon link color

### DIFF
--- a/carbon/components/PageHeader/styles.module.scss
+++ b/carbon/components/PageHeader/styles.module.scss
@@ -48,6 +48,7 @@
 }
 
 .subheading {
+  color: var(--brand-blue);
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Description

This PR makes the "What is digital carbon?" link blue.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1699 
<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
