### PR TITLE
Rename units for tons

### DIFF
--- a/carbon/lib/charts/helpers.ts
+++ b/carbon/lib/charts/helpers.ts
@@ -191,15 +191,15 @@ export function dateForQuery(date: number): string {
 // Common formatters
 export function formatQuantityAsMillionsOfTons(quantity: number): string {
   quantity = Math.floor(quantity / 1000000);
-  return `${quantity} MT`;
+  return `${quantity}m`;
 }
 export function formatQuantityAsKiloTons(quantity: number): string {
   quantity = Math.floor(quantity / 1000);
-  return `${quantity} KT`;
+  return `${quantity}k`;
 }
 export function formatQuantityAsTons(quantity: number): string {
   quantity = Math.floor(quantity);
-  return `${quantity} T`;
+  return `${quantity}`;
 }
 export function getTonsFormatter(quantity: number) {
   return quantity < 10 ** 4


### PR DESCRIPTION
## Description

- Replace KT by k
- Replace MT by m
- Remove the space between value and unit

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #1902

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|
![image](https://github.com/KlimaDAO/klimadao/assets/11857992/d0763e5a-999d-48f2-9cb8-bc9185d90987)
 |![image](https://github.com/KlimaDAO/klimadao/assets/11857992/11a0f8e1-f45e-496f-86eb-47a0b2cd7d8e)|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
