### PR TITLE
Makka / #1056 - zoom out of map on project details page

### DIFF
--- a/carbonmark/components/Carousel/Carousel.tsx
+++ b/carbonmark/components/Carousel/Carousel.tsx
@@ -79,7 +79,7 @@ const Carousel: React.FC<CarouselProps> = (props) => {
             <div className={styles.slide} key={`slide-${index}`}>
               {props.location && index === 0 ? (
                 <ProjectMap
-                  zoom={5}
+                  zoom={1.5}
                   lat={props.location?.geometry.coordinates[1]}
                   lng={props.location?.geometry.coordinates[0]}
                 />

--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -181,7 +181,7 @@ const Page: NextPage<PageProps> = (props) => {
                   <ProjectMap
                     lat={project.location?.geometry.coordinates[1]}
                     lng={project.location?.geometry.coordinates[0]}
-                    zoom={5}
+                    zoom={1.5}
                   />
                 </div>
               )}


### PR DESCRIPTION
## Description

Currently the map on project pages is very zoomed in. Change the map zoom to show the curvature of the globe.

## Related Ticket

Resolves #1056 

## Changes

| Before  | After  |
|---------|--------|
|<img width="800" alt="Screenshot 2023-11-24 at 14 45 48" src="https://github.com/KlimaDAO/klimadao/assets/92357475/8178ea37-cd92-429d-8723-6acd122cbabd">|<img width="800" alt="Screenshot 2023-11-24 at 14 45 55" src="https://github.com/KlimaDAO/klimadao/assets/92357475/1e540045-f1e2-4c1f-957a-ed2fe6720349">|

## Checklist

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
