### PR TITLE
Makka / 1711 add confirm text to create listing modal

### DIFF
--- a/carbonmark/components/CreateListing/index.tsx
+++ b/carbonmark/components/CreateListing/index.tsx
@@ -163,6 +163,14 @@ export const CreateListing: FC<Props> = (props) => {
             </Trans>
           </Text>
         )}
+        <Text t="body1" color="lighter">
+          <strong>
+            <Trans>
+              The Confirm amount below reflects the sum of all your listings for
+              this specific token.
+            </Trans>
+          </strong>
+        </Text>
       </div>
     );
   };

--- a/carbonmark/components/CreateListing/index.tsx
+++ b/carbonmark/components/CreateListing/index.tsx
@@ -155,14 +155,6 @@ export const CreateListing: FC<Props> = (props) => {
             transferred out of your wallet when a sale is completed.
           </Trans>
         </Text>
-        {getTotalAssetApproval(inputValues) > Number(inputValues?.amount) && (
-          <Text t="body1" color="lighter">
-            <Trans>
-              The value below reflects the sum of all of your listings for this
-              specific token.
-            </Trans>
-          </Text>
-        )}
         <Text t="body1" color="lighter">
           <strong>
             <Trans>

--- a/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
@@ -178,14 +178,14 @@ export const ListingEditable: FC<Props> = (props) => {
             transferred out of your wallet when a sale is completed.
           </Trans>
         </Text>
-        {getTotalAssetApproval(listingToEdit) > newQuantity && (
-          <Text t="body1" color="lighter">
+        <Text t="body1" color="lighter">
+          <strong>
             <Trans>
-              The value below reflects the sum of all of your listings for this
-              specific token.
+              The Confirm amount below reflects the sum of all your listings for
+              this specific token.
             </Trans>
-          </Text>
-        )}
+          </strong>
+        </Text>
       </div>
     );
   };

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -14,16 +14,6 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:168
-msgid "The Confirm amount below reflects the sum of all your listings for this specific token."
-msgstr ""
-
-#. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:211
-msgid "Create a listing"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: components/Activities/Activities.constants.ts:4
 msgid "created listing"
 msgstr ""
@@ -150,25 +140,30 @@ msgstr ""
 #. js-lingui-explicit-id
 #: components/CreateListing/index.tsx:160
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:183
-msgid "The value below reflects the sum of all of your listings for this specific token."
+msgid "The Confirm amount below reflects the sum of all your listings for this specific token."
 msgstr ""
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:182
+#: components/CreateListing/index.tsx:174
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:197
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
 msgstr ""
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:188
+#: components/CreateListing/index.tsx:180
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:203
 msgid "You can delete this listing at any time."
 msgstr ""
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:206
+#: components/CreateListing/index.tsx:198
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:229
 msgid "{amount} tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/index.tsx:203
+msgid "Create a listing"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -14,7 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:203
+#: components/CreateListing/index.tsx:168
+msgid "The Confirm amount below reflects the sum of all your listings for this specific token."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/index.tsx:211
 msgid "Create a listing"
 msgstr ""
 
@@ -149,19 +154,19 @@ msgid "The value below reflects the sum of all of your listings for this specifi
 msgstr ""
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:174
+#: components/CreateListing/index.tsx:182
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:197
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
 msgstr ""
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:180
+#: components/CreateListing/index.tsx:188
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:203
 msgid "You can delete this listing at any time."
 msgstr ""
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:198
+#: components/CreateListing/index.tsx:206
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:229
 msgid "{amount} tonnes"
 msgstr ""

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -14,7 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:203
+#: components/CreateListing/index.tsx:168
+msgid "The Confirm amount below reflects the sum of all your listings for this specific token."
+msgstr "The Confirm amount below reflects the sum of all your listings for this specific token."
+
+#. js-lingui-explicit-id
+#: components/CreateListing/index.tsx:211
 msgid "Create a listing"
 msgstr "Create a listing"
 
@@ -149,19 +154,19 @@ msgid "The value below reflects the sum of all of your listings for this specifi
 msgstr "The value below reflects the sum of all of your listings for this specific token."
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:174
+#: components/CreateListing/index.tsx:182
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:197
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
 msgstr "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:180
+#: components/CreateListing/index.tsx:188
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:203
 msgid "You can delete this listing at any time."
 msgstr "You can delete this listing at any time."
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:198
+#: components/CreateListing/index.tsx:206
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:229
 msgid "{amount} tonnes"
 msgstr "{amount} tonnes"

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -14,16 +14,6 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:168
-msgid "The Confirm amount below reflects the sum of all your listings for this specific token."
-msgstr "The Confirm amount below reflects the sum of all your listings for this specific token."
-
-#. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:211
-msgid "Create a listing"
-msgstr "Create a listing"
-
-#. js-lingui-explicit-id
 #: components/Activities/Activities.constants.ts:4
 msgid "created listing"
 msgstr "created listing"
@@ -150,26 +140,31 @@ msgstr "You can revoke this approval at any time. The assets will only be transf
 #. js-lingui-explicit-id
 #: components/CreateListing/index.tsx:160
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:183
-msgid "The value below reflects the sum of all of your listings for this specific token."
-msgstr "The value below reflects the sum of all of your listings for this specific token."
+msgid "The Confirm amount below reflects the sum of all your listings for this specific token."
+msgstr "The Confirm amount below reflects the sum of all your listings for this specific token."
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:182
+#: components/CreateListing/index.tsx:174
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:197
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
 msgstr "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:188
+#: components/CreateListing/index.tsx:180
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:203
 msgid "You can delete this listing at any time."
 msgstr "You can delete this listing at any time."
 
 #. js-lingui-explicit-id
-#: components/CreateListing/index.tsx:206
+#: components/CreateListing/index.tsx:198
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:229
 msgid "{amount} tonnes"
 msgstr "{amount} tonnes"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/index.tsx:203
+msgid "Create a listing"
+msgstr "Create a listing"
 
 #. js-lingui-explicit-id
 #: components/Dropdown/index.tsx:133


### PR DESCRIPTION
## Description

Add the following text in bold to the create listing modal

> The Confirm amount below reflects the sum of all your listings for this specific token.

## Related Ticket

Resolves #1711 

## Checklist

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
