### PR TITLE
[klima data] Makes Digital carbon pricing card respect design on larger screens

### DIFF
--- a/carbon/components/cards/overview/TokensPriceCard/index.tsx
+++ b/carbon/components/cards/overview/TokensPriceCard/index.tsx
@@ -1,6 +1,6 @@
 import { formatTonnes } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
-import { ArrowDropDown, ArrowDropUp, InfoOutlined } from "@mui/icons-material";
+import { InfoOutlined } from "@mui/icons-material";
 import { Tooltip } from "@mui/material";
 import PercentageChange from "components/PercentageChage";
 import ChartCard, { CardProps } from "components/cards/ChartCard";
@@ -40,8 +40,7 @@ export default function TokensPriceCard(props: CardProps) {
   );
 }
 
-/** Async server component
- */
+/** Async server component */
 async function TokenPricesChart(props: { layout: CoinTilesLayout }) {
   const locale = currentLocale();
   const prices7daysAgo: PricesItem = (
@@ -66,12 +65,6 @@ async function TokenPricesChart(props: { layout: CoinTilesLayout }) {
         prices7daysAgo[`${token}_price` as Extract<keyof PricesItem, number>];
       const priceChangePercentage =
         ((tokenInfo.price - price7DaysAgo) * 100) / tokenInfo.price;
-      const priceChangeIcon =
-        priceChangePercentage > 0 ? (
-          <ArrowDropUp color={"success"}></ArrowDropUp>
-        ) : (
-          <ArrowDropDown color={"error"}></ArrowDropDown>
-        );
 
       // Selective cost
       const selectiveCostInfo =

--- a/carbon/components/charts/helpers/CoinTiles/index.tsx
+++ b/carbon/components/charts/helpers/CoinTiles/index.tsx
@@ -39,6 +39,8 @@ export function CoinTile(props: { data: CoinTileData }) {
     </div>
   );
 }
+
+/** A component that renders tiles */
 export function CoinTiles(props: Props) {
   const tiles_styles =
     props.layout == "row"

--- a/carbon/components/charts/helpers/CoinTiles/styles.module.scss
+++ b/carbon/components/charts/helpers/CoinTiles/styles.module.scss
@@ -37,7 +37,7 @@ And enable css to be passed to items of all rows except the last one
     @include configureGrid(3);
   }
   @include breakpoints.desktopLarge {
-    @include configureGrid(4);
+    @include configureGrid(3);
   }
 }
 .tile {


### PR DESCRIPTION
## Description

Makes Digital carbon pricing card respect design on larger screens

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1730

## Changes

| Before  | After  |
|---------|--------|
|![image](https://github.com/KlimaDAO/klimadao/assets/11857992/8331bd63-d7f1-4c52-8a40-307300ea77a0) |![image](https://github.com/KlimaDAO/klimadao/assets/11857992/10861794-edb8-49c1-a50c-57b18228789c)|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
