### PR TITLE
Makes carbonmark use the version 2.0.2 of the API

### DIFF
--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -28,7 +28,7 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-export const API_PROD_URL = "https://v2.0.0.api.carbonmark.com";
+export const API_PROD_URL = "https://v2.0.2.api.carbonmark.com";
 
 /**
  * Optional preview URL can be provided via env var.


### PR DESCRIPTION
## Description

Makes carbonmark use the version 2.0.2 of the API

## Related Ticket

Also related to #1966

## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->
Specific pages, components or journeys that might be affected:
- 

Relevant preview URLs:
- 

Other notes:
- 
