### PR TITLE
carbon: make tabs and options sticky on mobile

### DIFF
--- a/carbon/components/MobileTabSelector/index.tsx
+++ b/carbon/components/MobileTabSelector/index.tsx
@@ -11,7 +11,7 @@ export const MobileTabSelector = <T extends string>(props: {
   value: string;
   options: Array<TypedOption<T>>;
   onSelectionChanged: (value: T) => void;
-  className: string;
+  className?: string;
 }) => {
   const handleChange = (event: SelectChangeEvent) => {
     props.onSelectionChanged(event.target.value as T);
@@ -19,7 +19,7 @@ export const MobileTabSelector = <T extends string>(props: {
 
   return (
     <Select
-      className={`${styles.select} ${props.className}`}
+      className={`${styles.select} ${props.className ?? ""}`}
       value={props.value}
       onChange={handleChange}
       IconComponent={KeyboardArrowDown}

--- a/carbon/components/MobileTabSelector/styles.module.scss
+++ b/carbon/components/MobileTabSelector/styles.module.scss
@@ -2,7 +2,7 @@
   width: 100%;
   font-size: 1.6rem;
   background-color: var(--brand-white);
-  margin-bottom: 1.6rem;
+  margin-bottom: 0.8rem;
 
   fieldset {
     border: 0;

--- a/carbon/components/pages/PageWithTabs/index.tsx
+++ b/carbon/components/pages/PageWithTabs/index.tsx
@@ -10,7 +10,6 @@ import { PageHeader } from "components/PageHeader/PageHeader";
 import { Options } from "lib/charts/options";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Key, ReactNode, useEffect, useState } from "react";
-import layout from "theme/layout.module.scss";
 import styles from "./styles.module.scss";
 
 type TabParam = {
@@ -115,18 +114,16 @@ export default function PageWithTabs(props: {
       <PageHeader title={props.title} />
       <TabContext value={activeTab}>
         <div className={styles.tabRoot}>
-          <MobileTabSelector
-            value={activeTab}
-            options={props.tabs.map((tab) => {
-              return { label: tab.label, value: tab.key };
-            })}
-            onSelectionChanged={(key: string) => setActiveTab(key)}
-            className={`${styles.mobileOnly} ${styles.mobileTabSelector}`}
-          />
-          <TabList
-            onChange={handleChange}
-            className={`${layout.desktopOnly} ${styles.tabList}`}
-          >
+          <div className={styles.mobileTabSelectorWrapper}>
+            <MobileTabSelector
+              value={activeTab}
+              options={props.tabs.map((tab) => {
+                return { label: tab.label, value: tab.key };
+              })}
+              onSelectionChanged={(key: string) => setActiveTab(key)}
+            />
+          </div>
+          <TabList onChange={handleChange} className={`${styles.tabList}`}>
             {props.tabs.map((tab) => (
               <Tab
                 key={tab.key}

--- a/carbon/components/pages/PageWithTabs/styles.module.scss
+++ b/carbon/components/pages/PageWithTabs/styles.module.scss
@@ -12,16 +12,20 @@
   }
 }
 
-.desktopOnly {
+.topPadding {
+  padding: 0;
+
+  @include breakpoints.large {
+    padding: 2rem 0 0 0;
+  }
+}
+
+.tabList {
   display: none;
 
   @include breakpoints.large {
     display: unset;
   }
-}
-
-.topPadding {
-  padding: 2rem 0 0 0;
 }
 
 .tabRoot {
@@ -30,19 +34,37 @@
   }
 }
 
+.mobileTabSelectorWrapper {
+  position: sticky;
+  top: 0;
+  padding-top: 0.8rem;
+  z-index: 700;
+  height: 6.4rem;
+  background-color: var(--brand-background);
+
+  @include breakpoints.large {
+    display: none;
+  }
+}
+
 .optionsSwitchers {
+  position: sticky;
+  top: 6.4rem;
+  z-index: 700;
+  background-color: var(--brand-background);
   display: grid;
   justify-content: space-between;
   row-gap: 0.8rem;
+  padding: 0.8rem 0;
+  grid-template-columns: repeat(auto-fill, 100%);
   grid-template-areas:
-    "one three"
-    "two two";
-
-  @include breakpoints.large {
-    grid-template-areas: "one two three";
-  }
+    "three"
+    "one"
+    "two";
 
   @include breakpoints.desktopLarge {
+    grid-template-areas: "one two three";
+    grid-template-columns: auto;
     position: absolute;
     top: 0;
     right: 0;
@@ -57,7 +79,6 @@
   }
   &:nth-child(2) {
     grid-area: two;
-    justify-self: center;
   }
   &:nth-child(3) {
     grid-area: three;
@@ -71,13 +92,19 @@
 }
 
 .optionsSwitcher {
+  width: 100%;
+
   li {
     display: flex;
     align-items: center;
+    justify-content: center;
     height: 4rem;
+    flex: 1;
   }
 
   @include breakpoints.desktopLarge {
+    width: min-content;
+    flex: 0;
     li {
       height: min-content;
     }


### PR DESCRIPTION
## Description

This PR makes the mobile tab selector as well as the chart options sticky.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1763 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
