### PR TITLE
fix: use correct fetch keys for swr preloading

### DIFF
--- a/carbonmark-api/src/routes/projects/get.ts
+++ b/carbonmark-api/src/routes/projects/get.ts
@@ -130,7 +130,6 @@ const handler = (fastify: FastifyInstance) =>
           marketplaceProjectData: project,
         });
       });
-
     /** Compose all the data together to unique entries (unsorted) */
     const entries = composeProjectEntries(ProjectMap, CMSDataMap, poolPrices);
 

--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -3,7 +3,6 @@ import { cx } from "@emotion/css";
 import { fetcher } from "@klimadao/carbonmark/lib/fetcher";
 import { Anchor } from "@klimadao/lib/components";
 import { REGISTRIES } from "@klimadao/lib/constants";
-import { useWeb3 } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import InfoOutlined from "@mui/icons-material/InfoOutlined";
 import LaunchIcon from "@mui/icons-material/Launch";
@@ -18,7 +17,6 @@ import { Stats } from "components/Stats";
 import { Text } from "components/Text";
 import { TextInfoTooltip } from "components/TextInfoTooltip";
 import { Vintage } from "components/Vintage";
-import { urls } from "lib/constants";
 import { formatList, formatToPrice } from "lib/formatNumbers";
 import { getActiveListings, getAllListings } from "lib/listingsGetter";
 import { isCategoryName, isTokenPrice } from "lib/types/carbonmark.guard";
@@ -254,13 +252,12 @@ const Page: NextPage<PageProps> = (props) => {
 };
 
 export const Project: NextPage<PageProps> = (props) => {
-  const { networkLabel } = useWeb3();
   return (
     <SWRConfig
       value={{
         fetcher,
         fallback: {
-          [`${urls.api.projects}/${props.projectID}?network=${networkLabel}`]:
+          [`/projects/${props.projectID}`]:
             props.project,
         },
       }}

--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -257,8 +257,7 @@ export const Project: NextPage<PageProps> = (props) => {
       value={{
         fetcher,
         fallback: {
-          [`/projects/${props.projectID}`]:
-            props.project,
+          [`/projects/${props.projectID}`]: props.project,
         },
       }}
     >

--- a/carbonmark/components/pages/Projects/index.tsx
+++ b/carbonmark/components/pages/Projects/index.tsx
@@ -102,7 +102,7 @@ export const Projects: NextPage<ProjectsPageStaticProps> = (props) => (
       // Prefill our API responses with server side fetched data
       // see: https://swr.vercel.app/docs/with-nextjs#pre-rendering-with-default-data
       fallback: {
-        ['/projects']: props.projects,
+        ["/projects"]: props.projects,
         [urls.api.vintages]: props.vintages,
         [urls.api.categories]: props.categories,
         [urls.api.countries]: props.countries,

--- a/carbonmark/components/pages/Projects/index.tsx
+++ b/carbonmark/components/pages/Projects/index.tsx
@@ -102,7 +102,7 @@ export const Projects: NextPage<ProjectsPageStaticProps> = (props) => (
       // Prefill our API responses with server side fetched data
       // see: https://swr.vercel.app/docs/with-nextjs#pre-rendering-with-default-data
       fallback: {
-        [urls.api.projects]: props.projects,
+        ['/projects']: props.projects,
         [urls.api.vintages]: props.vintages,
         [urls.api.categories]: props.categories,
         [urls.api.countries]: props.countries,

--- a/carbonmark/components/pages/Users/index.tsx
+++ b/carbonmark/components/pages/Users/index.tsx
@@ -27,10 +27,12 @@ const Page: NextPage<PageProps> = (props) => {
   return (
     <>
       <PageHead
-        title={t`${props.carbonmarkUser?.handle || concatAddress(props.userAddress)
-          } | Profile | Carbonmark`}
-        mediaTitle={`${props.carbonmarkUser?.handle || concatAddress(props.userAddress)
-          }'s Profile on Carbonmark`}
+        title={t`${
+          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+        } | Profile | Carbonmark`}
+        mediaTitle={`${
+          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+        }'s Profile on Carbonmark`}
         metaDescription={t`Create and edit listings, and track your activity with your Carbonmark profile.`}
       />
 

--- a/carbonmark/components/pages/Users/index.tsx
+++ b/carbonmark/components/pages/Users/index.tsx
@@ -6,7 +6,7 @@ import { useConnectedUser } from "hooks/useConnectedUser";
 import { fetcher } from "lib/fetcher";
 import { User } from "lib/types/carbonmark.types";
 import { NextPage } from "next";
-import { SWRConfig, unstable_serialize } from "swr";
+import { SWRConfig } from "swr";
 import { SellerConnected } from "./SellerConnected";
 import { SellerUnconnected } from "./SellerUnconnected";
 
@@ -27,12 +27,10 @@ const Page: NextPage<PageProps> = (props) => {
   return (
     <>
       <PageHead
-        title={t`${
-          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
-        } | Profile | Carbonmark`}
-        mediaTitle={`${
-          props.carbonmarkUser?.handle || concatAddress(props.userAddress)
-        }'s Profile on Carbonmark`}
+        title={t`${props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+          } | Profile | Carbonmark`}
+        mediaTitle={`${props.carbonmarkUser?.handle || concatAddress(props.userAddress)
+          }'s Profile on Carbonmark`}
         metaDescription={t`Create and edit listings, and track your activity with your Carbonmark profile.`}
       />
 
@@ -61,9 +59,7 @@ export const Users: NextPage<PageProps> = (props) => (
     value={{
       fetcher,
       fallback: {
-        // https://swr.vercel.app/docs/with-nextjs#complex-keys
-        [unstable_serialize(`users/${props.userAddress}`)]:
-          props.carbonmarkUser,
+        [`/users/${props.userAddress}`]: props.carbonmarkUser,
       },
     }}
   >

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -128,7 +128,6 @@ export const config = {
 export const urls = {
   api: {
     base: config.urls.api[ENVIRONMENT],
-    projects: `${config.urls.api[ENVIRONMENT]}/projects`,
     users: `${config.urls.api[ENVIRONMENT]}/users`,
     purchases: `${config.urls.api[ENVIRONMENT]}/purchases`,
     categories: `${config.urls.api[ENVIRONMENT]}/categories`,


### PR DESCRIPTION
## Description

SSR fetched project and projects data were not being passed to SWR hook because of incorrect keys in the SWRConfig prop.

/Projects & /Project should render with initial data correctly now.


## Related Ticket

Closes #1967

## Notes For QA
Please confirm that project loading behaves as expected

Relevant preview URLs:
`/projects` & `/projects/VCS-1190`

Other notes:
- 
