### PR TITLE
Fix token prices for klima based pools

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/carbonmark-api/src/routes/projects/get.constants.ts
+++ b/carbonmark-api/src/routes/projects/get.constants.ts
@@ -4,7 +4,6 @@ export const DEFAULT_POOL_PROJECT_TOKENS = {
   bct: "0xb139c4cc9d20a3618e9a2268d73eff18c496b991",
   nct: "0x6362364a37f34d39a1f4993fb595dab4116daf0d",
 };
-
 const POOL_ADDRESSES = {
   nbo: "0x6bca3b77c1909ce1a4ba1a20d1103bde8d222e48",
   ubo: "0x2b3ecb0991af0498ece9135bcd04013d7993110c",
@@ -12,11 +11,12 @@ const POOL_ADDRESSES = {
   nct: "0xd838290e877e0188a4a44700463419ed96c16107",
 };
 
-const LP_ADDRESSES = {
+export const LP_ADDRESSES = {
   ubo: "0x5400a05b8b45eaf9105315b4f2e31f806ab706de",
   nbo: "0x251ca6a70cbd93ccd7039b6b708d4cb9683c266c",
-  bct: "0x9803c7ae526049210a1725f7487af26fe2c24614",
+  bct: "0x1e67124681b402064cd0abe8ed1b5c79d2e02f64",
   nct: "0xdb995f975f1bfc3b2157495c47e4efb31196b2ca",
+  klima: "0x5786b267d35f9d011c4750e0b0ba584e1fdbead1",
 };
 
 export type PoolInfo = {
@@ -27,6 +27,7 @@ export type PoolInfo = {
   poolFeeRatio: number;
   assetSwapFeeRatio: number;
   retirementServiceFeeRatio: number;
+  isKlimaLp: boolean;
 };
 
 function c3PoolFee(fee: number) {
@@ -43,6 +44,7 @@ export const POOL_INFO: Record<string, PoolInfo> = {
     defaultProjectTokenAddress: DEFAULT_POOL_PROJECT_TOKENS["nbo"],
     poolAddress: POOL_ADDRESSES["nbo"],
     lpAddress: LP_ADDRESSES["nbo"],
+    isKlimaLp: true,
     poolName: "nbo",
     poolFeeRatio: c3PoolFee(0.025),
     assetSwapFeeRatio: 0.003,
@@ -52,6 +54,7 @@ export const POOL_INFO: Record<string, PoolInfo> = {
     defaultProjectTokenAddress: DEFAULT_POOL_PROJECT_TOKENS["ubo"],
     poolAddress: POOL_ADDRESSES["ubo"],
     lpAddress: LP_ADDRESSES["ubo"],
+    isKlimaLp: true,
     poolName: "ubo",
     poolFeeRatio: c3PoolFee(0.025),
     assetSwapFeeRatio: 0.003,
@@ -61,6 +64,7 @@ export const POOL_INFO: Record<string, PoolInfo> = {
     defaultProjectTokenAddress: DEFAULT_POOL_PROJECT_TOKENS["bct"],
     poolAddress: POOL_ADDRESSES["bct"],
     lpAddress: LP_ADDRESSES["bct"],
+    isKlimaLp: false,
     poolName: "bct",
     poolFeeRatio: toucanPoolFee(0.25),
     assetSwapFeeRatio: 0.006,
@@ -70,6 +74,7 @@ export const POOL_INFO: Record<string, PoolInfo> = {
     defaultProjectTokenAddress: DEFAULT_POOL_PROJECT_TOKENS["nct"],
     poolAddress: POOL_ADDRESSES["nct"],
     lpAddress: LP_ADDRESSES["nct"],
+    isKlimaLp: false,
     poolName: "nct",
     poolFeeRatio: toucanPoolFee(0.1),
     assetSwapFeeRatio: 0.003,

--- a/carbonmark-api/src/utils/helpers/fetchAllPoolPrices.ts
+++ b/carbonmark-api/src/utils/helpers/fetchAllPoolPrices.ts
@@ -1,4 +1,4 @@
-import { POOL_INFO } from "../../routes/projects/get.constants";
+import { LP_ADDRESSES, POOL_INFO } from "../../routes/projects/get.constants";
 import { GQL_SDK } from "../gqlSdk";
 
 /**
@@ -34,14 +34,18 @@ const calculateSelectivePrice = (
  */
 export const fetchAllPoolPrices = async (sdk: GQL_SDK) => {
   const data = await sdk.tokens.getPoolPrices();
-
   const allPrices = data?.prices ? data.prices : [];
+  const klimaPrice = allPrices.find((p) => p.address === LP_ADDRESSES.klima)
+    ?.price;
 
   return Object.keys(POOL_INFO).reduce<Record<string, PoolPrice>>(
     (prev, poolName) => {
-      const defaultPrice = allPrices.find(
+      let defaultPrice = allPrices.find(
         (p) => p.address === POOL_INFO[poolName].lpAddress
       )?.price;
+      if (POOL_INFO[poolName].isKlimaLp) {
+        defaultPrice *= klimaPrice;
+      }
       prev[poolName] = {
         poolName,
         defaultPrice: Number(defaultPrice).toFixed(6),

--- a/carbonmark-api/test/routes/projects/[id]/get.test.ts
+++ b/carbonmark-api/test/routes/projects/[id]/get.test.ts
@@ -99,8 +99,8 @@ describe("GET /projects/:id", () => {
     const project = await response.json();
     expect(response.statusCode).toEqual(200);
     expect(project.prices).toHaveLength(1);
-    expect(project.prices[0].singleUnitBuyPrice).toBe("0.358940");
-    expect(project.prices[0].singleUnitSellPrice).toBe("0.361620");
+    expect(project.prices[0].singleUnitBuyPrice).toBe("0.356549");
+    expect(project.prices[0].singleUnitSellPrice).toBe("0.359211");
   });
 
   test("Empty network param default is polygon", async () => {

--- a/carbonmark-api/test/routes/projects/get.test.ts
+++ b/carbonmark-api/test/routes/projects/get.test.ts
@@ -66,7 +66,7 @@ const expectedPrices = [
     poolName: "bct",
     projectTokenAddress:
       fixtures.digitalCarbon.digitalCarbonProject.carbonCredits[0].id,
-    singleUnitPrice: "0.267999",
+    singleUnitPrice: "0.266214",
     supply: "320307.9104911482",
   },
 ];
@@ -146,7 +146,7 @@ describe("GET /projects", () => {
           mockDigitalCarbonProject.carbonCredits[0].poolBalances[0].pool
             .dailySnapshots[0].lastUpdateTimestamp,
         country: mockCmsProject.country,
-        price: "0.267999",
+        price: expectedPrices[0].singleUnitPrice,
         prices: expectedPrices,
         key: mockDigitalCarbonProject.projectID,
         stats: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -589,7 +589,7 @@
     },
     "carbonmark-api": {
       "name": "@klimadao/carbonmark-api",
-      "version": "5.0.0",
+      "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",


### PR DESCRIPTION
## Description

Fixes token prices for klima based pools
- When the pool is based on the klima token, we multiply the amount by the price of Klima

Note: There is a big difference for NBO price between coingecko and the subgraph information.

## Related Ticket

Also related to #2080 

## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->

To check:

Coingecko prices:
- UBO: https://www.coingecko.com/en/coins/universal-basic-offset
- NBO: https://www.coingecko.com/en/coins/nature-based-offset
- NCT: https://www.coingecko.com/en/coins/toucan-protocol-nature-carbon-tonne
- BCT: https://www.coingecko.com/en/coins/toucan-protocol-base-carbon-tonne

Default pool projects prices:
- UBO: https://carbonmark-api-git-apifixpricecalculus-klimadao.vercel.app/projects/VCS-1140-2015?minSupply=1
- NBO: https://carbonmark-api-git-apifixpricecalculus-klimadao.vercel.app/projects/VCS-981-2014 (no longer has NBO liquidity see: #2091 )
- NCT: https://carbonmark-api-git-apifixpricecalculus-klimadao.vercel.app/projects/VCS-1529-2012?minSupply=1
- BCT: https://carbonmark-api-git-apifixpricecalculus-klimadao.vercel.app/projects/VCS-191-2008?minSupply=1

graphql query
- https://api.thegraph.com/subgraphs/name/klimadao/klimadao-pairs/graphql?query=%7B+pairs+%7B%0A++id%0A++token0+%7B%0A++++name%0A++++symbol%0A++%7D%0A+++token1+%7B%0A++++name%0A++++symbol%0A++%7D%0A++currentprice%0A%7D%7D