### PR TITLE
Emc/fix/1944-profile-portfolio-issues

### DIFF
--- a/carbonmark-api/src/models/User.model.ts
+++ b/carbonmark-api/src/models/User.model.ts
@@ -1,4 +1,5 @@
 import { Static, Type } from "@sinclair/typebox";
+import { isNil } from "lodash";
 import { ActivityModel } from "./Activity.model";
 import { AssetModel } from "./Asset.model";
 import { ListingModel } from "./Listing.model";
@@ -27,7 +28,7 @@ export function isUser(obj: any): obj is User {
     typeof obj.handle === "string" &&
     typeof obj.username === "string" &&
     typeof obj.description === "string" &&
-    (obj.profileImgUrl === null || typeof obj.profileImgUrl === "string") &&
+    (isNil(obj.profileImgUrl) || typeof obj.profileImgUrl === "string") &&
     typeof obj.updatedAt === "number" &&
     typeof obj.createdAt === "number" &&
     typeof obj.wallet === "string" &&

--- a/carbonmark/components/pages/Portfolio/PortfolioSidebar.tsx
+++ b/carbonmark/components/pages/Portfolio/PortfolioSidebar.tsx
@@ -8,7 +8,7 @@ import { Balances } from "./Balances";
 import * as styles from "./styles";
 
 type Props = {
-  user: User | null;
+  user?: User | null;
   isPending: boolean;
 };
 

--- a/carbonmark/components/pages/Portfolio/Retire/index.tsx
+++ b/carbonmark/components/pages/Portfolio/Retire/index.tsx
@@ -47,8 +47,7 @@ export const Retire: NextPage<RetirePageProps> = (props) => {
   const isConnectedUser = isConnected && address;
 
   const isCarbonmarkUser = isConnectedUser && !isLoading && !!carbonmarkUser;
-  const isUnregistered =
-    isConnectedUser && isNil(carbonmarkUser);
+  const isUnregistered = isConnectedUser && isNil(carbonmarkUser);
 
   const router = useRouter();
 

--- a/carbonmark/components/pages/Portfolio/Retire/index.tsx
+++ b/carbonmark/components/pages/Portfolio/Retire/index.tsx
@@ -12,6 +12,7 @@ import type {
   PcbProject,
 } from "lib/types/carbonmark.types";
 import { notNil } from "lib/utils/functional.utils";
+import { isNil } from "lodash";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -47,7 +48,7 @@ export const Retire: NextPage<RetirePageProps> = (props) => {
 
   const isCarbonmarkUser = isConnectedUser && !isLoading && !!carbonmarkUser;
   const isUnregistered =
-    isConnectedUser && !isLoading && carbonmarkUser === null;
+    isConnectedUser && isNil(carbonmarkUser);
 
   const router = useRouter();
 

--- a/carbonmark/components/pages/Portfolio/index.tsx
+++ b/carbonmark/components/pages/Portfolio/index.tsx
@@ -41,8 +41,7 @@ export const Portfolio: NextPage = () => {
 
   const isConnectedUser = isConnected && address;
   const isCarbonmarkUser = isConnectedUser && !isLoading && !!carbonmarkUser;
-  const isUnregistered =
-    isConnectedUser && isNil(carbonmarkUser);
+  const isUnregistered = isConnectedUser && isNil(carbonmarkUser);
 
   const onUpdateUser = async () => {
     if (!carbonmarkUser) return;

--- a/carbonmark/components/pages/Portfolio/index.tsx
+++ b/carbonmark/components/pages/Portfolio/index.tsx
@@ -111,9 +111,7 @@ export const Portfolio: NextPage = () => {
             </Col>
 
             <Col>
-              {carbonmarkUser && (
-                <PortfolioSidebar user={carbonmarkUser} isPending={isPending} />
-              )}
+              <PortfolioSidebar user={carbonmarkUser} isPending={isPending} />
             </Col>
           </TwoColLayout>
         </div>

--- a/carbonmark/components/pages/Portfolio/index.tsx
+++ b/carbonmark/components/pages/Portfolio/index.tsx
@@ -10,6 +10,7 @@ import { Col, TwoColLayout } from "components/TwoColLayout";
 import { Spinner } from "components/shared/Spinner";
 import { activityIsAdded, getUserUntil } from "lib/api";
 import { notNil } from "lib/utils/functional.utils";
+import { isNil } from "lodash";
 import { NextPage } from "next";
 import { useState } from "react";
 import { CarbonmarkAssets } from "./CarbonmarkAssets";
@@ -41,7 +42,7 @@ export const Portfolio: NextPage = () => {
   const isConnectedUser = isConnected && address;
   const isCarbonmarkUser = isConnectedUser && !isLoading && !!carbonmarkUser;
   const isUnregistered =
-    isConnectedUser && !isLoading && carbonmarkUser === null;
+    isConnectedUser && isNil(carbonmarkUser);
 
   const onUpdateUser = async () => {
     if (!carbonmarkUser) return;

--- a/carbonmark/components/pages/Retire/FromPortfolio/index.tsx
+++ b/carbonmark/components/pages/Retire/FromPortfolio/index.tsx
@@ -6,6 +6,7 @@ import { Text } from "components/Text";
 import { addProjectsToAssets, AssetWithProject } from "lib/actions";
 import { notNil } from "lib/utils/functional.utils";
 import { isListableToken } from "lib/utils/listings.utils";
+import { isNil } from "lodash";
 import { FC, useEffect, useState } from "react";
 import { AssetProject } from "./AssetProject";
 import * as styles from "./styles";
@@ -29,7 +30,7 @@ export const RetireFromPortfolio: FC<Props> = (props) => {
     !!carbonmarkUser && !isLoadingAssets && !assetsData?.length;
   const hasAssets =
     !!carbonmarkUser && !isLoadingAssets && !!listableAssets.length;
-  const isUnregistered = props.address && !isLoading && carbonmarkUser === null;
+  const isUnregistered = props.address && !isLoading && isNil(carbonmarkUser);
 
   useEffect(() => {
     if (!hasAssets) return;

--- a/carbonmark/components/pages/Users/ProfileHeader/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileHeader/index.tsx
@@ -7,7 +7,7 @@ import { FC } from "react";
 import * as styles from "./styles";
 
 type Props = {
-  carbonmarkUser: User | null;
+  carbonmarkUser?: User | null;
   userName: string;
   userAddress: string;
 };

--- a/carbonmark/components/pages/Users/ProfileSidebar/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileSidebar/index.tsx
@@ -5,7 +5,7 @@ import { User } from "lib/types/carbonmark.types";
 import { FC } from "react";
 
 type Props = {
-  user: User | null;
+  user?: User | null;
   isPending?: boolean;
   title: string;
 };

--- a/carbonmark/components/pages/Users/SellerConnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/index.tsx
@@ -120,13 +120,11 @@ export const SellerConnected: FC<Props> = (props) => {
         <LoginButton className="loginButton" />
       </div>
       <div className={styles.fullWidth}>
-        {carbonmarkUser && (
-          <ProfileHeader
-            carbonmarkUser={carbonmarkUser}
-            userName={props.userName}
-            userAddress={props.userAddress}
-          />
-        )}
+        <ProfileHeader
+          carbonmarkUser={carbonmarkUser}
+          userName={props.userName}
+          userAddress={props.userAddress}
+        />
       </div>
       <div className={styles.listings}>
         <div className={styles.listingsHeader}>
@@ -209,13 +207,11 @@ export const SellerConnected: FC<Props> = (props) => {
         </Col>
 
         <Col>
-          {carbonmarkUser && (
-            <ProfileSidebar
-              user={carbonmarkUser}
-              isPending={isPending}
-              title={t`Your seller data`}
-            />
-          )}
+          <ProfileSidebar
+            user={carbonmarkUser}
+            isPending={isPending}
+            title={t`Your seller data`}
+          />
         </Col>
       </TwoColLayout>
 

--- a/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
@@ -1,4 +1,4 @@
-import { useGetUsersWalletorhandle } from ".generated/carbonmark-api-sdk/hooks";
+import { User } from ".generated/carbonmark-api-sdk/types";
 import { useWeb3 } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
@@ -7,7 +7,6 @@ import { Text } from "components/Text";
 import { Col, TwoColLayout } from "components/TwoColLayout";
 import { createProjectPurchaseLink } from "lib/createUrls";
 import { getActiveListings, getSortByUpdateListings } from "lib/listingsGetter";
-import { notNil } from "lib/utils/functional.utils";
 import { FC } from "react";
 import { Listing } from "../Listing";
 import { ProfileHeader } from "../ProfileHeader";
@@ -15,22 +14,15 @@ import { ProfileSidebar } from "../ProfileSidebar";
 import * as styles from "./styles";
 
 type Props = {
+  user: User | null;
   userName: string;
   userAddress: string;
 };
 
 export const SellerUnconnected: FC<Props> = (props) => {
-  const { address, isConnected, toggleModal, networkLabel } = useWeb3();
-  const { data: carbonmarkUser } = useGetUsersWalletorhandle(
-    props.userAddress,
-    {
-      network: networkLabel,
-      expiresAfter: address === props.userAddress ? "0" : undefined,
-    },
-    { shouldFetch: notNil(props.userAddress) }
-  );
+  const { address, isConnected, toggleModal } = useWeb3();
 
-  const activeListings = getActiveListings(carbonmarkUser?.listings ?? []);
+  const activeListings = getActiveListings(props.user?.listings ?? []);
   const hasListings = !!activeListings.length;
 
   const sortedListings =
@@ -44,9 +36,9 @@ export const SellerUnconnected: FC<Props> = (props) => {
         <LoginButton className="loginButton" />
       </div>
       <div className={styles.fullWidth}>
-        {carbonmarkUser && (
+        {props.user && (
           <ProfileHeader
-            carbonmarkUser={carbonmarkUser}
+            carbonmarkUser={props.user}
             userName={props.userName}
             userAddress={props.userAddress}
           />
@@ -97,9 +89,9 @@ export const SellerUnconnected: FC<Props> = (props) => {
           )}
         </Col>
         <Col>
-          {carbonmarkUser && (
+          {props.user && (
             <ProfileSidebar
-              user={carbonmarkUser}
+              user={props.user}
               title={t`Data for this seller`}
             />
           )}

--- a/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
@@ -36,13 +36,11 @@ export const SellerUnconnected: FC<Props> = (props) => {
         <LoginButton className="loginButton" />
       </div>
       <div className={styles.fullWidth}>
-        {props.user && (
-          <ProfileHeader
-            carbonmarkUser={props.user}
-            userName={props.userName}
-            userAddress={props.userAddress}
-          />
-        )}
+        <ProfileHeader
+          carbonmarkUser={props.user}
+          userName={props.userName}
+          userAddress={props.userAddress}
+        />
       </div>
       <div className={styles.listings}>
         <div className={styles.listingsHeader}>
@@ -89,9 +87,7 @@ export const SellerUnconnected: FC<Props> = (props) => {
           )}
         </Col>
         <Col>
-          {props.user && (
-            <ProfileSidebar user={props.user} title={t`Data for this seller`} />
-          )}
+          <ProfileSidebar user={props.user} title={t`Data for this seller`} />
         </Col>
       </TwoColLayout>
     </div>

--- a/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
+++ b/carbonmark/components/pages/Users/SellerUnconnected/index.tsx
@@ -90,10 +90,7 @@ export const SellerUnconnected: FC<Props> = (props) => {
         </Col>
         <Col>
           {props.user && (
-            <ProfileSidebar
-              user={props.user}
-              title={t`Data for this seller`}
-            />
+            <ProfileSidebar user={props.user} title={t`Data for this seller`} />
           )}
         </Col>
       </TwoColLayout>

--- a/carbonmark/components/pages/Users/index.tsx
+++ b/carbonmark/components/pages/Users/index.tsx
@@ -3,7 +3,6 @@ import { t } from "@lingui/macro";
 import { Layout } from "components/Layout";
 import { PageHead } from "components/PageHead";
 import { useConnectedUser } from "hooks/useConnectedUser";
-import { getUsersWalletorHandleKey } from "lib/api/swr.keys";
 import { fetcher } from "lib/fetcher";
 import { User } from "lib/types/carbonmark.types";
 import { NextPage } from "next";
@@ -28,12 +27,10 @@ const Page: NextPage<PageProps> = (props) => {
   return (
     <>
       <PageHead
-        title={t`${
-          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
-        } | Profile | Carbonmark`}
-        mediaTitle={`${
-          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
-        }'s Profile on Carbonmark`}
+        title={t`${props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+          } | Profile | Carbonmark`}
+        mediaTitle={`${props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+          }'s Profile on Carbonmark`}
         metaDescription={t`Create and edit listings, and track your activity with your Carbonmark profile.`}
       />
 
@@ -47,6 +44,7 @@ const Page: NextPage<PageProps> = (props) => {
 
         {isUnconnectedUser && (
           <SellerUnconnected
+            user={props.carbonmarkUser}
             userAddress={props.userAddress}
             userName={userName}
           />
@@ -63,7 +61,7 @@ export const Users: NextPage<PageProps> = (props) => (
       fallback: {
         // https://swr.vercel.app/docs/with-nextjs#complex-keys
         [unstable_serialize(
-          getUsersWalletorHandleKey({}, { walletOrHandle: props.userAddress })
+          `users/${props.userAddress}`
         )]: props.carbonmarkUser,
       },
     }}

--- a/carbonmark/components/pages/Users/index.tsx
+++ b/carbonmark/components/pages/Users/index.tsx
@@ -27,10 +27,12 @@ const Page: NextPage<PageProps> = (props) => {
   return (
     <>
       <PageHead
-        title={t`${props.carbonmarkUser?.handle || concatAddress(props.userAddress)
-          } | Profile | Carbonmark`}
-        mediaTitle={`${props.carbonmarkUser?.handle || concatAddress(props.userAddress)
-          }'s Profile on Carbonmark`}
+        title={t`${
+          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+        } | Profile | Carbonmark`}
+        mediaTitle={`${
+          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+        }'s Profile on Carbonmark`}
         metaDescription={t`Create and edit listings, and track your activity with your Carbonmark profile.`}
       />
 
@@ -60,9 +62,8 @@ export const Users: NextPage<PageProps> = (props) => (
       fetcher,
       fallback: {
         // https://swr.vercel.app/docs/with-nextjs#complex-keys
-        [unstable_serialize(
-          `users/${props.userAddress}`
-        )]: props.carbonmarkUser,
+        [unstable_serialize(`users/${props.userAddress}`)]:
+          props.carbonmarkUser,
       },
     }}
   >

--- a/carbonmark/pages/portfolio/index.tsx
+++ b/carbonmark/pages/portfolio/index.tsx
@@ -1,8 +1,6 @@
 import { Portfolio } from "components/pages/Portfolio";
-import { withConditionalErrorBoundary } from "hocs/ConditionalErrorBoundary";
 import { loadTranslation } from "lib/i18n";
 import { GetStaticProps } from "next";
-import { isNotFoundError } from "next/dist/client/components/not-found";
 
 export const getStaticProps: GetStaticProps = async (ctx) => {
   try {
@@ -27,7 +25,4 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
 };
 
 /** We want to allow the page to render on user not found (404s) */
-export default withConditionalErrorBoundary(Portfolio, {
-  fallback: <h1>User cannot be found</h1>,
-  predicate: isNotFoundError,
-});
+export default Portfolio;

--- a/carbonmark/pages/users/[user].tsx
+++ b/carbonmark/pages/users/[user].tsx
@@ -2,13 +2,11 @@ import { getUsersWalletorhandle } from ".generated/carbonmark-api-sdk/clients";
 import { User } from ".generated/carbonmark-api-sdk/types";
 import { PageProps, Users } from "components/pages/Users";
 import { isAddress } from "ethers-v6";
-import { withConditionalErrorBoundary } from "hocs/ConditionalErrorBoundary";
 import { VALID_HANDLE_REGEX } from "lib/constants";
 import { loadTranslation } from "lib/i18n";
 import { getAddressByDomain } from "lib/shared/getAddressByDomain";
 import { getIsDomainInURL } from "lib/shared/getIsDomainInURL";
 import { GetStaticProps } from "next";
-import { isNotFoundError } from "next/dist/client/components/not-found";
 import { ParsedUrlQuery } from "querystring";
 
 interface Params extends ParsedUrlQuery {
@@ -118,6 +116,7 @@ const resolveHandle = async (params: { handle: string; locale?: string }) => {
 export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   ctx
 ) => {
+  console.log("WHATU")
   const { params, locale } = ctx;
   if (!params || !params?.user) {
     throw new Error("No matching params found");
@@ -150,7 +149,4 @@ export const getStaticPaths = async () => {
   };
 };
 
-export default withConditionalErrorBoundary(Users, {
-  fallback: <h1>User cannot be found</h1>,
-  predicate: isNotFoundError,
-});
+export default Users;

--- a/carbonmark/pages/users/[user].tsx
+++ b/carbonmark/pages/users/[user].tsx
@@ -116,7 +116,6 @@ const resolveHandle = async (params: { handle: string; locale?: string }) => {
 export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   ctx
 ) => {
-  console.log("WHATU")
   const { params, locale } = ctx;
   if (!params || !params?.user) {
     throw new Error("No matching params found");

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -96,8 +96,8 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
   const projectTokenName = retirement.pending
     ? null
     : retirement.offset.bridge === "Toucan"
-      ? "tco2"
-      : "c3t";
+    ? "tco2"
+    : "c3t";
   const carbonTokenName = poolTokenName || projectTokenName;
   const tokenData = carbonTokenName && carbonTokenInfoMap[carbonTokenName];
 
@@ -180,8 +180,9 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
                   }
                   text={
                     <Link
-                      href={`/retirements/${props.nameserviceDomain || props.beneficiaryAddress
-                        }`}
+                      href={`/retirements/${
+                        props.nameserviceDomain || props.beneficiaryAddress
+                      }`}
                       className="address"
                     >
                       {props.nameserviceDomain ||

--- a/site/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/site/components/pages/Retirements/SingleRetirement/index.tsx
@@ -23,6 +23,7 @@ import { PageHead } from "components/PageHead";
 import { TweetButton } from "components/TweetButton";
 import { carbonTokenInfoMap } from "lib/getTokenInfo";
 import { normalizeProjectId } from "lib/normalizeProjectId";
+import { isNil } from "lodash";
 import { NextPage } from "next";
 import dynamic from "next/dynamic";
 import Image from "next/image";
@@ -95,8 +96,8 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
   const projectTokenName = retirement.pending
     ? null
     : retirement.offset.bridge === "Toucan"
-    ? "tco2"
-    : "c3t";
+      ? "tco2"
+      : "c3t";
   const carbonTokenName = poolTokenName || projectTokenName;
   const tokenData = carbonTokenName && carbonTokenInfoMap[carbonTokenName];
 
@@ -179,9 +180,8 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
                   }
                   text={
                     <Link
-                      href={`/retirements/${
-                        props.nameserviceDomain || props.beneficiaryAddress
-                      }`}
+                      href={`/retirements/${props.nameserviceDomain || props.beneficiaryAddress
+                        }`}
                       className="address"
                     >
                       {props.nameserviceDomain ||
@@ -228,7 +228,7 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
           </Text>
           <div className={styles.pledge_button}>
             <ViewPledgeButton pledge={props.pledge} />
-            {props.pledge === null && (
+            {isNil(props.pledge) && (
               <Text className={styles.create_pledge} t="caption" align="center">
                 <Trans id="retirement.single.is_this_your_retirement">
                   Is this your retirement?


### PR DESCRIPTION
## Description

* Replace a `=== null` check that was failing because of `undefined`
* Pass the User object directly from getStaticProps rather than through SWRConfig

Resolves the following from #1944:
- [x] When I access another users public profile (for example https://www.carbonmark.com/users/offsetra) the initial screen view flashes the Listings - No active listings page before rendering properly

`JABBY CONFIRMS FIXED`

- [x] Recent portfolio page content changes that were merged as part of https://github.com/KlimaDAO/klimadao/issues/1063 not longer seem to be there anymore. Currently if you do not have a profile, the Portfolio page is completely blank.

`JABBY CONFIRMS FIXED`

- [x] A new login with no Profile created should still show the temp avatar and wallet and stats / activity components. The figma design for a seller that has logged in but not yet set up their profile is [here](https://www.figma.com/file/tnBViWV19Ln9jjFDekksY7/Profile?type=design&node-id=13-13294&mode=design&t=g8WQBIgLuA3J3cXB-4); assuming the Marketplace navigation item is still active; i.e. start from the marketplace, click login, go through the login modal, end up on this page.

`JABBY CONFIRMS FIXED`