### PR TITLE
revised query for listings and activities

### DIFF
--- a/carbonmark-api/src/.generated/types/marketplace.types.ts
+++ b/carbonmark-api/src/.generated/types/marketplace.types.ts
@@ -1303,12 +1303,12 @@ export type GetPurchaseByIdQueryVariables = Exact<{
 export type GetPurchaseByIdQuery = { __typename?: 'Query', purchase: { __typename?: 'Purchase', amount: string, id: any, price: string, listing: { __typename?: 'Listing', id: string, tokenAddress: any, project: { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, category: { __typename?: 'Category', id: string }, country: { __typename?: 'Country', id: string } }, seller: { __typename?: 'User', id: any } } } | null };
 
 export type GetUserByWalletQueryVariables = Exact<{
-  wallet: InputMaybe<Scalars['Bytes']>;
+  wallet: InputMaybe<Scalars['String']>;
   expiresAfter: InputMaybe<Scalars['BigInt']>;
 }>;
 
 
-export type GetUserByWalletQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', listings: Array<{ __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, category: { __typename?: 'Category', id: string }, country: { __typename?: 'Country', id: string } } }> | null, activities: Array<{ __typename?: 'Activity', id: string, amount: string | null, previousAmount: string | null, price: string | null, previousPrice: string | null, timeStamp: string | null, activityType: ActivityType, project: { __typename?: 'Project', key: string, vintage: string }, buyer: { __typename?: 'User', id: any } | null, seller: { __typename?: 'User', id: any } }> | null }> };
+export type GetUserByWalletQuery = { __typename?: 'Query', listings: Array<{ __typename?: 'Listing', id: string, totalAmountToSell: string, leftToSell: string, tokenAddress: any, active: boolean | null, deleted: boolean | null, singleUnitPrice: string, createdAt: string | null, updatedAt: string | null, expiration: string, minFillAmount: string, seller: { __typename?: 'User', id: any }, project: { __typename?: 'Project', id: string, key: string, vintage: string, name: string, methodology: string, category: { __typename?: 'Category', id: string }, country: { __typename?: 'Country', id: string } } }>, activities: Array<{ __typename?: 'Activity', id: string, amount: string | null, previousAmount: string | null, price: string | null, previousPrice: string | null, timeStamp: string | null, activityType: ActivityType, project: { __typename?: 'Project', key: string, vintage: string }, buyer: { __typename?: 'User', id: any } | null, seller: { __typename?: 'User', id: any } }> };
 
 export type GetProjectsQueryVariables = Exact<{
   search: InputMaybe<Scalars['String']>;
@@ -1425,14 +1425,17 @@ export const GetPurchaseByIdDocument = gql`
 }
     ${ProjectFragmentFragmentDoc}`;
 export const GetUserByWalletDocument = gql`
-    query getUserByWallet($wallet: Bytes, $expiresAfter: BigInt) {
-  users(where: {id: $wallet}) {
-    listings(where: {expiration_gt: $expiresAfter}) {
-      ...ListingFragment
-    }
-    activities(orderBy: timeStamp, orderDirection: desc, first: 10) {
-      ...ActivityFragment
-    }
+    query getUserByWallet($wallet: String, $expiresAfter: BigInt) {
+  listings(where: {seller: $wallet, expiration_gt: $expiresAfter}) {
+    ...ListingFragment
+  }
+  activities(
+    orderBy: timeStamp
+    orderDirection: desc
+    first: 10
+    where: {or: [{seller: $wallet, activityType_not: Purchase}, {buyer: $wallet}]}
+  ) {
+    ...ActivityFragment
   }
 }
     ${ListingFragmentFragmentDoc}

--- a/carbonmark-api/src/graphql/marketplace.gql
+++ b/carbonmark-api/src/graphql/marketplace.gql
@@ -37,14 +37,19 @@ query getPurchaseById($id: ID!) {
   }
 }
 
-query getUserByWallet($wallet: Bytes, $expiresAfter: BigInt) {
-  users(where: { id: $wallet }) {
-    listings(where: { expiration_gt: $expiresAfter }) {
-      ...ListingFragment
+query getUserByWallet($wallet: String, $expiresAfter: BigInt) {
+  listings(where: { seller: $wallet, expiration_gt: $expiresAfter }) {
+    ...ListingFragment
+  }
+  activities(
+    orderBy: timeStamp
+    orderDirection: desc
+    first: 10
+    where: {
+      or: [{ seller: $wallet, activityType_not: Purchase }, { buyer: $wallet }]
     }
-    activities(orderBy: timeStamp, orderDirection: desc, first: 10) {
-      ...ActivityFragment
-    }
+  ) {
+    ...ActivityFragment
   }
 }
 

--- a/carbonmark-api/src/routes/users/get.utils.ts
+++ b/carbonmark-api/src/routes/users/get.utils.ts
@@ -71,11 +71,11 @@ export const getUserByWallet = async (params: {
   const sdk = gql_sdk(params.network);
   const expiresAfter =
     params.expiresAfter || Math.floor(Date.now() / 1000).toString();
-  const { users } = await sdk.marketplace.getUserByWallet({
+  const { listings, activities } = await sdk.marketplace.getUserByWallet({
     wallet: params.address.toLowerCase(),
     expiresAfter,
   });
-  return users.at(0);
+  return { listings, activities };
 };
 
 /** Network-aware fetcher for users holdings */

--- a/carbonmark/lib/api.ts
+++ b/carbonmark/lib/api.ts
@@ -171,7 +171,7 @@ export const getUserUntil = async (params: {
   retryInterval?: number;
   network?: "mumbai" | "polygon";
 }): Promise<User> => {
-  const fetchUser = () =>
+  const fetchUserData = () =>
     refreshUser({
       walletOrHandle: params.address,
       network: params.network,
@@ -179,7 +179,7 @@ export const getUserUntil = async (params: {
     });
 
   const updatedUser = await pollUntil({
-    fn: fetchUser,
+    fn: fetchUserData,
     validate: params.retryUntil,
     ms: params.retryInterval || 1000,
     maxAttempts: params.maxAttempts || 50,


### PR DESCRIPTION
## Description

Addresses missing activities and redundancy. Purchases by Atmos now up on Shimon's activities.

<img width="351" alt="Screen Shot 2023-10-19 at 1 17 03 PM" src="https://github.com/KlimaDAO/klimadao/assets/72105234/53aa9e59-04b3-4048-bb07-0b29f698e8bd">


## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1680 #1682 

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
