### PR TITLE
Carbon Dashboard - Adjust display text for percentage as a decimal

### DIFF
--- a/carbon/lib/tokens.tsx
+++ b/carbon/lib/tokens.tsx
@@ -35,7 +35,9 @@ export async function getTokenSelectiveFeeDescription(token: Token) {
 
   if (tokenInfo.fee_redeem_factor == 0)
     return t`There is no selective redemption/retirement functionality for ${tokenInfo.name}.`;
-  return t`This cost includes the asset spot price + the ${tokenInfo.fee_redeem_factor.toFixed(
+  return t`This cost includes the asset spot price + the ${(
+    tokenInfo.fee_redeem_factor * 100
+  ).toFixed(
     2
   )}% fee to selectively redeem or retire an underlying carbon project charged by ${
     tokenInfo.bridge


### PR DESCRIPTION
Currently the selective fee amount is represented in decimal form (2.25% = 0.0225).

Adjust for this before creating the display text on the pricing sidebar.

Current:
<img width="311" alt="image" src="https://github.com/KlimaDAO/klimadao/assets/92617969/f0396886-f890-40d4-a372-b6245a610322">

Preview:
<img width="305" alt="image" src="https://github.com/KlimaDAO/klimadao/assets/92617969/22cdff38-297e-44c9-903a-e79a9ed8f596">

