### PR TITLE
fix paddings and spacings

### DIFF
--- a/carbon/components/pages/PageWithTabs/index.tsx
+++ b/carbon/components/pages/PageWithTabs/index.tsx
@@ -136,44 +136,35 @@ export default function PageWithTabs(props: {
               ></Tab>
             ))}
           </TabList>
-          {props.tabs.map(
-            (tab, tabIndex) =>
-              tabsDynamicOptionsList[tabIndex] && (
-                <TabPanel
-                  key={tabIndex}
-                  value={tab.key}
-                  className={styles.noPadding}
-                >
-                  <div className={styles.optionsSwitchers}>
-                    {tabsDynamicOptionsList[tabIndex].map(
-                      (options, widgetIndex) => (
-                        <div
-                          key={widgetIndex}
-                          className={styles.optionsSwitcherWrapper}
-                        >
-                          <OptionsSwitcher
-                            options={options}
-                            onSelectionChange={onOptionChange(
-                              tabIndex,
-                              widgetIndex
-                            )}
-                            value={optionKeys[tabIndex][widgetIndex]}
-                            className={styles.optionsSwitcher}
-                          />
-                        </div>
-                      )
-                    )}
-                  </div>
-                </TabPanel>
-              )
-          )}
 
           {props.tabs.map((tab, tabIndex) => (
             <TabPanel
               key={tabIndex}
               value={tab.key}
-              className={styles.noPadding}
+              className={styles.topPadding}
             >
+              {tabsDynamicOptionsList[tabIndex] && (
+                <div className={styles.optionsSwitchers}>
+                  {tabsDynamicOptionsList[tabIndex].map(
+                    (options, widgetIndex) => (
+                      <div
+                        key={widgetIndex}
+                        className={styles.optionsSwitcherWrapper}
+                      >
+                        <OptionsSwitcher
+                          options={options}
+                          onSelectionChange={onOptionChange(
+                            tabIndex,
+                            widgetIndex
+                          )}
+                          value={optionKeys[tabIndex][widgetIndex]}
+                          className={styles.optionsSwitcher}
+                        />
+                      </div>
+                    )
+                  )}
+                </div>
+              )}
               {displayedTab(tabIndex)}
             </TabPanel>
           ))}

--- a/carbon/components/pages/PageWithTabs/styles.module.scss
+++ b/carbon/components/pages/PageWithTabs/styles.module.scss
@@ -20,10 +20,8 @@
   }
 }
 
-.noPadding {
-  padding-left: 0;
-  padding-right: 0;
-  padding-bottom: 0;
+.topPadding {
+  padding: 2rem 0 0 0;
 }
 
 .tabRoot {

--- a/carbon/theme/layout.module.scss
+++ b/carbon/theme/layout.module.scss
@@ -39,7 +39,7 @@
 
   @include breakpoints.desktop {
     display: flex;
-    gap: 1rem;
+    gap: 2rem;
   }
 }
 .cardRowWrap {


### PR DESCRIPTION
## Description

This PR fixes the top padding on tabbed pages as well as tweaking the padding between the cards to match the figma design.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1746 
Resolves #1758

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
