### PR TITLE
carbon: update font and border-radius of cta button

### DIFF
--- a/carbon/app/[locale]/globals.css
+++ b/carbon/app/[locale]/globals.css
@@ -1,5 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=Inter:regular,bold,italic&subset=latin,latin-ext");
-@import url("https://fonts.googleapis.com/css?family=Poppins:regular,bold,italic&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap");
 
 body {
   padding: 0;

--- a/carbon/components/PageHeader/styles.module.scss
+++ b/carbon/components/PageHeader/styles.module.scss
@@ -68,6 +68,9 @@
   height: 4.8rem;
   color: var(--brand-black);
   background-color: var(--brand-green);
+  border-radius: 4rem;
+  font-family: Poppins;
+  font-weight: 600;
 
   &:hover {
     background-color: var(--brand-green);


### PR DESCRIPTION
## Description

This PR updates the style of the "Explore Marketplace" button to look like this:

<img width="259" alt="grafik" src="https://github.com/KlimaDAO/klimadao/assets/138768831/29b84f8f-d4e6-4444-9850-02c516de91ba">


<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1875 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
