### PR TITLE
chore: Set code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/carbonmark/ @Atmosfearful @0xemc @0xMakka @biwano @psparacino @sprrwhwk
+/carbonmark-api/ @Atmosfearful @0xemc @0xMakka @biwano @psparacino @sprrwhwk


### PR DESCRIPTION
## Description
Sets @Atmosfearful @0xemc @0xMakka @biwano @psparacino @sprrwhwk as code owners of the carbonmark and carbonmark-api directories.

This will help us set automatic reviewers on PRs to hopefully keep them moving