### PR TITLE
[DRAFT] Makka / #1957 sort dropdown not updating with table sort

### DIFF
--- a/carbonmark/components/pages/Projects/ProjectSort/index.tsx
+++ b/carbonmark/components/pages/Projects/ProjectSort/index.tsx
@@ -9,7 +9,7 @@ import * as styles from "../styles";
 export const ProjectSort = () => {
   const { params, updateQueryParams } = useProjectsParams();
 
-  const { control } = useForm<{ sort: SortOption }>({
+  const { control, setValue } = useForm<{ sort: SortOption }>({
     defaultValues: { sort: params.sort },
   });
 
@@ -19,6 +19,11 @@ export const ProjectSort = () => {
     if (!sort) return;
     updateQueryParams({ ...params, sort });
   }, [sort]);
+
+  useEffect(() => {
+    if (!params.sort) return;
+    setValue("sort", params.sort);
+  }, [params]);
 
   return (
     <Dropdown


### PR DESCRIPTION
## Description

Sorting the table in the "list view" by the sortable columns (Price & Vintage) the sort dropdown should update to match the sorted column. This currently isn't working in production.

## Related Ticket

Closes #1957 

## Notes For QA
* [ ] When sorting the table by price newest (up arrow icon) - the sort dropdown value should update to "Price Newest"
* [ ] When sorting the table by price oldest (down arrow icon) - the sort dropdown value should update to "Price Oldest"
* [ ] When sorting the table by vintage newest (up arrow icon) - the sort dropdown value should update to "Vintage Newest"
* [ ] When sorting the table by vintage oldest (down arrow icon)- the sort dropdown value should update to "Vintage Oldest"

Specific pages, components or journeys that might be affected:
- Projects View

