### PR TITLE
center chart legend on mobile

### DIFF
--- a/carbon/components/charts/helpers/KAreaChart/index.tsx
+++ b/carbon/components/charts/helpers/KAreaChart/index.tsx
@@ -9,6 +9,7 @@ import {
   getXAxisProps,
   getYAxisProps,
 } from "../props";
+import styles from "../styles.module.scss";
 
 /** FIXME: Refactor to KlimaAreaChart */
 export default function KAreaChart<T extends object>(props: ChartProps<T>) {
@@ -22,7 +23,11 @@ export default function KAreaChart<T extends object>(props: ChartProps<T>) {
     );
 
   return (
-    <ChartWrapper data={props.data} noDataText={props.noDataText}>
+    <ChartWrapper
+      data={props.data}
+      noDataText={props.noDataText}
+      className={styles.mobileCenteredLegend}
+    >
       <AreaChart data={props.data}>
         {KlimaStackedAreas(props.configuration)}
         <XAxis {...getXAxisProps(props)} />

--- a/carbon/components/charts/helpers/KBarChart/index.tsx
+++ b/carbon/components/charts/helpers/KBarChart/index.tsx
@@ -9,6 +9,7 @@ import {
   getXAxisProps,
   getYAxisProps,
 } from "../props";
+import styles from "../styles.module.scss";
 
 /** FIXME: Refactor to KlimaBarChart */
 export default function KBarChart<T extends object>(props: ChartProps<T>) {
@@ -20,7 +21,11 @@ export default function KBarChart<T extends object>(props: ChartProps<T>) {
       BOTTOM_LEFT_LEGEND_PROPS
     );
   return (
-    <ChartWrapper data={props.data} noDataText={props.noDataText}>
+    <ChartWrapper
+      data={props.data}
+      noDataText={props.noDataText}
+      className={styles.mobileCenteredLegend}
+    >
       <BarChart data={props.data} barCategoryGap={"5%"}>
         {props.XAxis && <XAxis {...getXAxisProps(props)} />}
         {props.YAxis && <YAxis {...getYAxisProps(props)} />}

--- a/carbon/components/charts/helpers/KLineChart/index.tsx
+++ b/carbon/components/charts/helpers/KLineChart/index.tsx
@@ -9,6 +9,7 @@ import {
   getXAxisProps,
   getYAxisProps,
 } from "../props";
+import styles from "../styles.module.scss";
 
 /** FIXME: Refactor to KlimaLineChart */
 export default function KLineChart<T extends object>(props: ChartProps<T>) {
@@ -21,7 +22,11 @@ export default function KLineChart<T extends object>(props: ChartProps<T>) {
     );
 
   return (
-    <ChartWrapper data={props.data} noDataText={props.noDataText}>
+    <ChartWrapper
+      data={props.data}
+      noDataText={props.noDataText}
+      className={styles.mobileCenteredLegend}
+    >
       <LineChart data={props.data}>
         <XAxis {...getXAxisProps(props)} />
         <YAxis {...getYAxisProps(props)} />

--- a/carbon/components/charts/helpers/styles.module.scss
+++ b/carbon/components/charts/helpers/styles.module.scss
@@ -1,3 +1,5 @@
+@use "~@klimadao/lib/theme/breakpoints.scss";
+
 .chartLegendText {
   color: var(--lightmode-font-01);
   font-size: 1.2rem;
@@ -37,5 +39,16 @@
     display: block;
     width: 0.8rem;
     height: 0.8rem;
+  }
+}
+
+.mobileCenteredLegend {
+  ul {
+    display: flex;
+    justify-content: center;
+
+    @include breakpoints.desktop {
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR centers the chart legends on mobile screens for:
* Line charts
* Bar charts
* Area charts 

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1766

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
