### PR TITLE
carbon: enable card titles to wrap on mobile

### DIFF
--- a/carbon/components/cards/ChartCard/index.tsx
+++ b/carbon/components/cards/ChartCard/index.tsx
@@ -71,9 +71,14 @@ export default function ChartCard<T extends Key, B extends Key>(
   const bottomDetailUrlComponent =
     detailUrlPosition == "bottom" ? detailUrlComponent : <></>;
 
-  const cardHeaderTitleStyle = `${styles.cardHeaderTitle} ${
-    props.centerTitle ? layout.textCenter : ""
-  }`;
+  // Computes the style of the header title
+  let cardHeaderTitleStyle = styles.cardHeaderTitle;
+  // Center the title if requested
+  if (props.centerTitle)
+    cardHeaderTitleStyle = `${cardHeaderTitleStyle} ${layout.textCenter}`;
+  // Prevent title from growing if there are top options, so top options are perfectly centered
+  if (props.topOptions)
+    cardHeaderTitleStyle = `${cardHeaderTitleStyle} ${styles.cardHeaderTitleNoGrow}`;
 
   /** Returns the chart to display given the chosen options
    If the the chart attribute is filled, it is that chart.

--- a/carbon/components/cards/ChartCard/styles.module.scss
+++ b/carbon/components/cards/ChartCard/styles.module.scss
@@ -38,15 +38,17 @@
 }
 
 .cardHeaderTitle {
-  min-width: 30rem;
   @include breakpoints.large {
     white-space: nowrap;
     min-width: auto;
   }
-  flex: 1 1 0;
+  flex: 3 1 0;
   font-size: 1.4rem;
   font-weight: 700;
   margin: 0;
+}
+.cardHeaderTitleNoGrow {
+  flex-grow: 1;
 }
 
 .cardHeaderDetailsLink {

--- a/carbon/components/cards/ChartCard/styles.module.scss
+++ b/carbon/components/cards/ChartCard/styles.module.scss
@@ -38,7 +38,11 @@
 }
 
 .cardHeaderTitle {
-  white-space: nowrap;
+  min-width: 30rem;
+  @include breakpoints.large {
+    white-space: nowrap;
+    min-width: auto;
+  }
   flex: 1 1 0;
   font-size: 1.4rem;
   font-weight: 700;

--- a/carbon/components/cards/ChartCard/styles.module.scss
+++ b/carbon/components/cards/ChartCard/styles.module.scss
@@ -32,8 +32,7 @@
 .cardHeader {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  align-items: center;
+  align-items: start;
   margin-bottom: 1.2rem;
 }
 


### PR DESCRIPTION
## Description

Enables card titles to wrap on mobile devices

## Related Ticket

Resolves #1798 
<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|![image](https://github.com/KlimaDAO/klimadao/assets/11857992/ade2a367-1970-4f49-b82e-9b58d39ebea4) |![image](https://github.com/KlimaDAO/klimadao/assets/11857992/0425863d-5b24-4bb1-bc03-9a0aa3972d22)|


## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
