### PR TITLE
carbon: add explore button to mobile menu

### DIFF
--- a/carbon/components/ExploreMarketplaceButton/index.tsx
+++ b/carbon/components/ExploreMarketplaceButton/index.tsx
@@ -1,0 +1,18 @@
+import { urls } from "@klimadao/lib/constants";
+import { t } from "@lingui/macro";
+import { Button } from "@mui/material";
+import Link from "components/Link";
+import { FC } from "react";
+import styles from "./styles.module.scss";
+
+export const ExploreMarketplaceButton: FC<{ className?: string }> = ({
+  className = "",
+}) => {
+  return (
+    <Link href={urls.marketplace}>
+      <Button className={`${styles.exploreMarketplaceButton} ${className}`}>
+        {t`Explore Marketplace`}
+      </Button>
+    </Link>
+  );
+};

--- a/carbon/components/ExploreMarketplaceButton/styles.module.scss
+++ b/carbon/components/ExploreMarketplaceButton/styles.module.scss
@@ -1,0 +1,15 @@
+.exploreMarketplaceButton {
+  white-space: nowrap;
+  font-size: 1.4rem;
+  padding: 0 2.4rem;
+  height: 4.8rem;
+  color: var(--brand-black);
+  background-color: var(--brand-green);
+  border-radius: 4rem;
+  font-family: Poppins;
+  font-weight: 600;
+
+  &:hover {
+    background-color: var(--brand-green);
+  }
+}

--- a/carbon/components/Layout/MobileMenuButton/index.tsx
+++ b/carbon/components/Layout/MobileMenuButton/index.tsx
@@ -3,6 +3,7 @@
 import ClearIcon from "@mui/icons-material/Clear";
 import MenuIcon from "@mui/icons-material/Menu";
 import { Button, Drawer } from "@mui/material";
+import { ExploreMarketplaceButton } from "components/ExploreMarketplaceButton";
 import { useState } from "react";
 import { navItems } from "../NavItems";
 import layoutStyles from "../styles.module.scss";
@@ -22,10 +23,15 @@ export function MobileMenuButton() {
       </Button>
       <Drawer anchor="bottom" open={showDrawer} onClick={toggleDrawer}>
         <div className={styles.wrapper}>
-          <div className={styles.links}>
-            {navItems().map((navItem) => (
-              <MobileMenuButtonItem key={navItem.url} navItem={navItem} />
-            ))}
+          <div className={styles.content}>
+            <div className={styles.links}>
+              {navItems().map((navItem) => (
+                <MobileMenuButtonItem key={navItem.url} navItem={navItem} />
+              ))}
+            </div>
+            <ExploreMarketplaceButton
+              className={styles.exploreMarketplaceButton}
+            />
           </div>
         </div>
       </Drawer>

--- a/carbon/components/Layout/MobileMenuButton/styles.module.scss
+++ b/carbon/components/Layout/MobileMenuButton/styles.module.scss
@@ -1,16 +1,32 @@
 .wrapper {
   padding-top: 6.4rem;
   height: 100vh;
+  height: 100dvh;
   display: flex;
+  flex-direction: column;
   pointer-events: all;
 }
+
+.exploreMarketplaceButton {
+  width: 100%;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: var(--brand-white);
+  padding: 0 1.6rem;
+  padding-top: 4rem;
+  padding-bottom: 7.2rem;
+}
+
 .links {
   flex: 1;
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
-  padding: 1.2rem 2.4rem;
-  background-color: var(--brand-white);
 }
 
 .button {

--- a/carbon/components/PageHeader/PageHeader.tsx
+++ b/carbon/components/PageHeader/PageHeader.tsx
@@ -1,6 +1,4 @@
-import { urls } from "@klimadao/lib/constants";
-import { t } from "@lingui/macro";
-import { Button } from "@mui/material";
+import { ExploreMarketplaceButton } from "components/ExploreMarketplaceButton";
 import { ChangeLanguageButton } from "components/Layout/ChangeLanguageButton";
 import Link from "components/Link";
 import { FC } from "react";
@@ -32,11 +30,7 @@ export const PageHeader: FC<{
       <div className={layout.desktopOnly}>
         <div className={styles.buttons}>
           <ChangeLanguageButton />
-          <Link href={urls.marketplace}>
-            <Button className={styles.exploreButton}>
-              {t`Explore Marketplace`}
-            </Button>
-          </Link>
+          <ExploreMarketplaceButton />
         </div>
       </div>
     </div>

--- a/carbon/components/PageHeader/styles.module.scss
+++ b/carbon/components/PageHeader/styles.module.scss
@@ -60,19 +60,3 @@
     gap: 1.2rem;
   }
 }
-
-.exploreButton {
-  white-space: nowrap;
-  font-size: 1.4rem;
-  padding: 0 2.4rem;
-  height: 4.8rem;
-  color: var(--brand-black);
-  background-color: var(--brand-green);
-  border-radius: 4rem;
-  font-family: Poppins;
-  font-weight: 600;
-
-  &:hover {
-    background-color: var(--brand-green);
-  }
-}


### PR DESCRIPTION
## Description

This PR adds the "Explore Marketplace" button to the mobile menu.

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1896 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
