### PR TITLE
[klima data] carbon: Better scale fonts for digital carbon supply detail page

### DIFF
--- a/carbon/components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx
+++ b/carbon/components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx
@@ -13,7 +13,9 @@ import styles from "./styles.module.scss";
 export default function CarbonSupplyQuickFactsCard(props: CardProps) {
   const chart = (
     /* @ts-expect-error async Server component */
-    <CarbonSupplyQuickFactsChart></CarbonSupplyQuickFactsChart>
+    <CarbonSupplyQuickFactsChart
+      isDetailPage={props.isDetailPage}
+    ></CarbonSupplyQuickFactsChart>
   );
 
   return (
@@ -27,7 +29,7 @@ export default function CarbonSupplyQuickFactsCard(props: CardProps) {
 }
 
 /** Async server component that renders a Recharts client component */
-async function CarbonSupplyQuickFactsChart() {
+async function CarbonSupplyQuickFactsChart(props: { isDetailPage?: boolean }) {
   const metricsNow = await getLatestCarbonMetrics();
   const metrics7DaysAgo = await getCarbonMetrics7daysAgo();
 
@@ -113,9 +115,12 @@ async function CarbonSupplyQuickFactsChart() {
       </div>
     );
   }
+  const wrapperclassName = props.isDetailPage
+    ? `${styles.wrapper} ${styles.detailsPageWrapper}`
+    : styles.wrapper;
 
   return (
-    <div className={styles.wrapper}>
+    <div className={wrapperclassName}>
       {data.map((item) => CarbonSupplyQuickFactsColumn(item))}
     </div>
   );

--- a/carbon/components/cards/supply/CarbonSupplyQuickFactsCard/styles.module.scss
+++ b/carbon/components/cards/supply/CarbonSupplyQuickFactsCard/styles.module.scss
@@ -1,3 +1,5 @@
+@use "~@klimadao/lib/theme/breakpoints.scss";
+
 .wrapper {
   display: flex;
   flex-shrink: 0;
@@ -35,5 +37,21 @@
 
   [aria-describedby="label"] {
     font-size: 0.8rem;
+  }
+}
+// Font scalling for details page
+.detailsPageWrapper {
+  .title {
+    font-size: 1.6rem;
+  }
+  .fact {
+    font-size: 1.6rem;
+  }
+  [aria-describedby="value"] {
+    font-size: 1.6rem;
+  }
+
+  [aria-describedby="label"] {
+    font-size: 1.2rem;
   }
 }


### PR DESCRIPTION
## Description

Better scale fonts for digital carbon supply detail page

## Related Ticket

Resolves #1745 


## Changes

| Before  | After  |
|---------|--------|
|![image](https://github.com/KlimaDAO/klimadao/assets/11857992/37909c5d-335a-4877-b08a-b6b8a7353ef3) |![image](https://github.com/KlimaDAO/klimadao/assets/11857992/85892f43-e915-4e24-8b99-591965a11364)|



## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
