### PR TITLE
fix desktop colors for header buttons

### DIFF
--- a/carbon/components/Layout/styles.module.scss
+++ b/carbon/components/Layout/styles.module.scss
@@ -34,6 +34,10 @@
   color: var(--lightmode-font-01);
   background-color: var(--lightmode-surface-02);
 
+  @include breakpoints.desktop {
+    background-color: var(--brand-white);
+  }
+
   svg {
     width: 2.4rem;
     height: 2.4rem;


### PR DESCRIPTION
## Description

The change language button background color was wrong on desktop layouts since it was changed to appear on the mobile header. This PR makes uses the figma colors on both layouts.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #<issue-number>

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
