### PR TITLE
fix:1940 Use corrrect address for fetch check

### DIFF
--- a/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
@@ -17,7 +17,7 @@ import { ProfileLogo } from "../../ProfileLogo";
 import * as styles from "./styles";
 
 type Props = {
-  user: User | null;
+  user?: User | null;
   onSubmit: (data: User) => void;
   isCarbonmarkUser: boolean;
 };

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -44,7 +44,7 @@ export const SellerConnected: FC<Props> = (props) => {
       network,
       expiresAfter: address === props.userAddress ? "0" : undefined,
     },
-    { shouldFetch: notNil(address) }
+    { shouldFetch: notNil(props.userAddress) }
   );
   const [isPending, setIsPending] = useState(false);
   const [showEditProfileModal, setShowEditProfileModal] = useState(false);

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -227,13 +227,11 @@ export const SellerConnected: FC<Props> = (props) => {
         showModal={showEditProfileModal}
         onToggleModal={() => setShowEditProfileModal((s) => !s)}
       >
-        {carbonmarkUser && (
-          <EditProfile
-            user={carbonmarkUser}
-            onSubmit={onEditProfile}
-            isCarbonmarkUser={isCarbonmarkUser}
-          />
-        )}
+        <EditProfile
+          user={carbonmarkUser}
+          onSubmit={onEditProfile}
+          isCarbonmarkUser={isCarbonmarkUser}
+        />
       </Modal>
 
       {!!carbonmarkUser?.assets?.length && (

--- a/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
@@ -27,7 +27,7 @@ export const SellerUnconnected: FC<Props> = (props) => {
       network: networkLabel,
       expiresAfter: address === props.userAddress ? "0" : undefined,
     },
-    { shouldFetch: notNil(address) }
+    { shouldFetch: notNil(props.userAddress) }
   );
 
   const activeListings = getActiveListings(carbonmarkUser?.listings ?? []);


### PR DESCRIPTION
## Description

In some instances the `address` value from `useWeb3` was being used in place of the provided URL address param to determine if the useFetchUser hook should fire or not... Whoops..

The EditProfile modal is also secretly the "CreateProfile" modal. Removed the check for `isCarbonmarkUser` before opening this modal... Whoops again :(

Closes #1940 