### PR TITLE
Rejigger CMS entities to support ICR projects and add subcategories and methodology links

### DIFF
--- a/carbon-projects/README.md
+++ b/carbon-projects/README.md
@@ -22,6 +22,6 @@ Finally, update the Sanity GraphQL deployment:
 npm run deploy-graphql
 ```
 
-Assuming there are breaking changes, the codegen also needs to be re-run for the main repo workspace, and any breaking schema changes need to be consumed in our gql fragments and queries here: 
+If there are breaking changes, the codegen also needs to be re-run for the main repo workspace, and any breaking schema changes need to be consumed in our gql fragments and queries here: 
 - https://github.com/KlimaDAO/klimadao/blob/staging/carbonmark-api/src/graphql/cms.fragments.gql
 - https://github.com/KlimaDAO/klimadao/blob/staging/carbonmark-api/src/graphql/cms.gql

--- a/carbon-projects/README.md
+++ b/carbon-projects/README.md
@@ -1,3 +1,27 @@
 # Project Data CMS
 
 Single source of truth for Methodologies and Projects
+
+# Deployment
+
+When changes have been made to the schema, first build locally from inside this folder after running `npm install` for the top-level workspace of this repo:
+
+```
+npm run build
+```
+
+Assuming the build is successful, deploy the changes to Sanity Studio:
+
+```
+npm run deploy
+```
+
+Finally, update the Sanity GraphQL deployment:
+
+```
+npm run deploy-graphql
+```
+
+Assuming there are breaking changes, the codegen also needs to be re-run for the main repo workspace, and any breaking schema changes need to be consumed in our gql fragments and queries here: 
+- https://github.com/KlimaDAO/klimadao/blob/staging/carbonmark-api/src/graphql/cms.fragments.gql
+- https://github.com/KlimaDAO/klimadao/blob/staging/carbonmark-api/src/graphql/cms.gql

--- a/carbon-projects/schemas/externalFile.ts
+++ b/carbon-projects/schemas/externalFile.ts
@@ -1,0 +1,27 @@
+export default {
+	name: 'externalFile',
+	type: 'array',
+	title: 'External file',
+	of: [
+		{
+			type: 'string',
+            title: 'File name',
+            name: 'filename',
+		},
+		{
+			type: 'url',
+            title: 'URI',
+            name: 'uri',
+		},
+		{
+			type: 'string',
+            title: 'Description or Caption',
+            name: 'description',
+		},
+		{
+			type: 'string',
+            title: 'MIME Type',
+            name: 'mimetype',
+		},
+	]
+};

--- a/carbon-projects/schemas/index.ts
+++ b/carbon-projects/schemas/index.ts
@@ -1,4 +1,5 @@
 import methodology from "./methodology";
+import externalFile from "./objects/externalFile";
 import project from "./project";
 import projectContent from "./projectContent";
-export const schemaTypes = [project, methodology, projectContent];
+export const schemaTypes = [project, methodology, projectContent, externalFile];

--- a/carbon-projects/schemas/objects/externalFile.ts
+++ b/carbon-projects/schemas/objects/externalFile.ts
@@ -1,8 +1,10 @@
-export default {
+import { defineType } from 'sanity';
+
+export default defineType ({
 	name: 'externalFile',
-	type: 'array',
+	type: 'object',
 	title: 'External file',
-	of: [
+	fields: [
 		{
 			type: 'string',
             title: 'File name',
@@ -12,6 +14,9 @@ export default {
 			type: 'url',
             title: 'URI',
             name: 'uri',
+			validation: Rule => [
+				Rule.required(),
+			],
 		},
 		{
 			type: 'string',
@@ -24,4 +29,4 @@ export default {
             name: 'mimetype',
 		},
 	]
-};
+});

--- a/carbon-projects/schemas/objects/externalFile.ts
+++ b/carbon-projects/schemas/objects/externalFile.ts
@@ -1,32 +1,30 @@
-import { defineType } from 'sanity';
+import { defineType } from "sanity";
 
-export default defineType ({
-	name: 'externalFile',
-	type: 'object',
-	title: 'External file',
-	fields: [
-		{
-			type: 'string',
-            title: 'File name',
-            name: 'filename',
-		},
-		{
-			type: 'url',
-            title: 'URI',
-            name: 'uri',
-			validation: Rule => [
-				Rule.required(),
-			],
-		},
-		{
-			type: 'string',
-            title: 'Description or Caption',
-            name: 'description',
-		},
-		{
-			type: 'string',
-            title: 'MIME Type',
-            name: 'mimetype',
-		},
-	]
+export default defineType({
+  name: "externalFile",
+  type: "object",
+  title: "External file",
+  fields: [
+    {
+      type: "string",
+      title: "File name",
+      name: "filename",
+    },
+    {
+      type: "url",
+      title: "URI",
+      name: "uri",
+      validation: (Rule) => [Rule.required()],
+    },
+    {
+      type: "string",
+      title: "Description or Caption",
+      name: "description",
+    },
+    {
+      type: "string",
+      title: "MIME Type",
+      name: "mimetype",
+    },
+  ],
 });

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -37,9 +37,8 @@ const subcategories = [
   { title: "Improved Forest Management (IFM)", value: "ifm" },
   { title: "Avoided Deforestation", value: "redd" },
   { title: "Afforestation", value: "afforestation" },
-  { title: "Mangrove Restoration", value: "mangroves"},
+  { title: "Mangrove Restoration", value: "mangroves" },
 ];
-
 
 export default defineType({
   name: "project",
@@ -94,7 +93,7 @@ export default defineType({
           { title: "Verra", value: "VCS" },
           { title: "Gold Standard", value: "GS" },
           { title: "EcoRegistry", value: "ECO" },
-          { title: "International Carbon Registry", value: "ICR"},
+          { title: "International Carbon Registry", value: "ICR" },
         ],
       },
       validation: (r) => r.required(),
@@ -234,7 +233,8 @@ export default defineType({
     }),
     defineField({
       name: "url",
-      description: "Project's website or resource url on the registry, if exists",
+      description:
+        "Project's website or resource url on the registry, if exists",
       group: "media",
       type: "url",
     }),
@@ -246,18 +246,17 @@ export default defineType({
     }),
     defineField({
       name: "externalMedia",
-      description:
-        "Arrays of external media URIs and associated captions",
+      description: "Arrays of external media URIs and associated captions",
       group: "media",
       type: "array",
-      of: [{type: "externalFile"}],
+      of: [{ type: "externalFile" }],
     }),
     defineField({
       name: "externalDocuments",
       description: "External PDF documents associated with this project",
       group: "media",
       type: "array",
-      of: [{type: "externalFile"}],
+      of: [{ type: "externalFile" }],
     }),
   ],
 });

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -30,6 +30,17 @@ const ccbs = [
   { title: "CCB Community Gold", value: "CCB-Community Gold" },
 ];
 
+const subcategories = [
+  { title: "Solar Energy", value: "solar" },
+  { title: "Wind Energy", value: "wind" },
+  { title: "Hydroelectric Energy", value: "hydro" },
+  { title: "Improved Forest Management (IFM)", value: "ifm" },
+  { title: "Avoided Deforestation", value: "redd" },
+  { title: "Afforestation", value: "afforestation" },
+  { title: "Mangrove Restoration", value: "mangroves"},
+];
+
+
 export default defineType({
   name: "project",
   title: "Project",
@@ -83,6 +94,7 @@ export default defineType({
           { title: "Verra", value: "VCS" },
           { title: "Gold Standard", value: "GS" },
           { title: "EcoRegistry", value: "ECO" },
+          { title: "International Carbon Registry", value: "ICR"},
         ],
       },
       validation: (r) => r.required(),
@@ -147,6 +159,14 @@ export default defineType({
           },
         },
       ],
+    }),
+    defineField({
+      name: "subcategory",
+      description: "From our predefined ontology of subcategories",
+      type: "string",
+      options: {
+        list: subcategories,
+      },
     }),
     {
       name: "region",
@@ -214,30 +234,30 @@ export default defineType({
     }),
     defineField({
       name: "url",
-      description: "Project website or resource url, if exists",
+      description: "Project's website or resource url on the registry, if exists",
       group: "media",
       type: "url",
     }),
     defineField({
-      name: "documents",
-      description: "Other PDF documents associated with this project",
+      name: "projectWebsite",
+      description: "External project website, if exists",
+      group: "media",
+      type: "url",
+    }),
+    defineField({
+      name: "externalMedia",
+      description:
+        "Arrays of external media URIs and associated captions",
       group: "media",
       type: "array",
-      of: [
-        {
-          type: "file",
-          options: {
-            accept: ".pdf",
-          },
-          fields: [
-            {
-              name: "description",
-              description: "Description of the file",
-              type: "string",
-            },
-          ],
-        },
-      ],
+      of: [{type: "externalFile"}],
+    }),
+    defineField({
+      name: "externalDocuments",
+      description: "External PDF documents associated with this project",
+      group: "media",
+      type: "array",
+      of: [{type: "externalFile"}],
     }),
   ],
 });


### PR DESCRIPTION
## Description

Supports additional registries (including ICR) in the CMS, plus adds subcategories for projects and methodology links

Should not have any breaking impact on the frontend's API as only new fields were added (existing fields untouched)
