### PR TITLE
[klima data] fix Verra credits breakdown cards css

### DIFF
--- a/carbon/app/[locale]/off-chain-vs-on-chain/page.tsx
+++ b/carbon/app/[locale]/off-chain-vs-on-chain/page.tsx
@@ -7,6 +7,7 @@ import OffVsOnChainClientWrapper from "components/pages/offVsOnChain/OffVsOnChai
 import OffVsOnChainTab from "components/pages/offVsOnChain/OffVsOnChainTab";
 import { PageLinks } from "lib/PageLinks";
 import layout from "theme/layout.module.scss";
+import styles from "./styles.module.scss";
 
 export default function OffVsOnChainPage() {
   const issuedCreditsTab = <OffVsOnChainTab status="issued" />;
@@ -15,7 +16,9 @@ export default function OffVsOnChainPage() {
     <div>
       <PageHeader title={t`Off vs On-chain carbon`} />
       <div className={layout.cardStackedRows}>
-        <div className={`${layout.cardRow} ${layout.prioritizeFirstCard}`}>
+        <div
+          className={`${layout.cardRow} ${layout.prioritizeFirstCard} ${styles.firstRow}`}
+        >
           <VerraCreditsBreakdownCard className={layout.zIndexSeven} />
           <TokenizedCreditsByBridgeCard
             className={layout.zIndexSix}

--- a/carbon/app/[locale]/off-chain-vs-on-chain/styles.module.scss
+++ b/carbon/app/[locale]/off-chain-vs-on-chain/styles.module.scss
@@ -1,0 +1,10 @@
+@use "~@klimadao/lib/theme/breakpoints.scss";
+
+.firstRow {
+  min-height: auto;
+  max-width: auto;
+  height: auto;
+  @include breakpoints.desktopLarge {
+    max-height: 28.4rem;
+  }
+}

--- a/carbon/app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx
+++ b/carbon/app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx
@@ -1,4 +1,5 @@
 import { t } from "@lingui/macro";
+import cardStyles from "components/cards/ChartCard/styles.module.scss";
 import VerraCreditsBreakdownCard from "components/cards/offVsOnChain/VerraCreditsBreakdownCard";
 import DetailPage from "components/pages/DetailPage";
 import { PageLinks } from "lib/PageLinks";
@@ -7,7 +8,12 @@ export default function VerraCreditsBreakdownPage() {
   return (
     <DetailPage
       pageTitle={t`Verra credits breakdown`}
-      card={<VerraCreditsBreakdownCard isDetailPage={true} />}
+      card={
+        <VerraCreditsBreakdownCard
+          isDetailPage={true}
+          className={cardStyles.rowCardContainer}
+        />
+      }
       overview={t`The total number of carbon credits that have been issued by carbon registry Verra and what portion have been bridged, tokenized, and retired on-chain.`}
       backButtonHref={PageLinks.OffChainVsOnChain}
     />

--- a/carbon/components/Layout/styles.module.scss
+++ b/carbon/components/Layout/styles.module.scss
@@ -15,6 +15,9 @@
   display: flex;
   flex-direction: column;
   background-color: var(--brand-background);
+  @include breakpoints.desktop {
+    max-width: calc(100vw - 22rem);
+  }
 }
 
 .desktopLayout {

--- a/carbon/components/cards/ChartCard/index.tsx
+++ b/carbon/components/cards/ChartCard/index.tsx
@@ -114,7 +114,6 @@ export default function ChartCard<T extends Key, B extends Key>(
   if (bottomOptionsPosition == "center") {
     footerClassName = `${footerClassName} ${styles.overlapLegend}`;
   }
-
   return (
     <div
       className={cx(cardClassName, props.className)}

--- a/carbon/components/cards/ChartCard/styles.module.scss
+++ b/carbon/components/cards/ChartCard/styles.module.scss
@@ -25,7 +25,7 @@
 
   &[aria-roledescription="detailPage"] {
     min-height: 40rem;
-    height: 40rem;
+    height: auto;
   }
 }
 

--- a/carbon/components/cards/ChartCard/styles.module.scss
+++ b/carbon/components/cards/ChartCard/styles.module.scss
@@ -38,7 +38,6 @@
 
 .cardHeaderTitle {
   @include breakpoints.desktopLarge {
-    white-space: nowrap;
     min-width: auto;
   }
   flex: 3 1 0;

--- a/carbon/components/cards/ChartCard/styles.module.scss
+++ b/carbon/components/cards/ChartCard/styles.module.scss
@@ -37,7 +37,7 @@
 }
 
 .cardHeaderTitle {
-  @include breakpoints.large {
+  @include breakpoints.desktopLarge {
     white-space: nowrap;
     min-width: auto;
   }

--- a/carbon/components/cards/offVsOnChain/VerraCreditsBreakdownCard/index.tsx
+++ b/carbon/components/cards/offVsOnChain/VerraCreditsBreakdownCard/index.tsx
@@ -1,6 +1,5 @@
 import { t } from "@lingui/macro";
 import ChartCard, { CardProps } from "components/cards/ChartCard";
-import layout from "theme/layout.module.scss";
 import { IssuedVsTokenizedCreditsChart } from "./issuedVsTokenizedCreditsChart";
 import {
   OffchainRetiredCreditsCard,
@@ -15,15 +14,20 @@ export default function VerraCreditsBreakdownCard(props: CardProps) {
     : styles.wrapper;
   const chart = (
     <div className={wrapperClassName}>
-      {/* @ts-expect-error async Server component */}
-      <IssuedVsTokenizedCreditsChart />
-      {/* @ts-expect-error async Server component */}
-      <OffchainRetiredCreditsCard />
-      {/* @ts-expect-error async Server component */}
-      <OnchainRetiredCreditsCard />
+      <div>
+        {/* @ts-expect-error async Server component */}
+        <IssuedVsTokenizedCreditsChart />
+      </div>
+      <div>
+        {/* @ts-expect-error async Server component */}
+        <OffchainRetiredCreditsCard />
+        {/* @ts-expect-error async Server component */}
+        <OnchainRetiredCreditsCard />
+      </div>
     </div>
   );
   const title = t`Verra credits breakdown`;
+  const cardClassName = `${props.className} ${styles.card}`;
 
   return (
     <ChartCard
@@ -31,7 +35,8 @@ export default function VerraCreditsBreakdownCard(props: CardProps) {
       title={title}
       detailUrl="/off-chain-vs-on-chain/verra-credits-breakdown"
       chart={chart}
-      className={layout.zIndexSeven}
+      isColumnCard={true}
+      className={cardClassName}
     />
   );
 }

--- a/carbon/components/cards/offVsOnChain/VerraCreditsBreakdownCard/styles.module.scss
+++ b/carbon/components/cards/offVsOnChain/VerraCreditsBreakdownCard/styles.module.scss
@@ -1,26 +1,33 @@
 @use "~@klimadao/lib/theme/breakpoints.scss";
 
+.card {
+  @include breakpoints.large {
+    height: 28.4rem;
+    min-height: 28.4rem;
+  }
+}
 .wrapper {
-  display: flex;
   line-height: normal;
   height: 100%;
-  & > div {
-    min-width: 14rem;
-  }
+  display: flex;
+  flex-direction: column;
   & > div:nth-child(1) {
     flex: 10 1 0;
   }
   & > div:nth-child(2) {
     flex: 0 0 0;
+    display: flex;
+    justify-content: center;
   }
-  & > div:nth-child(3) {
-    flex: 0 0 0;
+  @include breakpoints.large {
+    flex-direction: row;
+    align-items: center;
   }
 }
 .wrapperDetailsPage {
   & > div {
     @include breakpoints.desktopLarge {
-      min-width: 28rem;
+      min-width: 46rem;
     }
   }
 }
@@ -31,7 +38,7 @@
   justify-content: center;
   div[aria-describedby="chart"] {
     max-width: calc(100% - 1rem);
-    min-height: 2.4rem;
+    height: 2.4rem;
   }
 }
 .issuedvsRetiredWrapper {
@@ -41,10 +48,14 @@
   align-items: center;
   justify-content: center;
   text-align: center;
+  min-width: 14rem;
 }
 .pieChartWrapper {
   max-width: calc(100% - 1rem);
   min-width: calc(100% - 1rem);
+  height: 14rem;
+
+  position: relative;
   flex-grow: 10;
 }
 .pieChartInnerLegend {
@@ -71,4 +82,14 @@
 }
 .highlight {
   color: var(--brand-green);
+}
+// Layout adjustments for dettail page
+[aria-roledescription="detailPage"] {
+  .issuedvsRetiredWrapper {
+    width: 24rem;
+  }
+  .pieChartWrapper {
+    min-height: 24rem;
+    height: 24rem;
+  }
 }

--- a/carbon/components/pages/PageWithTabs/index.tsx
+++ b/carbon/components/pages/PageWithTabs/index.tsx
@@ -131,7 +131,7 @@ export default function PageWithTabs(props: {
               value={tab.key}
               className={styles.topPadding}
             >
-              {tabsDynamicOptionsList[tabIndex] && (
+              {tabsDynamicOptionsList[tabIndex].length > 0 && (
                 <div className={styles.optionsSwitchers}>
                   {tabsDynamicOptionsList[tabIndex].map(
                     (options, widgetIndex) => (

--- a/carbon/components/pages/PageWithTabs/styles.module.scss
+++ b/carbon/components/pages/PageWithTabs/styles.module.scss
@@ -61,7 +61,9 @@
     "three"
     "one"
     "two";
-
+  @include breakpoints.large {
+    top: 0;
+  }
   @include breakpoints.desktopLarge {
     grid-template-areas: "one two three";
     grid-template-columns: auto;

--- a/carbon/theme/layout.module.scss
+++ b/carbon/theme/layout.module.scss
@@ -46,7 +46,7 @@
   @include breakpoints.desktop {
     flex-wrap: wrap;
     & > div {
-      flex-basis: 49%;
+      flex-basis: calc(50% - 2rem);
       flex-grow: 0;
     }
   }


### PR DESCRIPTION
## Description

 fix Verra credits breakdown cards css

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1841

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|![image](https://github.com/KlimaDAO/klimadao/assets/11857992/baaf6eeb-4ba9-4c20-8115-cc1cb3137fb4) |![image](https://github.com/KlimaDAO/klimadao/assets/11857992/b5487c26-5112-4756-b494-05787b509550)|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
