### PR TITLE
Fix inputs for default retirements

### DIFF
--- a/carbonmark/components/pages/Project/Purchase/Pool/PurchaseForm.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Pool/PurchaseForm.tsx
@@ -145,7 +145,7 @@ export const PurchaseForm: FC<Props> = (props) => {
       const result = await redeemCarbonTransaction({
         paymentMethod: inputValues.paymentMethod,
         pool: props.price.poolName,
-        maxCost: inputValues.totalPrice,
+        maxCost: getApprovalValue(),
         projectTokenAddress: props.price.projectTokenAddress,
         isPoolDefault: props.price.isPoolDefault,
         quantity: inputValues.quantity,

--- a/carbonmark/lib/actions.redeem.ts
+++ b/carbonmark/lib/actions.redeem.ts
@@ -75,8 +75,8 @@ export const redeemCarbonTransaction = async (params: {
       txn = await aggregator[method](
         getAddress(params.paymentMethod),
         getAddress(params.pool),
-        parseUnits(params.maxCost, getTokenDecimals(params.paymentMethod)),
         parseUnits(params.quantity, 18),
+        parseUnits(params.maxCost, getTokenDecimals(params.paymentMethod)),
         TransferMode.EXTERNAL,
         TransferMode.EXTERNAL
       );


### PR DESCRIPTION
## Description
Bad inputs. Unclear how this did not get noticed. I think an API regression meant we were never using pool default pricing, so this chunk of code was never accessed.

Expediting to get in morning release.

## Related Ticket

Closes #2043
