### PR TITLE
center switch on screen

### DIFF
--- a/carbon/components/OptionsSwitcher/index.tsx
+++ b/carbon/components/OptionsSwitcher/index.tsx
@@ -19,6 +19,7 @@ export default function OptionsSwitcher<T extends Key>(props: {
     return props.onSelectionChange(value);
   };
   return (
+    // FIXME: this doesn't let you override certain styles
     <ul
       className={`${styles.list} ${!!props.className ? props.className : ""}`}
     >

--- a/carbon/components/pages/offVsOnChain/OffVsOnChainClientWrapper/styles.module.scss
+++ b/carbon/components/pages/offVsOnChain/OffVsOnChainClientWrapper/styles.module.scss
@@ -1,4 +1,4 @@
 .centered {
-  display: flex;
-  margin: 1rem auto 2rem auto;
+  display: flex !important;
+  margin: 1rem auto 2rem auto !important;
 }


### PR DESCRIPTION
## Description

This PR force-centers the issued/retired switch on screen.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1734 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
