### PR TITLE
Hide USDC icon for carbon approvals

### DIFF
--- a/carbonmark/components/Transaction/Approve.tsx
+++ b/carbonmark/components/Transaction/Approve.tsx
@@ -60,7 +60,8 @@ export const Approve: FC<Props> = (props) => {
             </Text>
           }
           value={props.amount}
-          icon={carbonmarkTokenInfoMap["usdc"].icon}
+          /* No icon for retiring/listing carbon etc. */
+          icon={props.price ? carbonmarkTokenInfoMap["usdc"].icon : undefined}
           iconName="usdc"
         />
         {!!props.price && (


### PR DESCRIPTION
## Description

Closes #2058 

## Notes For QA
See ticket, USDC icon should only appear when approving/paying USDC
Icon should not appear when retiring own carbon or creating a listing

This only touches the icon in the Approval view of the Transaction modal, which appears in 4 places:
- Purchase from listing
- Purchase from pool
- Retire Now from pool
- Retire Now from portfolio
Other checkout flows use a different modal.