### PR TITLE
Wait for the API to come online on preview environments

### DIFF
--- a/carbonmark/lib/waitForApi.ts
+++ b/carbonmark/lib/waitForApi.ts
@@ -3,7 +3,7 @@ import { getVintages } from ".generated/carbonmark-api-sdk/clients";
 export const waitForApi = async (): Promise<boolean> => {
   let counter = 0;
 
-  while (counter < 20) {
+  while (counter < 24) {
     try {
       await getVintages();
       return true;

--- a/carbonmark/lib/waitForApi.ts
+++ b/carbonmark/lib/waitForApi.ts
@@ -1,0 +1,18 @@
+import { getVintages } from ".generated/carbonmark-api-sdk/clients";
+
+export const waitForApi = async (): Promise<boolean> => {
+  let counter = 0;
+
+  while (counter < 20) {
+    try {
+      await getVintages();
+      return true;
+    } catch (e) {
+      console.debug(`Waiting for API to come online (${counter})`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    counter++;
+  }
+  console.debug(`Failed to contact API`);
+  return false;
+};

--- a/carbonmark/pages/index.tsx
+++ b/carbonmark/pages/index.tsx
@@ -1,12 +1,15 @@
 import { getProjectsId } from ".generated/carbonmark-api-sdk/clients";
 import { Home } from "components/pages/Home";
 import { loadTranslation } from "lib/i18n";
+import { waitForApi } from "lib/waitForApi";
 import { compact } from "lodash";
 import { GetStaticProps } from "next";
 
 const defaultProjectKeys = ["VCS-674-2014", "VCS-292-2020", "VCS-981-2017"];
 
 export const getStaticProps: GetStaticProps = async (ctx) => {
+  // Wait for the preview environment API to come online
+  if (process.env.NEXT_PUBLIC_USE_PREVIEW_CARBONMARK_API) await waitForApi();
   const translation = await loadTranslation(ctx.locale);
   const projects = await Promise.all(
     defaultProjectKeys.map((project) => getProjectsId(project))


### PR DESCRIPTION
## Description

Small quality of life PR.
This makes carbonmark FE wait for the preview API if it is configured to use it.
This prevents vercel builds to crash because queries fail.

## Related Ticket

NA

## Notes For QA
* [x] This PR is low-risk or narrow in scope, QA is not needed.
