### PR TITLE
fix #1927 only fetch project if id is present

### DIFF
--- a/carbonmark/pages/retirements/[beneficiary]/[retirement_index].tsx
+++ b/carbonmark/pages/retirements/[beneficiary]/[retirement_index].tsx
@@ -84,9 +84,12 @@ export const getStaticProps: GetStaticProps<
       throw new Error("No translation found");
     }
 
-    const project = await getProjectsId(
-      `${retirement.offset.projectID}-${retirement.offset.vintageYear}`
-    );
+    let project;
+    if (retirement.offset.projectID && retirement.offset.vintageYear) {
+      project = await getProjectsId(
+        `${retirement.offset.projectID}-${retirement.offset.vintageYear}`
+      );
+    }
 
     return {
       props: {


### PR DESCRIPTION
## Description

The FE is already equipped to handle a `null` project incl. mco2, somewhere a regression happened where we always fetch the project even if the subgraph didn't give us an id etc.

## Related Ticket

Closes #1927