### PR TITLE
Revert package.json version in carbonmark-api to v4.0.0

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "5.0.2",
+  "version": "4.0.0",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -589,7 +589,7 @@
     },
     "carbonmark-api": {
       "name": "@klimadao/carbonmark-api",
-      "version": "5.0.2",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",


### PR DESCRIPTION
## Description

Because all tags and releases after 4.x were merged we need to revert the package.json version in carbonmark-api
