### PR TITLE
fix:1987 trim Category strings in [id]/get and projects/get

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/carbonmark-api/src/routes/projects/[id]/get.ts
+++ b/carbonmark-api/src/routes/projects/[id]/get.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { compact, concat, min } from "lodash";
-import { pipe, uniq } from "lodash/fp";
+import { mapValues, pipe, trim, uniq } from "lodash/fp";
 import { DetailedProject } from "../../../models/DetailedProject.model";
 import { CreditId } from "../../../utils/CreditId";
 import { gql_sdk } from "../../../utils/gqlSdk";
@@ -75,7 +75,8 @@ const handler = (fastify: FastifyInstance) =>
       registry: projectDetails.registry,
       url: projectDetails.url,
       name: projectDetails.name,
-      methodologies: projectDetails.methodologies ?? [],
+      /** Sanitize category values */
+      methodologies: projectDetails.methodologies?.map(mapValues(trim)) ?? [],
       short_description: projectDetails.shortDescription,
       long_description: projectDetails.longDescription,
       projectID: projectDetails.registryProjectId,

--- a/carbonmark-api/src/routes/projects/get.utils.ts
+++ b/carbonmark-api/src/routes/projects/get.utils.ts
@@ -270,7 +270,7 @@ export const composeProjectEntries = (
     // construct CarbonmarkProjectT and make typescript happy
     const entry: Project = {
       //Remove string padding on methodologies
-      methodologies: map(mapValues(trim))(carbonProject?.methodologies) ?? [],
+      methodologies: carbonProject?.methodologies?.map(mapValues(trim)) ?? [],
       description: carbonProject?.description || null,
       short_description: carbonProject?.content?.shortDescription || null,
       name: carbonProject?.name || poolBalances?.name || "",


### PR DESCRIPTION
## Description

The Industrial Processing category was being returned as "Industrial Processing ". The additional space at the end of string caused it to fail when matching hardcoded categories.

I've sanitised categories with `trim` on the API side going forward.

https://github.com/KlimaDAO/klimadao/issues/1987#issuecomment-1847170247