### PR TITLE
Makka / address issue with wallet connect loading

### DIFF
--- a/lib/components/Web3Context/index.tsx
+++ b/lib/components/Web3Context/index.tsx
@@ -20,7 +20,7 @@ export const Web3ContextProvider: FC<Props> = ({
   showMumbaiOption,
   walletConnectProjectId,
 }) => {
-  const providerState = useProvider();
+  const providerState = useProvider(walletConnectProjectId);
   const [showModal, setShowModal] = useState(false);
   const toggleModal = () => setShowModal((s) => !s);
   const renderModal = useCallback(

--- a/lib/utils/useProvider/index.tsx
+++ b/lib/utils/useProvider/index.tsx
@@ -33,7 +33,9 @@ const getWeb3Provider = (p: any): TypedProvider => {
 };
 
 /** React Hook to create and manage the web3Modal lifecycle */
-export const useProvider = (): Web3ModalState => {
+export const useProvider = (
+  walletConnectProjectId?: string
+): Web3ModalState => {
   const [web3state, setWeb3State] = useState<Web3State>(web3InitialState);
 
   const disconnect = async () => {
@@ -175,7 +177,7 @@ export const useProvider = (): Web3ModalState => {
   useEffect(() => {
     const wallet = localStorage.getItem("web3-wallet") as WalletLabel | null;
     if (wallet) {
-      connect(wallet, { useCache: true });
+      connect(wallet, { useCache: true, walletConnectProjectId });
     } else {
       setWeb3State((s) => ({ ...s, initializing: false }));
     }


### PR DESCRIPTION
## Description

@Atmosfearful There has been reports of wallet connect issues. I ran into this issue myself and done some investigation. It looks on first login with wallet connect, everything works as expected, but if the user reloads, the `walletConnectProjectId` never gets passed along to the connect function. 

It needs to be passed into the useProvider hook as I tried passing it into `Web3Context.Provider` as a value, but because the useProvider hook is called first, the value never gets passed along. 

## Related Ticket

Resolves #<issue-number>

## Checklist

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
