### PR TITLE
Remove google tag manager when not in production

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { GTMScript } from "@klimadao/lib/components";
 import "@klimadao/lib/theme/globals.css";
 import "@klimadao/lib/theme/normalize.css";
 import "@klimadao/lib/theme/variables.css";
@@ -5,8 +6,8 @@ import { useTabListener } from "@klimadao/lib/utils";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { StyledEngineProvider } from "@mui/material/styles";
+import { IS_PRODUCTION } from "lib/constants";
 import type { AppProps } from "next/app";
-import Script from "next/script";
 
 // StyledEngineProvider allows us to pass "injectFirst", which makes it easier to override mui styles in our css
 function MyApp({ Component, pageProps }: AppProps) {
@@ -18,19 +19,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           <Component {...pageProps} />
         </I18nProvider>
       </StyledEngineProvider>
-      <Script
-        id="google-analytics"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-          __html: `
-            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-KWFJ9R2');
-            `,
-        }}
-      />
+      <GTMScript tag="GTM-KWFJ9R2" is_production={IS_PRODUCTION} />
     </>
   );
 }

--- a/carbonmark/pages/_app.tsx
+++ b/carbonmark/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { Web3ContextProvider } from "@klimadao/lib/components";
+import { GTMScript, Web3ContextProvider } from "@klimadao/lib/components";
 import { useTabListener } from "@klimadao/lib/utils";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
@@ -6,9 +6,7 @@ import { UserTracker } from "components/UserTracker";
 import { IS_PRODUCTION, WALLETCONNECT_PROJECT_ID } from "lib/constants";
 import { activateLocale, loadTranslation } from "lib/i18n";
 import type { AppProps } from "next/app";
-import Script from "next/script";
 import { useEffect, useRef } from "react";
-
 // organize-imports-ignore
 import "@klimadao/lib/theme/normalize.css";
 // organize-imports-ignore
@@ -74,19 +72,7 @@ function MyApp({ Component, pageProps, router }: AppProps) {
           </I18nProvider>
         </UserTracker>
       </Web3ContextProvider>
-      <Script
-        id="google-analytics"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-          __html: `
-            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-PN73CG3');
-            `,
-        }}
-      />
+      <GTMScript tag="GTM-PN73CG3" is_production={IS_PRODUCTION} />
     </>
   );
 }

--- a/lib/components/GTMScript/index.tsx
+++ b/lib/components/GTMScript/index.tsx
@@ -1,0 +1,24 @@
+import Script from "next/script";
+import React from "react";
+
+export const GTMScript = (props: { tag: string; is_production: boolean }) => {
+  const script = props.is_production
+    ? `
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','${props.tag}');
+    `
+    : "";
+
+  return (
+    <Script
+      id="google-analytics"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{
+        __html: script,
+      }}
+    />
+  );
+};

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -5,6 +5,7 @@ export { ButtonPrimary } from "./Buttons/ButtonPrimary";
 export { ButtonSecondary } from "./Buttons/ButtonSecondary";
 export { ConnectModal } from "./ConnectModal";
 export { CopyValueButton } from "./CopyValueButton";
+export { GTMScript } from "./GTMScript";
 export { BraveIcon } from "./Icons/BraveIcon";
 export { CircleWalletIcon } from "./Icons/CircleWalletIcon";
 export { CoinbaseWalletIcon } from "./Icons/CoinbaseWalletIcon";

--- a/site/pages/_app.tsx
+++ b/site/pages/_app.tsx
@@ -1,11 +1,15 @@
-import { GridContainer, Web3ContextProvider } from "@klimadao/lib/components";
+import {
+  GTMScript,
+  GridContainer,
+  Web3ContextProvider,
+} from "@klimadao/lib/components";
 import "@klimadao/lib/theme/normalize.css";
 import "@klimadao/lib/theme/variables.css";
 import { useTabListener } from "@klimadao/lib/utils";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
+import { IS_PRODUCTION } from "lib/constants";
 import type { AppProps } from "next/app";
-import Script from "next/script";
 import { useEffect, useRef } from "react";
 
 // keep globals on new line so that it is imported after variables.css
@@ -68,19 +72,7 @@ function MyApp({ Component, pageProps, router }: AppProps) {
           </GridContainer>
         </I18nProvider>
       </Web3ContextProvider>
-      <Script
-        id="google-analytics"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-          __html: `
-            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-KWFJ9R2');
-            `,
-        }}
-      />
+      <GTMScript tag="GTM-KWFJ9R2" is_production={IS_PRODUCTION} />
     </>
   );
 }


### PR DESCRIPTION
## Description

Removes google tag manager when not in production. For app, site and carbonmark
It does not specifically disable UserTracker, but since lucky orange is not loaded. The traces set up by user tracker are never picked up.

I noticed that app and site share the same google tag manager id. Is it normal?



## Related Ticket

Closes #2057
Also related to <issue-number>

## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->
Specific pages, components or journeys that might be affected:
- None

Relevant preview URLs:
- None

Other notes:
- To see if it works, visit Lucky orange and google analytics backends
