### PR TITLE
Makka / 1862 revert icon imports in lib

### DIFF
--- a/lib/components/CopyValueButton/index.tsx
+++ b/lib/components/CopyValueButton/index.tsx
@@ -1,6 +1,5 @@
 import { cx } from "@emotion/css";
-import CheckIcon from "@mui/icons-material/Check";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import { Check, ContentCopy } from "@mui/icons-material";
 
 import React, { FC, useEffect, useState } from "react";
 
@@ -30,7 +29,7 @@ export const CopyValueButton: FC<Props> = (props) => {
       variant={"transparent"}
       {...props}
       className={className}
-      icon={copied ? <CheckIcon /> : <ContentCopyIcon />}
+      icon={copied ? <Check /> : <ContentCopy />}
       onClick={() => cachedValue && doCopy(cachedValue)}
       iconPos="suffix"
     />


### PR DESCRIPTION
## Description

Material UI icon imports are breaking inside the `lib` folder. I've reverted these as currently `app` and `carbonmark` are breaking when using the `CopyValueButton` component. 

They were changed in the following PR so adding @sprrwhwk for context - https://github.com/KlimaDAO/klimadao/pull/1851/files#diff-507100aff726f7ba477b1c5b048c00bf862de1f1da681c3a04b9c1e01c7207d8

I haven't pinned down what the exact issue is, but it seems like they get imported as an object inside `lib` and not exported correctly. Opening this PR to revert and provide a quick fix to `carbonmark` and `app` until I can pinpoint what is causing the issue.

Related issue on material-ui github - 
- https://github.com/mui/material-ui/issues/35233

## Related Ticket

Resolves #1862 

## Checklist

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
