### PR TITLE
Fix projects default pool detection

### DIFF
--- a/carbonmark-api/src/utils/helpers/fetchProjectPoolInfo.ts
+++ b/carbonmark-api/src/utils/helpers/fetchProjectPoolInfo.ts
@@ -132,6 +132,7 @@ export const fetchProjectPoolInfo = async (
       const poolAddress = POOL_INFO[poolName].poolAddress;
       let totalSupply = 0;
       let matchingTokenInfo: PoolBalance | undefined;
+      let matchingTokenAddress: string | undefined;
 
       for (const token of tokens) {
         const potentialMatch = token.poolBalances.find(
@@ -140,6 +141,7 @@ export const fetchProjectPoolInfo = async (
 
         if (potentialMatch) {
           matchingTokenInfo = potentialMatch;
+          matchingTokenAddress = token.id;
           const decimals = potentialMatch.pool.decimals;
           const numberBalance = parseFloat(
             ethers.utils.formatUnits(potentialMatch.balance, decimals)
@@ -148,10 +150,9 @@ export const fetchProjectPoolInfo = async (
         }
       }
 
-      if (!matchingTokenInfo) {
+      if (!matchingTokenInfo || !matchingTokenAddress) {
         return prevMap;
       }
-
       return {
         ...prevMap,
         [poolName]: {
@@ -159,7 +160,7 @@ export const fetchProjectPoolInfo = async (
           supply: totalSupply.toString(),
           poolAddress,
           isPoolDefault:
-            matchingTokenInfo.id.toLowerCase() ===
+            matchingTokenAddress.toLowerCase() ===
             POOL_INFO[poolName].defaultProjectTokenAddress.toLowerCase(),
           projectTokenAddress: get(tokens[0], "id", ""),
         },


### PR DESCRIPTION
## Description

Fixes projects default pool detection
It seems this got broken during the migration to the `polygon-digital-carbon` graph

## Related Ticket

Closes #1964

## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->
Specific pages, components or journeys that might be affected:
- all projects pages

Relevant preview URLs:
- https://www.carbonmark.com/fr/retire

Other notes:
- 
