### PR TITLE
fix button background on mobile

### DIFF
--- a/carbon/components/ChangeLanguageButton/styles.module.scss
+++ b/carbon/components/ChangeLanguageButton/styles.module.scss
@@ -5,7 +5,7 @@
   min-height: 4.8rem;
   width: 4.8rem;
   height: 4.8rem;
-  background-color: var(--brand-white);
+  background-color: var(--lightmode-surface-02);
   color: var(--lightmode-font-01);
 
   svg {


### PR DESCRIPTION
## Description

This PR fixes the background color of the language menu button on mobile.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1767 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
