### PR TITLE
update icon imports

### DIFF
--- a/carbon/components/Layout/Footer/index.tsx
+++ b/carbon/components/Layout/Footer/index.tsx
@@ -1,11 +1,9 @@
 import { urls } from "@klimadao/lib/constants";
-import {
-  GitHub,
-  LinkedIn,
-  Telegram,
-  Twitter,
-  YouTube,
-} from "@mui/icons-material";
+import GitHubIcon from "@mui/icons-material/GitHub";
+import LinkedInIcon from "@mui/icons-material/LinkedIn";
+import TelegramIcon from "@mui/icons-material/Telegram";
+import TwitterIcon from "@mui/icons-material/Twitter";
+import YouTubeIcon from "@mui/icons-material/YouTube";
 import { Link } from "@mui/material";
 import { FC } from "react";
 import layout from "theme/layout.module.scss";
@@ -34,22 +32,22 @@ export const Footer: FC = () => {
       </div>
       <div className={styles.footerSocialLinks}>
         <Link href={urls.twitter}>
-          <Twitter />
+          <TwitterIcon />
         </Link>
         <Link href={urls.youtube}>
-          <YouTube />
+          <YouTubeIcon />
         </Link>
         <Link href={urls.discordInvite}>
           <DiscordSvg />
         </Link>
         <Link href={urls.github} className={layout.mobileOnly}>
-          <GitHub />
+          <GitHubIcon />
         </Link>
         <Link href={urls.linkedIn}>
-          <LinkedIn />
+          <LinkedInIcon />
         </Link>
         <Link href={urls.telegram}>
-          <Telegram />
+          <TelegramIcon />
         </Link>
       </div>
     </div>

--- a/carbon/components/Layout/MobileMenuButton/index.tsx
+++ b/carbon/components/Layout/MobileMenuButton/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Clear, Menu } from "@mui/icons-material";
+import ClearIcon from "@mui/icons-material/Clear";
+import MenuIcon from "@mui/icons-material/Menu";
 import { Button, Drawer } from "@mui/material";
 import { useState } from "react";
 import { navItems } from "../NavItems";
@@ -16,8 +17,8 @@ export function MobileMenuButton() {
   return (
     <>
       <Button onClick={toggleDrawer} className={layoutStyles.topBarButton}>
-        {!showDrawer && <Menu />}
-        {showDrawer && <Clear />}
+        {!showDrawer && <MenuIcon />}
+        {showDrawer && <ClearIcon />}
       </Button>
       <Drawer anchor="bottom" open={showDrawer} onClick={toggleDrawer}>
         <div className={styles.wrapper}>

--- a/carbon/components/Layout/NavItems/index.tsx
+++ b/carbon/components/Layout/NavItems/index.tsx
@@ -1,11 +1,9 @@
 import { t } from "@lingui/macro";
-import {
-  BarChart,
-  Link,
-  PaidOutlined,
-  StackedLineChart,
-  TokenOutlined,
-} from "@mui/icons-material";
+import BarChartIcon from "@mui/icons-material/BarChart";
+import LinkIcon from "@mui/icons-material/Link";
+import PaidOutlinedIcon from "@mui/icons-material/PaidOutlined";
+import StackedLineChartIcon from "@mui/icons-material/StackedLineChart";
+import TokenOutlinedIcon from "@mui/icons-material/TokenOutlined";
 import { PageLinks } from "lib/PageLinks";
 
 export interface NavItem {
@@ -19,31 +17,31 @@ export const navItems = (): Array<NavItem> => {
   return [
     {
       label: t`Overview`,
-      icon: <TokenOutlined />,
+      icon: <TokenOutlinedIcon />,
       url: PageLinks.Overview,
       path: "/overview",
     },
     {
       label: t`Off vs On-Chain`,
-      icon: <Link />,
+      icon: <LinkIcon />,
       url: PageLinks.OffChainVsOnChain,
       path: PageLinks.OffChainVsOnChain,
     },
     {
       label: t`Supply`,
-      icon: <BarChart />,
+      icon: <BarChartIcon />,
       url: PageLinks.Supply,
       path: PageLinks.Supply,
     },
     {
       label: t`Retirement Trends`,
-      icon: <StackedLineChart />,
+      icon: <StackedLineChartIcon />,
       url: PageLinks.RetirementTrends,
       path: PageLinks.RetirementTrends,
     },
     {
       label: t`Token Details`,
-      icon: <PaidOutlined />,
+      icon: <PaidOutlinedIcon />,
       url: PageLinks.TokenDetails,
       path: PageLinks.TokenDetails,
     },

--- a/carbon/components/PercentageChange/index.tsx
+++ b/carbon/components/PercentageChange/index.tsx
@@ -1,4 +1,5 @@
-import { ArrowDropDown, ArrowDropUp } from "@mui/icons-material";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 import { formatPercentage } from "lib/charts/helpers";
 import styles from "./styles.module.scss";
 
@@ -13,9 +14,9 @@ export default function PercentageChange(props: {
 
   const icon =
     percentage > 0 ? (
-      <ArrowDropUp color={"success"}></ArrowDropUp>
+      <ArrowDropUpIcon color={"success"} />
     ) : (
-      <ArrowDropDown color={"error"}></ArrowDropDown>
+      <ArrowDropDownIcon color={"error"} />
     );
   return (
     <span className={styles.priceChangeValue}>

--- a/carbon/components/cards/overview/TokensPriceCard/index.tsx
+++ b/carbon/components/cards/overview/TokensPriceCard/index.tsx
@@ -1,6 +1,6 @@
 import { formatTonnes } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
-import { InfoOutlined } from "@mui/icons-material";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import PercentageChange from "components/PercentageChange";
 import ChartCard, { CardProps } from "components/cards/ChartCard";
 import {
@@ -84,7 +84,7 @@ async function TokenPricesChart(props: { layout: CoinTilesLayout }) {
             label: (
               <div className={styles.selectiveFee}>
                 {t`Selective cost`}
-                <InfoOutlined fontSize={"inherit"} />
+                <InfoOutlinedIcon fontSize={"inherit"} />
               </div>
             ),
             value: selectiveCostInfo,

--- a/carbon/components/charts/helpers/DataTable/Pagination/index.tsx
+++ b/carbon/components/charts/helpers/DataTable/Pagination/index.tsx
@@ -1,9 +1,7 @@
-import {
-  KeyboardArrowLeft,
-  KeyboardArrowRight,
-  KeyboardDoubleArrowLeft,
-  KeyboardDoubleArrowRight,
-} from "@mui/icons-material";
+import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import KeyboardDoubleArrowLeftIcon from "@mui/icons-material/KeyboardDoubleArrowLeft";
+import KeyboardDoubleArrowRightIcon from "@mui/icons-material/KeyboardDoubleArrowRight";
 import styles from "./styles.module.scss";
 
 /** Client component that renders a Data Table pagination element
@@ -24,13 +22,13 @@ export default function Pagination(props: {
             className={styles.paginationIcon}
             onClick={() => props.onPageChange(0)}
           >
-            <KeyboardDoubleArrowLeft></KeyboardDoubleArrowLeft>
+            <KeyboardDoubleArrowLeftIcon />
           </div>
           <div
             className={styles.paginationIcon}
             onClick={() => props.onPageChange(props.page - 1)}
           >
-            <KeyboardArrowLeft></KeyboardArrowLeft>
+            <KeyboardArrowLeftIcon />
           </div>
         </div>
       )}
@@ -45,13 +43,13 @@ export default function Pagination(props: {
             onClick={() => props.onPageChange(props.page + 1)}
             role="button"
           >
-            <KeyboardArrowRight></KeyboardArrowRight>
+            <KeyboardArrowRightIcon />
           </div>
           <div
             className={styles.paginationIcon}
             onClick={() => props.onPageChange(props.pages_count - 1)}
           >
-            <KeyboardDoubleArrowRight></KeyboardDoubleArrowRight>
+            <KeyboardDoubleArrowRightIcon />
           </div>
         </div>
       )}

--- a/carbon/components/charts/helpers/DataTable/VerticalTableHeader/index.tsx
+++ b/carbon/components/charts/helpers/DataTable/VerticalTableHeader/index.tsx
@@ -1,5 +1,8 @@
 "use client";
-import { ExpandLess, ExpandMore, UnfoldMore } from "@mui/icons-material";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
+
 import { SortQueryParams } from "lib/charts/types";
 import { ConfigurationKey, getColumns } from "../configurations";
 import tableStyles from "../configurations/styles.module.scss";
@@ -42,11 +45,12 @@ export default function VerticalTableHeader<P>(props: {
   }
   /** Computes the button associated to the header */
   function sortButtonComponent(key: string): JSX.Element {
-    let Element = UnfoldMore;
+    let Element = UnfoldMoreIcon;
     const dataKey = columns[key].dataKey;
 
     if (props.sortParams.sort_by == dataKey) {
-      Element = props.sortParams.sort_order == "asc" ? ExpandLess : ExpandMore;
+      Element =
+        props.sortParams.sort_order == "asc" ? ExpandLessIcon : ExpandMoreIcon;
     }
     return <Element onClick={() => setSortParamsWrapper(key)} />;
   }

--- a/carbon/components/charts/helpers/TableLink/index.tsx
+++ b/carbon/components/charts/helpers/TableLink/index.tsx
@@ -1,4 +1,4 @@
-import { ArrowForward } from "@mui/icons-material";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import Link from "components/Link";
 
 import styles from "./styles.module.scss";
@@ -7,7 +7,7 @@ export default function TableLink(props: { label: string; href: string }) {
   return (
     <Link href={props.href} className={styles.tableLink}>
       <span>{props.label}</span>
-      <ArrowForward fontSize="medium" />
+      <ArrowForwardIcon fontSize="medium" />
     </Link>
   );
 }

--- a/carbonmark/components/CopyAddressButton/index.tsx
+++ b/carbonmark/components/CopyAddressButton/index.tsx
@@ -1,5 +1,6 @@
 import { cx } from "@emotion/css";
-import { Check, ContentCopy } from "@mui/icons-material";
+import CheckIcon from "@mui/icons-material/Check";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { FC, useEffect, useState } from "react";
 
 import { ButtonBaseProps, ButtonPrimary } from "@klimadao/lib/components";
@@ -35,7 +36,7 @@ export const CopyAddressButton: FC<Props> = (props) => {
         {...props}
         label={<Trans>Copy</Trans>}
         className={styles.copyButton}
-        icon={copied ? <Check /> : <ContentCopy />}
+        icon={copied ? <CheckIcon /> : <ContentCopyIcon />}
         onClick={() => cachedAddress && doCopy(cachedAddress)}
         iconPos="suffix"
       />

--- a/carbonmark/components/Stats/StatsBar.tsx
+++ b/carbonmark/components/Stats/StatsBar.tsx
@@ -1,6 +1,6 @@
 import { trimWithLocale } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
-import { InfoOutlined } from "@mui/icons-material";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { Text } from "components/Text";
 import { TextInfoTooltip } from "components/TextInfoTooltip";
 import { DetailedProject } from "lib/types/carbonmark.types";
@@ -40,7 +40,7 @@ export const StatsBar: FC<Props> = (props) => {
               align="start"
               tooltip={t`Amount of credits from this project/vintage combination that have been retired.`}
             >
-              <InfoOutlined className={styles.tooltipIcon} />
+              <InfoOutlinedIcon className={styles.tooltipIcon} />
             </TextInfoTooltip>
           </div>
 
@@ -60,7 +60,7 @@ export const StatsBar: FC<Props> = (props) => {
               align="start"
               tooltip={t`Amount of credits that have been bridged from this project/vintage combination but not yet retired.`}
             >
-              <InfoOutlined className={styles.tooltipIcon} />
+              <InfoOutlinedIcon className={styles.tooltipIcon} />
             </TextInfoTooltip>
           </div>
 

--- a/carbonmark/components/ViewWalletButton/index.tsx
+++ b/carbonmark/components/ViewWalletButton/index.tsx
@@ -1,5 +1,5 @@
 import { cx } from "@emotion/css";
-import { Launch } from "@mui/icons-material";
+import LaunchIcon from "@mui/icons-material/Launch";
 import { FC } from "react";
 
 import { ButtonPrimary } from "@klimadao/lib/components";
@@ -25,7 +25,7 @@ export const ViewWalletButton: FC<Props> = (props) => {
         label={<Trans>View</Trans>}
         variant="transparent"
         className={styles.viewButton}
-        icon={<Launch />}
+        icon={<LaunchIcon />}
         iconPos="suffix"
       />
     </div>

--- a/carbonmark/components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx
+++ b/carbonmark/components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx
@@ -1,6 +1,6 @@
 import { Text } from "@klimadao/lib/components";
 import { Trans } from "@lingui/macro";
-import { CelebrationOutlined } from "@mui/icons-material";
+import CelebrationOutlinedIcon from "@mui/icons-material/CelebrationOutlined";
 import { CarbonmarkButton } from "components/CarbonmarkButton";
 import { Modal } from "components/shared/Modal";
 import Link from "next/link";
@@ -20,7 +20,7 @@ export const RetirementStatusModal: FC<Props> = (props) => (
   <Modal
     title={
       <div className={styles.title}>
-        <CelebrationOutlined fontSize="large" />
+        <CelebrationOutlinedIcon fontSize="large" />
         <Trans>Retirement Successful!</Trans>
       </div>
     }

--- a/carbonmark/components/pages/Projects/ProjectFilters/index.tsx
+++ b/carbonmark/components/pages/Projects/ProjectFilters/index.tsx
@@ -1,4 +1,4 @@
-import { Close } from "@mui/icons-material";
+import CloseIcon from "@mui/icons-material/Close";
 import { Text } from "components/Text";
 import { useElementWidth } from "hooks/useElementWidth";
 import { FilterValues } from "hooks/useProjectsFilterParams";
@@ -47,7 +47,7 @@ export const ProjectFilters: FC<Props> = (props) => {
           {filters?.map((filter: string, key: number) => (
             <div key={key} className={styles.pill}>
               <span>{filter}</span>
-              <Close onClick={() => handleRemoveFilter(filter)} />
+              <CloseIcon onClick={() => handleRemoveFilter(filter)} />
             </div>
           ))}
           {hasOverflow && (

--- a/carbonmark/components/pages/Projects/ProjectsController/index.tsx
+++ b/carbonmark/components/pages/Projects/ProjectsController/index.tsx
@@ -1,5 +1,6 @@
 import { cx } from "@emotion/css";
-import { GridViewOutlined, ListOutlined } from "@mui/icons-material";
+import GridViewOutlinedIcon from "@mui/icons-material/GridViewOutlined";
+import ListOutlinedIcon from "@mui/icons-material/ListOutlined";
 import MapOutlinedIcon from "@mui/icons-material/MapOutlined";
 import { LoginButton } from "components/LoginButton";
 import { ProjectFilterModal } from "components/ProjectFilterModal";
@@ -28,7 +29,7 @@ const ProjectsController = () => {
 
   const viewOptions = [
     {
-      content: <GridViewOutlined />,
+      content: <GridViewOutlinedIcon />,
       value: "grid",
       tooltip: "Grid view",
     },
@@ -42,7 +43,7 @@ const ProjectsController = () => {
   // If we're on desktop let the user select the list view
   if (isDesktop)
     viewOptions.splice(1, 0, {
-      content: <ListOutlined />,
+      content: <ListOutlinedIcon />,
       value: "list",
       tooltip: "List view",
     });

--- a/carbonmark/components/pages/Users/Badge/index.tsx
+++ b/carbonmark/components/pages/Users/Badge/index.tsx
@@ -1,5 +1,6 @@
 import { t } from "@lingui/macro";
-import { ErrorOutlineOutlined, TimerOffOutlined } from "@mui/icons-material";
+import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
+import TimerOffOutlinedIcon from "@mui/icons-material/TimerOffOutlined";
 import { TextInfoTooltip } from "components/TextInfoTooltip";
 import { FC } from "react";
 import * as styles from "./styles";
@@ -7,12 +8,12 @@ import * as styles from "./styles";
 const BadgeType = {
   Invalid: {
     title: t`Invalid`,
-    icon: <ErrorOutlineOutlined />,
+    icon: <ErrorOutlineOutlinedIcon />,
     tooltipText: t`This listing is no longer valid and is hidden from the marketplace. Please resubmit or delete the listing.`,
   },
   Expired: {
     title: t`Expired`,
-    icon: <TimerOffOutlined />,
+    icon: <TimerOffOutlinedIcon />,
     tooltipText: t`This listing has expired and is hidden from the marketplace. Please resubmit or delete the listing.`,
   },
 };

--- a/lib/components/CopyValueButton/index.tsx
+++ b/lib/components/CopyValueButton/index.tsx
@@ -1,5 +1,7 @@
 import { cx } from "@emotion/css";
-import { Check, ContentCopy } from "@mui/icons-material";
+import CheckIcon from "@mui/icons-material/Check";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+
 import React, { FC, useEffect, useState } from "react";
 
 import { ButtonBaseProps, ButtonPrimary } from "@klimadao/lib/components";
@@ -28,7 +30,7 @@ export const CopyValueButton: FC<Props> = (props) => {
       variant={"transparent"}
       {...props}
       className={className}
-      icon={copied ? <Check /> : <ContentCopy />}
+      icon={copied ? <CheckIcon /> : <ContentCopyIcon />}
       onClick={() => cachedValue && doCopy(cachedValue)}
       iconPos="suffix"
     />


### PR DESCRIPTION
## Description

This PR updates all imports for material icons so that only the components are imported.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1381 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
