### PR TITLE
carbon: add carbonmark and klimadao footer links

### DIFF
--- a/carbon/components/Layout/Footer/index.tsx
+++ b/carbon/components/Layout/Footer/index.tsx
@@ -14,16 +14,20 @@ export const Footer: FC = () => {
     <div className={styles.footer}>
       <div className={styles.footerNavLinks}>
         <Link href={urls.app} className={layout.mobileOnly}>
+          KlimaDAO
+        </Link>
+        <Link href={urls.app} className={layout.mobileOnly}>
           App
+        </Link>
+        <Link href={urls.carbonmark}>Carbonmark</Link>
+        <Link href={urls.app} className={layout.desktopOnly}>
+          KlimaDAO
         </Link>
         <Link href={urls.officialDocs} className={layout.mobileOnly}>
           Docs
         </Link>
         <Link href={urls.app} className={layout.desktopOnly}>
           Klima App
-        </Link>
-        <Link href={urls.carbonmark} className={layout.desktopOnly}>
-          Carbonmark
         </Link>
         <Link href={urls.officialDocs} className={layout.desktopOnly}>
           Official Docs

--- a/carbon/components/Layout/Footer/index.tsx
+++ b/carbon/components/Layout/Footer/index.tsx
@@ -6,32 +6,16 @@ import TwitterIcon from "@mui/icons-material/Twitter";
 import YouTubeIcon from "@mui/icons-material/YouTube";
 import { Link } from "@mui/material";
 import { FC } from "react";
-import layout from "theme/layout.module.scss";
 import styles from "./styles.module.scss";
 
 export const Footer: FC = () => {
   return (
     <div className={styles.footer}>
       <div className={styles.footerNavLinks}>
-        <Link href={urls.app} className={layout.mobileOnly}>
-          KlimaDAO
-        </Link>
-        <Link href={urls.app} className={layout.mobileOnly}>
-          App
-        </Link>
+        <Link href={urls.home}>KlimaDAO</Link>
+        <Link href={urls.app}>Klima App</Link>
         <Link href={urls.carbonmark}>Carbonmark</Link>
-        <Link href={urls.app} className={layout.desktopOnly}>
-          KlimaDAO
-        </Link>
-        <Link href={urls.officialDocs} className={layout.mobileOnly}>
-          Docs
-        </Link>
-        <Link href={urls.app} className={layout.desktopOnly}>
-          Klima App
-        </Link>
-        <Link href={urls.officialDocs} className={layout.desktopOnly}>
-          Official Docs
-        </Link>
+        <Link href={urls.officialDocs}>Official Docs</Link>
         <Link href={urls.disclaimer}>Disclaimer</Link>
       </div>
       <div className={styles.footerSocialLinks}>
@@ -44,7 +28,7 @@ export const Footer: FC = () => {
         <Link href={urls.discordInvite}>
           <DiscordSvg />
         </Link>
-        <Link href={urls.github} className={layout.mobileOnly}>
+        <Link href={urls.github}>
           <GitHubIcon />
         </Link>
         <Link href={urls.linkedIn}>


### PR DESCRIPTION
## Description

This PR adds footer links for KlimaDAO and Carbonmark. 

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1892 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
