### PR TITLE
fix: Resolve v2.0.0 and v2.0.3 api differences

### DIFF
--- a/carbonmark-api/src/routes/projects/get.ts
+++ b/carbonmark-api/src/routes/projects/get.ts
@@ -87,13 +87,20 @@ const handler = (fastify: FastifyInstance) =>
         return;
       }
       const [standard, registryProjectId] = project.projectID.split("-");
+      // if (project.projectID.includes("VCS-903")) {
+      //   console.log(project.carbonCredits);
+      // }
       project.carbonCredits.forEach((credit) => {
         const { creditId: key } = new CreditId({
           standard,
           registryProjectId,
           vintage: credit.vintage.toString(),
         });
-        ProjectMap.set(key, { poolProjectData: project, key });
+        ProjectMap.set(key, {
+          /** We need to remove all other credits from this asset so that it is a one to one mapping of credit to project */
+          poolProjectData: { ...project, carbonCredits: [credit] },
+          key,
+        });
       });
     });
 
@@ -130,12 +137,10 @@ const handler = (fastify: FastifyInstance) =>
           marketplaceProjectData: project,
         });
       });
-
     /** Compose all the data together to unique entries (unsorted) */
     const entries = composeProjectEntries(ProjectMap, CMSDataMap, poolPrices);
 
     const sortedEntries = sortBy(entries, (e) => Number(e.price));
-
     // Send the transformed projects array as a JSON string in the response
     return reply
       .status(200)

--- a/carbonmark-api/src/routes/projects/get.ts
+++ b/carbonmark-api/src/routes/projects/get.ts
@@ -87,9 +87,6 @@ const handler = (fastify: FastifyInstance) =>
         return;
       }
       const [standard, registryProjectId] = project.projectID.split("-");
-      // if (project.projectID.includes("VCS-903")) {
-      //   console.log(project.carbonCredits);
-      // }
       project.carbonCredits.forEach((credit) => {
         const { creditId: key } = new CreditId({
           standard,

--- a/carbonmark-api/src/routes/projects/get.utils.ts
+++ b/carbonmark-api/src/routes/projects/get.utils.ts
@@ -85,7 +85,6 @@ export const getDigitalCarbonTokenPrices = (
   /**
    * @todo mc02 poolPrices are NaN because there is no default project
    */
-
   const credits = digitalCarbonProject.carbonCredits;
 
   for (const credit of credits) {
@@ -166,6 +165,7 @@ export const isValidPoolProject = (project: CarbonProjectType) => {
       Number(balance.balance) > 0
   );
 };
+
 export const isActiveListing = (l: {
   active?: boolean | null;
   deleted?: boolean | null;
@@ -223,7 +223,7 @@ const pickBestPrice = (
   data: ProjectData,
   poolPrices: Record<string, PoolPrice>
 ): string | undefined => {
-  const listings = compact(data.marketplaceProjectData?.listings || []);
+  const listings = compact(data.marketplaceProjectData?.listings);
   // Careful, singleUnitPrice is a bigint string
   const cheapestListing = minBy(listings, (l) => BigInt(l.singleUnitPrice));
   const cheapestListingUSDC =
@@ -239,6 +239,7 @@ const pickBestPrice = (
     Number(cheapestListingUSDC),
     Number(cheapestPoolPrice),
   ])?.toString();
+
   return bestPrice;
 };
 
@@ -262,9 +263,6 @@ export const composeProjectEntries = (
       registryProjectId,
     } = new CreditId(data.key);
     const carbonProject = cmsDataMap.get(projectId);
-    // if (projectId.includes("VCS-903")) {
-    //   console.log(poolBalances);
-    // }
     /** If there are no prices hide this project */
     const price = pickBestPrice(data, poolPrices);
     if (!price) return;

--- a/carbonmark-api/src/routes/projects/get.utils.ts
+++ b/carbonmark-api/src/routes/projects/get.utils.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from "fastify";
 import { compact, isNil, max, maxBy, minBy, sortBy } from "lodash";
-import { map, toLower } from "lodash/fp";
+import { map, mapValues, toLower, trim } from "lodash/fp";
 import { FindDigitalCarbonProjectsQuery } from "src/.generated/types/digitalCarbon.types";
 import { Geopoint } from "../../.generated/types/carbonProjects.types";
 import { GetProjectsQuery } from "../../.generated/types/marketplace.types";
@@ -269,7 +269,8 @@ export const composeProjectEntries = (
 
     // construct CarbonmarkProjectT and make typescript happy
     const entry: Project = {
-      methodologies: carbonProject?.methodologies ?? [],
+      //Remove string padding on methodologies
+      methodologies: map(mapValues(trim))(carbonProject?.methodologies) ?? [],
       description: carbonProject?.description || null,
       short_description: carbonProject?.content?.shortDescription || null,
       name: carbonProject?.name || poolBalances?.name || "",

--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -56,7 +56,7 @@ const Page: NextPage<PageProps> = (props) => {
   const prices = compact(project?.prices);
   const activeListings = getActiveListings(project.listings);
   const methodologies = compact(project.methodologies);
-  const category = methodologies.at(0)?.category ?? "Other";
+  const category = methodologies.at(0)?.category?.trim() ?? "Other";
   const allMethodologyIds = compact(methodologies.map(extract("id")));
   const allMethodologyNames = compact(methodologies.map(extract("name")));
 

--- a/carbonmark/lib/types/carbonmark.guard.ts
+++ b/carbonmark/lib/types/carbonmark.guard.ts
@@ -17,4 +17,4 @@ export function isTokenPrice(
 }
 
 export const isCategoryName = (name?: string | null): name is CategoryName =>
-  Object.keys(CATEGORY_INFO).includes(name as CategoryName);
+  Object.keys(CATEGORY_INFO).includes(name?.trim() as CategoryName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -589,7 +589,7 @@
     },
     "carbonmark-api": {
       "name": "@klimadao/carbonmark-api",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",


### PR DESCRIPTION
## Description

Because the API made an assumption of a one to one mapping of credits to projects (old technical debt)  only the first credit of any project was returning a project. This has been resolved by creating a new "Project" object per credit and adding it to the response.

Between v2.0.0 and v2.0.3 (the current version) the underlying subgraph has changed from 

https://api.thegraph.com/subgraphs/name/klimadao/polygon-bridged-carbon/

to

https://api.thegraph.com/subgraphs/name/klimadao/polygon-digital-carbon

The underlying data appears to be equivalent however the data structures are different with credits nested within projects. (@note we should really use the 'credits' graphql interface in the new subgraph)

### Number of projects returned:
v2.0.0.api.carbonmark.com ->  314
**this pr** ->  331

### Difference between api versions:
**Projects in V2.0.0 only**:  
[ 'VCS-903-2019' ]

**Projects in this PR only**:  [
  'VCS-1094-2009', 'VCS-1382-2015',
  'VCS-1566-2019', 'VCS-1671-2018',
  'VCS-1686-2017', 'VCS-1686-2019',
  'VCS-1715-2017', 'VCS-1762-2019',
  'VCS-1792-2020', 'VCS-1985-2019',
  'VCS-2307-2018', 'VCS-614-2010',
  'VCS-614-2011',  'VCS-614-2012',
  'VCS-614-2013',  'VCS-614-2014',
  'VCS-614-2015',  'VCS-614-2016'
]

There is a single project present in the old api that is not present in the new one 'VCS-903-2019' this is a result of the same Credit present across multiple Bridges (see: https://github.com/KlimaDAO/klimadao/issues/1994)

Additionally since this change some projects are now present that were not visible before.. I am not sure if they were hidden previously or if they are in error.

## Related Ticket

Closes 1987

## Notes For QA
We need to confirm that the newly visible projects are legitimate and not duplicates or contain some error.