### PR TITLE
Retirement page fallback improvements

### DIFF
--- a/carbonmark/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
@@ -130,7 +130,7 @@ export const ProjectDetails: FC<Props> = (props) => {
           variant="transparent"
           className="copyButton"
         />
-        {!props.retirement?.pending && props.retirement?.transaction?.id && (
+        {props.retirement?.transaction?.id && (
           <CarbonmarkButton
             icon={<LaunchIcon />}
             target="_blank"

--- a/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
@@ -71,24 +71,20 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
       <GridContainer>
         <Navigation activePage="Home" />
         <Section className={styles.section}>
-          <div className={styles.gridLayout}>
-            <Col className="column">
-              <div className={styles.pending}>
-                <div className="spinnerTitle">
-                  <Spinner />
-                  <Text>
-                    <Trans>Processing retirement...</Trans>
-                  </Text>
-                </div>
-                <Text t="button" align="center">
-                  <Trans>
-                    Your retirement was successful, but the blockchain data is
-                    still processing. This usually takes a few seconds, but
-                    might take longer if the network is congested.
-                  </Trans>
-                </Text>
-              </div>
-            </Col>
+          <div className={styles.pending}>
+            <div className="spinnerTitle">
+              <Spinner />
+              <Text t="h5">
+                <Trans>Processing retirement...</Trans>
+              </Text>
+            </div>
+            <Text align="center">
+              <Trans>
+                Your transaction was successful, but the network is taking
+                longer than expected to process the data. Your retirement
+                details should appear here in just a few seconds!
+              </Trans>
+            </Text>
           </div>
         </Section>
       </GridContainer>

--- a/carbonmark/components/pages/Retirements/SingleRetirement/styles.ts
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/styles.ts
@@ -85,8 +85,11 @@ export const pending = css`
   border-radius: 0.8rem;
   padding: 1.6rem;
   display: grid;
+  grid-column: main;
+  max-width: 40rem;
   gap: 2.4rem;
   justify-items: center;
+  justify-self: center;
 
   .spinnerTitle {
     display: flex;

--- a/examples/nextjs-typescript-integration/utils/fetchGasPrices.ts
+++ b/examples/nextjs-typescript-integration/utils/fetchGasPrices.ts
@@ -22,7 +22,7 @@ interface GasOptions {
 /** Invoke this immediately before dispatching a txn */
 export const fetchGasPrices = async (): Promise<GasOptions> => {
   try {
-    const res = await fetch("https://gasstation-mainnet.matic.network/v2", {
+    const res = await fetch("https://gasstation.polygon.technology/v2", {
       headers: {
         "Cache-Control": "max-age=1800 s-maxage=1800",
       },

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -143,7 +143,7 @@ export const urls = {
     "https://transferto.xyz/showcase/etherspot-klima?fromChain=eth&toChain=pol&toToken=0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
   lifiOffset:
     "https://transferto.xyz/showcase/carbon-offset?fromChain=eth&toChain=pol&toToken=0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
-  polyscanGasStation: "https://gasstation-mainnet.matic.network/v2",
+  polyscanGasStation: "https://gasstation.polygon.technology/v2",
   polygonscan: "https://polygonscan.com",
   polygonBridge: "https://wallet.polygon.technology/polygon/bridge/deposit",
   polygonTor: "https://polygon.tor.us/",

--- a/lib/types/subgraph.ts
+++ b/lib/types/subgraph.ts
@@ -28,16 +28,6 @@ export interface KlimaRetire {
     category: string;
     currentSupply: string;
   };
-  pending?: undefined;
-}
-
-/** When the subgraph index is behind, we can still use the storage contract to return the following info */
-export interface PendingKlimaRetire {
-  beneficiaryAddress: string;
-  beneficiary: string;
-  retirementMessage: string;
-  amount: string;
-  pending: true;
 }
 
 export interface QueryKlimaRetires {

--- a/site/pages/retirements/[beneficiary]/[retirement_index].tsx
+++ b/site/pages/retirements/[beneficiary]/[retirement_index].tsx
@@ -3,7 +3,7 @@ import { GetStaticProps } from "next";
 import { ParsedUrlQuery } from "querystring";
 
 import { urls } from "@klimadao/lib/constants";
-import { KlimaRetire, PendingKlimaRetire } from "@klimadao/lib/types/subgraph";
+import { KlimaRetire as IKlimaRetire } from "@klimadao/lib/types/subgraph";
 import {
   getRetirementDetails,
   queryKlimaRetireByIndex,
@@ -22,7 +22,14 @@ interface Params extends ParsedUrlQuery {
   beneficiary: string;
   retirement_index: string;
 }
-
+export type KlimaRetire = IKlimaRetire & { pending?: boolean };
+export interface PendingKlimaRetire {
+  beneficiaryAddress: string;
+  beneficiary: string;
+  retirementMessage: string;
+  amount: string;
+  pending: true;
+}
 export interface SingleRetirementPageProps {
   /** The resolved 0x address */
   beneficiaryAddress: string;


### PR DESCRIPTION
## Description

I was doing some demo testing and ran into a 404 after retirement. There is no ticket for this.

I take back my prior recommendations in #1018 -- this was dumb of me, we need fallbacks for API users. By fallbacks I mean, the page itself should handle cases where the data is on-chain but not yet indexed in the subgraph.
The code for fallbacks was already present, it just wasn't wired correctly.

With this pr:
- Only 404 when both subgraph AND on-chain data is not present for the given retirement
- If the on-chain data is present, return `null`, but render the page
- Show this updated message:

<img width="783" alt="Screenshot 2023-12-01 165342" src="https://github.com/KlimaDAO/klimadao/assets/88635679/77dcc572-b786-4160-8f4a-32c23c7730b5">

# Notes For QA
### Which pages does this touch?
- /retirement/[beneficiary]/[index]
### Which user journeys?
Creating a new retirement from anywhere in the ecosystem, then navigating to the retirement page URL immediately.
This is a hard one to test because the fallback is only present when the subgraph is slow.
- Should either render the page, or render the fallback view.
- In the fallback view it should refresh after a few seconds.
### Example URL(s)
https://carbonmark-git-atmos-retirement-404-klimadao.vercel.app/retirements/0xa17B52d5E17254B03dFdf7b4dfF2fc0C6108FaAc/67