### PR TITLE
[klima data] carbon: Fix tooltip y axis formatter

### DIFF
--- a/carbon/components/charts/helpers/KlimaTooltip.tsx
+++ b/carbon/components/charts/helpers/KlimaTooltip.tsx
@@ -1,4 +1,3 @@
-import { t } from "@lingui/macro";
 import { TooltipProps } from "recharts";
 import {
   NameType,
@@ -37,7 +36,7 @@ export function KlimaTooltip(params: {
                 <div>
                   {pld.value !== undefined &&
                     params.yAxisFormatter &&
-                    params.yAxisFormatter(pld.value as number) + t`T`}
+                    params.yAxisFormatter(pld.value as number)}
                 </div>
               </div>
             ))}

--- a/carbon/components/charts/helpers/props.ts
+++ b/carbon/components/charts/helpers/props.ts
@@ -119,7 +119,7 @@ export function getToolTipYAxisFormatter(YAxis: YAxisType) {
   const locale = currentLocale();
   // Default format tons
   let toolTipYAxisFormatter = (x: number) =>
-    helpers.formatTonnes({ amount: x, maximumFractionDigits: 2 });
+    helpers.formatTonnes({ amount: x, maximumFractionDigits: 2 }) + `T`;
   if (YAxis == "price") {
     toolTipYAxisFormatter = helpers.formatPrice;
   }


### PR DESCRIPTION
## Description

Fix tooltip y axis formatter

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1774

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
