### PR TITLE
fix select & arrow design

### DIFF
--- a/carbon/components/MobileTabSelector/index.tsx
+++ b/carbon/components/MobileTabSelector/index.tsx
@@ -1,3 +1,4 @@
+import { KeyboardArrowDown } from "@mui/icons-material";
 import { MenuItem, Select, SelectChangeEvent } from "@mui/material";
 import styles from "./styles.module.scss";
 
@@ -21,6 +22,7 @@ export const MobileTabSelector = <T extends string>(props: {
       className={`${styles.select} ${props.className}`}
       value={props.value}
       onChange={handleChange}
+      IconComponent={() => <KeyboardArrowDown className={styles.selectArrow} />}
     >
       {props.options.map((option) => {
         return (

--- a/carbon/components/MobileTabSelector/index.tsx
+++ b/carbon/components/MobileTabSelector/index.tsx
@@ -22,7 +22,7 @@ export const MobileTabSelector = <T extends string>(props: {
       className={`${styles.select} ${props.className}`}
       value={props.value}
       onChange={handleChange}
-      IconComponent={() => <KeyboardArrowDown className={styles.selectArrow} />}
+      IconComponent={KeyboardArrowDown}
     >
       {props.options.map((option) => {
         return (

--- a/carbon/components/MobileTabSelector/styles.module.scss
+++ b/carbon/components/MobileTabSelector/styles.module.scss
@@ -1,12 +1,18 @@
 .select {
   width: 100%;
   font-size: 1.6rem;
-  background-color: var(--surface-04);
+  background-color: var(--brand-white);
   margin-bottom: 1.6rem;
 
   fieldset {
     border: 0;
   }
+}
+
+.selectArrow {
+  margin: 1.2rem;
+  width: 2rem;
+  height: 2rem;
 }
 
 .menuItem {

--- a/carbon/components/MobileTabSelector/styles.module.scss
+++ b/carbon/components/MobileTabSelector/styles.module.scss
@@ -7,12 +7,11 @@
   fieldset {
     border: 0;
   }
-}
 
-.selectArrow {
-  margin: 1.2rem;
-  width: 2rem;
-  height: 2rem;
+  svg {
+    width: 2rem;
+    height: 2rem;
+  }
 }
 
 .menuItem {


### PR DESCRIPTION
## Description

This PR fixes the background color as well as the arrow icon for the mobile tab selector.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1765 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
