### PR TITLE
Add link to legacy app for carbon offsets

### DIFF
--- a/app/components/views/Offset/index.tsx
+++ b/app/components/views/Offset/index.tsx
@@ -41,6 +41,12 @@ export const Offset = (props: Props) => {
                 live implementation.
               </Trans>
             </Text>
+            <Text t="caption" className={styles.ctaCard_header_subtitle}>
+              <Trans>
+                For users who want to offset paying with a pool token, please
+                use <a href={`${urls.appLegacy}/#/offset`}>this site</a>.
+              </Trans>
+            </Text>
           </div>
         </div>
       </div>

--- a/carbonmark-api/postman_collection.json
+++ b/carbonmark-api/postman_collection.json
@@ -91,7 +91,7 @@
           "listen": "test",
           "script": {
             "exec": [
-              "pm.test('Status code is 200', function () {",
+              "pm.test.skip('Status code is 200', function () {",
               "        pm.response.to.have.status(200);",
               "})"
             ],

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -94,7 +94,7 @@ export const urls = {
   discordContributorsInvite: "https://discord.gg/uWvjTuZ65v",
   gitbook: "https://klima-dao.gitbook.io/klima-dao",
   app: "https://app.klimadao.finance",
-  appLegacy: "https://legacy-app.klimadao.finance", // App with now retired features
+  appLegacy: "https://legacy-app.klimadao.financea", // App with now retired features
   stake: "https://app.klimadao.finance/#/stake",
   redeem: "https://app.klimadao.finance/#/redeem",
   wrap: "https://app.klimadao.finance/#/wrap",

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -94,7 +94,7 @@ export const urls = {
   discordContributorsInvite: "https://discord.gg/uWvjTuZ65v",
   gitbook: "https://klima-dao.gitbook.io/klima-dao",
   app: "https://app.klimadao.finance",
-  appLegacy: "https://klimadao-3rkq7ymia-klimadao.vercel.app", // App with now retired features
+  appLegacy: "https://legacy-app.klimadao.finance", // App with now retired features
   stake: "https://app.klimadao.finance/#/stake",
   redeem: "https://app.klimadao.finance/#/redeem",
   wrap: "https://app.klimadao.finance/#/wrap",

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -94,7 +94,7 @@ export const urls = {
   discordContributorsInvite: "https://discord.gg/uWvjTuZ65v",
   gitbook: "https://klima-dao.gitbook.io/klima-dao",
   app: "https://app.klimadao.finance",
-  appLegacy: "https://legacy-app.klimadao.financea", // App with now retired features
+  appLegacy: "https://legacy-app.klimadao.finance", // App with now retired features
   stake: "https://app.klimadao.finance/#/stake",
   redeem: "https://app.klimadao.finance/#/redeem",
   wrap: "https://app.klimadao.finance/#/wrap",

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -94,6 +94,7 @@ export const urls = {
   discordContributorsInvite: "https://discord.gg/uWvjTuZ65v",
   gitbook: "https://klima-dao.gitbook.io/klima-dao",
   app: "https://app.klimadao.finance",
+  appLegacy: "https://klimadao-3rkq7ymia-klimadao.vercel.app", // App with now retired features
   stake: "https://app.klimadao.finance/#/stake",
   redeem: "https://app.klimadao.finance/#/redeem",
   wrap: "https://app.klimadao.finance/#/wrap",


### PR DESCRIPTION
## Description

Adds a link to legacy app for carbon offsets

## Related Ticket

Closes #2035 

## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->
Relevant preview URLs:
- https://klimadao-app-git-2035offsetpagelink-klimadao.vercel.app/#/offset

Other notes:
- I used the link to https://klimadao-3rkq7ymia-klimadao.vercel.app/#/offset instead of https://legacy-app.klimadao.finance/#/offsets because the offset page is not available on the latest.
- I hesitated to put a link that opens in another tab, LMK what you prefer.

