### PR TITLE
[carbonmark] fix safemath

### DIFF
--- a/carbonmark-api/src/.generated/types/marketplace.types.ts
+++ b/carbonmark-api/src/.generated/types/marketplace.types.ts
@@ -1426,7 +1426,7 @@ export const GetPurchaseByIdDocument = gql`
     ${ProjectFragmentFragmentDoc}`;
 export const GetUserByWalletDocument = gql`
     query getUserByWallet($wallet: String, $expiresAfter: BigInt) {
-  listings(where: {seller: $wallet, expiration_gt: $expiresAfter}) {
+  listings(where: {seller: $wallet, expiration_gt: $expiresAfter, active: true}) {
     ...ListingFragment
   }
   activities(

--- a/carbonmark-api/src/graphql/marketplace.gql
+++ b/carbonmark-api/src/graphql/marketplace.gql
@@ -38,7 +38,9 @@ query getPurchaseById($id: ID!) {
 }
 
 query getUserByWallet($wallet: String, $expiresAfter: BigInt) {
-  listings(where: { seller: $wallet, expiration_gt: $expiresAfter }) {
+  listings(
+    where: { seller: $wallet, expiration_gt: $expiresAfter, active: true }
+  ) {
     ...ListingFragment
   }
   activities(

--- a/carbonmark/.generated/carbonmark-api.schema.ts
+++ b/carbonmark/.generated/carbonmark-api.schema.ts
@@ -2,7 +2,7 @@ export default {
   "openapi": "3.0.3",
   "info": {
     "title": "Carbonmark REST API",
-    "description": "\nWelcome to the API Reference docs for **version 2.0.0-10** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
+    "description": "\nWelcome to the API Reference docs for **version 2.0.0-11** of the Carbonmark REST API. Use this API to view assets, prices, supply, activity and more.\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
     "termsOfService": "https://www.carbonmark.com/blog/terms-of-use",
     "contact": {
       "name": "Support",
@@ -12,7 +12,7 @@ export default {
       "name": "MIT",
       "url": "https://github.com/KlimaDAO/klimadao/blob/main/LICENSE"
     },
-    "version": "2.0.0-10"
+    "version": "2.0.0-11"
   },
   "components": {
     "schemas": {
@@ -4521,7 +4521,7 @@ export default {
   },
   "servers": [
     {
-      "url": "https://v2.0.0-10.api.carbonmark.com"
+      "url": "https://v2.0.0-11.api.carbonmark.com"
     }
   ],
   "externalDocs": {

--- a/carbonmark/components/CreateListing/index.tsx
+++ b/carbonmark/components/CreateListing/index.tsx
@@ -88,8 +88,8 @@ export const CreateListing: FC<Props> = (props) => {
       .filter(
         (l) => l.tokenAddress.toLowerCase() === form.tokenAddress.toLowerCase()
       )
-      .reduce((a, b) => Number(safeAdd(a.toString(), b.leftToSell)), 0);
-    return Number(safeAdd(sumOtherListings.toString(), form?.amount || "0"));
+      .reduce((a, b) => safeAdd(a, b.leftToSell), "0");
+    return Number(safeAdd(sumOtherListings, form?.amount || "0"));
   };
 
   /**

--- a/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
@@ -85,8 +85,8 @@ export const ListingEditable: FC<Props> = (props) => {
           l.tokenAddress.toLowerCase() === listing.tokenAddress.toLowerCase() &&
           l.id !== listing.id
       )
-      .reduce((a, b) => Number(safeAdd(a.toString(), b.leftToSell)), 0);
-    return Number(safeAdd(sumOtherListings.toString(), newQuantity.toString()));
+      .reduce((a, b) => safeAdd(a, b.leftToSell), "0");
+    return Number(safeAdd(sumOtherListings, newQuantity.toString()));
   };
 
   /** Return true if the user has exactly the required approval for all listings of this asset */

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -28,7 +28,7 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-export const API_PROD_URL = "https://v2.0.0-10.api.carbonmark.com";
+export const API_PROD_URL = "https://v2.0.0-11.api.carbonmark.com";
 
 /**
  * Optional preview URL can be provided via env var.

--- a/carbonmark/lib/listingsGetter.ts
+++ b/carbonmark/lib/listingsGetter.ts
@@ -1,17 +1,15 @@
 import { safeAdd, safeSub } from "@klimadao/lib/utils";
 import { Listing } from "lib/types/carbonmark.types";
 
-export const getAmountLeftToSell = (listings: Listing[]) =>
-  listings.reduce((acc, curr) => {
-    return Number(safeAdd(acc.toString(), curr.leftToSell));
-  }, 0);
+export const getAmountLeftToSell = (listings: Listing[]): number =>
+  Number(listings.reduce((acc, curr) => safeAdd(acc, curr.leftToSell), "0"));
 
-export const getTotalAmountToSell = (listings: Listing[]) =>
-  listings.reduce((acc, curr) => {
-    return Number(safeAdd(acc.toString(), curr.totalAmountToSell));
-  }, 0);
+export const getTotalAmountToSell = (listings: Listing[]): number =>
+  Number(
+    listings.reduce((acc, curr) => safeAdd(acc, curr.totalAmountToSell), "0")
+  );
 
-export const getTotalAmountSold = (listings: Listing[]) => {
+export const getTotalAmountSold = (listings: Listing[]): string => {
   const totalAmount = getTotalAmountToSell(listings);
   const leftToSell = getAmountLeftToSell(listings);
   return safeSub(totalAmount.toString(), leftToSell.toString());
@@ -24,4 +22,6 @@ export const getAllListings = (listings: Listing[]) =>
   listings.filter((l) => l.deleted === false);
 
 export const getSortByUpdateListings = (listings: Listing[]) =>
-  listings.sort((a, b) => Number(safeSub(b.updatedAt!, a.updatedAt!)));
+  listings.sort((a, b) =>
+    Number(safeSub(b.updatedAt || "0", a.updatedAt || "0"))
+  );

--- a/carbonmark/lib/utils/listings.utils.ts
+++ b/carbonmark/lib/utils/listings.utils.ts
@@ -24,9 +24,8 @@ export const getListedBalance = (asset: Asset, listings: Listing[]): number => {
   const assetListings = listings.filter(
     (l) => l.tokenAddress.toLowerCase() === asset.token.id.toLowerCase()
   );
-  return assetListings.reduce(
-    (sum, l) => Number(safeAdd(sum.toString(), l.leftToSell)),
-    0
+  return Number(
+    assetListings.reduce((sum, l) => safeAdd(sum, l.leftToSell), "0")
   );
 };
 


### PR DESCRIPTION
## Description
Converting a decimal with .toString() was creating strings with exponent syntax `1.12e10`which would cause the ethers parseUnits to fail.
Now we do all the math with strings and convert to number at the end.

Also snuck in a change to the gql query to not return deleted listings related to #1750

## Checklist

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
