### PR TITLE
Makka / #1993 new feature banner for bank transfer feature

### DIFF
--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -6,65 +6,110 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
-#: components/DisclaimerModal/index.tsx:84
-msgid "Acknowledge and Accept"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:93
-#: components/views/Bond/index.tsx:454
-#: components/views/Stake/index.tsx:252
-#: components/views/Wrap/index.tsx:230
-msgid "Approve"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
 msgstr ""
 
-#: components/views/Redeem/index.tsx:25
-msgid "Buy & Redeem Carbon"
+#. js-lingui-explicit-id
+#: components/CarbonBalancesCard/index.tsx:131
+#: components/CarbonTonnesRetiredCard/index.tsx:29
+msgid "Not Connected"
 msgstr ""
 
-#: components/NavMenu/index.tsx:202
-msgid "Buy Carbon"
-msgstr ""
-
-#: components/views/Bond/index.tsx:697
-msgid "Capacity"
-msgstr ""
-
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
-msgstr ""
-
-#: components/views/Stake/index.tsx:242
-#: components/views/Wrap/index.tsx:212
-msgid "Enter quantity"
-msgstr ""
-
-#: components/views/Offset/index.tsx:45
-msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
-msgstr ""
-
-#: components/views/Stake/index.tsx:247
-#: components/views/Wrap/index.tsx:225
-msgid "Insufficient balance"
-msgstr ""
-
-#: components/DisclaimerModal/index.tsx:47
-msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
-msgstr ""
-
-#: components/views/Bond/index.tsx:411
-#: components/views/PKlima/index.tsx:157
-msgid "Loading"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/CarbonBalancesCard/index.tsx:138
 msgid "Loading balances..."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/CarbonBalancesCard/index.tsx:168
+msgid "No balances found."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonBalancesCard/index.tsx:171
+msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:39
+msgid "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:29
+msgid "Risk Disclaimer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:32
+msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:39
+msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:47
+msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:53
+msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:60
+msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:75
+msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:84
+msgid "Acknowledge and Accept"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:63
+msgid "Wrong Network"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:68
+msgid "This app only works on Polygon Mainnet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:72
+msgid "Switch to Polygon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:202
+msgid "Buy Carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/RebaseCard/index.tsx:58
 #: components/RebaseCard/index.tsx:69
 #: components/views/Loading/index.tsx:11
@@ -75,622 +120,446 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:93
+#: components/views/Bond/index.tsx:454
+#: components/views/Stake/index.tsx:252
+#: components/views/Wrap/index.tsx:230
+msgid "Approve"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:411
+#: components/views/PKlima/index.tsx:157
+msgid "Loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:697
+msgid "Capacity"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Home/index.tsx:178
 msgid "Login"
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:39
-msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
-msgstr ""
-
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
-msgstr ""
-
-#: components/CarbonBalancesCard/index.tsx:168
-msgid "No balances found."
-msgstr ""
-
-#: components/CarbonBalancesCard/index.tsx:131
-#: components/CarbonTonnesRetiredCard/index.tsx:29
-msgid "Not Connected"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/Offset/index.tsx:27
 msgid "Offset"
 msgstr ""
 
-#: components/CheckURLBanner/index.tsx:39
-msgid "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:45
+msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:60
-msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:25
+msgid "Buy & Redeem Carbon"
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:32
-msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:242
+#: components/views/Wrap/index.tsx:212
+msgid "Enter quantity"
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:53
-msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:247
+#: components/views/Wrap/index.tsx:225
+msgid "Insufficient balance"
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:29
-msgid "Risk Disclaimer"
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:72
-msgid "Switch to Polygon"
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:68
-msgid "This app only works on Polygon Mainnet."
-msgstr ""
-
-#: components/DisclaimerModal/index.tsx:75
-msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:63
-msgid "Wrong Network"
-msgstr ""
-
-#: components/CarbonBalancesCard/index.tsx:171
-msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr ""
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr ""
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr ""
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr ""
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr ""
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr ""
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr ""
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr ""
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr ""
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr ""
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr ""
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr ""
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr ""
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr ""
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr ""
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr ""
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr ""
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr ""
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr ""
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr ""
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr ""
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:924
-msgid "bond.unredeemed.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr ""
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:746
-#: components/views/Bond/index.tsx:890
-msgid "bond.you_will_get"
-msgstr ""
-
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr ""
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr ""
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr ""
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr ""
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr ""
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr ""
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr ""
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr ""
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr ""
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr ""
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr ""
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/ChooseBond/index.tsx:239
 msgid "choose_bond.percent_discount"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
 msgstr ""
 
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr ""
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr ""
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr ""
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr ""
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr ""
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr ""
-
-#: lib/constants.ts:40
-msgid "connect_modal.error_processing"
-msgstr ""
-
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
-msgstr ""
-
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
-msgstr ""
-
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
-msgstr ""
-
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
 msgstr ""
 
 #. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
 msgstr ""
 
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
 msgstr ""
 
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
 msgstr ""
 
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr ""
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr ""
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr ""
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr ""
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr ""
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr ""
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr ""
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr ""
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr ""
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr ""
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr ""
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr ""
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr ""
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr ""
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr ""
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
-msgstr ""
-
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/PKlima/index.tsx:170
 msgid "pklima.approve_pklima"
 msgstr ""
 
 #. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
 msgstr ""
 
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
 msgstr ""
 
 #. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
 msgstr ""
 
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr ""
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
 msgstr ""
 
 #. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
 msgstr ""
 
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr ""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr ""
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr ""
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr ""
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/errors/Custom404.tsx:16
 msgid "shared.404"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/BalancesCard/index.tsx:47
 msgid "shared.balances"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/ChangeLanguageButton/index.tsx:56
 msgid "shared.change_language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:432
 #: components/views/PKlima/index.tsx:165
 #: components/views/Wrap/index.tsx:220
 msgid "shared.confirming"
 msgstr ""
 
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:259
 #: components/views/Stake/index.tsx:268
 msgid "shared.enter_amount"
 msgstr ""
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:475
 #: components/views/Bond/index.tsx:494
 #: components/views/Stake/index.tsx:276
@@ -698,6 +567,118 @@ msgstr ""
 msgid "shared.error"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:397
 #: components/views/Buy/index.tsx:65
 #: components/views/Home/index.tsx:154
@@ -707,6 +688,19 @@ msgstr ""
 msgid "shared.login_connect"
 msgstr ""
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:605
 #: components/views/PKlima/index.tsx:239
 #: components/views/Stake/index.tsx:372
@@ -714,237 +708,467 @@ msgstr ""
 msgid "shared.max"
 msgstr ""
 
-#: components/views/Bond/index.tsx:405
-msgid "shared.sold_out"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
 msgstr ""
 
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
 msgstr ""
 
-#. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr ""
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
-msgstr ""
-
-#. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
 msgstr ""
 
 #. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
 msgstr ""
 
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
 msgstr ""
 
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
 msgstr ""
 
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
 msgstr ""
 
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
 msgstr ""
 
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
 msgstr ""
 
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
 msgstr ""
 
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/RebaseCard/index.tsx:73
 msgid "stake.percent_payout"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/RebaseCard/index.tsx:44
 msgid "stake.rebase"
 msgstr ""
 
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:924
+msgid "bond.unredeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:40
+msgid "connect_modal.error_processing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:405
+msgid "shared.sold_out"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:335
 msgid "stake.stake"
 msgstr ""
 
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:258
 #: components/views/Stake/index.tsx:306
 #: components/views/Stake/index.tsx:471
 msgid "stake.stake_klima"
 msgstr ""
 
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:347
 msgid "stake.unstake"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:267
 #: components/views/Stake/index.tsx:473
 msgid "stake.unstake_klima"
 msgstr ""
 
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr ""
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr ""
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr ""
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr ""
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr ""
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr ""
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr ""
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:324
 msgid "wrap.unwrap"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:313
 msgid "wrap.wrap"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:279
 msgid "wrap.wrap_sklima"
 msgstr ""
 
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
 msgstr ""
 
 #. Long sentence
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:282
 msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:55
 msgid "wrap.wsklima_to_unwrap"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:746
+#: components/views/Bond/index.tsx:890
+msgid "bond.you_will_get"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
 msgstr ""
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
 msgstr ""

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -13,64 +13,103 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/DisclaimerModal/index.tsx:84
-msgid "Acknowledge and Accept"
-msgstr "Acknowledge and Accept"
-
-#: components/TransactionModal/Approve.tsx:93
-#: components/views/Bond/index.tsx:454
-#: components/views/Stake/index.tsx:252
-#: components/views/Wrap/index.tsx:230
-msgid "Approve"
-msgstr "Approve"
-
+#. js-lingui-explicit-id
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
 msgstr "Balances"
 
-#: components/views/Redeem/index.tsx:25
-msgid "Buy & Redeem Carbon"
-msgstr "Buy & Redeem Carbon"
+#. js-lingui-explicit-id
+#: components/CarbonBalancesCard/index.tsx:131
+#: components/CarbonTonnesRetiredCard/index.tsx:29
+msgid "Not Connected"
+msgstr "Not Connected"
 
-#: components/NavMenu/index.tsx:202
-msgid "Buy Carbon"
-msgstr "Buy Carbon"
-
-#: components/views/Bond/index.tsx:697
-msgid "Capacity"
-msgstr "Capacity"
-
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
-msgstr "Enter Quantity"
-
-#: components/views/Stake/index.tsx:242
-#: components/views/Wrap/index.tsx:212
-msgid "Enter quantity"
-msgstr "Enter quantity"
-
-#: components/views/Offset/index.tsx:45
-msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
-msgstr "For users who want to offset paying with a pool token, please use <0>this site</0>."
-
-#: components/views/Stake/index.tsx:247
-#: components/views/Wrap/index.tsx:225
-msgid "Insufficient balance"
-msgstr "Insufficient balance"
-
-#: components/DisclaimerModal/index.tsx:47
-msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
-msgstr "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
-
-#: components/views/Bond/index.tsx:411
-#: components/views/PKlima/index.tsx:157
-msgid "Loading"
-msgstr "Loading"
-
+#. js-lingui-explicit-id
 #: components/CarbonBalancesCard/index.tsx:138
 msgid "Loading balances..."
 msgstr "Loading balances..."
 
+#. js-lingui-explicit-id
+#: components/CarbonBalancesCard/index.tsx:168
+msgid "No balances found."
+msgstr "No balances found."
+
+#. js-lingui-explicit-id
+#: components/CarbonBalancesCard/index.tsx:171
+msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
+msgstr "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:39
+msgid "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
+msgstr "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:29
+msgid "Risk Disclaimer"
+msgstr "Risk Disclaimer"
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:32
+msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+msgstr "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:39
+msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
+msgstr "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:47
+msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
+msgstr "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:53
+msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
+msgstr "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:60
+msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
+msgstr "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:75
+msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
+msgstr "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
+
+#. js-lingui-explicit-id
+#: components/DisclaimerModal/index.tsx:84
+msgid "Acknowledge and Accept"
+msgstr "Acknowledge and Accept"
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:63
+msgid "Wrong Network"
+msgstr "Wrong Network"
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:68
+msgid "This app only works on Polygon Mainnet."
+msgstr "This app only works on Polygon Mainnet."
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:72
+msgid "Switch to Polygon"
+msgstr "Switch to Polygon"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:202
+msgid "Buy Carbon"
+msgstr "Buy Carbon"
+
+#. js-lingui-explicit-id
 #: components/RebaseCard/index.tsx:58
 #: components/RebaseCard/index.tsx:69
 #: components/views/Loading/index.tsx:11
@@ -81,622 +120,446 @@ msgstr "Loading balances..."
 msgid "Loading..."
 msgstr "Loading..."
 
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:93
+#: components/views/Bond/index.tsx:454
+#: components/views/Stake/index.tsx:252
+#: components/views/Wrap/index.tsx:230
+msgid "Approve"
+msgstr "Approve"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:411
+#: components/views/PKlima/index.tsx:157
+msgid "Loading"
+msgstr "Loading"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr "Enter Quantity"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:697
+msgid "Capacity"
+msgstr "Capacity"
+
+#. js-lingui-explicit-id
 #: components/views/Home/index.tsx:178
 msgid "Login"
 msgstr "Login"
 
-#: components/DisclaimerModal/index.tsx:39
-msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
-msgstr "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
-
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
-msgstr "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
-
-#: components/CarbonBalancesCard/index.tsx:168
-msgid "No balances found."
-msgstr "No balances found."
-
-#: components/CarbonBalancesCard/index.tsx:131
-#: components/CarbonTonnesRetiredCard/index.tsx:29
-msgid "Not Connected"
-msgstr "Not Connected"
-
+#. js-lingui-explicit-id
 #: components/views/Offset/index.tsx:27
 msgid "Offset"
 msgstr "Offset"
 
-#: components/CheckURLBanner/index.tsx:39
-msgid "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
-msgstr "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update your bookmarks."
-
-#: components/DisclaimerModal/index.tsx:60
-msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
-msgstr "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
-
-#: components/DisclaimerModal/index.tsx:32
-msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
-msgstr "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
-
-#: components/DisclaimerModal/index.tsx:53
-msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
-msgstr "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
-
-#: components/DisclaimerModal/index.tsx:29
-msgid "Risk Disclaimer"
-msgstr "Risk Disclaimer"
-
-#: components/InvalidNetworkModal/index.tsx:72
-msgid "Switch to Polygon"
-msgstr "Switch to Polygon"
-
-#: components/InvalidNetworkModal/index.tsx:68
-msgid "This app only works on Polygon Mainnet."
-msgstr "This app only works on Polygon Mainnet."
-
-#: components/DisclaimerModal/index.tsx:75
-msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
-msgstr "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
-
-#: components/InvalidNetworkModal/index.tsx:63
-msgid "Wrong Network"
-msgstr "Wrong Network"
-
-#: components/CarbonBalancesCard/index.tsx:171
-msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
-msgstr "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr "SOLD OUT. All demand has been filled for this bond. Thank you, Klimates!"
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr "Balance"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr "Balance available for bonding"
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr "Bond"
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr "Bond price"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr "Discounted price. Total amount to bond 1 full KLIMA (fractional bonds are also allowed)"
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr "Current trading price of KLIMA on the market"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr "Bond {0}"
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr "CAPACITY EXCEEDED"
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr "Date of full vesting"
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr "Date when the entire bond value can be redeemed"
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr "Debt ratio"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr "Protocol's current ratio of supply to outstanding bonds"
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr "Bond discount"
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr "Percentage discount (or premium if negative) relative to the market value of KLIMA."
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr "Amount to bond"
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr "Amount to redeem"
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr "Premium"
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr "Premium relative to the market value of KLIMA."
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr "Market price"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr "Current trading price of KLIMA, without bond discount"
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr "MAX EXCEEDED"
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr "Maximum"
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr "Maximum amount you can acquire by bonding"
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr "Not Redeemable"
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr "Payout per KLIMA"
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr "If you bond 1 KLIMA, you will receive this amount in USDC."
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr "Redeem"
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr "Redeemable"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr "Amount of KLIMA that has already vested and can be redeemed"
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr "Automatically stake for sKLIMA"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr "⚠️ Warning: this bond price is inflated because the current discount rate is negative."
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr "Bond {0}"
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr "Redeem Klima"
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr "Unredeemed"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:924
-msgid "bond.unredeemed.tooltip"
-msgstr "Remaining unredeemed value (vested and un-vested)"
-
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr "Vesting term end"
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr "If you bond now, your vesting term ends at this date. Klima is slowly unlocked for redemption over the duration of this term."
-
-#: components/views/Bond/index.tsx:746
-#: components/views/Bond/index.tsx:890
-msgid "bond.you_will_get"
-msgstr "You will get"
-
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr "Amount you will get, at the provided input quantity"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr "Amount of bonded KLIMA you will get, at the provided input quantity"
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr "Buy KLIMA"
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr "This feature is available only to users who are logged in. You can log in or create an account via the button below."
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr "If you are a beginner, we recommend following our step-by-step tutorial: <0>How to Buy KLIMA</0>."
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr "Otherwise, if you already have a wallet with MATIC on Polygon, the best way to get KLIMA is to swap on <0>Sushi.com</0>. If you prefer to pay with a credit card instead, you can use <1>Transak</1> to buy KLIMA directly."
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr "Please Log In Or Connect A Wallet"
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr "This is the amount of USDC in the contract available for bonds."
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr "Don't Remind Me"
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr "Got it"
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr "<0>app.klimadao.finance</0> is the only official domain."
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr "⚠️ Verify the URL and bookmark this page!"
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr "Toucan Base Carbon Tonne"
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr "Bond Carbon"
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr "The best way to buy KLIMA. Commit carbon to our treasury, and receive KLIMA at a discount. All bonds (except inverse bonds) have a mandatory 5 day vesting period."
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr "Choose a bond"
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr "Provide KLIMA, receive USDC"
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr "KLIMA/BCT Sushiswap Liquidity"
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr "KLIMA/USDC Sushiswap Liquidity"
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr "MOSS Carbon Credit Token"
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr "KLIMA/MCO2 Quickswap Liquidity"
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr "C3 Nature Based Offset"
-
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:45
+msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
+msgstr "For users who want to offset paying with a pool token, please use <0>this site</0>."
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:25
+msgid "Buy & Redeem Carbon"
+msgstr "Buy & Redeem Carbon"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:242
+#: components/views/Wrap/index.tsx:212
+msgid "Enter quantity"
+msgstr "Enter quantity"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:247
+#: components/views/Wrap/index.tsx:225
+msgid "Insufficient balance"
+msgstr "Insufficient balance"
+
+#. js-lingui-explicit-id
 #: components/views/ChooseBond/index.tsx:239
 msgid "choose_bond.percent_discount"
 msgstr "% Discount"
 
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr "SOLD OUT"
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr "<0>app.klimadao.finance</0> is the only official domain."
 
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr "Treasury Balance"
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr "C3 Universal Basic Offset"
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr "social or email"
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr "connect a wallet"
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr "Connecting..."
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr "We had some trouble connecting. Please try again."
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr "User refused connection."
-
-#: lib/constants.ts:40
-msgid "connect_modal.error_processing"
-msgstr "Request already processing. Please open your wallet and complete the request."
-
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
-msgstr "Connection Error"
-
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
-msgstr "Sorry, looks like we sent you the wrong way. <0/>Please select a destination from the menu."
-
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
-msgstr "How to get started"
-
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
-msgstr "New to KLIMA?"
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr "⚠️ Verify the URL and bookmark this page!"
 
 #. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
-msgstr "1. Open Metamask and switch to Ethereum Mainnet"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr "⚠️ Warning: this bond price is inflated because the current discount rate is negative."
 
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr "2. Go to Settings/Networks/Polygon and click 'delete'"
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr "❌ Error: something went wrong..."
 
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr "3. Return to app.klimadao.finance and click 'switch to mainnet'."
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr "1. Approve"
 
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr "If the app says 'loading...' this is likely a problem with your network configuration in Metamask. To fix this:"
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr "Metamask should prompt you to add Polygon, with the correct RPC configuration."
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr "Why won't the app load for me?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr "Common app-related questions and useful links. For comprehensive reading on KlimaDAO, see our <0>official documentation</0>."
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr "Info & FAQ"
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr "Official Contract Addresses"
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr "The network could not be reached. This is most likely caused by an old Polygon RPC configuration in your wallet. See <0>this guide</0> for a fix. Otherwise, reach out to us on <1>Discord</1> if problems persist."
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr "Check your network settings"
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr "Bond Carbon"
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr "Buy KLIMA"
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr "Info"
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr "JUST FOR YOU"
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr "NOT CONNECTED"
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr "Offset"
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr "Stake KLIMA"
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr "Your Wallet Address"
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr "Wrap sKLIMA"
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr "SUCCESS!"
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr "FAILURE!"
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr "PENDING"
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr "CONFIRMATION"
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr "BACK"
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
-msgstr "KlimaDAO's retirement aggregator is an open-source tool that enables the retirement of digital carbon credits."
-
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr "Visit our <0> documentation </0> to build it into your application, or visit <1> Carbonmark </1> to use a live implementation."
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr "Total retirements"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr "Tonnes of carbon"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr "View Retirements"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr "You've Retired"
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr "2. Approve BCT"
-
+#. js-lingui-explicit-id
 #: components/views/PKlima/index.tsx:170
 msgid "pklima.approve_pklima"
 msgstr "1. Approve pKLIMA"
 
 #. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr "Make sure to stake your redeemed pKLIMA, and stay staked, until global GHG emissions have plateaued."
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr "1. Open Metamask and switch to Ethereum Mainnet"
 
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr "EXERCISE"
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr "Exercise 1 pKLIMA and 1 BCT to receive 1 KLIMA."
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr "Index adjusted"
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr "2. Approve BCT"
 
 #. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr "Equivalent sKLIMA claimed, assuming you staked all of your redeemed KLIMA until today."
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr "2. Go to Settings/Networks/Polygon and click 'delete'"
 
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr "pKLIMA to exercise"
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr "You've claimed more KLIMA than your supply-share limit. This is likely due to a fix implemented on November 24th, 2021 to the pKLIMA redemption contract."
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr "Redeem pKLIMA"
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
-msgstr "Redeemed"
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr "2. Submit"
 
 #. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr "Total KLIMA you have redeemed so far."
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr "3. Return to app.klimadao.finance and click 'switch to mainnet'."
 
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr "Supply limit"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr "A percent of total token supply. Your index-adjusted claim may not exceed this value."
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr "The updated contract now assumes pKLIMA holders have staked and earned rewards on previously claimed tokens. Prior to the November fix, these staking rewards were not counted against your supply share limit, which meant your share of the total KLIMA supply could surpass the limit defined in your terms."
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr "KlimaDAO's digital carbon liquidity pools are common resources available for driving environmental impact."
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr "Visit our <0>documentation </0> to find the LP contract addresses, or visit <1> Carbonmark </1> to acquire carbon via a simple user interface."
-
+#. js-lingui-explicit-id
 #: components/views/errors/Custom404.tsx:16
 msgid "shared.404"
 msgstr "404 - Page Not Found"
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr "5 Day Rewards"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr "A percent of total token supply. Your index-adjusted claim may not exceed this value."
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr "AKR"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr "Amount of bonded KLIMA you will get, at the provided input quantity"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr "Amount of KLIMA that has already vested and can be redeemed"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Used to calculate wsKLIMA value."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Useful for accounting purposes."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr "Amount to bond"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr "Amount to redeem"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr "Amount to stake"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr "Amount to unstake"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr "Amount you will get, at the provided input quantity"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
+msgstr "Annualized KLIMA Rewards, including compounding, should the current reward rate remain unchanged for 12 months (reward rate may be subject to change)."
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr "Approx. next rebase"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr "Approximate rewards, including compounding, should you remain staked for 5 days."
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr "Automatically stake for sKLIMA"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr "BACK"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr "Balance"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr "Balance"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr "Balance available for bonding"
+
+#. js-lingui-explicit-id
 #: components/BalancesCard/index.tsx:47
 msgid "shared.balances"
 msgstr "Balances"
 
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr "Bond"
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr "Bond {0}"
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr "Bond {0}"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr "Bond Carbon"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr "Bond Carbon"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr "Bond discount"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
+msgstr "Bond price"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr "Buy KLIMA"
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr "Buy KLIMA"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr "C3 Nature Based Offset"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr "C3 Universal Basic Offset"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr "CAPACITY EXCEEDED"
+
+#. js-lingui-explicit-id
 #: components/ChangeLanguageButton/index.tsx:56
 msgid "shared.change_language"
 msgstr "Change language"
 
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr "Check your network settings"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr "Choose a bond"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr "Close"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr "Common app-related questions and useful links. For comprehensive reading on KlimaDAO, see our <0>official documentation</0>."
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr "Confirm amount"
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr "CONFIRMATION"
+
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:432
 #: components/views/PKlima/index.tsx:165
 #: components/views/Wrap/index.tsx:220
 msgid "shared.confirming"
 msgstr "Confirming"
 
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr "Loading..."
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr "connect a wallet"
 
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr "Connect with your browser web3 provider"
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr "Connecting..."
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr "Connection Error"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr "Contract address"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr "Contract address"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr "Cross-chain staking is now available through <0>LI.FI and Etherspot</0>, with support for multiple chains and tokens."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr "Current trading price of KLIMA on the market"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr "Current trading price of KLIMA, without bond discount"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr "Date of full vesting"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr "Date when the entire bond value can be redeemed"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr "Debt ratio"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr "Discounted price. Total amount to bond 1 full KLIMA (fractional bonds are also allowed)"
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr "Don't Remind Me"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr "Easy one-click wallet by Torus"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr "Email or Social"
+
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:259
 #: components/views/Stake/index.tsx:268
 msgid "shared.enter_amount"
 msgstr "Enter Amount"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr "Equivalent sKLIMA claimed, assuming you staked all of your redeemed KLIMA until today."
+
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:475
 #: components/views/Bond/index.tsx:494
 #: components/views/Stake/index.tsx:276
@@ -704,6 +567,118 @@ msgstr "Enter Amount"
 msgid "shared.error"
 msgstr "ERROR"
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr "Est. payout (sKLIMA)"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr "EXERCISE"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr "Exercise 1 pKLIMA and 1 BCT to receive 1 KLIMA."
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr "FAILURE!"
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr "Got it"
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr "How to get started"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr "If the app says 'loading...' this is likely a problem with your network configuration in Metamask. To fix this:"
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr "If you are a beginner, we recommend following our step-by-step tutorial: <0>How to Buy KLIMA</0>."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr "If you bond 1 KLIMA, you will receive this amount in USDC."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr "If you bond now, your vesting term ends at this date. Klima is slowly unlocked for redemption over the duration of this term."
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr "Index"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr "Index"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr "Index adjusted"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr "Info"
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
+msgstr "Info & FAQ"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr "JUST FOR YOU"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr "KLIMA/BCT Sushiswap Liquidity"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr "KLIMA/MCO2 Quickswap Liquidity"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr "KLIMA/USDC Sushiswap Liquidity"
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr "KlimaDAO's digital carbon liquidity pools are common resources available for driving environmental impact."
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
+msgstr "KlimaDAO's retirement aggregator is an open-source tool that enables the retirement of digital carbon credits."
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr "Loading..."
+
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:397
 #: components/views/Buy/index.tsx:65
 #: components/views/Home/index.tsx:154
@@ -713,6 +688,19 @@ msgstr "ERROR"
 msgid "shared.login_connect"
 msgstr "Login / Connect"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr "Make sure to stake your redeemed pKLIMA, and stay staked, until global GHG emissions have plateaued."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr "Market price"
+
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:605
 #: components/views/PKlima/index.tsx:239
 #: components/views/Stake/index.tsx:372
@@ -720,237 +708,467 @@ msgstr "Login / Connect"
 msgid "shared.max"
 msgstr "Max"
 
-#: components/views/Bond/index.tsx:405
-msgid "shared.sold_out"
-msgstr "Sold Out"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr "MAX EXCEEDED"
 
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
-msgstr "5 Day Rewards"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr "Maximum"
 
-#. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr "Approximate rewards, including compounding, should you remain staked for 5 days."
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
-msgstr "AKR"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
-msgstr "Annualized KLIMA Rewards, including compounding, should the current reward rate remain unchanged for 12 months (reward rate may be subject to change)."
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr "Maximum amount you can acquire by bonding"
 
 #. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
-msgstr "Stake your KLIMA tokens to receive sKLIMA. After every rebase, your sKLIMA balance will increase by the given percentage."
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr "Metamask should prompt you to add Polygon, with the correct RPC configuration."
 
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr "Est. payout (sKLIMA)"
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr "MOSS Carbon Credit Token"
 
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr "Index"
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr "New to KLIMA?"
 
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Useful for accounting purposes."
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
+msgstr "Next"
 
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr "Amount to stake"
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr "NOT CONNECTED"
 
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr "Amount to unstake"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr "Not Redeemable"
 
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr "Cross-chain staking is now available through <0>LI.FI and Etherspot</0>, with support for multiple chains and tokens."
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr "Official Contract Addresses"
 
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr "Approx. next rebase"
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
+msgstr "Offset"
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr "Otherwise, if you already have a wallet with MATIC on Polygon, the best way to get KLIMA is to swap on <0>Sushi.com</0>. If you prefer to pay with a credit card instead, you can use <1>Transak</1> to buy KLIMA directly."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr "Payout per KLIMA"
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr "PENDING"
+
+#. js-lingui-explicit-id
 #: components/RebaseCard/index.tsx:73
 msgid "stake.percent_payout"
 msgstr "Percent payout"
 
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr "Percentage discount (or premium if negative) relative to the market value of KLIMA."
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr "pKLIMA"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr "pKLIMA to exercise"
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr "Please click 'confirm' in your wallet to continue."
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr "Please Log In Or Connect A Wallet"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr "Please submit the transaction."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr "Premium"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr "Premium relative to the market value of KLIMA."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr "Protocol's current ratio of supply to outstanding bonds"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr "Provide KLIMA, receive USDC"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr "Quantity to approve"
+
+#. js-lingui-explicit-id
 #: components/RebaseCard/index.tsx:44
 msgid "stake.rebase"
 msgstr "Rebase"
 
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr "The protocol automatically mints and distributes rewards. Your payout is a percentage of your sKLIMA balance"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
+msgstr "Redeem"
 
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr "Redeem Klima"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr "Redeem pKLIMA"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr "Redeemable"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
+msgstr "Redeemed"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:924
+msgid "bond.unredeemed.tooltip"
+msgstr "Remaining unredeemed value (vested and un-vested)"
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:40
+msgid "connect_modal.error_processing"
+msgstr "Request already processing. Please open your wallet and complete the request."
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr "Scan with Coinbase to connect"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr "Scan with WalletConnect to connect"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
+msgstr "sKLIMA to wrap"
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
+msgstr "social or email"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:405
+msgid "shared.sold_out"
+msgstr "Sold Out"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
+msgstr "SOLD OUT"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
+msgstr "SOLD OUT. All demand has been filled for this bond. Thank you, Klimates!"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr "Some find this useful for accounting purposes, but the rewards are exactly the same. Wrap and unwrap values are calculated based on the current index."
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
+msgstr "Sorry, looks like we sent you the wrong way. <0/>Please select a destination from the menu."
+
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:335
 msgid "stake.stake"
 msgstr "Stake"
 
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
-msgstr "Stake, hold, and earn compounding sKLIMA."
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
+msgstr "Stake KLIMA"
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:258
 #: components/views/Stake/index.tsx:306
 #: components/views/Stake/index.tsx:471
 msgid "stake.stake_klima"
 msgstr "Stake KLIMA"
 
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr "Stake your KLIMA tokens to receive sKLIMA. After every rebase, your sKLIMA balance will increase by the given percentage."
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr "Stake, hold, and earn compounding sKLIMA."
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr "Submit"
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr "SUCCESS!"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
+msgstr "Supply limit"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr "The best way to buy KLIMA. Commit carbon to our treasury, and receive KLIMA at a discount. All bonds (except inverse bonds) have a mandatory 5 day vesting period."
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr "The network could not be reached. This is most likely caused by an old Polygon RPC configuration in your wallet. See <0>this guide</0> for a fix. Otherwise, reach out to us on <1>Discord</1> if problems persist."
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr "The protocol automatically mints and distributes rewards. Your payout is a percentage of your sKLIMA balance"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr "The updated contract now assumes pKLIMA holders have staked and earned rewards on previously claimed tokens. Prior to the November fix, these staking rewards were not counted against your supply share limit, which meant your share of the total KLIMA supply could surpass the limit defined in your terms."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr "This feature is available only to users who are logged in. You can log in or create an account via the button below."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr "This is the amount of USDC in the contract available for bonds."
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr "Tonnes of carbon"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr "Total KLIMA you have redeemed so far."
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr "Total retirements"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr "Toucan Base Carbon Tonne"
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr "Transaction complete."
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr "Transaction initiated. Waiting for network confirmation."
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr "Treasury Balance"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr "Unredeemed"
+
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:347
 msgid "stake.unstake"
 msgstr "Unstake"
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:267
 #: components/views/Stake/index.tsx:473
 msgid "stake.unstake_klima"
 msgstr "Unstake KLIMA"
 
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr "Transaction complete."
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr "❌ Error: something went wrong..."
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr "Transaction initiated. Waiting for network confirmation."
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr "Please click 'confirm' in your wallet to continue."
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr "You chose to reject the transaction"
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr "pKLIMA"
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr "You must first give permission to our smart contract to transfer tokens on your behalf."
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr "Contract address"
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr "Quantity to approve"
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr "Close"
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr "Next"
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr "Confirm amount"
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr "Submit"
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr "Please submit the transaction."
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr "Contract address"
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Approve"
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Submit"
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr "Connect with your browser web3 provider"
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr "Easy one-click wallet by Torus"
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr "Email or Social"
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr "Scan with WalletConnect to connect"
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr "Scan with Coinbase to connect"
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr "Balance"
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr "Wrap sKLIMA to receive index-adjusted wrapped-staked-KLIMA"
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr "Index"
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Used to calculate wsKLIMA value."
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr "sKLIMA to wrap"
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:324
 msgid "wrap.unwrap"
 msgstr "Unwrap"
 
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr "unwrapped"
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr "User refused connection."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr "Vesting term end"
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr "View Retirements"
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr "Visit our <0> documentation </0> to build it into your application, or visit <1> Carbonmark </1> to use a live implementation."
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr "Visit our <0>documentation </0> to find the LP contract addresses, or visit <1> Carbonmark </1> to acquire carbon via a simple user interface."
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr "We had some trouble connecting. Please try again."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr "Why won't the app load for me?"
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:313
 msgid "wrap.wrap"
 msgstr "Wrap"
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr "Wrap sKLIMA"
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:279
 msgid "wrap.wrap_sklima"
 msgstr "Wrap sKLIMA"
 
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
-msgstr "Some find this useful for accounting purposes, but the rewards are exactly the same. Wrap and unwrap values are calculated based on the current index."
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
+msgstr "Wrap sKLIMA to receive index-adjusted wrapped-staked-KLIMA"
 
 #. Long sentence
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:282
 msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
 msgstr "Wrap sKLIMA to receive wsKLIMA. Unlike sKLIMA, your wsKLIMA balance will not increase over time."
 
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:55
 msgid "wrap.wsklima_to_unwrap"
 msgstr "wsKLIMA to unwrap"
 
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr "You chose to reject the transaction"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr "You must first give permission to our smart contract to transfer tokens on your behalf."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:746
+#: components/views/Bond/index.tsx:890
+msgid "bond.you_will_get"
+msgstr "You will get"
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
 msgstr "You Will Get"
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
-msgstr "unwrapped"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr "You've claimed more KLIMA than your supply-share limit. This is likely due to a fix implemented on November 24th, 2021 to the pKLIMA redemption contract."
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr "You've Retired"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
+msgstr "Your Wallet Address"

--- a/carbon/locale/en-pseudo/messages.po
+++ b/carbon/locale/en-pseudo/messages.po
@@ -6,322 +6,185 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
+#. js-lingui-explicit-id
+#: app/[locale]/layout.tsx:44
+msgid "Klima Data"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/layout.tsx:44
+msgid "Carbon Dashboard"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:15
+msgid "Off vs On-chain carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx:9
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/index.tsx:29
+msgid "Verra credits breakdown"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra and what portion have been bridged, tokenized, and retired on-chain."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-project-type/page.tsx:9
+msgid "Credits issued by project type"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-project-type/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra sorted by carbon project type."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-vintage-date/page.tsx:9
+msgid "Credits issued by vintage start date"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-vintage-date/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra sorted by the vintage start date of the carbon credit."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-over-time/page.tsx:9
+msgid "Verra credits retired over time"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra that have been retired over time."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-project-type/page.tsx:9
+msgid "Credits retired by project type"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-project-type/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by carbon project type."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-vintage-date/page.tsx:9
+msgid "Credits retired by vintage start date"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-vintage-date/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by the vintage start date of the carbon credit."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-off-chain-over-time/page.tsx:9
+msgid "Off-chain Verra credits retired over time"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-off-chain-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra and retired over time. Off-chain refers carbon credits retired via legacy methods as compared to on-chain digital carbon credits bridged and tokenized on a public blockchain."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
+msgid "On-chain Verra credits retired over time"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra and retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
+#: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:9
+#: components/cards/overview/TokenizedCreditsByBridgeCard/index.tsx:23
+msgid "Tokenized credits by bridge"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
 msgid "A breakdown of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain."
 msgstr ""
 
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:14
-msgid "A breakdown of the carbon projects for which the carbon credits were issued and then bridged and pooled via {bridgeLabel}."
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-over-time/page.tsx:9
+msgid "Verra credits tokenized over time"
 msgstr ""
 
-#: app/[locale]/token-details/breakdown-of-digital-carbon/[bridge]/page.tsx:15
-msgid "A breakdown of the current supply of carbon credits bridged via {bridgeLabel} and pooled into digital carbon pools."
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain over time."
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:12
-msgid "A breakdown of the current supply of digital carbon credits available on public blockchains."
-msgstr ""
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:14
-msgid "A breakdown of the methodologies used to validate and issue each carbon credit bridged via {bridgeLabel}."
-msgstr ""
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:15
-msgid "A breakdown of the vintage dates of each carbon credit bridged via {bridgeLabel}."
-msgstr ""
-
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:12
-msgid "A collection of data for quick reference including total supply, supply changes, and retirement trends."
-msgstr ""
-
-#: lib/charts/options.ts:70
-#: lib/charts/options.ts:88
-msgid "All Tokens"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
-msgid "Amount bridged"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:35
-#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:47
-msgid "Amount retired"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
-msgid "Avg tonnes per transaction"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
-#: components/cards/tokenDetails/helpers.ts:57
-#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
-#: lib/charts/options.ts:92
-msgid "BCT"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:125
-msgid "BCT pooled VCUs"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:126
-msgid "BCT retired VCUs"
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr ""
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
-msgid "Beneficiary"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/helpers.ts:11
-msgid "Beneficiary address"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:45
-msgid "Breakdown of {0} pooled"
-msgstr ""
-
-#: app/[locale]/token-details/breakdown-of-digital-carbon/[bridge]/page.tsx:11
-msgid "Breakdown of {bridgeLabel} pooled"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:33
-#: lib/charts/options.ts:106
-msgid "Bridged"
-msgstr ""
-
-#: app/[locale]/retirement-trends/page.tsx:51
-msgid "By beneficiary"
-msgstr ""
-
-#: app/[locale]/retirement-trends/page.tsx:46
-msgid "By chain"
-msgstr ""
-
-#: app/[locale]/retirement-trends/page.tsx:36
-msgid "By pool"
-msgstr ""
-
-#: app/[locale]/retirement-trends/page.tsx:41
-msgid "By token"
-msgstr ""
-
-#: app/[locale]/token-details/page.tsx:94
-msgid "C3"
-msgstr ""
-
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:86
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
-msgid "C3 bridged VCUs"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:87
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
-msgid "C3 retired VCUs"
-msgstr ""
-
-#: app/[locale]/layout.tsx:44
-msgid "Carbon Dashboard"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:25
-msgid "Carbon pool redemptions / retirements"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:27
-msgid "Carbon retirements"
-msgstr ""
-
-#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:22
-msgid "Carbon supply by blockchain"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:24
-msgid "Carbon token retirements"
-msgstr ""
-
-#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:48
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:52
-#: lib/charts/options.ts:60
-msgid "Celo"
-msgstr ""
-
-#: components/cards/supply/DailyCeloCarbonSupplyCard/index.tsx:15
-msgid "Celo supply"
-msgstr ""
-
-#: components/Layout/ChangeLanguageButton/index.tsx:42
-msgid "Change language"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:33
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:33
-msgid "Country"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:39
-msgid "Country code"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsDistributionOfProjectsCard/index.tsx:30
-msgid "Credits by project type"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsByBridgeAndVintageCard/index.tsx:19
-msgid "Credits by vintage start dates"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-project-type/page.tsx:9
-msgid "Credits issued by project type"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-vintage-date/page.tsx:9
-msgid "Credits issued by vintage start date"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-project-type/page.tsx:9
-msgid "Credits retired by project type"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-vintage-date/page.tsx:9
-msgid "Credits retired by vintage start date"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsOriginCard/index.tsx:24
-msgid "Credits retired off-chain vs on-chain by origin"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsOriginCard/index.tsx:23
-msgid "Credits tokenized vs credits issued by origin"
-msgstr ""
-
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:53
-msgid "Cumulative Verra registry credits issued over time"
-msgstr ""
-
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:87
-msgid "Cumulative Verra registry credits tokenized over time"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:70
-msgid "Date"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByBeneficiaryListCard/index.tsx:18
-#: components/cards/retirementTrends/RetirementsByChainListCard/index.tsx:18
-#: components/cards/retirementTrends/RetirementsByPoolListCard/index.tsx:18
-#: components/cards/retirementTrends/RetirementsByTokenListCard/index.tsx:18
-msgid "Detailed list of KlimaDAO retirements"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:33
-msgid "Digital carbon pricing"
-msgstr ""
-
-#: app/[locale]/supply/digital-carbon-retirements/[chain]/page.tsx:12
-msgid "Digital carbon retirements - {chainLabel}"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: app/[locale]/overview/digital-carbon-retirements-snapshot/page.tsx:9
 msgid "Digital carbon retirements snapshot"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon-retirements-snapshot/page.tsx:12
+msgid "The total number of digital carbon credits retired on-chain over time sorted by blockchain and what portion was retired via infrastructure built by KlimaDAO."
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
-msgid "Digital carbon supply - {chainLabel}"
-msgstr ""
-
-#: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
-msgid "Digital carbon supply by Blockchain"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: app/[locale]/overview/digital-carbon-supply-snapshot/page.tsx:9
 msgid "Digital carbon supply snapshot"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon-supply-snapshot/page.tsx:12
+msgid "The total supply of digital carbon on each blockchain broken down by digital carbon pool."
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
-msgid "Distribution of methodologies"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon/page.tsx:12
+#: app/[locale]/overview/digital-carbon/page.tsx:42
+#: app/[locale]/overview/page.tsx:37
+msgid "What is digital carbon?"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
-msgid "Distribution of vintage start dates"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon/page.tsx:15
+msgid "The term 'digital carbon' refers to a carbon credit that has been bridged from an off-chain carbon registry and tokenized, so that the credit now exists solely on a public blockchain."
 msgstr ""
 
-#: app/[locale]/token-details/page.tsx:18
-msgid "Dive deep into different digital carbon token pools, including C3, Toucan, and Moss-bridged carbon tonnes."
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
 msgstr ""
 
-#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:42
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:48
-#: lib/charts/options.ts:50
-msgid "Ethereum"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon/page.tsx:44
+msgid ""
+"The term 'digital carbon' refers to a carbon credit that has been\n"
+"bridged from an off-chain carbon registry and tokenized, so that the\n"
+"credit now exists solely on a public blockchain (e.g. Polygon). In\n"
+"being brought on chain, digital carbon inherits the immutability,\n"
+"transparency, and trust of the underlying blockchain database."
 msgstr ""
 
-#: components/cards/supply/DailyEthRetirementsCard/index.tsx:14
-msgid "Ethereum retirements"
-msgstr ""
-
-#: components/cards/supply/DailyEthCarbonSupplyCard/index.tsx:15
-msgid "Ethereum supply"
-msgstr ""
-
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr ""
-
-#: app/[locale]/retirement-trends/page.tsx:14
-msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
-msgstr ""
-
-#: app/[locale]/supply/page.tsx:18
-msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
-msgstr ""
-
-#: components/Skeleton/index.tsx:4
-msgid "Fetching data…"
-msgstr ""
-
-#: components/cards/overview/HistoricalPriceCard/index.tsx:18
-msgid "Historical prices (USD)"
-msgstr ""
-
-#: components/pages/DetailPage/index.tsx:36
-msgid "Insights"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
-#: lib/charts/options.ts:32
-msgid "Issued"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: app/[locale]/overview/digital-carbon/page.tsx:51
 msgid ""
 "Just like off-chain carbon credits, a digital carbon credit\n"
@@ -334,256 +197,313 @@ msgid ""
 "and ultimately, dramatically scale financing to carbon reduction projects."
 msgstr ""
 
-#: app/[locale]/layout.tsx:44
-msgid "Klima Data"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
 msgstr ""
 
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:37
-msgid "KlimaDAO retirements by chain"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 msgstr ""
 
-#: components/cards/retirementTrends/RetirementsByPoolBarCard/index.tsx:20
-#: components/cards/retirementTrends/RetirementsByPoolSummaryCard/index.tsx:19
-msgid "KlimaDAO retirements by pool"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/price-of-digital-carbon/page.tsx:11
+msgid "Price of digital carbon"
 msgstr ""
 
-#: components/cards/retirementTrends/RetirementsByTokenBarCard/index.tsx:20
-msgid "KlimaDAO retirements by token"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/price-of-digital-carbon/page.tsx:14
+msgid "The prices of various digital carbon pool tokens and their selective costs charged by bridges to redeem or retire a specific underlying digital carbon credit token. Note: The chart shows MCO2 price data from the KLIMA/MCO2 pool launched in January 2022."
 msgstr ""
 
-#: lib/charts/options.ts:124
-msgid "Last 30 days"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/verra-credits-over-time/page.tsx:9
+msgid "Verra credits over time"
 msgstr ""
 
-#: components/cards/overview/TokensPriceCard/index.tsx:94
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:106
-#: lib/charts/options.ts:128
-msgid "Last 7 days"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/verra-credits-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra over time and the number of credits retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
 msgstr ""
 
-#: lib/charts/options.ts:120
-msgid "Lifetime"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: app/[locale]/overview/verra-credits-over-time/page.tsx:31
 #: components/pages/retirementTrends/RetirementTrendsByBeneficiaryTab/index.tsx:16
 msgid "Lorem Ipsum"
 msgstr ""
 
-#: components/cards/tokenDetails/helpers.ts:88
-#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:76
-msgid "MCO2"
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:11
+msgid "Retirement trends"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/helpers.ts:14
-msgid "Missing"
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:14
+msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:36
+msgid "By pool"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:41
+msgid "By token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:46
+msgid "By chain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:51
+msgid "By beneficiary"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
+msgid "Retirements by chain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
+msgid "The percentage of all carbon credit retirements that are retired via infrastructure built by KlimaDAO over a given time period."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-pool/page.tsx:9
+msgid "Retirements by pool"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-pool/page.tsx:12
+msgid "The percentage of total retirements from each digital carbon pool in a given period."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-token/page.tsx:9
+msgid "Retirements by token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-token/page.tsx:12
+msgid "The percentage of retirements via infrastructure built by KlimaDAO from each digital carbon token in a given period."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-retirements/[chain]/page.tsx:12
+msgid "Digital carbon retirements - {chainLabel}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-retirements/[chain]/page.tsx:16
+msgid "The total number of digital carbon credits retired over time on the {chainLabel} blockchain."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
+msgid "Digital carbon supply by Blockchain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:12
+msgid "A breakdown of the current supply of digital carbon credits available on public blockchains."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:12
+msgid "A collection of data for quick reference including total supply, supply changes, and retirement trends."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
+msgid "Digital carbon supply - {chainLabel}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
+msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/page.tsx:18
+msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/breakdown-of-digital-carbon/[bridge]/page.tsx:11
+msgid "Breakdown of {bridgeLabel} pooled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/breakdown-of-digital-carbon/[bridge]/page.tsx:15
+msgid "A breakdown of the current supply of carbon credits bridged via {bridgeLabel} and pooled into digital carbon pools."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/page.tsx:15
+msgid "Token details"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/page.tsx:18
+msgid "Dive deep into different digital carbon token pools, including C3, Toucan, and Moss-bridged carbon tonnes."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/page.tsx:78
+msgid "Toucan"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: app/[locale]/token-details/page.tsx:88
 msgid "Moss"
 msgstr ""
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/page.tsx:94
+msgid "C3"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:145
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
-msgid "Moss bridged VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:146
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:51
-msgid "Moss retired VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:14
+msgid "The volume of deposited digital carbon credits in the {poolLabel} pool over a given time period."
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:51
-#: components/charts/helpers/VerraProjectLink/index.tsx:18
-msgid "N/A"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
-#: components/cards/tokenDetails/helpers.ts:46
-#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
-#: lib/charts/options.ts:78
-msgid "NBO"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:14
+msgid "The volume of redeemed digital carbon credits in the {poolLabel} pool over a given time period."
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:104
-msgid "NBO pooled VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:105
-msgid "NBO retired VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:14
+msgid "The volume of retired digital carbon credits in the {poolLabel} pool over a given time period."
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
-#: components/cards/tokenDetails/helpers.ts:68
-#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
-#: lib/charts/options.ts:96
-msgid "NCT"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/state-of-digital-carbon/[bridge]/page.tsx:11
+msgid "State of {bridgeLabel} digital carbon"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:134
-msgid "NCT pooled VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/state-of-digital-carbon/[bridge]/page.tsx:15
+msgid "The total number of digital carbon credits bridged via {bridgeLabel} broken down by the current outstanding supply and retired digital carbon credits."
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:135
-msgid "NCT retired VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
 msgstr ""
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:14
+msgid "A breakdown of the methodologies used to validate and issue each carbon credit bridged via {bridgeLabel}."
 msgstr ""
 
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
 msgstr ""
 
-#: components/charts/helpers/NoDataWrapper/index.tsx:14
-msgid "No data availble"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:14
+msgid "A breakdown of the carbon projects for which the carbon credits were issued and then bridged and pooled via {bridgeLabel}."
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
-msgid "Not pooled"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:41
-msgid "Number of retirements"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:15
+msgid "A breakdown of the vintage dates of each carbon credit bridged via {bridgeLabel}."
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
-msgid "Number of transactions"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
 msgstr ""
 
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
-msgid "Of total retired credits"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:14
+msgid "The volume of digital carbon credits in {bridgeLabel} digital carbon pools over a given time period."
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:25
-msgid "Off vs On-Chain"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:87
+msgid "Cumulative Verra registry credits tokenized over time"
 msgstr ""
 
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:15
-msgid "Off vs On-chain carbon"
-msgstr ""
-
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:52
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:81
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:28
-#: lib/charts/options.ts:22
-msgid "Off-chain"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-off-chain-over-time/page.tsx:9
-msgid "Off-chain Verra credits retired over time"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
 msgid "On-Chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:58
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:61
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:28
-#: lib/charts/options.ts:18
-msgid "On-chain"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:53
+msgid "Cumulative Verra registry credits issued over time"
 msgstr ""
 
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
-msgid "On-chain Verra credits retired over time"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:19
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:38
+msgid "Verra credits retired"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
-msgid "On/Off chain"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenOriginsCard/index.tsx:27
-msgid "Origin of credits"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:56
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:104
-msgid "Outstanding"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
+#: lib/charts/options.ts:32
+msgid "Issued"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:19
-#: components/pages/DetailPage/index.tsx:30
-msgid "Overview"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:64
-msgid "Percentage of tokenized VCUs"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
-msgid "Percentage retired onchain"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:84
-msgid "Percentage tokenized"
-msgstr ""
-
-#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:36
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:44
-#: lib/charts/options.ts:46
-msgid "Polygon"
-msgstr ""
-
-#: components/cards/supply/DailyPolygonRetirementsCard/index.tsx:14
-msgid "Polygon retirements"
-msgstr ""
-
-#: components/cards/supply/DailyPolygonCarbonSupplyCard/index.tsx:14
-msgid "Polygon supply"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:48
-msgid "Pool"
-msgstr ""
-
-#: app/[locale]/overview/price-of-digital-carbon/page.tsx:11
-msgid "Price of digital carbon"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:80
-msgid "Price per tonne"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:38
-msgid "Project"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:34
-msgid "Proof"
-msgstr ""
-
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:25
-msgid "Quick facts"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:76
-#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:75
-msgid "Redeemed via KlimaDAO"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:61
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:50
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:98
@@ -592,405 +512,717 @@ msgstr ""
 msgid "Retired"
 msgstr ""
 
-#: components/charts/DailyCarbonRetirementsChart/index.tsx:19
-#: components/charts/DailyCarbonRetirementsChart/index.tsx:35
-msgid "Retired outside of KlimaDAO"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
 msgstr ""
 
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
-#: components/charts/DailyCarbonRetirementsChart/index.tsx:13
-msgid "Retired via KlimaDAO"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:33
+#: lib/charts/options.ts:106
+msgid "Bridged"
 msgstr ""
 
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:51
+msgid "Verra credits issued"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
-msgid "Retirement Details"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:68
+msgid "Verra credits tokenized"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsByBridgeAndVintageCard/index.tsx:19
+msgid "Credits by vintage start dates"
 msgstr ""
 
-#: app/[locale]/retirement-trends/page.tsx:11
-msgid "Retirement trends"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsDistributionOfProjectsCard/index.tsx:30
+msgid "Credits by project type"
 msgstr ""
 
-#: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
-msgid "Retirements by chain"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsOriginCard/index.tsx:23
+msgid "Credits tokenized vs credits issued by origin"
 msgstr ""
 
-#: app/[locale]/retirement-trends/retirement-trends-by-pool/page.tsx:9
-msgid "Retirements by pool"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsOriginCard/index.tsx:24
+msgid "Credits retired off-chain vs on-chain by origin"
 msgstr ""
 
-#: app/[locale]/retirement-trends/retirement-trends-by-token/page.tsx:9
-msgid "Retirements by token"
+#. js-lingui-explicit-id
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/cards/overview/DailyVerraCreditsOverviewCard/index.tsx:126
+msgid "Verra credits"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/overview/HistoricalPriceCard/index.tsx:18
+msgid "Historical prices (USD)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/overview/TokensPriceCard/index.tsx:33
+msgid "Digital carbon pricing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/overview/TokensPriceCard/index.tsx:80
+msgid "Price per tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/cards/overview/TokensPriceCard/index.tsx:86
 msgid "Selective cost"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
+#. js-lingui-explicit-id
+#: components/cards/overview/TokensPriceCard/index.tsx:94
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:106
+#: lib/charts/options.ts:128
+msgid "Last 7 days"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
-msgid "State of {0} digital carbon"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByBeneficiaryListCard/index.tsx:18
+#: components/cards/retirementTrends/RetirementsByChainListCard/index.tsx:18
+#: components/cards/retirementTrends/RetirementsByPoolListCard/index.tsx:18
+#: components/cards/retirementTrends/RetirementsByTokenListCard/index.tsx:18
+msgid "Detailed list of KlimaDAO retirements"
 msgstr ""
 
-#: app/[locale]/token-details/state-of-digital-carbon/[bridge]/page.tsx:11
-msgid "State of {bridgeLabel} digital carbon"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:52
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:81
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:28
+#: lib/charts/options.ts:22
+msgid "Off-chain"
 msgstr ""
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:58
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:61
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:28
+#: lib/charts/options.ts:18
+msgid "On-chain"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:37
+msgid "KlimaDAO retirements by chain"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
-msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:27
+msgid "Carbon retirements"
 msgstr ""
 
-#: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
-msgid "The percentage of all carbon credit retirements that are retired via infrastructure built by KlimaDAO over a given time period."
-msgstr ""
-
-#: app/[locale]/retirement-trends/retirement-trends-by-token/page.tsx:12
-msgid "The percentage of retirements via infrastructure built by KlimaDAO from each digital carbon token in a given period."
-msgstr ""
-
-#: app/[locale]/retirement-trends/retirement-trends-by-pool/page.tsx:12
-msgid "The percentage of total retirements from each digital carbon pool in a given period."
-msgstr ""
-
-#: app/[locale]/overview/price-of-digital-carbon/page.tsx:14
-msgid "The prices of various digital carbon pool tokens and their selective costs charged by bridges to redeem or retire a specific underlying digital carbon credit token. Note: The chart shows MCO2 price data from the KLIMA/MCO2 pool launched in January 2022."
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:44
-msgid ""
-"The term 'digital carbon' refers to a carbon credit that has been\n"
-"bridged from an off-chain carbon registry and tokenized, so that the\n"
-"credit now exists solely on a public blockchain (e.g. Polygon). In\n"
-"being brought on chain, digital carbon inherits the immutability,\n"
-"transparency, and trust of the underlying blockchain database."
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:15
-msgid "The term 'digital carbon' refers to a carbon credit that has been bridged from an off-chain carbon registry and tokenized, so that the credit now exists solely on a public blockchain."
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-off-chain-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra and retired over time. Off-chain refers carbon credits retired via legacy methods as compared to on-chain digital carbon credits bridged and tokenized on a public blockchain."
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra and retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
-msgstr ""
-
-#: app/[locale]/overview/verra-credits-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra over time and the number of credits retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra that have been retired over time."
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain over time."
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-project-type/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by carbon project type."
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-vintage-date/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by the vintage start date of the carbon credit."
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra and what portion have been bridged, tokenized, and retired on-chain."
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-project-type/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra sorted by carbon project type."
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-vintage-date/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra sorted by the vintage start date of the carbon credit."
-msgstr ""
-
-#: app/[locale]/token-details/state-of-digital-carbon/[bridge]/page.tsx:15
-msgid "The total number of digital carbon credits bridged via {bridgeLabel} broken down by the current outstanding supply and retired digital carbon credits."
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon-retirements-snapshot/page.tsx:12
-msgid "The total number of digital carbon credits retired on-chain over time sorted by blockchain and what portion was retired via infrastructure built by KlimaDAO."
-msgstr ""
-
-#: app/[locale]/supply/digital-carbon-retirements/[chain]/page.tsx:16
-msgid "The total number of digital carbon credits retired over time on the {chainLabel} blockchain."
-msgstr ""
-
-#: components/pages/retirementTrends/RetirementTrendsByBeneficiaryTab/index.tsx:14
-msgid "The total number of retirements and amount of digital carbon credits retired via infrastructure built by KlimaDAO from a given beneficiary address."
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon-supply-snapshot/page.tsx:12
-msgid "The total supply of digital carbon on each blockchain broken down by digital carbon pool."
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:14
-msgid "The volume of deposited digital carbon credits in the {poolLabel} pool over a given time period."
-msgstr ""
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:14
-msgid "The volume of digital carbon credits in {bridgeLabel} digital carbon pools over a given time period."
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:14
-msgid "The volume of redeemed digital carbon credits in the {poolLabel} pool over a given time period."
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:14
-msgid "The volume of retired digital carbon credits in the {poolLabel} pool over a given time period."
-msgstr ""
-
-#: lib/tokens.tsx:39
-msgid "There is no selective redemption/retirement functionality for {0}."
-msgstr ""
-
-#: lib/tokens.tsx:40
-msgid "This cost includes the asset spot price + the {0}% fee to selectively redeem or retire an underlying carbon project charged by {1}"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:56
-msgid "Token"
-msgstr ""
-
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr ""
-
-#: app/[locale]/token-details/page.tsx:15
-msgid "Token details"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
-#: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:9
-#: components/cards/overview/TokenizedCreditsByBridgeCard/index.tsx:23
-msgid "Tokenized credits by bridge"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
-msgid "Tonnes"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
-msgid "Total issued VCUs"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:70
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:76
-msgid "Total retired VCUs"
-msgstr ""
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:72
-msgid "Total retired VCUs offchain"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:67
-msgid "Total retired VCUs onchain"
-msgstr ""
-
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:110
-msgid "Total retirements (tonnes)"
-msgstr ""
-
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:96
-msgid "Total supply (tonnes)"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:66
-msgid "Total tokenized VCUs"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:69
-#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:68
-msgid "Total tonnes redeemed"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:65
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:85
 msgid "Total tonnes retired"
 msgstr ""
 
-#: app/[locale]/token-details/page.tsx:78
-msgid "Toucan"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
 msgstr ""
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
+msgid "Of total retired credits"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:116
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
-msgid "Toucan bridged VCUs"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByPoolBarCard/index.tsx:20
+#: components/cards/retirementTrends/RetirementsByPoolSummaryCard/index.tsx:19
+msgid "KlimaDAO retirements by pool"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:117
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:42
-msgid "Toucan retired VCUs"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:25
+msgid "Carbon pool redemptions / retirements"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:69
+#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:68
+msgid "Total tonnes redeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:76
+#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:75
+msgid "Redeemed via KlimaDAO"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByTokenBarCard/index.tsx:20
+msgid "KlimaDAO retirements by token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:24
+msgid "Carbon token retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:22
+msgid "Carbon supply by blockchain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:36
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:44
+#: lib/charts/options.ts:46
+msgid "Polygon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:42
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:48
+#: lib/charts/options.ts:50
+msgid "Ethereum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:48
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:52
+#: lib/charts/options.ts:60
+msgid "Celo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:25
+msgid "Quick facts"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:96
+msgid "Total supply (tonnes)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:110
+msgid "Total retirements (tonnes)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
+#: components/charts/DailyCarbonRetirementsChart/index.tsx:13
+msgid "Retired via KlimaDAO"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyCeloCarbonSupplyCard/index.tsx:15
+msgid "Celo supply"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyEthCarbonSupplyCard/index.tsx:15
+msgid "Ethereum supply"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyEthRetirementsCard/index.tsx:14
+msgid "Ethereum retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyPolygonCarbonSupplyCard/index.tsx:14
+msgid "Polygon supply"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyPolygonRetirementsCard/index.tsx:14
+msgid "Polygon retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:95
-msgid "UBO pooled VCUs"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
+#: lib/charts/options.ts:78
+msgid "NBO"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:96
-msgid "UBO retired VCUs"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
+#: lib/charts/options.ts:92
+msgid "BCT"
 msgstr ""
 
-#: lib/tokens.tsx:18
-msgid "Universal Basic Offset (UBO)"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
+#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
+#: lib/charts/options.ts:96
+msgid "NCT"
 msgstr ""
 
-#: components/cards/overview/DailyVerraCreditsOverviewCard/index.tsx:126
-msgid "Verra credits"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:79
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
+msgid "Not pooled"
 msgstr ""
 
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx:9
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/index.tsx:29
-msgid "Verra credits breakdown"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:88
+#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:76
+msgid "MCO2"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:51
-msgid "Verra credits issued"
-msgstr ""
-
-#: app/[locale]/overview/verra-credits-over-time/page.tsx:9
-msgid "Verra credits over time"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:19
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:38
-msgid "Verra credits retired"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-over-time/page.tsx:9
-msgid "Verra credits retired over time"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:68
-msgid "Verra credits tokenized"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-over-time/page.tsx:9
-msgid "Verra credits tokenized over time"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/cards/tokenDetails/PoolVolumeOverTimeCard/index.tsx:26
 msgid "Volume deposited over time"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenVolumeOverTimeCard/index.tsx:23
-msgid "Volume over time"
-msgstr ""
-
-#: components/cards/tokenDetails/PoolVolumeOverTimeCard/index.tsx:30
-msgid "Volume redeemed over time"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/cards/tokenDetails/PoolVolumeOverTimeCard/index.tsx:28
 msgid "Volume retired over time"
 msgstr ""
 
-#: app/[locale]/overview/digital-carbon/page.tsx:12
-#: app/[locale]/overview/digital-carbon/page.tsx:42
-#: app/[locale]/overview/page.tsx:37
-msgid "What is digital carbon?"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/PoolVolumeOverTimeCard/index.tsx:30
+msgid "Volume redeemed over time"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
+msgid "Distribution of methodologies"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
+msgid "Distribution of vintage start dates"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenOriginsCard/index.tsx:27
+msgid "Origin of credits"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:45
+msgid "Breakdown of {0} pooled"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
+msgid "State of {0} digital carbon"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:56
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:104
+msgid "Outstanding"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
 msgid "{0} retired"
 msgstr ""
 
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
 msgstr ""
 
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
 msgstr ""
 
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenVolumeOverTimeCard/index.tsx:23
+msgid "Volume over time"
 msgstr ""
 
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
+#. js-lingui-explicit-id
+#: components/charts/DailyCarbonRetirementsChart/index.tsx:19
+#: components/charts/DailyCarbonRetirementsChart/index.tsx:35
+msgid "Retired outside of KlimaDAO"
 msgstr ""
 
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
 msgstr ""
 
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
 msgstr ""
 
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:64
+msgid "Percentage of tokenized VCUs"
 msgstr ""
 
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:70
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:76
+msgid "Total retired VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:72
+msgid "Total retired VCUs offchain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:86
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
+msgid "C3 bridged VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:87
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
+msgid "C3 retired VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:95
+msgid "UBO pooled VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:96
+msgid "UBO retired VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:104
+msgid "NBO pooled VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:105
+msgid "NBO retired VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:116
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
+msgid "Toucan bridged VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:117
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:42
+msgid "Toucan retired VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:125
+msgid "BCT pooled VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:126
+msgid "BCT retired VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:134
+msgid "NCT pooled VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:135
+msgid "NCT retired VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:145
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
+msgid "Moss bridged VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:146
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:51
+msgid "Moss retired VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/helpers.ts:11
+msgid "Beneficiary address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/helpers.ts:14
+msgid "Missing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:35
+#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:47
+msgid "Amount retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:41
+msgid "Number of retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
+msgid "Retirement Details"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
+msgid "On/Off chain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:34
+msgid "Proof"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
+msgid "Beneficiary"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
+msgid "Number of transactions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
+msgid "Avg tonnes per transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:38
+msgid "Project"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:48
+msgid "Pool"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:51
+#: components/charts/helpers/VerraProjectLink/index.tsx:18
+msgid "N/A"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:56
+msgid "Token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:70
+msgid "Date"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
+msgid "Tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:33
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:33
+msgid "Country"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:39
+msgid "Country code"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
+msgid "Amount bridged"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:66
+msgid "Total tokenized VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:67
+msgid "Total retired VCUs onchain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
+msgid "Total issued VCUs"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:84
+msgid "Percentage tokenized"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
+msgid "Percentage retired onchain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/NoDataWrapper/index.tsx:14
+msgid "No data availble"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/ChangeLanguageButton/index.tsx:42
+msgid "Change language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavItems/index.tsx:19
+#: components/pages/DetailPage/index.tsx:30
+msgid "Overview"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavItems/index.tsx:25
+msgid "Off vs On-Chain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/DetailPage/index.tsx:36
+msgid "Insights"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/retirementTrends/RetirementTrendsByBeneficiaryTab/index.tsx:14
+msgid "The total number of retirements and amount of digital carbon credits retired via infrastructure built by KlimaDAO from a given beneficiary address."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Skeleton/index.tsx:4
+msgid "Fetching data…"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/charts/options.ts:70
+#: lib/charts/options.ts:88
+msgid "All Tokens"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/charts/options.ts:120
+msgid "Lifetime"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/charts/options.ts:124
+msgid "Last 30 days"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:18
+msgid "Universal Basic Offset (UBO)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:39
+msgid "There is no selective redemption/retirement functionality for {0}."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:40
+msgid "This cost includes the asset spot price + the {0}% fee to selectively redeem or retire an underlying carbon project charged by {1}"
 msgstr ""

--- a/carbon/locale/en/messages.po
+++ b/carbon/locale/en/messages.po
@@ -13,321 +13,183 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#. js-lingui-explicit-id
+#: app/[locale]/layout.tsx:44
+msgid "Klima Data"
+msgstr "Klima Data"
+
+#. js-lingui-explicit-id
+#: app/[locale]/layout.tsx:44
+msgid "Carbon Dashboard"
+msgstr "Carbon Dashboard"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:15
+msgid "Off vs On-chain carbon"
+msgstr "Off vs On-chain carbon"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
+msgstr "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx:9
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/index.tsx:29
+msgid "Verra credits breakdown"
+msgstr "Verra credits breakdown"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra and what portion have been bridged, tokenized, and retired on-chain."
+msgstr "The total number of carbon credits that have been issued by carbon registry Verra and what portion have been bridged, tokenized, and retired on-chain."
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-project-type/page.tsx:9
+msgid "Credits issued by project type"
+msgstr "Credits issued by project type"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-project-type/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra sorted by carbon project type."
+msgstr "The total number of carbon credits that have been issued by carbon registry Verra sorted by carbon project type."
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-vintage-date/page.tsx:9
+msgid "Credits issued by vintage start date"
+msgstr "Credits issued by vintage start date"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-vintage-date/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra sorted by the vintage start date of the carbon credit."
+msgstr "The total number of carbon credits that have been issued by carbon registry Verra sorted by the vintage start date of the carbon credit."
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-over-time/page.tsx:9
+msgid "Verra credits retired over time"
+msgstr "Verra credits retired over time"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra that have been retired over time."
+msgstr "The total number of carbon credits issued by carbon registry Verra that have been retired over time."
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-project-type/page.tsx:9
+msgid "Credits retired by project type"
+msgstr "Credits retired by project type"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-project-type/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by carbon project type."
+msgstr "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by carbon project type."
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-vintage-date/page.tsx:9
+msgid "Credits retired by vintage start date"
+msgstr "Credits retired by vintage start date"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-vintage-date/page.tsx:12
+msgid "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by the vintage start date of the carbon credit."
+msgstr "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by the vintage start date of the carbon credit."
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-off-chain-over-time/page.tsx:9
+msgid "Off-chain Verra credits retired over time"
+msgstr "Off-chain Verra credits retired over time"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-off-chain-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra and retired over time. Off-chain refers carbon credits retired via legacy methods as compared to on-chain digital carbon credits bridged and tokenized on a public blockchain."
+msgstr "The total number of carbon credits issued by carbon registry Verra and retired over time. Off-chain refers carbon credits retired via legacy methods as compared to on-chain digital carbon credits bridged and tokenized on a public blockchain."
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
+msgid "On-chain Verra credits retired over time"
+msgstr "On-chain Verra credits retired over time"
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra and retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
+msgstr "The total number of carbon credits issued by carbon registry Verra and retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
+
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
+#: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:9
+#: components/cards/overview/TokenizedCreditsByBridgeCard/index.tsx:23
+msgid "Tokenized credits by bridge"
+msgstr "Tokenized credits by bridge"
+
+#. js-lingui-explicit-id
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
 msgid "A breakdown of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain."
 msgstr "A breakdown of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain."
 
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:14
-msgid "A breakdown of the carbon projects for which the carbon credits were issued and then bridged and pooled via {bridgeLabel}."
-msgstr "A breakdown of the carbon projects for which the carbon credits were issued and then bridged and pooled via {bridgeLabel}."
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-over-time/page.tsx:9
+msgid "Verra credits tokenized over time"
+msgstr "Verra credits tokenized over time"
 
-#: app/[locale]/token-details/breakdown-of-digital-carbon/[bridge]/page.tsx:15
-msgid "A breakdown of the current supply of carbon credits bridged via {bridgeLabel} and pooled into digital carbon pools."
-msgstr "A breakdown of the current supply of carbon credits bridged via {bridgeLabel} and pooled into digital carbon pools."
+#. js-lingui-explicit-id
+#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain over time."
+msgstr "The total number of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain over time."
 
-#: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:12
-msgid "A breakdown of the current supply of digital carbon credits available on public blockchains."
-msgstr "A breakdown of the current supply of digital carbon credits available on public blockchains."
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:14
-msgid "A breakdown of the methodologies used to validate and issue each carbon credit bridged via {bridgeLabel}."
-msgstr "A breakdown of the methodologies used to validate and issue each carbon credit bridged via {bridgeLabel}."
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:15
-msgid "A breakdown of the vintage dates of each carbon credit bridged via {bridgeLabel}."
-msgstr "A breakdown of the vintage dates of each carbon credit bridged via {bridgeLabel}."
-
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:12
-msgid "A collection of data for quick reference including total supply, supply changes, and retirement trends."
-msgstr "A collection of data for quick reference including total supply, supply changes, and retirement trends."
-
-#: lib/charts/options.ts:70
-#: lib/charts/options.ts:88
-msgid "All Tokens"
-msgstr "All Tokens"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr "Amount Retired"
-
-#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
-msgid "Amount bridged"
-msgstr "Amount bridged"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:35
-#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:47
-msgid "Amount retired"
-msgstr "Amount retired"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
-msgid "Avg tonnes per transaction"
-msgstr "Avg tonnes per transaction"
-
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
-#: components/cards/tokenDetails/helpers.ts:57
-#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
-#: lib/charts/options.ts:92
-msgid "BCT"
-msgstr "BCT"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:125
-msgid "BCT pooled VCUs"
-msgstr "BCT pooled VCUs"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:126
-msgid "BCT retired VCUs"
-msgstr "BCT retired VCUs"
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr "Banner image"
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
-msgstr "Base Carbon Tonne (BCT)"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
-msgid "Beneficiary"
-msgstr "Beneficiary"
-
-#: components/charts/helpers/DataTable/configurations/helpers.ts:11
-msgid "Beneficiary address"
-msgstr "Beneficiary address"
-
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:45
-msgid "Breakdown of {0} pooled"
-msgstr "Breakdown of {0} pooled"
-
-#: app/[locale]/token-details/breakdown-of-digital-carbon/[bridge]/page.tsx:11
-msgid "Breakdown of {bridgeLabel} pooled"
-msgstr "Breakdown of {bridgeLabel} pooled"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:33
-#: lib/charts/options.ts:106
-msgid "Bridged"
-msgstr "Bridged"
-
-#: app/[locale]/retirement-trends/page.tsx:51
-msgid "By beneficiary"
-msgstr "By beneficiary"
-
-#: app/[locale]/retirement-trends/page.tsx:46
-msgid "By chain"
-msgstr "By chain"
-
-#: app/[locale]/retirement-trends/page.tsx:36
-msgid "By pool"
-msgstr "By pool"
-
-#: app/[locale]/retirement-trends/page.tsx:41
-msgid "By token"
-msgstr "By token"
-
-#: app/[locale]/token-details/page.tsx:94
-msgid "C3"
-msgstr "C3"
-
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr "C3 Carbon Credit (C3T)"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:86
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
-msgid "C3 bridged VCUs"
-msgstr "C3 bridged VCUs"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:87
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
-msgid "C3 retired VCUs"
-msgstr "C3 retired VCUs"
-
-#: app/[locale]/layout.tsx:44
-msgid "Carbon Dashboard"
-msgstr "Carbon Dashboard"
-
-#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:25
-msgid "Carbon pool redemptions / retirements"
-msgstr "Carbon pool redemptions / retirements"
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:27
-msgid "Carbon retirements"
-msgstr "Carbon retirements"
-
-#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:22
-msgid "Carbon supply by blockchain"
-msgstr "Carbon supply by blockchain"
-
-#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:24
-msgid "Carbon token retirements"
-msgstr "Carbon token retirements"
-
-#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:48
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:52
-#: lib/charts/options.ts:60
-msgid "Celo"
-msgstr "Celo"
-
-#: components/cards/supply/DailyCeloCarbonSupplyCard/index.tsx:15
-msgid "Celo supply"
-msgstr "Celo supply"
-
-#: components/Layout/ChangeLanguageButton/index.tsx:42
-msgid "Change language"
-msgstr "Change language"
-
-#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:33
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:33
-msgid "Country"
-msgstr "Country"
-
-#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:39
-msgid "Country code"
-msgstr "Country code"
-
-#: components/cards/offVsOnChain/VerraCreditsDistributionOfProjectsCard/index.tsx:30
-msgid "Credits by project type"
-msgstr "Credits by project type"
-
-#: components/cards/offVsOnChain/VerraCreditsByBridgeAndVintageCard/index.tsx:19
-msgid "Credits by vintage start dates"
-msgstr "Credits by vintage start dates"
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-project-type/page.tsx:9
-msgid "Credits issued by project type"
-msgstr "Credits issued by project type"
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-vintage-date/page.tsx:9
-msgid "Credits issued by vintage start date"
-msgstr "Credits issued by vintage start date"
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-project-type/page.tsx:9
-msgid "Credits retired by project type"
-msgstr "Credits retired by project type"
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-vintage-date/page.tsx:9
-msgid "Credits retired by vintage start date"
-msgstr "Credits retired by vintage start date"
-
-#: components/cards/offVsOnChain/VerraCreditsOriginCard/index.tsx:24
-msgid "Credits retired off-chain vs on-chain by origin"
-msgstr "Credits retired off-chain vs on-chain by origin"
-
-#: components/cards/offVsOnChain/VerraCreditsOriginCard/index.tsx:23
-msgid "Credits tokenized vs credits issued by origin"
-msgstr "Credits tokenized vs credits issued by origin"
-
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:53
-msgid "Cumulative Verra registry credits issued over time"
-msgstr "Cumulative Verra registry credits issued over time"
-
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:87
-msgid "Cumulative Verra registry credits tokenized over time"
-msgstr "Cumulative Verra registry credits tokenized over time"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:70
-msgid "Date"
-msgstr "Date"
-
-#: components/cards/retirementTrends/RetirementsByBeneficiaryListCard/index.tsx:18
-#: components/cards/retirementTrends/RetirementsByChainListCard/index.tsx:18
-#: components/cards/retirementTrends/RetirementsByPoolListCard/index.tsx:18
-#: components/cards/retirementTrends/RetirementsByTokenListCard/index.tsx:18
-msgid "Detailed list of KlimaDAO retirements"
-msgstr "Detailed list of KlimaDAO retirements"
-
-#: components/cards/overview/TokensPriceCard/index.tsx:33
-msgid "Digital carbon pricing"
-msgstr "Digital carbon pricing"
-
-#: app/[locale]/supply/digital-carbon-retirements/[chain]/page.tsx:12
-msgid "Digital carbon retirements - {chainLabel}"
-msgstr "Digital carbon retirements - {chainLabel}"
-
+#. js-lingui-explicit-id
 #: app/[locale]/overview/digital-carbon-retirements-snapshot/page.tsx:9
 msgid "Digital carbon retirements snapshot"
 msgstr "Digital carbon retirements snapshot"
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr "Digital carbon supply - quick facts"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon-retirements-snapshot/page.tsx:12
+msgid "The total number of digital carbon credits retired on-chain over time sorted by blockchain and what portion was retired via infrastructure built by KlimaDAO."
+msgstr "The total number of digital carbon credits retired on-chain over time sorted by blockchain and what portion was retired via infrastructure built by KlimaDAO."
 
-#: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
-msgid "Digital carbon supply - {chainLabel}"
-msgstr "Digital carbon supply - {chainLabel}"
-
-#: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
-msgid "Digital carbon supply by Blockchain"
-msgstr "Digital carbon supply by Blockchain"
-
+#. js-lingui-explicit-id
 #: app/[locale]/overview/digital-carbon-supply-snapshot/page.tsx:9
 msgid "Digital carbon supply snapshot"
 msgstr "Digital carbon supply snapshot"
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr "Distribution of Projects"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon-supply-snapshot/page.tsx:12
+msgid "The total supply of digital carbon on each blockchain broken down by digital carbon pool."
+msgstr "The total supply of digital carbon on each blockchain broken down by digital carbon pool."
 
-#: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
-msgid "Distribution of methodologies"
-msgstr "Distribution of methodologies"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon/page.tsx:12
+#: app/[locale]/overview/digital-carbon/page.tsx:42
+#: app/[locale]/overview/page.tsx:37
+msgid "What is digital carbon?"
+msgstr "What is digital carbon?"
 
-#: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
-msgid "Distribution of vintage start dates"
-msgstr "Distribution of vintage start dates"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon/page.tsx:15
+msgid "The term 'digital carbon' refers to a carbon credit that has been bridged from an off-chain carbon registry and tokenized, so that the credit now exists solely on a public blockchain."
+msgstr "The term 'digital carbon' refers to a carbon credit that has been bridged from an off-chain carbon registry and tokenized, so that the credit now exists solely on a public blockchain."
 
-#: app/[locale]/token-details/page.tsx:18
-msgid "Dive deep into different digital carbon token pools, including C3, Toucan, and Moss-bridged carbon tonnes."
-msgstr "Dive deep into different digital carbon token pools, including C3, Toucan, and Moss-bridged carbon tonnes."
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr "Banner image"
 
-#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:42
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:48
-#: lib/charts/options.ts:50
-msgid "Ethereum"
-msgstr "Ethereum"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/digital-carbon/page.tsx:44
+msgid ""
+"The term 'digital carbon' refers to a carbon credit that has been\n"
+"bridged from an off-chain carbon registry and tokenized, so that the\n"
+"credit now exists solely on a public blockchain (e.g. Polygon). In\n"
+"being brought on chain, digital carbon inherits the immutability,\n"
+"transparency, and trust of the underlying blockchain database."
+msgstr ""
+"The term 'digital carbon' refers to a carbon credit that has been\n"
+"bridged from an off-chain carbon registry and tokenized, so that the\n"
+"credit now exists solely on a public blockchain (e.g. Polygon). In\n"
+"being brought on chain, digital carbon inherits the immutability,\n"
+"transparency, and trust of the underlying blockchain database."
 
-#: components/cards/supply/DailyEthRetirementsCard/index.tsx:14
-msgid "Ethereum retirements"
-msgstr "Ethereum retirements"
-
-#: components/cards/supply/DailyEthCarbonSupplyCard/index.tsx:15
-msgid "Ethereum supply"
-msgstr "Ethereum supply"
-
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr "Explore Marketplace"
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-
-#: app/[locale]/retirement-trends/page.tsx:14
-msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
-msgstr "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
-
-#: app/[locale]/supply/page.tsx:18
-msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
-msgstr "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
-
-#: components/Skeleton/index.tsx:4
-msgid "Fetching data…"
-msgstr "Fetching data…"
-
-#: components/cards/overview/HistoricalPriceCard/index.tsx:18
-msgid "Historical prices (USD)"
-msgstr "Historical prices (USD)"
-
-#: components/pages/DetailPage/index.tsx:36
-msgid "Insights"
-msgstr "Insights"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
-#: lib/charts/options.ts:32
-msgid "Issued"
-msgstr "Issued"
-
+#. js-lingui-explicit-id
 #: app/[locale]/overview/digital-carbon/page.tsx:51
 msgid ""
 "Just like off-chain carbon credits, a digital carbon credit\n"
@@ -348,256 +210,313 @@ msgstr ""
 "programmable and can be used to power applications, enable new use cases,\n"
 "and ultimately, dramatically scale financing to carbon reduction projects."
 
-#: app/[locale]/layout.tsx:44
-msgid "Klima Data"
-msgstr "Klima Data"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
+msgstr "State of the Digital Carbon Market"
 
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:37
-msgid "KlimaDAO retirements by chain"
-msgstr "KlimaDAO retirements by chain"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+msgstr "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 
-#: components/cards/retirementTrends/RetirementsByPoolBarCard/index.tsx:20
-#: components/cards/retirementTrends/RetirementsByPoolSummaryCard/index.tsx:19
-msgid "KlimaDAO retirements by pool"
-msgstr "KlimaDAO retirements by pool"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/price-of-digital-carbon/page.tsx:11
+msgid "Price of digital carbon"
+msgstr "Price of digital carbon"
 
-#: components/cards/retirementTrends/RetirementsByTokenBarCard/index.tsx:20
-msgid "KlimaDAO retirements by token"
-msgstr "KlimaDAO retirements by token"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/price-of-digital-carbon/page.tsx:14
+msgid "The prices of various digital carbon pool tokens and their selective costs charged by bridges to redeem or retire a specific underlying digital carbon credit token. Note: The chart shows MCO2 price data from the KLIMA/MCO2 pool launched in January 2022."
+msgstr "The prices of various digital carbon pool tokens and their selective costs charged by bridges to redeem or retire a specific underlying digital carbon credit token. Note: The chart shows MCO2 price data from the KLIMA/MCO2 pool launched in January 2022."
 
-#: lib/charts/options.ts:124
-msgid "Last 30 days"
-msgstr "Last 30 days"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/verra-credits-over-time/page.tsx:9
+msgid "Verra credits over time"
+msgstr "Verra credits over time"
 
-#: components/cards/overview/TokensPriceCard/index.tsx:94
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:106
-#: lib/charts/options.ts:128
-msgid "Last 7 days"
-msgstr "Last 7 days"
+#. js-lingui-explicit-id
+#: app/[locale]/overview/verra-credits-over-time/page.tsx:12
+msgid "The total number of carbon credits issued by carbon registry Verra over time and the number of credits retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
+msgstr "The total number of carbon credits issued by carbon registry Verra over time and the number of credits retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
 
-#: lib/charts/options.ts:120
-msgid "Lifetime"
-msgstr "Lifetime"
-
+#. js-lingui-explicit-id
 #: app/[locale]/overview/verra-credits-over-time/page.tsx:31
 #: components/pages/retirementTrends/RetirementTrendsByBeneficiaryTab/index.tsx:16
 msgid "Lorem Ipsum"
 msgstr "Lorem Ipsum"
 
-#: components/cards/tokenDetails/helpers.ts:88
-#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:76
-msgid "MCO2"
-msgstr "MCO2"
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:11
+msgid "Retirement trends"
+msgstr "Retirement trends"
 
-#: components/charts/helpers/DataTable/configurations/helpers.ts:14
-msgid "Missing"
-msgstr "Missing"
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:14
+msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
+msgstr "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:36
+msgid "By pool"
+msgstr "By pool"
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:41
+msgid "By token"
+msgstr "By token"
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:46
+msgid "By chain"
+msgstr "By chain"
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/page.tsx:51
+msgid "By beneficiary"
+msgstr "By beneficiary"
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
+msgid "Retirements by chain"
+msgstr "Retirements by chain"
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
+msgid "The percentage of all carbon credit retirements that are retired via infrastructure built by KlimaDAO over a given time period."
+msgstr "The percentage of all carbon credit retirements that are retired via infrastructure built by KlimaDAO over a given time period."
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-pool/page.tsx:9
+msgid "Retirements by pool"
+msgstr "Retirements by pool"
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-pool/page.tsx:12
+msgid "The percentage of total retirements from each digital carbon pool in a given period."
+msgstr "The percentage of total retirements from each digital carbon pool in a given period."
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-token/page.tsx:9
+msgid "Retirements by token"
+msgstr "Retirements by token"
+
+#. js-lingui-explicit-id
+#: app/[locale]/retirement-trends/retirement-trends-by-token/page.tsx:12
+msgid "The percentage of retirements via infrastructure built by KlimaDAO from each digital carbon token in a given period."
+msgstr "The percentage of retirements via infrastructure built by KlimaDAO from each digital carbon token in a given period."
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-retirements/[chain]/page.tsx:12
+msgid "Digital carbon retirements - {chainLabel}"
+msgstr "Digital carbon retirements - {chainLabel}"
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-retirements/[chain]/page.tsx:16
+msgid "The total number of digital carbon credits retired over time on the {chainLabel} blockchain."
+msgstr "The total number of digital carbon credits retired over time on the {chainLabel} blockchain."
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
+msgid "Digital carbon supply by Blockchain"
+msgstr "Digital carbon supply by Blockchain"
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:12
+msgid "A breakdown of the current supply of digital carbon credits available on public blockchains."
+msgstr "A breakdown of the current supply of digital carbon credits available on public blockchains."
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
+msgstr "Digital carbon supply - quick facts"
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:12
+msgid "A collection of data for quick reference including total supply, supply changes, and retirement trends."
+msgstr "A collection of data for quick reference including total supply, supply changes, and retirement trends."
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
+msgid "Digital carbon supply - {chainLabel}"
+msgstr "Digital carbon supply - {chainLabel}"
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
+msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
+msgstr "Supply"
+
+#. js-lingui-explicit-id
+#: app/[locale]/supply/page.tsx:18
+msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/breakdown-of-digital-carbon/[bridge]/page.tsx:11
+msgid "Breakdown of {bridgeLabel} pooled"
+msgstr "Breakdown of {bridgeLabel} pooled"
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/breakdown-of-digital-carbon/[bridge]/page.tsx:15
+msgid "A breakdown of the current supply of carbon credits bridged via {bridgeLabel} and pooled into digital carbon pools."
+msgstr "A breakdown of the current supply of carbon credits bridged via {bridgeLabel} and pooled into digital carbon pools."
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/page.tsx:15
+msgid "Token details"
+msgstr "Token details"
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/page.tsx:18
+msgid "Dive deep into different digital carbon token pools, including C3, Toucan, and Moss-bridged carbon tonnes."
+msgstr "Dive deep into different digital carbon token pools, including C3, Toucan, and Moss-bridged carbon tonnes."
+
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/page.tsx:78
+msgid "Toucan"
+msgstr "Toucan"
+
+#. js-lingui-explicit-id
 #: app/[locale]/token-details/page.tsx:88
 msgid "Moss"
 msgstr "Moss"
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr "Moss Carbon Credit (MCO2)"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/page.tsx:94
+msgid "C3"
+msgstr "C3"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:145
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
-msgid "Moss bridged VCUs"
-msgstr "Moss bridged VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr "{poolLabel} volume deposited over time"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:146
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:51
-msgid "Moss retired VCUs"
-msgstr "Moss retired VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:14
+msgid "The volume of deposited digital carbon credits in the {poolLabel} pool over a given time period."
+msgstr "The volume of deposited digital carbon credits in the {poolLabel} pool over a given time period."
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:51
-#: components/charts/helpers/VerraProjectLink/index.tsx:18
-msgid "N/A"
-msgstr "N/A"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr "{poolLabel} volume redeemed over time"
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
-#: components/cards/tokenDetails/helpers.ts:46
-#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
-#: lib/charts/options.ts:78
-msgid "NBO"
-msgstr "NBO"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:14
+msgid "The volume of redeemed digital carbon credits in the {poolLabel} pool over a given time period."
+msgstr "The volume of redeemed digital carbon credits in the {poolLabel} pool over a given time period."
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:104
-msgid "NBO pooled VCUs"
-msgstr "NBO pooled VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr "{poolLabel} volume retired over time"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:105
-msgid "NBO retired VCUs"
-msgstr "NBO retired VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:14
+msgid "The volume of retired digital carbon credits in the {poolLabel} pool over a given time period."
+msgstr "The volume of retired digital carbon credits in the {poolLabel} pool over a given time period."
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
-#: components/cards/tokenDetails/helpers.ts:68
-#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
-#: lib/charts/options.ts:96
-msgid "NCT"
-msgstr "NCT"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/state-of-digital-carbon/[bridge]/page.tsx:11
+msgid "State of {bridgeLabel} digital carbon"
+msgstr "State of {bridgeLabel} digital carbon"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:134
-msgid "NCT pooled VCUs"
-msgstr "NCT pooled VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/state-of-digital-carbon/[bridge]/page.tsx:15
+msgid "The total number of digital carbon credits bridged via {bridgeLabel} broken down by the current outstanding supply and retired digital carbon credits."
+msgstr "The total number of digital carbon credits bridged via {bridgeLabel} broken down by the current outstanding supply and retired digital carbon credits."
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:135
-msgid "NCT retired VCUs"
-msgstr "NCT retired VCUs"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr "{bridgeLabel} distribution of methodologies"
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr "Nature Based Offset (NBO)"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:14
+msgid "A breakdown of the methodologies used to validate and issue each carbon credit bridged via {bridgeLabel}."
+msgstr "A breakdown of the methodologies used to validate and issue each carbon credit bridged via {bridgeLabel}."
 
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr "Nature Carbon Tonne (NCT)"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr "{bridgeLabel} distribution of projects"
 
-#: components/charts/helpers/NoDataWrapper/index.tsx:14
-msgid "No data availble"
-msgstr "No data availble"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:14
+msgid "A breakdown of the carbon projects for which the carbon credits were issued and then bridged and pooled via {bridgeLabel}."
+msgstr "A breakdown of the carbon projects for which the carbon credits were issued and then bridged and pooled via {bridgeLabel}."
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
-msgid "Not pooled"
-msgstr "Not pooled"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr "{bridgeLabel} Distribution of vintage start dates"
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:41
-msgid "Number of retirements"
-msgstr "Number of retirements"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:15
+msgid "A breakdown of the vintage dates of each carbon credit bridged via {bridgeLabel}."
+msgstr "A breakdown of the vintage dates of each carbon credit bridged via {bridgeLabel}."
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
-msgid "Number of transactions"
-msgstr "Number of transactions"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr "{bridgeLabel} volume over time"
 
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
-msgid "Of total retired credits"
-msgstr "Of total retired credits"
+#. js-lingui-explicit-id
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:14
+msgid "The volume of digital carbon credits in {bridgeLabel} digital carbon pools over a given time period."
+msgstr "The volume of digital carbon credits in {bridgeLabel} digital carbon pools over a given time period."
 
-#: components/Layout/NavItems/index.tsx:25
-msgid "Off vs On-Chain"
-msgstr "Off vs On-Chain"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:87
+msgid "Cumulative Verra registry credits tokenized over time"
+msgstr "Cumulative Verra registry credits tokenized over time"
 
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:15
-msgid "Off vs On-chain carbon"
-msgstr "Off vs On-chain carbon"
-
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
-msgstr "Off-Chain Verra credits retired over time"
-
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:52
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:81
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:28
-#: lib/charts/options.ts:22
-msgid "Off-chain"
-msgstr "Off-chain"
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-off-chain-over-time/page.tsx:9
-msgid "Off-chain Verra credits retired over time"
-msgstr "Off-chain Verra credits retired over time"
-
+#. js-lingui-explicit-id
 #: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
 msgid "On-Chain Verra credits retired over time"
 msgstr "On-Chain Verra credits retired over time"
 
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
-#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:58
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:61
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:28
-#: lib/charts/options.ts:18
-msgid "On-chain"
-msgstr "On-chain"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:53
+msgid "Cumulative Verra registry credits issued over time"
+msgstr "Cumulative Verra registry credits issued over time"
 
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
-msgid "On-chain Verra credits retired over time"
-msgstr "On-chain Verra credits retired over time"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
+msgstr "Off-Chain Verra credits retired over time"
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
-msgstr "On-chain retirements"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:19
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:38
+msgid "Verra credits retired"
+msgstr "Verra credits retired"
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
-msgid "On/Off chain"
-msgstr "On/Off chain"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
+msgstr "off-chain"
 
-#: components/cards/tokenDetails/TokenOriginsCard/index.tsx:27
-msgid "Origin of credits"
-msgstr "Origin of credits"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
+msgstr "on-chain"
 
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:56
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:104
-msgid "Outstanding"
-msgstr "Outstanding"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
+#: lib/charts/options.ts:32
+msgid "Issued"
+msgstr "Issued"
 
-#: components/Layout/NavItems/index.tsx:19
-#: components/pages/DetailPage/index.tsx:30
-msgid "Overview"
-msgstr "Overview"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr "Percentage of VCUs retired offchain"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:64
-msgid "Percentage of tokenized VCUs"
-msgstr "Percentage of tokenized VCUs"
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
-msgid "Percentage retired onchain"
-msgstr "Percentage retired onchain"
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:84
-msgid "Percentage tokenized"
-msgstr "Percentage tokenized"
-
-#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:36
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:44
-#: lib/charts/options.ts:46
-msgid "Polygon"
-msgstr "Polygon"
-
-#: components/cards/supply/DailyPolygonRetirementsCard/index.tsx:14
-msgid "Polygon retirements"
-msgstr "Polygon retirements"
-
-#: components/cards/supply/DailyPolygonCarbonSupplyCard/index.tsx:14
-msgid "Polygon supply"
-msgstr "Polygon supply"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:48
-msgid "Pool"
-msgstr "Pool"
-
-#: app/[locale]/overview/price-of-digital-carbon/page.tsx:11
-msgid "Price of digital carbon"
-msgstr "Price of digital carbon"
-
-#: components/cards/overview/TokensPriceCard/index.tsx:80
-msgid "Price per tonne"
-msgstr "Price per tonne"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:38
-msgid "Project"
-msgstr "Project"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:34
-msgid "Proof"
-msgstr "Proof"
-
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:25
-msgid "Quick facts"
-msgstr "Quick facts"
-
-#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:76
-#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:75
-msgid "Redeemed via KlimaDAO"
-msgstr "Redeemed via KlimaDAO"
-
+#. js-lingui-explicit-id
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:61
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:50
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:98
@@ -606,410 +525,717 @@ msgstr "Redeemed via KlimaDAO"
 msgid "Retired"
 msgstr "Retired"
 
-#: components/charts/DailyCarbonRetirementsChart/index.tsx:19
-#: components/charts/DailyCarbonRetirementsChart/index.tsx:35
-msgid "Retired outside of KlimaDAO"
-msgstr "Retired outside of KlimaDAO"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
+msgstr "of retired credits"
 
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
-#: components/charts/DailyCarbonRetirementsChart/index.tsx:13
-msgid "Retired via KlimaDAO"
-msgstr "Retired via KlimaDAO"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:33
+#: lib/charts/options.ts:106
+msgid "Bridged"
+msgstr "Bridged"
 
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
-msgstr "Retired via klimaDAO"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:51
+msgid "Verra credits issued"
+msgstr "Verra credits issued"
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
-msgid "Retirement Details"
-msgstr "Retirement Details"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:68
+msgid "Verra credits tokenized"
+msgstr "Verra credits tokenized"
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr "Retirement Trends"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsByBridgeAndVintageCard/index.tsx:19
+msgid "Credits by vintage start dates"
+msgstr "Credits by vintage start dates"
 
-#: app/[locale]/retirement-trends/page.tsx:11
-msgid "Retirement trends"
-msgstr "Retirement trends"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsDistributionOfProjectsCard/index.tsx:30
+msgid "Credits by project type"
+msgstr "Credits by project type"
 
-#: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
-msgid "Retirements by chain"
-msgstr "Retirements by chain"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsOriginCard/index.tsx:23
+msgid "Credits tokenized vs credits issued by origin"
+msgstr "Credits tokenized vs credits issued by origin"
 
-#: app/[locale]/retirement-trends/retirement-trends-by-pool/page.tsx:9
-msgid "Retirements by pool"
-msgstr "Retirements by pool"
+#. js-lingui-explicit-id
+#: components/cards/offVsOnChain/VerraCreditsOriginCard/index.tsx:24
+msgid "Credits retired off-chain vs on-chain by origin"
+msgstr "Credits retired off-chain vs on-chain by origin"
 
-#: app/[locale]/retirement-trends/retirement-trends-by-token/page.tsx:9
-msgid "Retirements by token"
-msgstr "Retirements by token"
+#. js-lingui-explicit-id
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr "On-chain retirements"
 
+#. js-lingui-explicit-id
+#: components/cards/overview/DailyVerraCreditsOverviewCard/index.tsx:126
+msgid "Verra credits"
+msgstr "Verra credits"
+
+#. js-lingui-explicit-id
+#: components/cards/overview/HistoricalPriceCard/index.tsx:18
+msgid "Historical prices (USD)"
+msgstr "Historical prices (USD)"
+
+#. js-lingui-explicit-id
+#: components/cards/overview/TokensPriceCard/index.tsx:33
+msgid "Digital carbon pricing"
+msgstr "Digital carbon pricing"
+
+#. js-lingui-explicit-id
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr "{formattedCurrentSupply} tonnes available"
+
+#. js-lingui-explicit-id
+#: components/cards/overview/TokensPriceCard/index.tsx:80
+msgid "Price per tonne"
+msgstr "Price per tonne"
+
+#. js-lingui-explicit-id
 #: components/cards/overview/TokensPriceCard/index.tsx:86
 msgid "Selective cost"
 msgstr "Selective cost"
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr "State of the Digital Carbon Market"
+#. js-lingui-explicit-id
+#: components/cards/overview/TokensPriceCard/index.tsx:94
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:106
+#: lib/charts/options.ts:128
+msgid "Last 7 days"
+msgstr "Last 7 days"
 
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
-msgid "State of {0} digital carbon"
-msgstr "State of {0} digital carbon"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByBeneficiaryListCard/index.tsx:18
+#: components/cards/retirementTrends/RetirementsByChainListCard/index.tsx:18
+#: components/cards/retirementTrends/RetirementsByPoolListCard/index.tsx:18
+#: components/cards/retirementTrends/RetirementsByTokenListCard/index.tsx:18
+msgid "Detailed list of KlimaDAO retirements"
+msgstr "Detailed list of KlimaDAO retirements"
 
-#: app/[locale]/token-details/state-of-digital-carbon/[bridge]/page.tsx:11
-msgid "State of {bridgeLabel} digital carbon"
-msgstr "State of {bridgeLabel} digital carbon"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:52
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:81
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:28
+#: lib/charts/options.ts:22
+msgid "Off-chain"
+msgstr "Off-chain"
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
-msgstr "Supply"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:58
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:61
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:28
+#: lib/charts/options.ts:18
+msgid "On-chain"
+msgstr "On-chain"
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
-msgstr "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:37
+msgid "KlimaDAO retirements by chain"
+msgstr "KlimaDAO retirements by chain"
 
-#: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
-msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
-msgstr "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:27
+msgid "Carbon retirements"
+msgstr "Carbon retirements"
 
-#: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
-msgid "The percentage of all carbon credit retirements that are retired via infrastructure built by KlimaDAO over a given time period."
-msgstr "The percentage of all carbon credit retirements that are retired via infrastructure built by KlimaDAO over a given time period."
-
-#: app/[locale]/retirement-trends/retirement-trends-by-token/page.tsx:12
-msgid "The percentage of retirements via infrastructure built by KlimaDAO from each digital carbon token in a given period."
-msgstr "The percentage of retirements via infrastructure built by KlimaDAO from each digital carbon token in a given period."
-
-#: app/[locale]/retirement-trends/retirement-trends-by-pool/page.tsx:12
-msgid "The percentage of total retirements from each digital carbon pool in a given period."
-msgstr "The percentage of total retirements from each digital carbon pool in a given period."
-
-#: app/[locale]/overview/price-of-digital-carbon/page.tsx:14
-msgid "The prices of various digital carbon pool tokens and their selective costs charged by bridges to redeem or retire a specific underlying digital carbon credit token. Note: The chart shows MCO2 price data from the KLIMA/MCO2 pool launched in January 2022."
-msgstr "The prices of various digital carbon pool tokens and their selective costs charged by bridges to redeem or retire a specific underlying digital carbon credit token. Note: The chart shows MCO2 price data from the KLIMA/MCO2 pool launched in January 2022."
-
-#: app/[locale]/overview/digital-carbon/page.tsx:44
-msgid ""
-"The term 'digital carbon' refers to a carbon credit that has been\n"
-"bridged from an off-chain carbon registry and tokenized, so that the\n"
-"credit now exists solely on a public blockchain (e.g. Polygon). In\n"
-"being brought on chain, digital carbon inherits the immutability,\n"
-"transparency, and trust of the underlying blockchain database."
-msgstr ""
-"The term 'digital carbon' refers to a carbon credit that has been\n"
-"bridged from an off-chain carbon registry and tokenized, so that the\n"
-"credit now exists solely on a public blockchain (e.g. Polygon). In\n"
-"being brought on chain, digital carbon inherits the immutability,\n"
-"transparency, and trust of the underlying blockchain database."
-
-#: app/[locale]/overview/digital-carbon/page.tsx:15
-msgid "The term 'digital carbon' refers to a carbon credit that has been bridged from an off-chain carbon registry and tokenized, so that the credit now exists solely on a public blockchain."
-msgstr "The term 'digital carbon' refers to a carbon credit that has been bridged from an off-chain carbon registry and tokenized, so that the credit now exists solely on a public blockchain."
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-off-chain-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra and retired over time. Off-chain refers carbon credits retired via legacy methods as compared to on-chain digital carbon credits bridged and tokenized on a public blockchain."
-msgstr "The total number of carbon credits issued by carbon registry Verra and retired over time. Off-chain refers carbon credits retired via legacy methods as compared to on-chain digital carbon credits bridged and tokenized on a public blockchain."
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra and retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
-msgstr "The total number of carbon credits issued by carbon registry Verra and retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
-
-#: app/[locale]/overview/verra-credits-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra over time and the number of credits retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
-msgstr "The total number of carbon credits issued by carbon registry Verra over time and the number of credits retired over time. On-chain refers to credits bridged and tokenized on a public blockchain."
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra that have been retired over time."
-msgstr "The total number of carbon credits issued by carbon registry Verra that have been retired over time."
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-over-time/page.tsx:12
-msgid "The total number of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain over time."
-msgstr "The total number of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain over time."
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-project-type/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by carbon project type."
-msgstr "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by carbon project type."
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-by-vintage-date/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by the vintage start date of the carbon credit."
-msgstr "The total number of carbon credits that have been issued by carbon registry Verra and retired sorted by the vintage start date of the carbon credit."
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra and what portion have been bridged, tokenized, and retired on-chain."
-msgstr "The total number of carbon credits that have been issued by carbon registry Verra and what portion have been bridged, tokenized, and retired on-chain."
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-project-type/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra sorted by carbon project type."
-msgstr "The total number of carbon credits that have been issued by carbon registry Verra sorted by carbon project type."
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-by-vintage-date/page.tsx:12
-msgid "The total number of carbon credits that have been issued by carbon registry Verra sorted by the vintage start date of the carbon credit."
-msgstr "The total number of carbon credits that have been issued by carbon registry Verra sorted by the vintage start date of the carbon credit."
-
-#: app/[locale]/token-details/state-of-digital-carbon/[bridge]/page.tsx:15
-msgid "The total number of digital carbon credits bridged via {bridgeLabel} broken down by the current outstanding supply and retired digital carbon credits."
-msgstr "The total number of digital carbon credits bridged via {bridgeLabel} broken down by the current outstanding supply and retired digital carbon credits."
-
-#: app/[locale]/overview/digital-carbon-retirements-snapshot/page.tsx:12
-msgid "The total number of digital carbon credits retired on-chain over time sorted by blockchain and what portion was retired via infrastructure built by KlimaDAO."
-msgstr "The total number of digital carbon credits retired on-chain over time sorted by blockchain and what portion was retired via infrastructure built by KlimaDAO."
-
-#: app/[locale]/supply/digital-carbon-retirements/[chain]/page.tsx:16
-msgid "The total number of digital carbon credits retired over time on the {chainLabel} blockchain."
-msgstr "The total number of digital carbon credits retired over time on the {chainLabel} blockchain."
-
-#: components/pages/retirementTrends/RetirementTrendsByBeneficiaryTab/index.tsx:14
-msgid "The total number of retirements and amount of digital carbon credits retired via infrastructure built by KlimaDAO from a given beneficiary address."
-msgstr "The total number of retirements and amount of digital carbon credits retired via infrastructure built by KlimaDAO from a given beneficiary address."
-
-#: app/[locale]/overview/digital-carbon-supply-snapshot/page.tsx:12
-msgid "The total supply of digital carbon on each blockchain broken down by digital carbon pool."
-msgstr "The total supply of digital carbon on each blockchain broken down by digital carbon pool."
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:14
-msgid "The volume of deposited digital carbon credits in the {poolLabel} pool over a given time period."
-msgstr "The volume of deposited digital carbon credits in the {poolLabel} pool over a given time period."
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:14
-msgid "The volume of digital carbon credits in {bridgeLabel} digital carbon pools over a given time period."
-msgstr "The volume of digital carbon credits in {bridgeLabel} digital carbon pools over a given time period."
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:14
-msgid "The volume of redeemed digital carbon credits in the {poolLabel} pool over a given time period."
-msgstr "The volume of redeemed digital carbon credits in the {poolLabel} pool over a given time period."
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:14
-msgid "The volume of retired digital carbon credits in the {poolLabel} pool over a given time period."
-msgstr "The volume of retired digital carbon credits in the {poolLabel} pool over a given time period."
-
-#: lib/tokens.tsx:39
-msgid "There is no selective redemption/retirement functionality for {0}."
-msgstr "There is no selective redemption/retirement functionality for {0}."
-
-#: lib/tokens.tsx:40
-msgid "This cost includes the asset spot price + the {0}% fee to selectively redeem or retire an underlying carbon project charged by {1}"
-msgstr "This cost includes the asset spot price + the {0}% fee to selectively redeem or retire an underlying carbon project charged by {1}"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:56
-msgid "Token"
-msgstr "Token"
-
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr "Token Details"
-
-#: app/[locale]/token-details/page.tsx:15
-msgid "Token details"
-msgstr "Token details"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
-msgstr "Tokenized VCUs"
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
-#: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:9
-#: components/cards/overview/TokenizedCreditsByBridgeCard/index.tsx:23
-msgid "Tokenized credits by bridge"
-msgstr "Tokenized credits by bridge"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
-msgid "Tonnes"
-msgstr "Tonnes"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr "Total Issued VCUs"
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
-msgid "Total issued VCUs"
-msgstr "Total issued VCUs"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:70
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:76
-msgid "Total retired VCUs"
-msgstr "Total retired VCUs"
-
-#: components/charts/DistributionOfProjectsChart/index.tsx:72
-msgid "Total retired VCUs offchain"
-msgstr "Total retired VCUs offchain"
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:67
-msgid "Total retired VCUs onchain"
-msgstr "Total retired VCUs onchain"
-
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:110
-msgid "Total retirements (tonnes)"
-msgstr "Total retirements (tonnes)"
-
-#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:96
-msgid "Total supply (tonnes)"
-msgstr "Total supply (tonnes)"
-
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:66
-msgid "Total tokenized VCUs"
-msgstr "Total tokenized VCUs"
-
-#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:69
-#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:68
-msgid "Total tonnes redeemed"
-msgstr "Total tonnes redeemed"
-
+#. js-lingui-explicit-id
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:65
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:85
 msgid "Total tonnes retired"
 msgstr "Total tonnes retired"
 
-#: app/[locale]/token-details/page.tsx:78
-msgid "Toucan"
-msgstr "Toucan"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr "Retired via klimaDAO"
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr "Toucan Carbon Credit (TCO2)"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
+msgid "Of total retired credits"
+msgstr "Of total retired credits"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:116
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
-msgid "Toucan bridged VCUs"
-msgstr "Toucan bridged VCUs"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByPoolBarCard/index.tsx:20
+#: components/cards/retirementTrends/RetirementsByPoolSummaryCard/index.tsx:19
+msgid "KlimaDAO retirements by pool"
+msgstr "KlimaDAO retirements by pool"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:117
-#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:42
-msgid "Toucan retired VCUs"
-msgstr "Toucan retired VCUs"
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:25
+msgid "Carbon pool redemptions / retirements"
+msgstr "Carbon pool redemptions / retirements"
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:69
+#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:68
+msgid "Total tonnes redeemed"
+msgstr "Total tonnes redeemed"
+
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByPoolOverviewCard/index.tsx:76
+#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:75
+msgid "Redeemed via KlimaDAO"
+msgstr "Redeemed via KlimaDAO"
+
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByTokenBarCard/index.tsx:20
+msgid "KlimaDAO retirements by token"
+msgstr "KlimaDAO retirements by token"
+
+#. js-lingui-explicit-id
+#: components/cards/retirementTrends/RetirementsByTokenOverviewCard/index.tsx:24
+msgid "Carbon token retirements"
+msgstr "Carbon token retirements"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:22
+msgid "Carbon supply by blockchain"
+msgstr "Carbon supply by blockchain"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:36
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:44
+#: lib/charts/options.ts:46
+msgid "Polygon"
+msgstr "Polygon"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:42
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:48
+#: lib/charts/options.ts:50
+msgid "Ethereum"
+msgstr "Ethereum"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyByBlockchainCard/index.tsx:48
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:52
+#: lib/charts/options.ts:60
+msgid "Celo"
+msgstr "Celo"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:25
+msgid "Quick facts"
+msgstr "Quick facts"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:96
+msgid "Total supply (tonnes)"
+msgstr "Total supply (tonnes)"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:110
+msgid "Total retirements (tonnes)"
+msgstr "Total retirements (tonnes)"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
+#: components/charts/DailyCarbonRetirementsChart/index.tsx:13
+msgid "Retired via KlimaDAO"
+msgstr "Retired via KlimaDAO"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyCeloCarbonSupplyCard/index.tsx:15
+msgid "Celo supply"
+msgstr "Celo supply"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyEthCarbonSupplyCard/index.tsx:15
+msgid "Ethereum supply"
+msgstr "Ethereum supply"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyEthRetirementsCard/index.tsx:14
+msgid "Ethereum retirements"
+msgstr "Ethereum retirements"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyPolygonCarbonSupplyCard/index.tsx:14
+msgid "Polygon supply"
+msgstr "Polygon supply"
+
+#. js-lingui-explicit-id
+#: components/cards/supply/DailyPolygonRetirementsCard/index.tsx:14
+msgid "Polygon retirements"
+msgstr "Polygon retirements"
+
+#. js-lingui-explicit-id
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
 msgstr "UBO"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:95
-msgid "UBO pooled VCUs"
-msgstr "UBO pooled VCUs"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
+#: lib/charts/options.ts:78
+msgid "NBO"
+msgstr "NBO"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:96
-msgid "UBO retired VCUs"
-msgstr "UBO retired VCUs"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
+#: lib/charts/options.ts:92
+msgid "BCT"
+msgstr "BCT"
 
-#: lib/tokens.tsx:18
-msgid "Universal Basic Offset (UBO)"
-msgstr "Universal Basic Offset (UBO)"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
+#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
+#: lib/charts/options.ts:96
+msgid "NCT"
+msgstr "NCT"
 
-#: components/cards/overview/DailyVerraCreditsOverviewCard/index.tsx:126
-msgid "Verra credits"
-msgstr "Verra credits"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:79
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
+msgid "Not pooled"
+msgstr "Not pooled"
 
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-breakdown/page.tsx:9
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/index.tsx:29
-msgid "Verra credits breakdown"
-msgstr "Verra credits breakdown"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/helpers.ts:88
+#: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:76
+msgid "MCO2"
+msgstr "MCO2"
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:51
-msgid "Verra credits issued"
-msgstr "Verra credits issued"
-
-#: app/[locale]/overview/verra-credits-over-time/page.tsx:9
-msgid "Verra credits over time"
-msgstr "Verra credits over time"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:19
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:38
-msgid "Verra credits retired"
-msgstr "Verra credits retired"
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-issued-over-time/page.tsx:9
-msgid "Verra credits retired over time"
-msgstr "Verra credits retired over time"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:68
-msgid "Verra credits tokenized"
-msgstr "Verra credits tokenized"
-
-#: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-over-time/page.tsx:9
-msgid "Verra credits tokenized over time"
-msgstr "Verra credits tokenized over time"
-
+#. js-lingui-explicit-id
 #: components/cards/tokenDetails/PoolVolumeOverTimeCard/index.tsx:26
 msgid "Volume deposited over time"
 msgstr "Volume deposited over time"
 
-#: components/cards/tokenDetails/TokenVolumeOverTimeCard/index.tsx:23
-msgid "Volume over time"
-msgstr "Volume over time"
-
-#: components/cards/tokenDetails/PoolVolumeOverTimeCard/index.tsx:30
-msgid "Volume redeemed over time"
-msgstr "Volume redeemed over time"
-
+#. js-lingui-explicit-id
 #: components/cards/tokenDetails/PoolVolumeOverTimeCard/index.tsx:28
 msgid "Volume retired over time"
 msgstr "Volume retired over time"
 
-#: app/[locale]/overview/digital-carbon/page.tsx:12
-#: app/[locale]/overview/digital-carbon/page.tsx:42
-#: app/[locale]/overview/page.tsx:37
-msgid "What is digital carbon?"
-msgstr "What is digital carbon?"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/PoolVolumeOverTimeCard/index.tsx:30
+msgid "Volume redeemed over time"
+msgstr "Volume redeemed over time"
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr "of retired credits"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
+msgid "Distribution of methodologies"
+msgstr "Distribution of methodologies"
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr "off-chain"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
+msgstr "Distribution of Projects"
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr "on-chain"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
+msgid "Distribution of vintage start dates"
+msgstr "Distribution of vintage start dates"
 
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr "{0} Bridged"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenOriginsCard/index.tsx:27
+msgid "Origin of credits"
+msgstr "Origin of credits"
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr "{0} Tonnes"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:45
+msgid "Breakdown of {0} pooled"
+msgstr "Breakdown of {0} pooled"
 
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr "{0} outstanding"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
+msgid "State of {0} digital carbon"
+msgstr "State of {0} digital carbon"
 
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:56
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:104
+msgid "Outstanding"
+msgstr "Outstanding"
+
+#. js-lingui-explicit-id
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
 msgid "{0} retired"
 msgstr "{0} retired"
 
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr "{bridgeLabel} Distribution of vintage start dates"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr "{0} outstanding"
 
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr "{bridgeLabel} distribution of methodologies"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr "{0} Bridged"
 
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr "{bridgeLabel} distribution of projects"
+#. js-lingui-explicit-id
+#: components/cards/tokenDetails/TokenVolumeOverTimeCard/index.tsx:23
+msgid "Volume over time"
+msgstr "Volume over time"
 
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr "{bridgeLabel} volume over time"
+#. js-lingui-explicit-id
+#: components/charts/DailyCarbonRetirementsChart/index.tsx:19
+#: components/charts/DailyCarbonRetirementsChart/index.tsx:35
+msgid "Retired outside of KlimaDAO"
+msgstr "Retired outside of KlimaDAO"
 
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr "{formattedCurrentSupply} tonnes available"
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
+msgstr "Total Issued VCUs"
 
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr "{poolLabel} volume deposited over time"
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr "Tokenized VCUs"
 
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr "{poolLabel} volume redeemed over time"
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:64
+msgid "Percentage of tokenized VCUs"
+msgstr "Percentage of tokenized VCUs"
 
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
-msgstr "{poolLabel} volume retired over time"
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:70
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:76
+msgid "Total retired VCUs"
+msgstr "Total retired VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:72
+msgid "Total retired VCUs offchain"
+msgstr "Total retired VCUs offchain"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
+msgstr "Percentage of VCUs retired offchain"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:86
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
+msgid "C3 bridged VCUs"
+msgstr "C3 bridged VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:87
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
+msgid "C3 retired VCUs"
+msgstr "C3 retired VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:95
+msgid "UBO pooled VCUs"
+msgstr "UBO pooled VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:96
+msgid "UBO retired VCUs"
+msgstr "UBO retired VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:104
+msgid "NBO pooled VCUs"
+msgstr "NBO pooled VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:105
+msgid "NBO retired VCUs"
+msgstr "NBO retired VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:116
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
+msgid "Toucan bridged VCUs"
+msgstr "Toucan bridged VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:117
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:42
+msgid "Toucan retired VCUs"
+msgstr "Toucan retired VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:125
+msgid "BCT pooled VCUs"
+msgstr "BCT pooled VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:126
+msgid "BCT retired VCUs"
+msgstr "BCT retired VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:134
+msgid "NCT pooled VCUs"
+msgstr "NCT pooled VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:135
+msgid "NCT retired VCUs"
+msgstr "NCT retired VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:145
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
+msgid "Moss bridged VCUs"
+msgstr "Moss bridged VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/DistributionOfProjectsChart/index.tsx:146
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:51
+msgid "Moss retired VCUs"
+msgstr "Moss retired VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/helpers.ts:11
+msgid "Beneficiary address"
+msgstr "Beneficiary address"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/helpers.ts:14
+msgid "Missing"
+msgstr "Missing"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:35
+#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:47
+msgid "Amount retired"
+msgstr "Amount retired"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:41
+msgid "Number of retirements"
+msgstr "Number of retirements"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
+msgid "Retirement Details"
+msgstr "Retirement Details"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
+msgid "On/Off chain"
+msgstr "On/Off chain"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:34
+msgid "Proof"
+msgstr "Proof"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
+msgid "Beneficiary"
+msgstr "Beneficiary"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr "Amount Retired"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
+msgid "Number of transactions"
+msgstr "Number of transactions"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
+msgid "Avg tonnes per transaction"
+msgstr "Avg tonnes per transaction"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:38
+msgid "Project"
+msgstr "Project"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:48
+msgid "Pool"
+msgstr "Pool"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:51
+#: components/charts/helpers/VerraProjectLink/index.tsx:18
+msgid "N/A"
+msgstr "N/A"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:56
+msgid "Token"
+msgstr "Token"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:70
+msgid "Date"
+msgstr "Date"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
+msgid "Tonnes"
+msgstr "Tonnes"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr "{0} Tonnes"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:33
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:33
+msgid "Country"
+msgstr "Country"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:39
+msgid "Country code"
+msgstr "Country code"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
+msgid "Amount bridged"
+msgstr "Amount bridged"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:66
+msgid "Total tokenized VCUs"
+msgstr "Total tokenized VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:67
+msgid "Total retired VCUs onchain"
+msgstr "Total retired VCUs onchain"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
+msgid "Total issued VCUs"
+msgstr "Total issued VCUs"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:84
+msgid "Percentage tokenized"
+msgstr "Percentage tokenized"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
+msgid "Percentage retired onchain"
+msgstr "Percentage retired onchain"
+
+#. js-lingui-explicit-id
+#: components/charts/helpers/NoDataWrapper/index.tsx:14
+msgid "No data availble"
+msgstr "No data availble"
+
+#. js-lingui-explicit-id
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr "Explore Marketplace"
+
+#. js-lingui-explicit-id
+#: components/Layout/ChangeLanguageButton/index.tsx:42
+msgid "Change language"
+msgstr "Change language"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavItems/index.tsx:19
+#: components/pages/DetailPage/index.tsx:30
+msgid "Overview"
+msgstr "Overview"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavItems/index.tsx:25
+msgid "Off vs On-Chain"
+msgstr "Off vs On-Chain"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
+msgstr "Retirement Trends"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
+msgstr "Token Details"
+
+#. js-lingui-explicit-id
+#: components/pages/DetailPage/index.tsx:36
+msgid "Insights"
+msgstr "Insights"
+
+#. js-lingui-explicit-id
+#: components/pages/retirementTrends/RetirementTrendsByBeneficiaryTab/index.tsx:14
+msgid "The total number of retirements and amount of digital carbon credits retired via infrastructure built by KlimaDAO from a given beneficiary address."
+msgstr "The total number of retirements and amount of digital carbon credits retired via infrastructure built by KlimaDAO from a given beneficiary address."
+
+#. js-lingui-explicit-id
+#: components/Skeleton/index.tsx:4
+msgid "Fetching data…"
+msgstr "Fetching data…"
+
+#. js-lingui-explicit-id
+#: lib/charts/options.ts:70
+#: lib/charts/options.ts:88
+msgid "All Tokens"
+msgstr "All Tokens"
+
+#. js-lingui-explicit-id
+#: lib/charts/options.ts:120
+msgid "Lifetime"
+msgstr "Lifetime"
+
+#. js-lingui-explicit-id
+#: lib/charts/options.ts:124
+msgid "Last 30 days"
+msgstr "Last 30 days"
+
+#. js-lingui-explicit-id
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
+msgstr "C3 Carbon Credit (C3T)"
+
+#. js-lingui-explicit-id
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
+msgstr "Toucan Carbon Credit (TCO2)"
+
+#. js-lingui-explicit-id
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
+msgstr "Moss Carbon Credit (MCO2)"
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr "Base Carbon Tonne (BCT)"
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr "Nature Carbon Tonne (NCT)"
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:18
+msgid "Universal Basic Offset (UBO)"
+msgstr "Universal Basic Offset (UBO)"
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr "Nature Based Offset (NBO)"
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:39
+msgid "There is no selective redemption/retirement functionality for {0}."
+msgstr "There is no selective redemption/retirement functionality for {0}."
+
+#. js-lingui-explicit-id
+#: lib/tokens.tsx:40
+msgid "This cost includes the asset spot price + the {0}% fee to selectively redeem or retire an underlying carbon project charged by {1}"
+msgstr "This cost includes the asset spot price + the {0}% fee to selectively redeem or retire an underlying carbon project charged by {1}"

--- a/carbonmark/components/FeatureBanner/index.tsx
+++ b/carbonmark/components/FeatureBanner/index.tsx
@@ -1,0 +1,43 @@
+import { cx } from "@emotion/css";
+import { t } from "@lingui/macro";
+import { Celebration, Close } from "@mui/icons-material";
+import { Text } from "components/Text";
+import React, { FC } from "react";
+import * as styles from "./styles";
+
+type Props = {
+  title: string;
+  isVisible: boolean;
+  showClose?: boolean;
+  description: string;
+  onClose: () => void;
+  children: React.ReactNode;
+  showNewFeatureLabel?: boolean;
+};
+
+const FeatureBanner: FC<Props> = (props) => {
+  return (
+    <div
+      className={cx(styles.banner, {
+        "feature-banner": !!props.isVisible,
+      })}
+    >
+      {props.showClose && <Close className="close" onClick={props.onClose} />}
+      <div className="contents">
+        <div className={styles.title}>
+          {props.showNewFeatureLabel && (
+            <>
+              <Celebration />
+              <Text className="new-feature">{t`NEW FEATURE:`}</Text>
+            </>
+          )}
+          <Text>{props.title}</Text>
+        </div>
+        <Text>{props.description}</Text>
+        <div className={styles.buttons}>{props.children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default FeatureBanner;

--- a/carbonmark/components/FeatureBanner/index.tsx
+++ b/carbonmark/components/FeatureBanner/index.tsx
@@ -11,6 +11,7 @@ type Props = {
   showClose?: boolean;
   description: string;
   onClose: () => void;
+  isInitialBanner: boolean;
   children: React.ReactNode;
   showNewFeatureLabel?: boolean;
 };
@@ -20,16 +21,17 @@ const FeatureBanner: FC<Props> = (props) => {
     <div
       className={cx(styles.banner, {
         "feature-banner": !!props.isVisible,
+        "initial-banner": !!props.isVisible && !!props.isInitialBanner,
       })}
     >
       {props.showClose && <Close className="close" onClick={props.onClose} />}
       <div className="contents">
         <div className={styles.title}>
           {props.showNewFeatureLabel && (
-            <>
+            <div className="new-feature">
               <Celebration />
-              <Text className="new-feature">{t`NEW FEATURE:`}</Text>
-            </>
+              <Text>{t`NEW FEATURE:`}</Text>
+            </div>
           )}
           <Text>{props.title}</Text>
         </div>

--- a/carbonmark/components/FeatureBanner/styles.ts
+++ b/carbonmark/components/FeatureBanner/styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@emotion/css";
+import breakpoints from "@klimadao/lib/theme/breakpoints";
 
 export const banner = css`
   top: 0;
@@ -14,42 +15,71 @@ export const banner = css`
   grid-template-columns: inherit;
   box-shadow: 0 0.2rem 0.2rem 0 rgba(0, 0, 0, 0.24);
   transition: all 0.3s ease-in-out;
-  transform: translateY(-15rem);
+  transform: translateY(-18rem);
 
   &.feature-banner {
-    transform: translateY(0);
+    transform: translateY(6.6rem);
+  }
+
+  ${breakpoints.desktop} {
+    &.feature-banner {
+      transform: translateY(0);
+    }
   }
 
   .close {
-    top: 2rem;
-    right: 2.4rem;
+    top: 1.6rem;
+    right: 1.6rem;
     width: 2rem;
     height: 2rem;
     cursor: pointer;
     position: absolute;
+
+    ${breakpoints.desktop} {
+      top: 2rem;
+      right: 2.4rem;
+    }
   }
 
   .contents {
     gap: 1rem;
     display: grid;
     grid-column: full;
-    padding: 2rem 5.2rem;
+    padding: 1.6rem 2.4rem;
+
+    ${breakpoints.desktop} {
+      padding: 2rem 5.2rem;
+    }
   }
 `;
 
 export const title = css`
   gap: 1rem;
   display: flex;
-  align-items: center;
-  flex-direction: row;
+  align-items: flex-start;
+  flex-direction: column;
 
-  div {
-    display: flex;
+  ${breakpoints.desktop} {
+    align-items: center;
     flex-direction: row;
   }
 
+  div {
+    display: flex;
+    flex-direction: column;
+
+    ${breakpoints.desktop} {
+      flex-direction: row;
+    }
+  }
+
   svg {
-    margin-left: -2.4rem;
+    width: 2rem;
+    height: 2rem;
+
+    ${breakpoints.desktop} {
+      margin-left: -2.4rem;
+    }
   }
 
   p,
@@ -59,8 +89,16 @@ export const title = css`
   }
 
   .new-feature {
-    color: var(--black);
-    font-family: var(--font-family-secondary);
+    gap: 1.2rem;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    justify-content: center;
+
+    p {
+      color: var(--black);
+      font-family: var(--font-family-secondary);
+    }
   }
 `;
 
@@ -71,6 +109,13 @@ export const buttons = css`
 
   a,
   button {
+    width: 50%;
     min-height: 3.6rem;
+    padding: 0 1rem;
+
+    ${breakpoints.desktop} {
+      padding: 0 2.4rem;
+      width: fit-content;
+    }
   }
 `;

--- a/carbonmark/components/FeatureBanner/styles.ts
+++ b/carbonmark/components/FeatureBanner/styles.ts
@@ -1,0 +1,76 @@
+import { css } from "@emotion/css";
+
+export const banner = css`
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  z-index: 100;
+  display: grid;
+  position: absolute;
+  grid-column: full;
+  overflow: hidden;
+  background: #ebedff;
+  grid-template-columns: inherit;
+  box-shadow: 0 0.2rem 0.2rem 0 rgba(0, 0, 0, 0.24);
+  transition: all 0.3s ease-in-out;
+  transform: translateY(-15rem);
+
+  &.feature-banner {
+    transform: translateY(0);
+  }
+
+  .close {
+    top: 2rem;
+    right: 2.4rem;
+    width: 2rem;
+    height: 2rem;
+    cursor: pointer;
+    position: absolute;
+  }
+
+  .contents {
+    gap: 1rem;
+    display: grid;
+    grid-column: full;
+    padding: 2rem 5.2rem;
+  }
+`;
+
+export const title = css`
+  gap: 1rem;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+
+  div {
+    display: flex;
+    flex-direction: row;
+  }
+
+  svg {
+    margin-left: -2.4rem;
+  }
+
+  p,
+  svg {
+    font-weight: 700;
+    color: var(--bright-blue);
+  }
+
+  .new-feature {
+    color: var(--black);
+    font-family: var(--font-family-secondary);
+  }
+`;
+
+export const buttons = css`
+  display: flex;
+  flex-direction: row;
+  gap: 0.8rem;
+
+  a,
+  button {
+    min-height: 3.6rem;
+  }
+`;

--- a/carbonmark/components/FeatureBanner/styles.ts
+++ b/carbonmark/components/FeatureBanner/styles.ts
@@ -78,7 +78,7 @@ export const title = css`
     height: 2rem;
 
     ${breakpoints.desktop} {
-      margin-left: -2.4rem;
+      margin-left: -3.2rem;
     }
   }
 

--- a/carbonmark/components/Layout/index.tsx
+++ b/carbonmark/components/Layout/index.tsx
@@ -1,4 +1,4 @@
-import { cx } from "@emotion/css";
+import { ClassNamesArg, cx } from "@emotion/css";
 import { useWeb3 } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
 import Menu from "@mui/icons-material/Menu";
@@ -25,6 +25,7 @@ import * as styles from "./styles";
 type Props = {
   userAddress?: string;
   children: ReactNode;
+  customCss?: ClassNamesArg;
   fullContentWidth?: boolean;
   fullContentHeight?: boolean;
 };
@@ -71,7 +72,7 @@ export const Layout: FC<Props> = (props: Props) => {
           />
         </div>
         <div
-          className={cx(styles.layoutChildrenContainer, {
+          className={cx(styles.layoutChildrenContainer, props.customCss, {
             fullContentWidth: props.fullContentWidth,
           })}
         >

--- a/carbonmark/components/Layout/styles.ts
+++ b/carbonmark/components/Layout/styles.ts
@@ -95,8 +95,9 @@ export const layoutChildrenContainer = css`
 
   ${breakpoints.desktop} {
     padding: 4rem 2.4rem;
+
     &:has(.feature-banner.initial-banner),
-    &:has(.feature-banner) {
+    &:has(.feature-banner):not(.initial-banner) {
       padding: 16rem 2.4rem;
     }
   }

--- a/carbonmark/components/Layout/styles.ts
+++ b/carbonmark/components/Layout/styles.ts
@@ -80,8 +80,16 @@ export const layoutChildrenContainer = css`
   gap: 1.2rem 0rem;
   padding: 1.6rem;
   align-content: flex-start;
+
+  // Required for feature banner transition
+  transition: all 0.2s ease-in-out;
+
   ${breakpoints.desktop} {
     padding: 4rem 2.4rem;
+
+    &:has(.feature-banner) {
+      padding: 16rem 2.4rem;
+    }
   }
 
   &.fullContentWidth {

--- a/carbonmark/components/Layout/styles.ts
+++ b/carbonmark/components/Layout/styles.ts
@@ -40,6 +40,7 @@ export const container = css`
 `;
 
 export const mainContentGrid = css`
+  position: relative;
   display: grid;
   grid-template-rows: auto 1fr auto;
   grid-template-columns:
@@ -65,7 +66,7 @@ export const mobileLogo = css`
 
 export const desktopNavMenu = css`
   display: none;
-  //To properly allow modal overlay
+  // to properly allow modal overlay
   z-index: 1;
   ${breakpoints.desktop} {
     display: flex;
@@ -81,12 +82,20 @@ export const layoutChildrenContainer = css`
   padding: 1.6rem;
   align-content: flex-start;
 
-  // Required for feature banner transition
+  &:has(.feature-banner):not(.initial-banner) {
+    padding: 17rem 2.4rem;
+  }
+
+  &:has(.feature-banner.initial-banner) {
+    padding: 20rem 2.4rem;
+  }
+
+  // required for feature banner transition
   transition: all 0.2s ease-in-out;
 
   ${breakpoints.desktop} {
     padding: 4rem 2.4rem;
-
+    &:has(.feature-banner.initial-banner),
     &:has(.feature-banner) {
       padding: 16rem 2.4rem;
     }

--- a/carbonmark/components/Layout/styles.ts
+++ b/carbonmark/components/Layout/styles.ts
@@ -82,24 +82,8 @@ export const layoutChildrenContainer = css`
   padding: 1.6rem;
   align-content: flex-start;
 
-  &:has(.feature-banner):not(.initial-banner) {
-    padding: 17rem 2.4rem;
-  }
-
-  &:has(.feature-banner.initial-banner) {
-    padding: 20rem 2.4rem;
-  }
-
-  // required for feature banner transition
-  transition: all 0.2s ease-in-out;
-
   ${breakpoints.desktop} {
     padding: 4rem 2.4rem;
-
-    &:has(.feature-banner.initial-banner),
-    &:has(.feature-banner):not(.initial-banner) {
-      padding: 16rem 2.4rem;
-    }
   }
 
   &.fullContentWidth {

--- a/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
+++ b/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
@@ -39,8 +39,7 @@ export const BankTransferBanner: FC = () => {
   };
 
   const onClose = () => {
-    setIsVisible(false);
-    setStorageValues(["1"], false);
+    setStorageValues(["1"]);
   };
 
   const onShowLater = () => {

--- a/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
+++ b/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
@@ -5,50 +5,64 @@ import FeatureBanner from "components/FeatureBanner";
 import { urls } from "lib/constants";
 import { FC, useEffect, useState } from "react";
 
+type BannerState = "initial-banner" | "secondary-banner" | "none";
+type SessionState = "visible" | "hidden" | "not-shown";
+
 export const BankTransferBanner: FC = () => {
   const [isVisible, setIsVisible] = useState(false);
-  const [localStorage, setLocalStorage] = useState("0");
-  const [sessionStorage, setSessionStorage] = useState("0");
+  const [localStorage, setLocalStorage] =
+    useState<BannerState>("initial-banner");
+  const [sessionStorage, setSessionStorage] = useState<SessionState>("visible");
 
-  const isInitialBanner = localStorage === "0";
+  const isInitialBanner = localStorage === "initial-banner";
 
   useEffect(() => {
     updateStateValues();
   }, []);
 
   useEffect(() => {
-    setIsVisible(!(sessionStorage !== "0" || localStorage === "2"));
+    setIsVisible(!(sessionStorage !== "visible" || localStorage === "none"));
   }, [localStorage, sessionStorage]);
 
   const updateStateValues = () => {
-    setLocalStorage(window.localStorage.getItem("feature-banner") ?? "0");
-    setSessionStorage(window.sessionStorage.getItem("feature-banner") ?? "0");
+    setLocalStorage(
+      (window.localStorage.getItem("feature-banner") as BannerState) ??
+        "initial-banner"
+    );
+    setSessionStorage(
+      (window.sessionStorage.getItem("feature-banner") as SessionState) ??
+        "visible"
+    );
   };
 
   const setStorageValues = (
-    [local, session]: string[],
+    [local, session = "visible"]: [BannerState, SessionState?],
     shouldUpdate = true
   ) => {
-    window.localStorage.setItem("feature-banner", local || "0");
-    window.sessionStorage.setItem("feature-banner", session || "0");
+    window.localStorage.setItem("feature-banner", local || "initial-banner");
+    window.sessionStorage.setItem("feature-banner", session || "visible");
     if (shouldUpdate) updateStateValues();
   };
 
   const onLetsGo = () => {
-    setStorageValues(["1"], false);
+    // show secondary banner but don't re-render
+    setStorageValues(["secondary-banner"], false);
   };
 
   const onClose = () => {
-    setStorageValues(["1"]);
+    // hide the initial banner & show the secondary banner
+    setStorageValues(["secondary-banner"]);
   };
 
   const onShowLater = () => {
     setIsVisible(false);
-    setStorageValues(["0", "1"], false);
+    // show the initial banner but hide for the current session and don't re-render
+    setStorageValues(["initial-banner", "hidden"], false);
   };
 
   const onDontRemindLater = () => {
-    setStorageValues(["2", "2"]);
+    // hide the banner permanently
+    setStorageValues(["none", "not-shown"]);
   };
 
   return (

--- a/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
+++ b/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
@@ -1,0 +1,85 @@
+import { t } from "@lingui/macro";
+import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
+import { ButtonSecondary } from "components/Buttons/ButtonSecondary";
+import FeatureBanner from "components/FeatureBanner";
+import { urls } from "lib/constants";
+import { FC, useEffect, useState } from "react";
+
+export const BankTransferBanner: FC = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [localStorage, setLocalStorage] = useState("0");
+  const [sessionStorage, setSessionStorage] = useState("0");
+
+  const isInitialBanner = localStorage === "0";
+
+  useEffect(() => {
+    updateStateValues();
+  }, []);
+
+  useEffect(() => {
+    setIsVisible(!(sessionStorage !== "0" || localStorage === "2"));
+  }, [localStorage, sessionStorage]);
+
+  const updateStateValues = () => {
+    setLocalStorage(window.localStorage.getItem("feature-banner") ?? "0");
+    setSessionStorage(window.sessionStorage.getItem("feature-banner") ?? "0");
+  };
+
+  const setStorageValues = ([local, session]: string[]) => {
+    window.localStorage.setItem("feature-banner", local || "0");
+    window.sessionStorage.setItem("feature-banner", session || "0");
+    updateStateValues();
+  };
+
+  const onLetsGo = () => {
+    setStorageValues(["1"]);
+  };
+
+  const onShowLater = () => {
+    setStorageValues(["0", "1"]);
+  };
+
+  const onDontRemindLater = () => {
+    setStorageValues(["2", "2"]);
+  };
+
+  return (
+    <>
+      <FeatureBanner
+        isVisible={isVisible}
+        onClose={onDontRemindLater}
+        title={t`Pay via Bank Transfer / Wire`}
+        showClose={isInitialBanner}
+        showNewFeatureLabel={isInitialBanner}
+        description={
+          isInitialBanner
+            ? t`Purchase retirements from any project on Carbonmark and pay via bank transfer`
+            : t`Can we remind you about this new feature later?`
+        }
+      >
+        {isInitialBanner ? (
+          <>
+            <ButtonPrimary
+              onClick={onLetsGo}
+              label={t`Let's Go!`}
+              href="/retire/pay-with-bank"
+            />
+            <ButtonSecondary
+              target="_blank"
+              label={t`Learn More`}
+              href={urls.payViaBankDocs}
+            />
+          </>
+        ) : (
+          <>
+            <ButtonPrimary label={t`Sure`} onClick={onShowLater} />
+            <ButtonSecondary
+              label={t`Don't Remind Me`}
+              onClick={onDontRemindLater}
+            />
+          </>
+        )}
+      </FeatureBanner>
+    </>
+  );
+};

--- a/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
+++ b/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
@@ -10,6 +10,7 @@ type SessionState = "visible" | "hidden" | "not-shown";
 
 export const BankTransferBanner: FC = () => {
   const [isVisible, setIsVisible] = useState(false);
+  // @todo Makka - create useLocalStorage/useSessionStorage hook
   const [localStorage, setLocalStorage] =
     useState<BannerState>("initial-banner");
   const [sessionStorage, setSessionStorage] = useState<SessionState>("visible");
@@ -66,43 +67,41 @@ export const BankTransferBanner: FC = () => {
   };
 
   return (
-    <>
-      <FeatureBanner
-        isVisible={isVisible}
-        isInitialBanner={isInitialBanner}
-        onClose={onClose}
-        title={t`Pay via Bank Transfer / Wire`}
-        showClose={isInitialBanner}
-        showNewFeatureLabel={isInitialBanner}
-        description={
-          isInitialBanner
-            ? t`Purchase retirements from any project on Carbonmark and pay via bank transfer.`
-            : t`Can we remind you about this new feature later?`
-        }
-      >
-        {isInitialBanner ? (
-          <>
-            <ButtonPrimary
-              onClick={onLetsGo}
-              label={t`Let's Go!`}
-              href="/retire/pay-with-bank"
-            />
-            <ButtonSecondary
-              target="_blank"
-              label={t`Learn More`}
-              href={urls.payViaBankDocs}
-            />
-          </>
-        ) : (
-          <>
-            <ButtonPrimary label={t`Sure`} onClick={onShowLater} />
-            <ButtonSecondary
-              label={t`Don't Remind Me`}
-              onClick={onDontRemindLater}
-            />
-          </>
-        )}
-      </FeatureBanner>
-    </>
+    <FeatureBanner
+      isVisible={isVisible}
+      isInitialBanner={isInitialBanner}
+      onClose={onClose}
+      title={t`Pay via Bank Transfer / Wire`}
+      showClose={isInitialBanner}
+      showNewFeatureLabel={isInitialBanner}
+      description={
+        isInitialBanner
+          ? t`Purchase retirements from any project on Carbonmark and pay via bank transfer.`
+          : t`Can we remind you about this new feature later?`
+      }
+    >
+      {isInitialBanner ? (
+        <>
+          <ButtonPrimary
+            onClick={onLetsGo}
+            label={t`Let's Go!`}
+            href="/retire/pay-with-bank"
+          />
+          <ButtonSecondary
+            target="_blank"
+            label={t`Learn More`}
+            href={urls.payViaBankDocs}
+          />
+        </>
+      ) : (
+        <>
+          <ButtonPrimary label={t`Sure`} onClick={onShowLater} />
+          <ButtonSecondary
+            label={t`Don't Remind Me`}
+            onClick={onDontRemindLater}
+          />
+        </>
+      )}
+    </FeatureBanner>
   );
 };

--- a/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
+++ b/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
@@ -25,18 +25,27 @@ export const BankTransferBanner: FC = () => {
     setSessionStorage(window.sessionStorage.getItem("feature-banner") ?? "0");
   };
 
-  const setStorageValues = ([local, session]: string[]) => {
+  const setStorageValues = (
+    [local, session]: string[],
+    shouldUpdate = true
+  ) => {
     window.localStorage.setItem("feature-banner", local || "0");
     window.sessionStorage.setItem("feature-banner", session || "0");
-    updateStateValues();
+    if (shouldUpdate) updateStateValues();
   };
 
   const onLetsGo = () => {
-    setStorageValues(["1"]);
+    setStorageValues(["1"], false);
+  };
+
+  const onClose = () => {
+    setIsVisible(false);
+    setStorageValues(["1"], false);
   };
 
   const onShowLater = () => {
-    setStorageValues(["0", "1"]);
+    setIsVisible(false);
+    setStorageValues(["0", "1"], false);
   };
 
   const onDontRemindLater = () => {
@@ -47,13 +56,14 @@ export const BankTransferBanner: FC = () => {
     <>
       <FeatureBanner
         isVisible={isVisible}
-        onClose={onDontRemindLater}
+        isInitialBanner={isInitialBanner}
+        onClose={onClose}
         title={t`Pay via Bank Transfer / Wire`}
         showClose={isInitialBanner}
         showNewFeatureLabel={isInitialBanner}
         description={
           isInitialBanner
-            ? t`Purchase retirements from any project on Carbonmark and pay via bank transfer`
+            ? t`Purchase retirements from any project on Carbonmark and pay via bank transfer.`
             : t`Can we remind you about this new feature later?`
         }
       >

--- a/carbonmark/components/pages/Projects/index.tsx
+++ b/carbonmark/components/pages/Projects/index.tsx
@@ -16,6 +16,7 @@ import { useRouter } from "next/router";
 import { ProjectsPageStaticProps } from "pages/projects";
 import { useEffect } from "react";
 import { SWRConfig } from "swr";
+import { BankTransferBanner } from "./Banners/BankTransfer";
 import { GridView } from "./GridView/GridView";
 import { ListView } from "./ListView/ListView";
 import LazyLoadingMapView from "./MapView/LazyLoadingMapView";
@@ -72,6 +73,7 @@ const Page: NextPage = () => {
         metaDescription={t`Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now.`}
       />
       <Layout fullContentWidth={isMap} fullContentHeight={isMap}>
+        {!isMap && <BankTransferBanner />}
         <ProjectsController
           projects={projects}
           isLoading={isLoading}

--- a/carbonmark/components/pages/Projects/index.tsx
+++ b/carbonmark/components/pages/Projects/index.tsx
@@ -72,7 +72,11 @@ const Page: NextPage = () => {
         mediaTitle={t`Marketplace | Carbonmark`}
         metaDescription={t`Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now.`}
       />
-      <Layout fullContentWidth={isMap} fullContentHeight={isMap}>
+      <Layout
+        customCss={styles.featureBanner}
+        fullContentWidth={isMap}
+        fullContentHeight={isMap}
+      >
         {!isMap && <BankTransferBanner />}
         <ProjectsController
           projects={projects}

--- a/carbonmark/components/pages/Projects/styles.ts
+++ b/carbonmark/components/pages/Projects/styles.ts
@@ -84,3 +84,23 @@ export const projectsList = css`
 export const viewContainer = css`
   grid-column: full;
 `;
+
+export const featureBanner = css`
+  &:has(.feature-banner):not(.initial-banner) {
+    padding: 17rem 2.4rem;
+  }
+
+  &:has(.feature-banner.initial-banner) {
+    padding: 20rem 2.4rem;
+  }
+
+  // required for feature banner transition
+  transition: all 0.2s ease-in-out;
+
+  ${breakpoints.desktop} {
+    &:has(.feature-banner.initial-banner),
+    &:has(.feature-banner):not(.initial-banner) {
+      padding: 16rem 2.4rem;
+    }
+  }
+`;

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -148,6 +148,8 @@ export const urls = {
     "https://docs.carbonmark.com/get-started/understanding-fees-on-carbonmark",
   payViaBankForm:
     "https://api.hsforms.com/submissions/v3/integration/submit/26010207/2f87cd63-f8a7-43e9-9483-ac541a614762",
+  payViaBankDocs:
+    "/blog/carbonmark-now-accepts-bank-transfer-as-a-payment-method",
   projects: "/projects",
   users: "/users",
   help: "/blog/getting-started",

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -6,1464 +6,64 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
-#: components/pages/Home/index.tsx:361
-msgid "0% listing fee"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:200
-msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
 msgstr ""
 
-#: components/pages/errors/Custom404.tsx:13
-#: components/pages/errors/Custom404.tsx:14
-#: components/pages/errors/Custom404.tsx:15
-#: components/pages/errors/Custom404.tsx:22
-msgid "404 - Page Not Found"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
 msgstr ""
 
-#: components/pages/errors/Custom500.tsx:13
-#: components/pages/errors/Custom500.tsx:14
-#: components/pages/errors/Custom500.tsx:15
-msgid "500 - Server Error"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
 msgstr ""
 
-#: components/pages/errors/Custom500.tsx:22
-msgid "500 - Server error occurred"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:221
-msgid "<0>* </0> Required Field"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:171
-msgid "@Username (note: this can not be changed!)"
+#. js-lingui-explicit-id
+#: components/Activities/Activity.tsx:33
+msgid "at"
 msgstr ""
 
-#: components/pages/Project/PayWithBank/index.tsx:153
-msgid "A valid email address is required"
+#. js-lingui-explicit-id
+#: components/Activities/Activity.tsx:89
+msgid "for"
 msgstr ""
 
-#: components/pages/Resources/lib/cmsDataMap.ts:77
-msgid "A-Z"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:211
-#: components/shared/Navigation/index.tsx:81
-#: components/shared/Navigation/index.tsx:118
-msgid "About"
-msgstr ""
-
-#: components/Stats/StatsListings.tsx:49
-msgid "Active listings:"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/Activities/index.tsx:24
 msgid "Activity"
 msgstr ""
 
-#: lib/getCategoryInfo.ts:53
-msgid "Agriculture"
-msgstr ""
-
-#: components/pages/Home/index.tsx:365
-msgid "All assets sourced from major registries"
-msgstr ""
-
-#: components/CreateListing/Transaction/Submit.tsx:41
-msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:92
-msgid "Amount is required"
-msgstr ""
-
-#: components/Stats/StatsBar.tsx:41
-msgid "Amount of credits from this project/vintage combination that have been retired."
-msgstr ""
-
-#: components/Stats/StatsBar.tsx:61
-msgid "Amount of credits that have been bridged from this project/vintage combination but not yet retired."
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:49
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:86
-msgid "Amount to purchase"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:158
-msgid "Amount to retire"
-msgstr ""
-
-#: components/CreateListing/Transaction/Approve.tsx:81
-#: components/Transaction/Approve.tsx:101
-msgid "Approve"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:59
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:80
-msgid "Asset"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:21
-msgid "Asset Details"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:25
-msgid "Asset ID"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/AssetDetails/index.tsx:36
 msgid "Asset details"
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:121
-msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:85
-msgid ""
-"At this time, Carbonmark cannot process credit card payments\n"
-"exceeding {0}. Please adjust the\n"
-"quantity and try again later."
-msgstr ""
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:120
-msgid "Available balance exceeded"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:86
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:100
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:238
-msgid "Available supply exceeded"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:101
-msgid "Available to list: {0}"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:210
-msgid "Available to purchase"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:34
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:363
-msgid "Available to retire"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:211
-msgid "Available:"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:54
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:75
-msgid "Available: {0}"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
-msgid "Available: {unlistedBalance}"
-msgstr ""
-
-#: components/BetaBadge/index.tsx:13
-msgid "BETA"
-msgstr ""
-
-#: components/pages/Project/Purchase/index.tsx:49
-#: components/pages/Project/Retire/index.tsx:36
-msgid "Back to Project"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:390
-msgid "Balance"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:93
-msgid "Balance exceeded"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:101
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:115
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:320
-msgid "Balance: {0}"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:443
-msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:285
-msgid "Beneficiary Address"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:256
-msgid "Beneficiary name"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:232
-#: components/pages/Project/PayWithBank/index.tsx:349
-msgid "Beneficiary wallet address"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:299
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
-msgid "Beneficiary wallet address (optional)"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:34
-#: components/pages/Project/BuyOptions/SellerListing.tsx:62
-#: components/pages/Project/index.tsx:139
-msgid "Best Price"
-msgstr ""
-
-#: lib/getCategoryInfo.ts:65
-msgid "Blue Carbon"
-msgstr ""
-
-#: components/Layout/NavDrawer/index.tsx:94
-msgid "Book a demo"
-msgstr ""
-
-#: components/pages/Home/index.tsx:160
-#: components/pages/Home/index.tsx:191
-#: components/pages/Home/index.tsx:244
-#: components/pages/Project/PayWithBank/index.tsx:370
-#: components/shared/Navigation/index.tsx:54
-#: components/shared/Navigation/index.tsx:133
-msgid "Browse Projects"
-msgstr ""
-
-#: components/Layout/NavDrawer/index.tsx:102
-msgid "Built with 🌳 by <0>KlimaDAO</0>"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:45
-msgid "Buy"
-msgstr ""
-
-#: components/pages/Home/index.tsx:171
-msgid "Buy or retire carbon"
-msgstr ""
-
-#: components/ExitModal/index.tsx:44
-msgid "Cancel"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:30
-msgid "Carbon Pool"
-msgstr ""
-
-#: components/pages/Retire/index.tsx:48
-msgid "Carbon Retirements"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
-msgstr ""
-
-#: components/pages/Home/index.tsx:177
-msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:86
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:125
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:207
-msgid "Carbonmark fee"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:101
-msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
-msgstr ""
-
-#: components/pages/Home/index.tsx:54
-#: components/pages/Home/index.tsx:55
-msgid "Carbonmark | The Universal Carbon Marketplace"
-msgstr ""
-
-#: components/pages/Home/index.tsx:491
-msgid "Carbonmark's role"
-msgstr ""
-
-#: components/ProjectFilterModal/index.tsx:130
-msgid "Category"
-msgstr ""
-
-#: components/ChangeLanguageButton/index.tsx:44
-#: components/shared/ChangeLanguageButton/index.tsx:48
-msgid "Change language"
-msgstr ""
-
-#: components/pages/Home/index.tsx:209
-msgid "Choose a project and quantity"
-msgstr ""
-
-#: components/pages/Projects/index.tsx:72
-msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
-msgstr ""
-
-#: components/ProjectFilterModal/index.tsx:162
-#: components/pages/Projects/ProjectSearch/index.tsx:52
-msgid "Clear Filters"
-msgstr ""
-
-#: components/pages/Users/ProfileHeader/index.tsx:38
-msgid "Click the 'create profile' button to customize this page and get started."
-msgstr ""
-
-#: components/CreateListing/Transaction/Submit.tsx:98
-msgid "Close"
-msgstr ""
-
-#: components/Dropdown/index.tsx:133
-msgid "Coming soon"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:167
-#: components/pages/Project/PayWithBank/index.tsx:319
-msgid "Company name"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:173
-msgid "Company name is required"
-msgstr ""
-
-#: components/pages/Home/index.tsx:348
-msgid "Compare prices across all sellers and trading pools"
-msgstr ""
-
-#: components/ProjectFilterModal/index.tsx:170
-msgid "Compiling Results ..."
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
-#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:21
-msgid "Confirm Purchase"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:75
-msgid "Confirm Retirement"
-msgstr ""
-
-#: components/Footer/index.tsx:41
-#: components/pages/Home/index.tsx:553
-msgid "Contact"
-msgstr ""
-
-#: components/ExitModal/index.tsx:39
-#: components/pages/Project/Purchase/Listing/SubmitButton.tsx:44
-#: components/pages/Project/Purchase/Pool/SubmitButton.tsx:44
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:38
-#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:34
-msgid "Continue"
-msgstr ""
-
-#: components/CopyAddressButton/index.tsx:37
-msgid "Copy"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:59
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:459
-msgid "Could not calculate Total Cost"
-msgstr ""
-
-#: components/ProjectFilterModal/index.tsx:119
-msgid "Country"
-msgstr ""
-
-#: components/pages/Retire/FromPortfolio/index.tsx:94
-msgid "Create Carbonmark Profile"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/index.tsx:118
-msgid "Create Profile"
-msgstr ""
-
-#: components/CreateListing/index.tsx:152
-msgid "Create a listing"
-msgstr ""
-
-#: components/pages/Home/index.tsx:222
-msgid "Create a profile and get connected"
-msgstr ""
-
-#: components/pages/Home/index.tsx:282
-msgid "Create a seller profile"
-msgstr ""
-
-#: components/pages/Users/index.tsx:36
-msgid "Create and edit listings, and track your activity with your Carbonmark profile."
-msgstr ""
-
-#: components/pages/Home/index.tsx:316
-msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:67
-msgid "Create your own retirement"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:82
-msgid "Created:"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:103
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:79
-msgid "Credit card minimum purchase is {0}"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:237
-msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:428
-msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:144
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
-msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
-msgstr ""
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
-msgstr ""
-
-#: components/pages/Project/index.tsx:236
-msgid "Data for this project and vintage"
-msgstr ""
-
-#: components/pages/Users/Login/index.tsx:47
-#: components/pages/Users/SellerUnconnected/index.tsx:96
-msgid "Data for this seller"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:289
-msgid "Defaults to the connected wallet address"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:300
-msgid "Describe the purpose of this retirement"
-msgstr ""
-
-#: components/pages/Project/index.tsx:187
-msgid "Description"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:51
-msgid "Digital Carbon"
-msgstr ""
-
-#: components/pages/Home/index.tsx:267
-msgid "Digitize your carbon by using a supported bridge"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:188
-msgid "Display name"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:183
-msgid "Display name is required"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:36
-msgid "Download PDF"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:36
-msgid "Downloading ..."
-msgstr ""
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:189
-msgid "Edit"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/index.tsx:118
-msgid "Edit Profile"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:201
-msgid "Edit listing"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:143
-#: components/pages/Project/PayWithBank/index.tsx:307
-msgid "Email"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:149
-msgid "Email address is required"
-msgstr ""
-
-#: lib/getCategoryInfo.ts:47
-msgid "Energy Efficiency"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:169
-msgid "Expiration"
-msgstr ""
-
-#: components/pages/Users/Badge/index.tsx:15
-msgid "Expired"
-msgstr ""
-
-#: components/pages/Home/index.tsx:464
-msgid "FAQs"
-msgstr ""
-
-#: components/pages/Projects/ProjectSearch/index.tsx:45
-msgid "Filters"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:112
-msgid "Final price"
-msgstr ""
-
-#: components/pages/Resources/index.tsx:21
-msgid "Find the latest updates, guides, and resources to help you leverage the Carbonmark platform."
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:187
-#: components/pages/Project/PayWithBank/index.tsx:331
-msgid "First name"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:193
-msgid "First name is required"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:197
-msgid "First name should not contain numbers or special characters"
-msgstr ""
-
-#: components/CreateListing/Transaction/Approve.tsx:37
-msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
-msgstr ""
-
-#: components/pages/Home/index.tsx:343
-msgid "For carbon traders"
-msgstr ""
-
-#: components/pages/Home/index.tsx:388
-msgid "For project developers"
-msgstr ""
-
-#: lib/getCategoryInfo.ts:29
-msgid "Forestry"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:289
-msgid "Form complete"
-msgstr ""
-
-#: components/pages/Home/index.tsx:79
-msgid "Get Started"
-msgstr ""
-
-#: components/pages/Home/index.tsx:393
-msgid "Get paid immediately: transactions are resolved in seconds"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
-msgid "Go back"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:152
-msgid "Handle is required"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:161
-msgid "Handle should not be an address"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:156
-msgid "Handle should not contain any special characters"
-msgstr ""
-
-#: components/Footer/index.tsx:32
-#: components/pages/Home/index.tsx:544
-#: components/shared/Navigation/index.tsx:87
-#: components/shared/Navigation/index.tsx:124
-msgid "Help"
-msgstr ""
-
-#: components/pages/Retire/index.tsx:146
-msgid "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:74
-msgid "How many tonnes do you want to list for sale?"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:90
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:104
-msgid "How many tonnes of carbon do you want to buy?"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:242
-msgid "How many tonnes of carbon do you want to retire?"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:207
-msgid "How many tonnes of carbon would you like to retire?"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:301
-msgid "How many tonnes would you like to retire?"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:122
-msgid "How much would you like to retire?"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:90
-msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:116
-msgid "Indicates required field"
-msgstr ""
-
-#: lib/getCategoryInfo.ts:59
-msgid "Industrial Processing"
-msgstr ""
-
-#: components/pages/Home/index.tsx:369
-msgid "Instant settlement of all trades"
-msgstr ""
-
-#: components/pages/Home/index.tsx:437
-msgid "Introducing Carbonmark"
-msgstr ""
-
-#: components/pages/Users/Badge/index.tsx:10
-msgid "Invalid"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:181
-#: components/pages/Project/PayWithBank/index.tsx:325
-msgid "Job title"
-msgstr ""
-
-#: components/Footer/index.tsx:38
-#: components/pages/Home/index.tsx:550
-msgid "KlimaDAO"
-msgstr ""
-
-#: components/pages/Home/index.tsx:527
-msgid "KlimaDAO provides the transparent, neutral, and public infrastructure required to accelerate climate finance on a global scale."
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:206
-#: components/pages/Project/PayWithBank/index.tsx:337
-msgid "Last name"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:212
-msgid "Last name is required"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:216
-msgid "Last name should not contain numbers or special characters"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:67
-msgid "Latest First"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:101
-msgid "Learn More"
-msgstr ""
-
-#: components/pages/Home/index.tsx:420
-msgid "Learn more"
-msgstr ""
-
-#: components/pages/Home/index.tsx:494
-msgid "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
-msgstr ""
-
-#: components/pages/Home/index.tsx:399
-msgid "List and sell for free"
-msgstr ""
-
-#: components/pages/Home/index.tsx:295
-msgid "List your projects for sale in just a few clicks"
-msgstr ""
-
-#: components/pages/Portfolio/AssetProject/index.tsx:78
-msgid "Listed tonnes:"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/index.tsx:133
-#: components/pages/Users/SellerUnconnected/index.tsx:54
-msgid "Listings"
-msgstr ""
-
-#: components/pages/Portfolio/CarbonmarkAssets.tsx:57
-#: components/pages/Retire/FromPortfolio/index.tsx:60
-msgid "Loading your assets"
-msgstr ""
-
-#: components/Layout/NavDrawer/index.tsx:53
-#: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:285
-#: components/pages/Retire/Activity/Overview.tsx:73
-#: components/pages/Retire/Activity/Overview.tsx:84
-msgid "Loading..."
-msgstr ""
-
-#: components/Layout/NavDrawer/index.tsx:64
-#: components/LoginButton/index.tsx:13
-msgid "Log in"
-msgstr ""
-
-#: components/pages/Users/Login/index.tsx:34
-msgid "Log in to create a Carbonmark profile"
-msgstr ""
-
-#: components/Layout/NavDrawer/index.tsx:74
-#: components/LoginButton/index.tsx:15
-msgid "Log out"
-msgstr ""
-
-#: components/Layout/index.tsx:95
-#: components/LoginCard/index.tsx:32
-msgid "Login"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:373
-msgid "Login to pay with USDC"
-msgstr ""
-
-#: components/shared/Navigation/index.tsx:63
-#: components/shared/Navigation/index.tsx:100
-msgid "Marketplace"
-msgstr ""
-
-#: components/pages/Projects/index.tsx:70
-#: components/pages/Projects/index.tsx:71
-msgid "Marketplace | Carbonmark"
-msgstr ""
-
-#: components/pages/Home/index.tsx:174
-msgid "Maximize your climate impact."
-msgstr ""
-
-#: components/pages/Project/index.tsx:146
-msgid "Methodology"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:52
-msgid "Moss"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:99
-msgid "New Quantity"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:134
-msgid "New Unit Price (USDC)"
-msgstr ""
-
-#: components/CreateListing/Transaction/Approve.tsx:88
-msgid "Next"
-msgstr ""
-
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
-msgstr ""
-
-#: components/pages/Users/SellerConnected/index.tsx:196
-#: components/pages/Users/SellerUnconnected/index.tsx:90
-msgid "No active listings."
-msgstr ""
-
-#: components/pages/Retire/Activity/Quotes.tsx:38
-msgid "No activity to show"
-msgstr ""
-
-#: components/pages/Home/index.tsx:403
-msgid "No barriers to entry for verified carbon projects"
-msgstr ""
-
-#: components/pages/Retire/Activity/Overview.tsx:62
-msgid "No data to show"
-msgstr ""
-
-#: components/pages/Portfolio/CarbonmarkAssets.tsx:96
-msgid "No listable assets found."
-msgstr ""
-
-#: components/pages/Project/index.tsx:226
-msgid "No listings found for this project."
-msgstr ""
-
-#: components/pages/Projects/GridView/GridView.tsx:38
-#: components/pages/Projects/ListView/ListView.tsx:157
-msgid "No project description found"
-msgstr ""
-
-#: components/pages/Projects/index.tsx:86
-msgid "No projects found with current filters"
-msgstr ""
-
-#: components/ProjectCard/index.tsx:64
-msgid "No props.project description found"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:22
-msgid "No retirement message provided."
-msgstr ""
-
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:240
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:281
-msgid "Not a valid polygon address"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:72
-msgid "Oldest First"
-msgstr ""
-
-#: lib/getCategoryInfo.ts:41
-msgid "Other"
-msgstr ""
-
-#: lib/getCategoryInfo.ts:35
-msgid "Other Nature-Based"
-msgstr ""
-
-#: components/pages/Home/index.tsx:101
-msgid "Our Partners"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:35
-msgid "Our system is taking longer than expected. The retirement should appear in your<0>retirement history</0> soon."
-msgstr ""
-
-#: components/pages/Home/index.tsx:121
-msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
-msgstr ""
-
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:89
-#: components/pages/Project/PayWithBank/index.tsx:90
-msgid "Pay with Bank Transfer | Carbonmark"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:98
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:112
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:316
-msgid "Pay with:"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:61
-msgid "Payment Successful"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:233
-msgid "Payment processing fee"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:161
-#: components/pages/Project/PayWithBank/index.tsx:313
-msgid "Phone number"
-msgstr ""
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:30
-msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
-msgstr ""
-
-#: components/pages/Portfolio/index.tsx:66
-#: components/pages/Users/SellerConnected/index.tsx:81
-#: components/pages/Users/SellerConnected/index.tsx:107
-msgid "Please refresh the page. There was an error updating your data: {e}."
-msgstr ""
-
-#: components/pages/Portfolio/index.tsx:76
-#: components/pages/Portfolio/index.tsx:77
-msgid "Portfolio | Carbonmark"
-msgstr ""
-
-#: components/pages/Home/index.tsx:521
-msgid "Powered by"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:56
-msgid "Press Releases"
-msgstr ""
-
-#: components/ProjectFilterModal/constants.tsx:11
-msgid "Price Highest"
-msgstr ""
-
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:170
-msgid "Price includes network fees. <0>See docs to learn more.</0>"
-msgstr ""
-
-#: components/CreateListing/Transaction/Submit.tsx:62
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:94
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:166
-msgid "Price per tonne"
-msgstr ""
-
-#: components/Footer/index.tsx:26
-msgid "Privacy Policy"
-msgstr ""
-
-#: components/pages/Home/index.tsx:538
-msgid "Privacy policy"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:384
-msgid "Processing Fee:"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:83
-msgid "Processing Purchase"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:73
-msgid "Processing Retirement"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:80
-msgid "Processing retirement..."
-msgstr ""
-
-#: components/shared/Navigation/index.tsx:69
-#: components/shared/Navigation/index.tsx:106
-msgid "Profile"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:199
-msgid "Profile picture"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:253
-#: components/pages/Project/PayWithBank/index.tsx:357
-msgid "Project names of interest"
-msgstr ""
-
-#: components/pages/Retire/FromPortfolio/index.tsx:79
-msgid "Purchase Carbon"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:35
-#: components/pages/Purchases/index.tsx:36
-msgid "Purchase Receipt | Carbonmark"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:52
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
-msgid "Purchase amount (tonnes):"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:104
-msgid "Purchase more Carbon"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
-msgid "Purchase successful"
-msgstr ""
-
-#: components/pages/Project/Purchase/index.tsx:37
-#: components/pages/Project/Purchase/index.tsx:38
-msgid "Purchase {0} | Carbonmark"
-msgstr ""
-
-#: components/pages/Retire/Activity/Table.tsx:47
-msgid "QTY"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:97
-#: components/CreateListing/Transaction/Submit.tsx:53
-msgid "Quantity"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:41
-#: components/pages/Project/BuyOptions/SellerListing.tsx:78
-msgid "Quantity Available:"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:233
-msgid "Quantity is required"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:127
-msgid "Quantity listed: {listedQuantity}, Quantity unlisted: {unlistedQuantity}, Total available: {totalAvailableQuantity}"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:103
-msgid "Quantity purchased:"
-msgstr ""
-
-#: components/pages/Retire/index.tsx:141
-msgid "Quick Retire"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr ""
-
-#: components/pages/Project/index.tsx:200
-msgid "Read Less"
-msgstr ""
-
-#: components/pages/Project/index.tsx:200
-msgid "Read More"
-msgstr ""
-
-#: components/pages/Home/index.tsx:448
-#: components/pages/Home/index.tsx:475
-#: components/pages/Home/index.tsx:502
-#: components/pages/Resources/BlogPostCard/index.tsx:38
-#: components/pages/Resources/FeaturedArticles/Article.tsx:45
-msgid "Read more"
-msgstr ""
-
-#: components/pages/Home/index.tsx:354
-msgid "Real-time price and transaction data powered by the blockchain"
-msgstr ""
-
-#: components/ProjectFilterModal/constants.tsx:13
-msgid "Recently Updated"
-msgstr ""
-
-#: components/Stats/StatsBar.tsx:55
-msgid "Remaining Supply:"
-msgstr ""
-
-#: lib/getCategoryInfo.ts:23
-msgid "Renewable Energy"
-msgstr ""
-
-#: components/pages/Home/index.tsx:304
-#: components/pages/Home/index.tsx:328
-msgid "Request Demo"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:202
-msgid "Required Field"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:260
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:304
-msgid "Required when proceeding with Credit Card"
-msgstr ""
-
-#: components/Footer/index.tsx:35
-#: components/pages/Home/index.tsx:511
-#: components/pages/Home/index.tsx:547
-#: components/pages/Resources/ResourcesList/index.tsx:154
-#: components/shared/Navigation/index.tsx:75
-#: components/shared/Navigation/index.tsx:112
-msgid "Resources"
-msgstr ""
-
-#: components/pages/Resources/index.tsx:19
-#: components/pages/Resources/index.tsx:20
-msgid "Resources | Carbonmark"
-msgstr ""
-
-#: components/ProjectFilterModal/index.tsx:168
-msgid "Result"
-msgstr ""
-
-#: components/ProjectFilterModal/index.tsx:168
-msgid "Results"
-msgstr ""
-
-#: components/pages/Portfolio/AssetProject/index.tsx:85
-msgid "Retire"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
-msgid "Retire Carbon"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:207
-msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
-msgstr ""
-
-#: components/pages/Retire/index.tsx:77
-msgid "Retire from a featured project"
-msgstr ""
-
-#: components/pages/Retire/index.tsx:114
-msgid "Retire from your portfolio"
-msgstr ""
-
-#: components/pages/Project/Retire/index.tsx:24
-#: components/pages/Project/Retire/index.tsx:25
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr ""
-
-#: components/pages/Home/index.tsx:235
-msgid "Retire instantly, or purchase and hold digital carbon"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
-msgid "Retire more carbon"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:56
-msgid "Retire now"
-msgstr ""
-
-#: components/pages/Home/index.tsx:184
-msgid "Retire now, or acquire carbon to retire later - you decide what to do when you take ownership of your carbon assets."
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:91
-msgid "Retire your carbon via bank transfer."
-msgstr ""
-
-#: components/pages/Portfolio/Retire/index.tsx:92
-#: components/pages/Portfolio/Retire/index.tsx:93
-#: components/pages/Retire/index.tsx:39
-#: components/pages/Retire/index.tsx:40
-msgid "Retire | Carbonmark"
-msgstr ""
-
-#: components/pages/Retire/Activity/Quotes.tsx:32
-msgid "Retirement Activity"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:294
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:308
-msgid "Retirement Message"
-msgstr ""
-
-#: components/pages/Retire/Activity/Overview.tsx:60
-#: components/pages/Retire/Activity/Overview.tsx:70
-msgid "Retirement Overview"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:264
-#: components/pages/Project/PayWithBank/index.tsx:363
-msgid "Retirement message"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:74
-msgid "Retirement successful"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:362
-msgid "Retiring Token"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:208
-msgid "Say a few words about yourself. This will be visible in your seller profile."
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:99
-msgid "See your portfolio"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:104
-msgid "See your retirement receipt"
-msgstr ""
-
-#: components/pages/Portfolio/AssetProject/index.tsx:98
-#: components/pages/Portfolio/AssetProject/index.tsx:106
-msgid "Sell"
-msgstr ""
-
-#: components/pages/Home/index.tsx:313
-msgid "Sell carbon"
-msgstr ""
-
-#: components/pages/Home/index.tsx:409
-msgid "Sell your digital carbon directly to buyers"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:58
-msgid "Seller Listing"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
-#: components/pages/Project/Purchase/Pool/SubmitButton.tsx:31
-msgid "Sign In / Connect To Buy"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:129
-msgid "Single unit price"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
-msgid "Something went wrong loading the allowance"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:75
-msgid "Something went wrong. Please try again."
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:112
-msgid "Something went wrong. Please try again. {error}"
-msgstr ""
-
-#: components/pages/errors/Custom404.tsx:25
-msgid "Sorry, looks like we sent you the wrong way."
-msgstr ""
-
-#: components/pages/errors/Custom500.tsx:25
-msgid "Sorry, something went wrong."
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "Sorry, this handle already exists"
-msgstr ""
-
-#: components/Stats/index.tsx:23
-msgid "Stats"
-msgstr ""
-
-#: components/pages/Home/index.tsx:204
-#: components/pages/Home/index.tsx:262
-msgid "Step 1"
-msgstr ""
-
-#: components/pages/Home/index.tsx:217
-#: components/pages/Home/index.tsx:277
-msgid "Step 2"
-msgstr ""
-
-#: components/pages/Home/index.tsx:230
-#: components/pages/Home/index.tsx:290
-msgid "Step 3"
-msgstr ""
-
-#: components/CreateListing/Transaction/Submit.tsx:90
-#: components/pages/Project/PayWithBank/index.tsx:279
-msgid "Submit"
-msgstr ""
-
-#: components/pages/Portfolio/CarbonmarkAssets.tsx:85
-msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
-msgstr ""
-
-#: components/shared/InvalidNetworkModal/index.tsx:74
-msgid "Switch to Polygon"
-msgstr ""
-
-#: components/Footer/index.tsx:29
-msgid "Terms of Use"
-msgstr ""
-
-#: components/pages/Home/index.tsx:541
-msgid "Terms of use"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
-msgid "Thank you for supporting the planet!"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:72
-msgid "Thank you for supporting the planet! See purchase details below."
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:292
-msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
-msgstr ""
-
-#: components/pages/Home/index.tsx:68
-msgid "The Universal Carbon Marketplace"
-msgstr ""
-
-#: components/CreateListing/Transaction/Approve.tsx:50
-msgid "The allowance below reflects the sum of all your listings for this specific token."
-msgstr ""
-
-#: components/CreateListing/Transaction/Approve.tsx:43
-msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:34
-msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
-msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:213
-msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
-msgstr ""
-
-#: components/pages/Home/index.tsx:56
-#: components/pages/Home/index.tsx:71
-msgid "The largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading."
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:96
-msgid "The minimum amount to buy is 1 Tonne"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:55
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:61
-msgid "The minimum amount to retire is 0.001 Tonnes"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:133
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:73
-msgid "The minimum amount to retire is 1 Tonne"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:97
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:103
-msgid "The minimum amount to retire via bank transfer is 100 Tonnes"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:53
-msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
-msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:190
-msgid "There was an error during the checkout process. Please try again."
-msgstr ""
-
-#: components/pages/Retire/Activity/List.tsx:44
-msgid "There was an error getting your retirement data. Please refresh the page to try again."
-msgstr ""
-
-#: components/pages/Retire/Activity/Overview.tsx:49
-msgid "There was an error getting your total retirement data"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:61
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:124
-msgid "There was an error loading the total cost."
-msgstr ""
-
-#: components/shared/InvalidNetworkModal/index.tsx:70
-msgid "This app only works on Polygon Mainnet."
-msgstr ""
-
-#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
-msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
-msgstr ""
-
-#: components/pages/Users/Badge/index.tsx:17
-msgid "This listing has expired and is hidden from the marketplace. Please resubmit or delete the listing."
-msgstr ""
-
-#: components/pages/Users/Badge/index.tsx:12
-msgid "This listing is no longer valid and is hidden from the marketplace. Please resubmit or delete the listing."
-msgstr ""
-
-#: components/pages/Project/Purchase/InactivePurchase.tsx:24
-msgid "This offer no longer exists."
-msgstr ""
-
-#: components/BetaBadge/index.tsx:9
-msgid "This product is still in Beta and audits have not been completed yet."
-msgstr ""
-
-#: components/pages/Users/ProfileHeader/index.tsx:46
-msgid "This user has not yet created a carbonmark profile."
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
-msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:60
-msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
-msgstr ""
-
-#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:25
-msgid "To get started, be sure to complete your <0>profile</0> and then head to the <1>marketplace</1> to purchase carbon assets."
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:25
-msgid "To pay via bank transfer, we'll need to gather some information from you."
-msgstr ""
-
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr ""
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:110
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
-msgid "Toggle payment method"
-msgstr ""
-
-#: components/pages/Projects/ProjectSort/index.tsx:29
-msgid "Toggle sort menu"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
-msgid "Token you will receive"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
-msgid "Tokens received:"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/AssetDetails/index.tsx:54
 #: components/pages/Project/PayWithBank/index.tsx:125
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:51
@@ -1474,194 +74,917 @@ msgstr ""
 msgid "Tonnes"
 msgstr ""
 
-#: components/Stats/StatsListings.tsx:42
-msgid "Tonnes listed:"
-msgstr ""
-
-#: components/Stats/StatsListings.tsx:35
-msgid "Tonnes sold:"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:462
-msgid "Total Cost is required"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr ""
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr ""
-
-#: components/CreateListing/Transaction/Approve.tsx:59
-msgid "Total allowance"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:129
-msgid "Total amount of tonnes to retire is required"
-msgstr ""
-
-#: components/pages/Retire/Activity/Overview.tsx:72
-msgid "Total carbon tonnes retired"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:263
-msgid "Total cost"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:156
-msgid "Total price"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
-msgid "Total quantity to list for sale"
-msgstr ""
-
-#: components/pages/Retire/Activity/Overview.tsx:83
-msgid "Total retirement transactions"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
-msgid "Total sale cost"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:106
-msgid "USDC per tonne"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:111
-msgid "Unit price is required"
-msgstr ""
-
-#: components/pages/Portfolio/AssetProject/index.tsx:74
-msgid "Unlisted tonnes:"
-msgstr ""
-
-#: components/pages/Home/index.tsx:322
-msgid "Unprecedented transparency across the digital carbon market."
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:183
-msgid "Update listing"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:86
-msgid "Updated:"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/index.tsx:190
-msgid "Updating your data..."
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:61
-msgid "User Guides"
-msgstr ""
-
-#: components/pages/Users/Login/index.tsx:32
-#: components/pages/Users/Login/index.tsx:33
-msgid "User Profile | Carbonmark"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:41
-msgid "Verify all information is correct and click 'approve' to continue."
-msgstr ""
-
-#: components/ViewWalletButton/index.tsx:25
-msgid "View"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:50
-msgid "View Carbonmark Profile"
-msgstr ""
-
-#: components/pages/Project/index.tsx:209
-msgid "View Registry Details <0/>"
-msgstr ""
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
-msgstr ""
-
-#: components/pages/Portfolio/index.tsx:78
-msgid "View a complete overview of the digital carbon that you own in your Portfolio."
-msgstr ""
-
-#: components/pages/Portfolio/Retire/index.tsx:94
-msgid "View a complete overview of the digital carbon that you own in your Retire."
-msgstr ""
-
-#: components/pages/Retire/index.tsx:41
-msgid "View a complete overview of the digital carbon that you retired."
-msgstr ""
-
-#: components/pages/Retire/index.tsx:118
-msgid "View all Portfolio items"
-msgstr ""
-
-#: components/pages/Retire/index.tsx:83
-msgid "View all Projects"
-msgstr ""
-
-#: components/pages/Retire/Activity/Quotes.tsx:85
-#: components/pages/Retire/Activity/Table.tsx:77
-msgid "View all Retirements"
-msgstr ""
-
-#: components/pages/Project/index.tsx:116
-msgid "View and purchase this carbon offset project on Carbonmark"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:74
-msgid "View and share certificate"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/AssetDetails/index.tsx:60
 msgid "View on PolygonScan"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:47
-msgid "View on PolygonScan <0/>"
+#. js-lingui-explicit-id
+#: components/BetaBadge/index.tsx:9
+msgid "This product is still in Beta and audits have not been completed yet."
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:29
-msgid "View the project details and other info for this purchase."
+#. js-lingui-explicit-id
+#: components/BetaBadge/index.tsx:13
+msgid "BETA"
 msgstr ""
 
-#: components/ProjectFilterModal/index.tsx:141
-msgid "Vintage"
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:44
+#: components/shared/ChangeLanguageButton/index.tsx:48
+msgid "Change language"
 msgstr ""
 
-#: components/ProjectFilterModal/constants.tsx:14
-msgid "Vintage Newest"
+#. js-lingui-explicit-id
+#: components/CopyAddressButton/index.tsx:37
+msgid "Copy"
 msgstr ""
 
-#: components/ProjectFilterModal/constants.tsx:15
-msgid "Vintage Oldest"
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:59
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:80
+msgid "Asset"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:65
-msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:74
+msgid "How many tonnes do you want to list for sale?"
 msgstr ""
 
-#: components/pages/Retire/FromPortfolio/index.tsx:74
-#: components/pages/Retire/FromPortfolio/index.tsx:89
-msgid "We couldn't find any assets in your portfolio."
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:93
+msgid "Balance exceeded"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:89
-msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:97
+#: components/CreateListing/Transaction/Submit.tsx:53
+msgid "Quantity"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:101
+msgid "Available to list: {0}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:106
+msgid "USDC per tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:111
+msgid "Unit price is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:129
+msgid "Single unit price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/index.tsx:152
+msgid "Create a listing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:37
+msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:43
+msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:50
+msgid "The allowance below reflects the sum of all your listings for this specific token."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:59
+msgid "Total allowance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:81
+#: components/Transaction/Approve.tsx:101
+msgid "Approve"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:88
+msgid "Next"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:61
+msgid "{0} tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:41
+msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:47
+msgid "You can delete this listing at any time."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:62
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:94
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:166
+msgid "Price per tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:90
+#: components/pages/Project/PayWithBank/index.tsx:279
+msgid "Submit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:98
+msgid "Close"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Dropdown/index.tsx:133
+msgid "Coming soon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:39
+#: components/pages/Project/Purchase/Listing/SubmitButton.tsx:44
+#: components/pages/Project/Purchase/Pool/SubmitButton.tsx:44
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:38
+#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:34
+msgid "Continue"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:44
+msgid "Cancel"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/FeatureBanner/index.tsx:31
+msgid "NEW FEATURE:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:26
+msgid "Privacy Policy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:29
+msgid "Terms of Use"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:32
+#: components/pages/Home/index.tsx:544
+#: components/shared/Navigation/index.tsx:87
+#: components/shared/Navigation/index.tsx:124
+msgid "Help"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:35
+#: components/pages/Home/index.tsx:511
+#: components/pages/Home/index.tsx:547
+#: components/pages/Resources/ResourcesList/index.tsx:154
+#: components/shared/Navigation/index.tsx:75
+#: components/shared/Navigation/index.tsx:112
+msgid "Resources"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:38
+#: components/pages/Home/index.tsx:550
+msgid "KlimaDAO"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:41
+#: components/pages/Home/index.tsx:553
+msgid "Contact"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:95
+#: components/LoginCard/index.tsx:32
+msgid "Login"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:53
+#: components/LoginButton/index.tsx:11
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:285
+#: components/pages/Retire/Activity/Overview.tsx:73
+#: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
+msgid "Loading..."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:64
+#: components/LoginButton/index.tsx:13
+msgid "Log in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:74
+#: components/LoginButton/index.tsx:15
+msgid "Log out"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:94
+msgid "Book a demo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:102
+msgid "Built with 🌳 by <0>KlimaDAO</0>"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom404.tsx:13
+#: components/pages/errors/Custom404.tsx:14
+#: components/pages/errors/Custom404.tsx:15
+#: components/pages/errors/Custom404.tsx:22
+msgid "404 - Page Not Found"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom404.tsx:25
+msgid "Sorry, looks like we sent you the wrong way."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:13
+#: components/pages/errors/Custom500.tsx:14
+#: components/pages/errors/Custom500.tsx:15
+msgid "500 - Server Error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:22
+msgid "500 - Server error occurred"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:25
+msgid "Sorry, something went wrong."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:54
+#: components/pages/Home/index.tsx:55
+msgid "Carbonmark | The Universal Carbon Marketplace"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:56
+#: components/pages/Home/index.tsx:71
+msgid "The largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:68
+msgid "The Universal Carbon Marketplace"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:79
+msgid "Get Started"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:101
+msgid "Our Partners"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:121
+msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:160
+#: components/pages/Home/index.tsx:191
+#: components/pages/Home/index.tsx:244
+#: components/pages/Project/PayWithBank/index.tsx:370
+#: components/shared/Navigation/index.tsx:54
+#: components/shared/Navigation/index.tsx:133
+msgid "Browse Projects"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:171
+msgid "Buy or retire carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:174
+msgid "Maximize your climate impact."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:177
+msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:184
+msgid "Retire now, or acquire carbon to retire later - you decide what to do when you take ownership of your carbon assets."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:204
+#: components/pages/Home/index.tsx:262
+msgid "Step 1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:209
+msgid "Choose a project and quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:217
+#: components/pages/Home/index.tsx:277
+msgid "Step 2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:222
+msgid "Create a profile and get connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:230
+#: components/pages/Home/index.tsx:290
+msgid "Step 3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:235
+msgid "Retire instantly, or purchase and hold digital carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:267
+msgid "Digitize your carbon by using a supported bridge"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:282
+msgid "Create a seller profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:295
+msgid "List your projects for sale in just a few clicks"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:304
+#: components/pages/Home/index.tsx:328
+msgid "Request Demo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:313
+msgid "Sell carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:316
+msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:322
+msgid "Unprecedented transparency across the digital carbon market."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:343
+msgid "For carbon traders"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:348
+msgid "Compare prices across all sellers and trading pools"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:354
+msgid "Real-time price and transaction data powered by the blockchain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:361
+msgid "0% listing fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:365
+msgid "All assets sourced from major registries"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:369
+msgid "Instant settlement of all trades"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:388
+msgid "For project developers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:393
+msgid "Get paid immediately: transactions are resolved in seconds"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:399
+msgid "List and sell for free"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:403
+msgid "No barriers to entry for verified carbon projects"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:409
+msgid "Sell your digital carbon directly to buyers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:420
+msgid "Learn more"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:437
+msgid "Introducing Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:440
+msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:448
+#: components/pages/Home/index.tsx:475
+#: components/pages/Home/index.tsx:502
+#: components/pages/Resources/BlogPostCard/index.tsx:38
+#: components/pages/Resources/FeaturedArticles/Article.tsx:45
+msgid "Read more"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:464
+msgid "FAQs"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Home/index.tsx:467
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:491
+msgid "Carbonmark's role"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:494
+msgid "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:521
+msgid "Powered by"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:527
+msgid "KlimaDAO provides the transparent, neutral, and public infrastructure required to accelerate climate finance on a global scale."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:538
+msgid "Privacy policy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:541
+msgid "Terms of use"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/AssetProject/index.tsx:74
+msgid "Unlisted tonnes:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/AssetProject/index.tsx:78
+msgid "Listed tonnes:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/AssetProject/index.tsx:85
+msgid "Retire"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/AssetProject/index.tsx:98
+#: components/pages/Portfolio/AssetProject/index.tsx:106
+msgid "Sell"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/CarbonmarkAssets.tsx:57
+#: components/pages/Retire/FromPortfolio/index.tsx:60
+msgid "Loading your assets"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/CarbonmarkAssets.tsx:85
+msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/CarbonmarkAssets.tsx:96
+msgid "No listable assets found."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/index.tsx:66
+#: components/pages/Users/SellerConnected/index.tsx:81
+#: components/pages/Users/SellerConnected/index.tsx:107
+msgid "Please refresh the page. There was an error updating your data: {e}."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/index.tsx:76
+#: components/pages/Portfolio/index.tsx:77
+msgid "Portfolio | Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/index.tsx:78
+msgid "View a complete overview of the digital carbon that you own in your Portfolio."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/PortfolioSidebar.tsx:26
+#: components/pages/Users/SellerConnected/index.tsx:214
+msgid "Your seller data"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/index.tsx:92
+#: components/pages/Portfolio/Retire/index.tsx:93
+#: components/pages/Retire/index.tsx:39
+#: components/pages/Retire/index.tsx:40
+msgid "Retire | Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/index.tsx:94
+msgid "View a complete overview of the digital carbon that you own in your Retire."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:207
+msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:213
+msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:221
+msgid "<0>* </0> Required Field"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
+msgid "Available: {unlistedBalance}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:299
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
+msgid "Beneficiary wallet address (optional)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:21
+msgid "Asset Details"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:25
+msgid "Asset ID"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:29
+msgid "{tokenSymbol}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:34
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:363
+msgid "Available to retire"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:37
+msgid "tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:47
+msgid "View on PolygonScan <0/>"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:48
+msgid "You can view the successful transaction now on<0> PolygonScan.</0>"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
+msgid "Retire more carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:74
+msgid "View and share certificate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
+msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:19
+msgid "You must have a profile created to view carbon assets you own in your Carbonmark portfolio."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:25
+msgid "To get started, be sure to complete your <0>profile</0> and then head to the <1>marketplace</1> to purchase carbon assets."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:30
+msgid "Carbon Pool"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:34
+#: components/pages/Project/BuyOptions/SellerListing.tsx:62
+#: components/pages/Project/index.tsx:139
+msgid "Best Price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:41
+#: components/pages/Project/BuyOptions/SellerListing.tsx:78
+msgid "Quantity Available:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:45
+msgid "Buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:56
+msgid "Retire now"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:58
+msgid "Seller Listing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:82
+msgid "Created:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:86
+msgid "Updated:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:116
+msgid "View and purchase this carbon offset project on Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:146
+msgid "Methodology"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:187
+msgid "Description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:200
+msgid "Read Less"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:200
+msgid "Read More"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:209
+msgid "View Registry Details <0/>"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:226
+msgid "No listings found for this project."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:236
+msgid "Data for this project and vintage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:75
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:89
+#: components/pages/Project/PayWithBank/index.tsx:90
+msgid "Pay with Bank Transfer | Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:91
+msgid "Retire your carbon via bank transfer."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:101
+msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:116
+msgid "Indicates required field"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:122
+msgid "How much would you like to retire?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:129
+msgid "Total amount of tonnes to retire is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:133
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:73
+msgid "The minimum amount to retire is 1 Tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:143
+#: components/pages/Project/PayWithBank/index.tsx:307
+msgid "Email"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:149
+msgid "Email address is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:153
+msgid "A valid email address is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:161
+#: components/pages/Project/PayWithBank/index.tsx:313
+msgid "Phone number"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:167
+#: components/pages/Project/PayWithBank/index.tsx:319
+msgid "Company name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:173
+msgid "Company name is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:181
+#: components/pages/Project/PayWithBank/index.tsx:325
+msgid "Job title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:187
+#: components/pages/Project/PayWithBank/index.tsx:331
+msgid "First name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:193
+msgid "First name is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:197
+msgid "First name should not contain numbers or special characters"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:206
+#: components/pages/Project/PayWithBank/index.tsx:337
+msgid "Last name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:212
+msgid "Last name is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:216
+msgid "Last name should not contain numbers or special characters"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:250
@@ -1669,780 +992,2069 @@ msgstr ""
 msgid "Who will this retirement be credited to?"
 msgstr ""
 
-#: components/shared/InvalidNetworkModal/index.tsx:64
-msgid "Wrong Network"
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:232
+#: components/pages/Project/PayWithBank/index.tsx:349
+msgid "Beneficiary wallet address"
 msgstr ""
 
-#: components/pages/Retire/Activity/Quotes.tsx:71
-#: lib/formatWalletAddress.ts:9
-#: lib/formatWalletAddress.ts:21
-msgid "You"
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:240
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:281
+msgid "Not a valid polygon address"
 msgstr ""
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
-msgid "You are about to purchase a carbon asset."
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:253
+#: components/pages/Project/PayWithBank/index.tsx:357
+msgid "Project names of interest"
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:31
-msgid "You are about to retire a carbon asset."
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:264
+#: components/pages/Project/PayWithBank/index.tsx:363
+msgid "Retirement message"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:123
-msgid "You can also retire any carbon asset in your wallet."
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:289
+msgid "Form complete"
 msgstr ""
 
-#: components/CreateListing/Transaction/Submit.tsx:47
-msgid "You can delete this listing at any time."
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:292
+msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:48
-msgid "You can view the successful transaction now on <0>PolygonScan.</0>"
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:301
+msgid "How many tonnes would you like to retire?"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:48
-msgid "You can view the successful transaction now on<0> PolygonScan.</0>"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/InactivePurchase.tsx:24
+msgid "This offer no longer exists."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:110
-msgid "You chose to reject the transaction."
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/index.tsx:37
+#: components/pages/Project/Purchase/index.tsx:38
+msgid "Purchase {0} | Carbonmark"
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:275
-msgid "You either need to provide a beneficiary address or login with your browser wallet."
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/index.tsx:49
+#: components/pages/Project/Retire/index.tsx:36
+msgid "Back to Project"
 msgstr ""
 
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:63
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:65
-msgid "You exceeded your available amount of tokens"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:19
-msgid "You must have a profile created to view carbon assets you own in your Carbonmark portfolio."
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:43
-msgid "You successfully acquired carbon!"
-msgstr ""
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:405
-msgid "Your balance must equal at least 1% more than the cost of the transaction."
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:129
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:172
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:292
-msgid "Your balance:"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:178
-msgid "Your display name"
-msgstr ""
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
-msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
-msgstr ""
-
-#: components/pages/Portfolio/PortfolioSidebar.tsx:26
-#: components/pages/Users/SellerConnected/index.tsx:214
-msgid "Your seller data"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:84
-msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:144
-msgid "Your unique handle"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:82
-msgid "Z-A"
-msgstr ""
-
-#: components/pages/Home/index.tsx:440
-msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
-msgstr ""
-
-#: components/Activities/Activity.tsx:33
-msgid "at"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr ""
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:104
-msgid "buy"
-msgstr ""
-
-#: components/Layout/index.tsx:86
-msgid "connectModal.torus"
-msgstr ""
-
-#: components/Layout/index.tsx:90
-msgid "connectModal.wallet"
-msgstr ""
-
-#: components/Layout/index.tsx:96
-msgid "connect_modal.connecting"
-msgstr ""
-
-#: lib/constants.ts:80
-msgid "connect_modal.error_message_default"
-msgstr ""
-
-#: lib/constants.ts:84
-msgid "connect_modal.error_message_refused"
-msgstr ""
-
-#: lib/constants.ts:88
-msgid "connect_modal.error_processing"
-msgstr ""
-
-#: components/Layout/index.tsx:100
-msgid "connect_modal.error_title"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/Project/Purchase/Listing/Price.tsx:18
 #: components/pages/Project/Purchase/Pool/Price.tsx:17
 #: components/pages/Project/Retire/Pool/Price.tsx:17
 msgid "each"
 msgstr ""
 
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:52
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
+msgid "Purchase amount (tonnes):"
 msgstr ""
 
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:54
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:75
+msgid "Available: {0}"
 msgstr ""
 
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:86
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:100
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:238
+msgid "Available supply exceeded"
 msgstr ""
 
-#: components/Activities/Activity.tsx:89
-msgid "for"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:90
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:104
+msgid "How many tonnes of carbon do you want to buy?"
 msgstr ""
 
-#: components/pages/Retire/index.tsx:53
-msgid "for beneficiary"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:98
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:112
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:316
+msgid "Pay with:"
 msgstr ""
 
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:101
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:115
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:320
+msgid "Balance: {0}"
 msgstr ""
 
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:110
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
+msgid "Toggle payment method"
 msgstr ""
 
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:144
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
+msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
 msgstr ""
 
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
+#: components/pages/Project/Purchase/Pool/SubmitButton.tsx:31
+msgid "Sign In / Connect To Buy"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:229
-msgid "offset.amount_in_tonnes"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:319
-msgid "offset.default_retirement_address"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:49
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:86
+msgid "Amount to purchase"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:252
-msgid "offset.offset_quantity"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:170
+msgid "Price includes network fees. <0>See docs to learn more.</0>"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:403
-msgid "offset.retire_carbon"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:86
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:125
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:207
+msgid "Carbonmark fee"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:282
-msgid "offset.retirement_beneficiary_name"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:263
+msgid "Total cost"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:270
-msgid "offset.retirement_credit"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:129
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:172
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:292
+msgid "Your balance:"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:328
-msgid "offset.retirement_message"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
+msgid "Something went wrong loading the allowance"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:339
-msgid "offset.retirement_retirement_message"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
+msgid "Token you will receive"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:210
+msgid "Available to purchase"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:59
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:459
+msgid "Could not calculate Total Cost"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:63
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:65
+msgid "You exceeded your available amount of tokens"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:360
-msgid "offset_disclaimer"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:92
+msgid "Amount is required"
 msgstr ""
 
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:96
+msgid "The minimum amount to buy is 1 Tonne"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:135
-msgid "profile.addListing_modal.submit"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:405
+msgid "Your balance must equal at least 1% more than the cost of the transaction."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:230
-msgid "profile.edit_modal.submit"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
+msgid "You are about to purchase a carbon asset."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:220
-msgid "profile.edit_profile.title"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
+msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
 msgstr ""
 
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:155
-msgid "profile.listing.delete.error"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:41
+msgid "Verify all information is correct and click 'approve' to continue."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:216
-msgid "profile.listing.edit.delete_listing"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
+msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:48
-msgid "project.single.button.back_to_project_details"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
+msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:83
+msgid "Processing Purchase"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
+msgid "Purchase successful"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
+#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:21
+msgid "Confirm Purchase"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:43
+msgid "You successfully acquired carbon!"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:142
-msgid "purchase.button.view_assets"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
+msgid "Tokens received:"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:79
-msgid "purchase.input.amount.minimum"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
+msgid "Total sale cost"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:61
-msgid "purchase.input.amount.placeholder"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:99
+msgid "See your portfolio"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:72
-msgid "purchase.input.amount.required"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:104
+msgid "Purchase more Carbon"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:171
-msgid "purchase.input.price.maxAmount"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:61
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:124
+msgid "There was an error loading the total cost."
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:164
-msgid "purchase.input.price.required"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:156
+msgid "Total price"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-msgid "purchase.loading.allowance.error"
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/index.tsx:24
+#: components/pages/Project/Retire/index.tsx:25
+msgid "Retire from {fullProjectid} | Carbonmark"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:25
+msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:30
+msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:85
-msgid "purchase.transaction.modal.title.confirm"
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
 msgstr ""
 
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:89
-msgid "purchase.transaction.modal.title.processing"
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
+msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr ""
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
+msgid "Go back"
 msgstr ""
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:187
+msgid "{0}"
 msgstr ""
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:190
+msgid "There was an error during the checkout process. Please try again."
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:171
-msgid "resources.form.input.search.label"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:162
-msgid "resources.form.input.search.placeholder"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:200
-msgid "resources.form.input.sort_by.label"
-msgstr ""
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:21
-msgid "resources.form.input.sort_by.select"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:301
-msgid "resources.mobile_modal.button.show_results"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:274
-msgid "resources.mobile_modal.title"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:239
-msgid "resources.page.list.no_search_results.title"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:231
-msgid "resources.page.list.on_fetch_error"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:252
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:245
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:381
-msgid "retire.back_button"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:372
-msgid "retire.submit_button"
-msgstr ""
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr ""
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr ""
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:128
-msgid "retirement.head.metaDescription"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:41
-msgid "retirement.single.beneficiary.address.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:35
-msgid "retirement.single.beneficiary.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:35
-msgid "retirement.single.beneficiary_address.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:96
-msgid "retirement.single.country_region.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:121
-msgid "retirement.single.immutable_public_records.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:82
-msgid "retirement.single.methodology.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:29
-msgid "retirement.single.moss_offset.description"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:71
-msgid "retirement.single.moss_offset.name"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:114
-msgid "retirement.single.official_certificate.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.project.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:82
-msgid "retirement.single.project_description.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:42
-msgid "retirement.single.project_details.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:65
-msgid "retirement.single.project_name.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:29
-msgid "retirement.single.share_retirement.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:55
-msgid "retirement.single.transaction_id.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:49
-msgid "retirement.single.transaction_id.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:28
-msgid "retirement.single.transaction_record.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.type.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:140
-msgid "retirement.single.view_on_polygon_scan"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:109
-msgid "retirement.single.vintage.title"
-msgstr ""
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr ""
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:64
-msgid "retirement.totals.page_headline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:70
-msgid "retirement.totals.page_subline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:94
-msgid "retirement.totals.retired_assets"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:110
-msgid "retirement.totals.retirements"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:102
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:116
-msgid "retirement.totals.total_retirement_transactions"
-msgstr ""
-
-#: components/pages/Users/SellerUnconnected/index.tsx:77
-msgid "seller.listing.buy"
-msgstr ""
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr ""
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:94
-#: components/pages/Users/SellerUnconnected/index.tsx:67
-msgid "shared.connect_to_buy"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:51
-msgid "shared.head.description"
-msgstr ""
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:206
-msgid "shared.resources.sort_by.header"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:243
 msgid "something went wrong loading the allowance"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:362
+msgid "Retiring Token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:55
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:61
+msgid "The minimum amount to retire is 0.001 Tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:79
+msgid "Credit card minimum purchase is {0}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:85
+msgid ""
+"At this time, Carbonmark cannot process credit card payments\n"
+"exceeding {0}. Please adjust the\n"
+"quantity and try again later."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:97
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:103
+msgid "The minimum amount to retire via bank transfer is 100 Tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:202
+msgid "Required Field"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:207
+msgid "How many tonnes of carbon would you like to retire?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:211
+msgid "Available:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:233
+msgid "Quantity is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:242
+msgid "How many tonnes of carbon do you want to retire?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:256
+msgid "Beneficiary name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:260
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:304
+msgid "Required when proceeding with Credit Card"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:275
+msgid "You either need to provide a beneficiary address or login with your browser wallet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:285
+msgid "Beneficiary Address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:289
+msgid "Defaults to the connected wallet address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:294
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:308
+msgid "Retirement Message"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:300
+msgid "Describe the purpose of this retirement"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:324
+msgid "{0} maximum for credit cards"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:373
+msgid "Login to pay with USDC"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:384
+msgid "Processing Fee:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:390
+msgid "Balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:428
+msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:443
+msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:462
+msgid "Total Cost is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:31
+msgid "You are about to retire a carbon asset."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:34
+msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:53
+msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:60
+msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:73
+msgid "Processing Retirement"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:74
+msgid "Retirement successful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:75
+msgid "Confirm Retirement"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
+msgid "Retire Carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:35
+msgid "Our system is taking longer than expected. The retirement should appear in your<0>retirement history</0> soon."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:48
+msgid "You can view the successful transaction now on <0>PolygonScan.</0>"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
+msgid "Thank you for supporting the planet!"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:104
+msgid "See your retirement receipt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:103
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:121
+msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:158
+msgid "Amount to retire"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:233
+msgid "Payment processing fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:237
+msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:51
+msgid "Pay via Bank Transfer / Wire"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:56
+msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:57
+msgid "Can we remind you about this new feature later?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:64
+msgid "Let's Go!"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:69
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:101
+msgid "Learn More"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:75
+msgid "Sure"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:77
+msgid "Don't Remind Me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/GridView/GridView.tsx:38
+#: components/pages/Projects/ListView/ListView.tsx:157
+msgid "No project description found"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/index.tsx:71
+#: components/pages/Projects/index.tsx:72
+msgid "Marketplace | Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/index.tsx:73
+msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/index.tsx:88
+msgid "No projects found with current filters"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/ProjectSearch/index.tsx:45
+msgid "Filters"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/ProjectSearch/index.tsx:52
+#: components/ProjectFilterModal/index.tsx:162
+msgid "Clear Filters"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/ProjectSort/index.tsx:29
+msgid "Toggle sort menu"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:28
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:29
+msgid "View the project details and other info for this purchase."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:35
+#: components/pages/Purchases/index.tsx:36
+msgid "Purchase Receipt | Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:61
+msgid "Payment Successful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:65
+msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:72
+msgid "Thank you for supporting the planet! See purchase details below."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:90
+msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:103
+msgid "Quantity purchased:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:112
+msgid "Final price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:19
+#: components/pages/Resources/index.tsx:20
+msgid "Resources | Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:21
+msgid "Find the latest updates, guides, and resources to help you leverage the Carbonmark platform."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:51
+msgid "Digital Carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:56
+msgid "Press Releases"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:61
+msgid "User Guides"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:67
+msgid "Latest First"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:72
+msgid "Oldest First"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:77
+msgid "A-Z"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:82
+msgid "Z-A"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/List.tsx:44
+msgid "There was an error getting your retirement data. Please refresh the page to try again."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:49
+msgid "There was an error getting your total retirement data"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:60
+#: components/pages/Retire/Activity/Overview.tsx:70
+msgid "Retirement Overview"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:62
+msgid "No data to show"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:72
+msgid "Total carbon tonnes retired"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Retire/Activity/Overview.tsx:77
 #: components/pages/Retire/Activity/Quotes.tsx:76
 #: components/pages/Retire/Activity/Table.tsx:65
 msgid "t"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:37
-msgid "tonnes"
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:83
+msgid "Total retirement transactions"
 msgstr ""
 
-#: lib/statusMessage.ts:31
-msgid "transaction.status.done"
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:32
+msgid "Retirement Activity"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:38
+msgid "No activity to show"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:71
+#: lib/formatWalletAddress.ts:9
+#: lib/formatWalletAddress.ts:21
+msgid "You"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:85
+#: components/pages/Retire/Activity/Table.tsx:77
+msgid "View all Retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Table.tsx:47
+msgid "QTY"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/FromPortfolio/index.tsx:74
+#: components/pages/Retire/FromPortfolio/index.tsx:89
+msgid "We couldn't find any assets in your portfolio."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/FromPortfolio/index.tsx:79
+msgid "Purchase Carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/FromPortfolio/index.tsx:94
+msgid "Create Carbonmark Profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:41
+msgid "View a complete overview of the digital carbon that you retired."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:48
+msgid "Carbon Retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:53
+msgid "for beneficiary"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:77
+msgid "Retire from a featured project"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:83
+msgid "View all Projects"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:89
+msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:114
+msgid "Retire from your portfolio"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:118
+msgid "View all Portfolio items"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:123
+msgid "You can also retire any carbon asset in your wallet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:141
+msgid "Quick Retire"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:146
+msgid "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:50
+msgid "View Carbonmark Profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:80
+msgid "Processing retirement..."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:84
+msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:52
+msgid "Moss"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:22
+msgid "No retirement message provided."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:36
+msgid "Downloading ..."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:36
+msgid "Download PDF"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:67
+msgid "Create your own retirement"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Badge/index.tsx:10
+msgid "Invalid"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Badge/index.tsx:12
+msgid "This listing is no longer valid and is hidden from the marketplace. Please resubmit or delete the listing."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Badge/index.tsx:15
+msgid "Expired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Badge/index.tsx:17
+msgid "This listing has expired and is hidden from the marketplace. Please resubmit or delete the listing."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/index.tsx:36
+msgid "Create and edit listings, and track your activity with your Carbonmark profile."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Login/index.tsx:32
+#: components/pages/Users/Login/index.tsx:33
+msgid "User Profile | Carbonmark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Login/index.tsx:34
+msgid "Log in to create a Carbonmark profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Login/index.tsx:47
+#: components/pages/Users/SellerUnconnected/index.tsx:96
+msgid "Data for this seller"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:38
+msgid "Click the 'create profile' button to customize this page and get started."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:46
+msgid "This user has not yet created a carbonmark profile."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:99
+msgid "New Quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
+msgid "Total quantity to list for sale"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:120
+msgid "Available balance exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:127
+msgid "Quantity listed: {listedQuantity}, Quantity unlisted: {unlistedQuantity}, Total available: {totalAvailableQuantity}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:134
+msgid "New Unit Price (USDC)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:169
+msgid "Expiration"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:173
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:183
+msgid "Update listing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:110
+msgid "You chose to reject the transaction."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:112
+msgid "Something went wrong. Please try again. {error}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:144
+msgid "Your unique handle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:152
+msgid "Handle is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:156
+msgid "Handle should not contain any special characters"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:161
+msgid "Handle should not be an address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "Sorry, this handle already exists"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:171
+msgid "@Username (note: this can not be changed!)"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:178
+msgid "Your display name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:183
+msgid "Display name is required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:188
+msgid "Display name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:199
+msgid "Profile picture"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:200
+msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:208
+msgid "Say a few words about yourself. This will be visible in your seller profile."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:211
+#: components/shared/Navigation/index.tsx:81
+#: components/shared/Navigation/index.tsx:118
+msgid "About"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:118
+msgid "Edit Profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:118
+msgid "Create Profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:133
+#: components/pages/Users/SellerUnconnected/index.tsx:54
+msgid "Listings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:190
+msgid "Updating your data..."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:196
+#: components/pages/Users/SellerUnconnected/index.tsx:90
+msgid "No active listings."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:189
+msgid "Edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:201
+msgid "Edit listing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectCard/index.tsx:64
+msgid "No props.project description found"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:11
+msgid "Price Highest"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:13
+msgid "Recently Updated"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:14
+msgid "Vintage Newest"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:15
+msgid "Vintage Oldest"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:119
+msgid "Country"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:130
+msgid "Category"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:141
+msgid "Vintage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:168
+msgid "Result"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:168
+msgid "Results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:170
+msgid "Compiling Results ..."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/shared/InvalidNetworkModal/index.tsx:64
+msgid "Wrong Network"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/shared/InvalidNetworkModal/index.tsx:70
+msgid "This app only works on Polygon Mainnet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/shared/InvalidNetworkModal/index.tsx:74
+msgid "Switch to Polygon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/shared/Navigation/index.tsx:63
+#: components/shared/Navigation/index.tsx:100
+msgid "Marketplace"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/shared/Navigation/index.tsx:69
+#: components/shared/Navigation/index.tsx:106
+msgid "Profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Stats/index.tsx:23
+msgid "Stats"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsBar.tsx:41
+msgid "Amount of credits from this project/vintage combination that have been retired."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsBar.tsx:55
+msgid "Remaining Supply:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsBar.tsx:61
+msgid "Amount of credits that have been bridged from this project/vintage combination but not yet retired."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsListings.tsx:35
+msgid "Tonnes sold:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsListings.tsx:42
+msgid "Tonnes listed:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsListings.tsx:49
+msgid "Active listings:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ViewWalletButton/index.tsx:25
+msgid "View"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:23
+msgid "Renewable Energy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:29
+msgid "Forestry"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:35
+msgid "Other Nature-Based"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:41
+msgid "Other"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:47
+msgid "Energy Efficiency"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:53
+msgid "Agriculture"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:59
+msgid "Industrial Processing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:65
+msgid "Blue Carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: lib/statusMessage.ts:26
 msgid "transaction.status.error"
 msgstr ""
 
-#: lib/statusMessage.ts:41
-msgid "transaction.status.network_confirmation"
-msgstr ""
-
-#: lib/statusMessage.ts:36
-msgid "transaction.status.user_confirmation"
-msgstr ""
-
-#: lib/statusMessage.ts:20
-msgid "transaction.status.user_rejected"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr ""
-
-#: components/CreateListing/Transaction/index.tsx:81
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/CreateListing/Transaction/index.tsx:46
 #: components/Transaction/index.tsx:45
 msgid "transaction_modal.view.approve.title"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/CreateListing/Transaction/index.tsx:56
 #: components/Transaction/index.tsx:55
 msgid "transaction_modal.view.submit.title"
 msgstr ""
 
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
 msgstr ""
 
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:72
+msgid "purchase.input.amount.required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:381
+msgid "retire.back_button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:48
+msgid "project.single.button.back_to_project_details"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:360
+msgid "offset_disclaimer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:35
+msgid "retirement.single.beneficiary_address.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:282
+msgid "offset.retirement_beneficiary_name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:35
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:104
+msgid "buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:77
+msgid "seller.listing.buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:64
+msgid "retirement.totals.page_headline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:245
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:85
+msgid "purchase.transaction.modal.title.confirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:403
+msgid "offset.retire_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:90
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:96
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:100
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:155
+msgid "profile.listing.delete.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:96
+msgid "retirement.single.country_region.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:135
+msgid "profile.addListing_modal.submit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:319
+msgid "offset.default_retirement_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:216
+msgid "profile.listing.edit.delete_listing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:82
+msgid "retirement.single.project_description.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:51
+msgid "shared.head.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:252
+msgid "offset.offset_quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:70
+msgid "retirement.totals.page_subline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:81
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:229
+msgid "offset.amount_in_tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:28
+msgid "retirement.single.transaction_record.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:29
+msgid "retirement.single.moss_offset.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:82
+msgid "retirement.single.methodology.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:71
+msgid "retirement.single.moss_offset.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Activities/index.tsx:29
 msgid "user.activities.empty_state"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "user.edit.form.edit.price.placeholder"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:41
+msgid "retirement.single.beneficiary.address.placeholder"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:113
-msgid "user.listing.edit.input.quantity.minimum"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.placeholder"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:55
+msgid "retirement.single.transaction_id.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:114
+msgid "retirement.single.official_certificate.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/statusMessage.ts:36
+msgid "transaction.status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:252
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:164
+msgid "purchase.input.price.required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:89
+msgid "purchase.transaction.modal.title.processing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:42
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:65
+msgid "retirement.single.project_name.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.project.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:106
 msgid "user.listing.edit.input.quantity.required"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:88
+msgid "connect_modal.error_processing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:372
+msgid "retire.submit_button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:94
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:328
+msgid "offset.retirement_message"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:339
+msgid "offset.retirement_retirement_message"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:110
+msgid "retirement.totals.retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:230
+msgid "profile.edit_modal.submit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:171
+msgid "resources.form.input.search.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:162
+msgid "resources.form.input.search.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/SortyByDropDown/index.tsx:21
+msgid "resources.form.input.sort_by.select"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:29
+msgid "retirement.single.share_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:301
+msgid "resources.mobile_modal.button.show_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:94
+#: components/pages/Users/SellerUnconnected/index.tsx:67
+msgid "shared.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:144
+msgid "user.listing.form.input.singleUnitPrice.required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:86
+msgid "connectModal.torus"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+msgid "purchase.loading.allowance.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:231
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:239
+msgid "resources.page.list.no_search_results.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:200
+msgid "resources.form.input.sort_by.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:274
+msgid "resources.mobile_modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:206
+msgid "shared.resources.sort_by.header"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:79
+msgid "purchase.input.amount.minimum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:86
+msgid "user.listing.form.input.totalAmountToSell.minimum"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/CreateListing/Form/index.tsx:120
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:151
 msgid "user.listing.form.input.singleUnitPrice.minimum"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:144
-msgid "user.listing.form.input.singleUnitPrice.required"
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:113
+msgid "user.listing.edit.input.quantity.minimum"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:86
-msgid "user.listing.form.input.totalAmountToSell.minimum"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:79
-msgid "user.listing.form.input.totalAmountToSell.required"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/LoginCard/index.tsx:24
 msgid "user.login.description"
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:187
-msgid "{0}"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:121
+msgid "retirement.single.immutable_public_records.title"
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:324
-msgid "{0} maximum for credit cards"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
 msgstr ""
 
-#: components/CreateListing/Transaction/index.tsx:61
-msgid "{0} tonnes"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:61
+msgid "purchase.input.amount.placeholder"
 msgstr ""
 
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:79
+msgid "user.listing.form.input.totalAmountToSell.required"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:173
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:102
+msgid "retirement.totals.total_carbon_tonnes"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:28
-msgid "{amount} tonnes were purchased for project {0}"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:116
+msgid "retirement.totals.total_retirement_transactions"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:29
-msgid "{tokenSymbol}"
+#. js-lingui-explicit-id
+#: lib/statusMessage.ts:31
+msgid "transaction.status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:49
+msgid "retirement.single.transaction_id.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/statusMessage.ts:41
+msgid "transaction.status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:128
+msgid "retirement.head.metaDescription"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.type.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "user.edit.form.edit.price.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:84
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:140
+msgid "retirement.single.view_on_polygon_scan"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:142
+msgid "purchase.button.view_assets"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:109
+msgid "retirement.single.vintage.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:80
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:270
+msgid "offset.retirement_credit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/statusMessage.ts:20
+msgid "transaction.status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:171
+msgid "purchase.input.price.maxAmount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:220
+msgid "profile.edit_profile.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
 msgstr ""

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -13,1466 +13,57 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/pages/Home/index.tsx:361
-msgid "0% listing fee"
-msgstr "0% listing fee"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr "created listing"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:200
-msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
-msgstr "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
+msgstr "deleted listing"
 
-#: components/pages/errors/Custom404.tsx:13
-#: components/pages/errors/Custom404.tsx:14
-#: components/pages/errors/Custom404.tsx:15
-#: components/pages/errors/Custom404.tsx:22
-msgid "404 - Page Not Found"
-msgstr "404 - Page Not Found"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
+msgstr "bought from"
 
-#: components/pages/errors/Custom500.tsx:13
-#: components/pages/errors/Custom500.tsx:14
-#: components/pages/errors/Custom500.tsx:15
-msgid "500 - Server Error"
-msgstr "500 - Server Error"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr "sold to"
 
-#: components/pages/errors/Custom500.tsx:22
-msgid "500 - Server error occurred"
-msgstr "500 - Server error occurred"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr "updated price"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:221
-msgid "<0>* </0> Required Field"
-msgstr "<0>* </0> Required Field"
+#. js-lingui-explicit-id
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr "updated quantity"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:171
-msgid "@Username (note: this can not be changed!)"
-msgstr "@Username (note: this can not be changed!)"
+#. js-lingui-explicit-id
+#: components/Activities/Activity.tsx:33
+msgid "at"
+msgstr "at"
 
-#: components/pages/Project/PayWithBank/index.tsx:153
-msgid "A valid email address is required"
-msgstr "A valid email address is required"
+#. js-lingui-explicit-id
+#: components/Activities/Activity.tsx:89
+msgid "for"
+msgstr "for"
 
-#: components/pages/Resources/lib/cmsDataMap.ts:77
-msgid "A-Z"
-msgstr "A-Z"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:211
-#: components/shared/Navigation/index.tsx:81
-#: components/shared/Navigation/index.tsx:118
-msgid "About"
-msgstr "About"
-
-#: components/Stats/StatsListings.tsx:49
-msgid "Active listings:"
-msgstr "Active listings:"
-
+#. js-lingui-explicit-id
 #: components/Activities/index.tsx:24
 msgid "Activity"
 msgstr "Activity"
 
-#: lib/getCategoryInfo.ts:53
-msgid "Agriculture"
-msgstr "Agriculture"
-
-#: components/pages/Home/index.tsx:365
-msgid "All assets sourced from major registries"
-msgstr "All assets sourced from major registries"
-
-#: components/CreateListing/Transaction/Submit.tsx:41
-msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
-msgstr "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
-
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:92
-msgid "Amount is required"
-msgstr "Amount is required"
-
-#: components/Stats/StatsBar.tsx:41
-msgid "Amount of credits from this project/vintage combination that have been retired."
-msgstr "Amount of credits from this project/vintage combination that have been retired."
-
-#: components/Stats/StatsBar.tsx:61
-msgid "Amount of credits that have been bridged from this project/vintage combination but not yet retired."
-msgstr "Amount of credits that have been bridged from this project/vintage combination but not yet retired."
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:49
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:86
-msgid "Amount to purchase"
-msgstr "Amount to purchase"
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:158
-msgid "Amount to retire"
-msgstr "Amount to retire"
-
-#: components/CreateListing/Transaction/Approve.tsx:81
-#: components/Transaction/Approve.tsx:101
-msgid "Approve"
-msgstr "Approve"
-
-#: components/CreateListing/Form/index.tsx:59
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:80
-msgid "Asset"
-msgstr "Asset"
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:21
-msgid "Asset Details"
-msgstr "Asset Details"
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:25
-msgid "Asset ID"
-msgstr "Asset ID"
-
+#. js-lingui-explicit-id
 #: components/AssetDetails/index.tsx:36
 msgid "Asset details"
 msgstr "Asset details"
 
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:121
-msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
-msgstr "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:85
-msgid ""
-"At this time, Carbonmark cannot process credit card payments\n"
-"exceeding {0}. Please adjust the\n"
-"quantity and try again later."
-msgstr ""
-"At this time, Carbonmark cannot process credit card payments\n"
-"exceeding {0}. Please adjust the\n"
-"quantity and try again later."
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
-msgstr "Available Tonnes:"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:120
-msgid "Available balance exceeded"
-msgstr "Available balance exceeded"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:86
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:100
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:238
-msgid "Available supply exceeded"
-msgstr "Available supply exceeded"
-
-#: components/CreateListing/Form/index.tsx:101
-msgid "Available to list: {0}"
-msgstr "Available to list: {0}"
-
-#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:210
-msgid "Available to purchase"
-msgstr "Available to purchase"
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:34
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:363
-msgid "Available to retire"
-msgstr "Available to retire"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:211
-msgid "Available:"
-msgstr "Available:"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:54
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:75
-msgid "Available: {0}"
-msgstr "Available: {0}"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
-msgid "Available: {unlistedBalance}"
-msgstr "Available: {unlistedBalance}"
-
-#: components/BetaBadge/index.tsx:13
-msgid "BETA"
-msgstr "BETA"
-
-#: components/pages/Project/Purchase/index.tsx:49
-#: components/pages/Project/Retire/index.tsx:36
-msgid "Back to Project"
-msgstr "Back to Project"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:390
-msgid "Balance"
-msgstr "Balance"
-
-#: components/CreateListing/Form/index.tsx:93
-msgid "Balance exceeded"
-msgstr "Balance exceeded"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:101
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:115
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:320
-msgid "Balance: {0}"
-msgstr "Balance: {0}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:443
-msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
-msgstr "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:285
-msgid "Beneficiary Address"
-msgstr "Beneficiary Address"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:256
-msgid "Beneficiary name"
-msgstr "Beneficiary name"
-
-#: components/pages/Project/PayWithBank/index.tsx:232
-#: components/pages/Project/PayWithBank/index.tsx:349
-msgid "Beneficiary wallet address"
-msgstr "Beneficiary wallet address"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:299
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
-msgid "Beneficiary wallet address (optional)"
-msgstr "Beneficiary wallet address (optional)"
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:34
-#: components/pages/Project/BuyOptions/SellerListing.tsx:62
-#: components/pages/Project/index.tsx:139
-msgid "Best Price"
-msgstr "Best Price"
-
-#: lib/getCategoryInfo.ts:65
-msgid "Blue Carbon"
-msgstr "Blue Carbon"
-
-#: components/Layout/NavDrawer/index.tsx:94
-msgid "Book a demo"
-msgstr "Book a demo"
-
-#: components/pages/Home/index.tsx:160
-#: components/pages/Home/index.tsx:191
-#: components/pages/Home/index.tsx:244
-#: components/pages/Project/PayWithBank/index.tsx:370
-#: components/shared/Navigation/index.tsx:54
-#: components/shared/Navigation/index.tsx:133
-msgid "Browse Projects"
-msgstr "Browse Projects"
-
-#: components/Layout/NavDrawer/index.tsx:102
-msgid "Built with 🌳 by <0>KlimaDAO</0>"
-msgstr "Built with 🌳 by <0>KlimaDAO</0>"
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:45
-msgid "Buy"
-msgstr "Buy"
-
-#: components/pages/Home/index.tsx:171
-msgid "Buy or retire carbon"
-msgstr "Buy or retire carbon"
-
-#: components/ExitModal/index.tsx:44
-msgid "Cancel"
-msgstr "Cancel"
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:30
-msgid "Carbon Pool"
-msgstr "Carbon Pool"
-
-#: components/pages/Retire/index.tsx:48
-msgid "Carbon Retirements"
-msgstr "Carbon Retirements"
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-msgstr "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
-msgstr "Carbonmark Overview"
-
-#: components/pages/Home/index.tsx:177
-msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
-msgstr "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:86
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:125
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:207
-msgid "Carbonmark fee"
-msgstr "Carbonmark fee"
-
-#: components/pages/Project/PayWithBank/index.tsx:101
-msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
-msgstr "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
-
-#: components/pages/Home/index.tsx:54
-#: components/pages/Home/index.tsx:55
-msgid "Carbonmark | The Universal Carbon Marketplace"
-msgstr "Carbonmark | The Universal Carbon Marketplace"
-
-#: components/pages/Home/index.tsx:491
-msgid "Carbonmark's role"
-msgstr "Carbonmark's role"
-
-#: components/ProjectFilterModal/index.tsx:130
-msgid "Category"
-msgstr "Category"
-
-#: components/ChangeLanguageButton/index.tsx:44
-#: components/shared/ChangeLanguageButton/index.tsx:48
-msgid "Change language"
-msgstr "Change language"
-
-#: components/pages/Home/index.tsx:209
-msgid "Choose a project and quantity"
-msgstr "Choose a project and quantity"
-
-#: components/pages/Projects/index.tsx:72
-msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
-msgstr "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
-
-#: components/ProjectFilterModal/index.tsx:162
-#: components/pages/Projects/ProjectSearch/index.tsx:52
-msgid "Clear Filters"
-msgstr "Clear Filters"
-
-#: components/pages/Users/ProfileHeader/index.tsx:38
-msgid "Click the 'create profile' button to customize this page and get started."
-msgstr "Click the 'create profile' button to customize this page and get started."
-
-#: components/CreateListing/Transaction/Submit.tsx:98
-msgid "Close"
-msgstr "Close"
-
-#: components/Dropdown/index.tsx:133
-msgid "Coming soon"
-msgstr "Coming soon"
-
-#: components/pages/Project/PayWithBank/index.tsx:167
-#: components/pages/Project/PayWithBank/index.tsx:319
-msgid "Company name"
-msgstr "Company name"
-
-#: components/pages/Project/PayWithBank/index.tsx:173
-msgid "Company name is required"
-msgstr "Company name is required"
-
-#: components/pages/Home/index.tsx:348
-msgid "Compare prices across all sellers and trading pools"
-msgstr "Compare prices across all sellers and trading pools"
-
-#: components/ProjectFilterModal/index.tsx:170
-msgid "Compiling Results ..."
-msgstr "Compiling Results ..."
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
-#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:21
-msgid "Confirm Purchase"
-msgstr "Confirm Purchase"
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:75
-msgid "Confirm Retirement"
-msgstr "Confirm Retirement"
-
-#: components/Footer/index.tsx:41
-#: components/pages/Home/index.tsx:553
-msgid "Contact"
-msgstr "Contact"
-
-#: components/ExitModal/index.tsx:39
-#: components/pages/Project/Purchase/Listing/SubmitButton.tsx:44
-#: components/pages/Project/Purchase/Pool/SubmitButton.tsx:44
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:38
-#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:34
-msgid "Continue"
-msgstr "Continue"
-
-#: components/CopyAddressButton/index.tsx:37
-msgid "Copy"
-msgstr "Copy"
-
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:59
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:459
-msgid "Could not calculate Total Cost"
-msgstr "Could not calculate Total Cost"
-
-#: components/ProjectFilterModal/index.tsx:119
-msgid "Country"
-msgstr "Country"
-
-#: components/pages/Retire/FromPortfolio/index.tsx:94
-msgid "Create Carbonmark Profile"
-msgstr "Create Carbonmark Profile"
-
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr "Create New Listing"
-
-#: components/pages/Users/SellerConnected/index.tsx:118
-msgid "Create Profile"
-msgstr "Create Profile"
-
-#: components/CreateListing/index.tsx:152
-msgid "Create a listing"
-msgstr "Create a listing"
-
-#: components/pages/Home/index.tsx:222
-msgid "Create a profile and get connected"
-msgstr "Create a profile and get connected"
-
-#: components/pages/Home/index.tsx:282
-msgid "Create a seller profile"
-msgstr "Create a seller profile"
-
-#: components/pages/Users/index.tsx:36
-msgid "Create and edit listings, and track your activity with your Carbonmark profile."
-msgstr "Create and edit listings, and track your activity with your Carbonmark profile."
-
-#: components/pages/Home/index.tsx:316
-msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
-msgstr "Create your own carbon storefront. Sell directly to organizations and individuals alike."
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:67
-msgid "Create your own retirement"
-msgstr "Create your own retirement"
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:82
-msgid "Created:"
-msgstr "Created:"
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:103
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
-msgstr "Credit card minimum purchase is ${formattedFiatMinimum}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:79
-msgid "Credit card minimum purchase is {0}"
-msgstr "Credit card minimum purchase is {0}"
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:237
-msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
-msgstr "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:428
-msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
-msgstr "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:144
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
-msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
-msgstr "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
-msgstr "DATE"
-
-#: components/pages/Project/index.tsx:236
-msgid "Data for this project and vintage"
-msgstr "Data for this project and vintage"
-
-#: components/pages/Users/Login/index.tsx:47
-#: components/pages/Users/SellerUnconnected/index.tsx:96
-msgid "Data for this seller"
-msgstr "Data for this seller"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:289
-msgid "Defaults to the connected wallet address"
-msgstr "Defaults to the connected wallet address"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:300
-msgid "Describe the purpose of this retirement"
-msgstr "Describe the purpose of this retirement"
-
-#: components/pages/Project/index.tsx:187
-msgid "Description"
-msgstr "Description"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:51
-msgid "Digital Carbon"
-msgstr "Digital Carbon"
-
-#: components/pages/Home/index.tsx:267
-msgid "Digitize your carbon by using a supported bridge"
-msgstr "Digitize your carbon by using a supported bridge"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:188
-msgid "Display name"
-msgstr "Display name"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:183
-msgid "Display name is required"
-msgstr "Display name is required"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:36
-msgid "Download PDF"
-msgstr "Download PDF"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:36
-msgid "Downloading ..."
-msgstr "Downloading ..."
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:189
-msgid "Edit"
-msgstr "Edit"
-
-#: components/pages/Users/SellerConnected/index.tsx:118
-msgid "Edit Profile"
-msgstr "Edit Profile"
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:201
-msgid "Edit listing"
-msgstr "Edit listing"
-
-#: components/pages/Project/PayWithBank/index.tsx:143
-#: components/pages/Project/PayWithBank/index.tsx:307
-msgid "Email"
-msgstr "Email"
-
-#: components/pages/Project/PayWithBank/index.tsx:149
-msgid "Email address is required"
-msgstr "Email address is required"
-
-#: lib/getCategoryInfo.ts:47
-msgid "Energy Efficiency"
-msgstr "Energy Efficiency"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:169
-msgid "Expiration"
-msgstr "Expiration"
-
-#: components/pages/Users/Badge/index.tsx:15
-msgid "Expired"
-msgstr "Expired"
-
-#: components/pages/Home/index.tsx:464
-msgid "FAQs"
-msgstr "FAQs"
-
-#: components/pages/Projects/ProjectSearch/index.tsx:45
-msgid "Filters"
-msgstr "Filters"
-
-#: components/pages/Purchases/index.tsx:112
-msgid "Final price"
-msgstr "Final price"
-
-#: components/pages/Resources/index.tsx:21
-msgid "Find the latest updates, guides, and resources to help you leverage the Carbonmark platform."
-msgstr "Find the latest updates, guides, and resources to help you leverage the Carbonmark platform."
-
-#: components/pages/Project/PayWithBank/index.tsx:187
-#: components/pages/Project/PayWithBank/index.tsx:331
-msgid "First name"
-msgstr "First name"
-
-#: components/pages/Project/PayWithBank/index.tsx:193
-msgid "First name is required"
-msgstr "First name is required"
-
-#: components/pages/Project/PayWithBank/index.tsx:197
-msgid "First name should not contain numbers or special characters"
-msgstr "First name should not contain numbers or special characters"
-
-#: components/CreateListing/Transaction/Approve.tsx:37
-msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
-msgstr "First, approve the Carbonmark system to transfer this asset on your behalf."
-
-#: components/pages/Home/index.tsx:343
-msgid "For carbon traders"
-msgstr "For carbon traders"
-
-#: components/pages/Home/index.tsx:388
-msgid "For project developers"
-msgstr "For project developers"
-
-#: lib/getCategoryInfo.ts:29
-msgid "Forestry"
-msgstr "Forestry"
-
-#: components/pages/Project/PayWithBank/index.tsx:289
-msgid "Form complete"
-msgstr "Form complete"
-
-#: components/pages/Home/index.tsx:79
-msgid "Get Started"
-msgstr "Get Started"
-
-#: components/pages/Home/index.tsx:393
-msgid "Get paid immediately: transactions are resolved in seconds"
-msgstr "Get paid immediately: transactions are resolved in seconds"
-
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
-msgstr "Go Back"
-
-#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
-msgid "Go back"
-msgstr "Go back"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:152
-msgid "Handle is required"
-msgstr "Handle is required"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:161
-msgid "Handle should not be an address"
-msgstr "Handle should not be an address"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:156
-msgid "Handle should not contain any special characters"
-msgstr "Handle should not contain any special characters"
-
-#: components/Footer/index.tsx:32
-#: components/pages/Home/index.tsx:544
-#: components/shared/Navigation/index.tsx:87
-#: components/shared/Navigation/index.tsx:124
-msgid "Help"
-msgstr "Help"
-
-#: components/pages/Retire/index.tsx:146
-msgid "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
-msgstr "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
-
-#: components/CreateListing/Form/index.tsx:74
-msgid "How many tonnes do you want to list for sale?"
-msgstr "How many tonnes do you want to list for sale?"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:90
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:104
-msgid "How many tonnes of carbon do you want to buy?"
-msgstr "How many tonnes of carbon do you want to buy?"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:242
-msgid "How many tonnes of carbon do you want to retire?"
-msgstr "How many tonnes of carbon do you want to retire?"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:207
-msgid "How many tonnes of carbon would you like to retire?"
-msgstr "How many tonnes of carbon would you like to retire?"
-
-#: components/pages/Project/PayWithBank/index.tsx:301
-msgid "How many tonnes would you like to retire?"
-msgstr "How many tonnes would you like to retire?"
-
-#: components/pages/Project/PayWithBank/index.tsx:122
-msgid "How much would you like to retire?"
-msgstr "How much would you like to retire?"
-
-#: components/pages/Purchases/index.tsx:90
-msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
-msgstr "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
-
-#: components/pages/Project/PayWithBank/index.tsx:116
-msgid "Indicates required field"
-msgstr "Indicates required field"
-
-#: lib/getCategoryInfo.ts:59
-msgid "Industrial Processing"
-msgstr "Industrial Processing"
-
-#: components/pages/Home/index.tsx:369
-msgid "Instant settlement of all trades"
-msgstr "Instant settlement of all trades"
-
-#: components/pages/Home/index.tsx:437
-msgid "Introducing Carbonmark"
-msgstr "Introducing Carbonmark"
-
-#: components/pages/Users/Badge/index.tsx:10
-msgid "Invalid"
-msgstr "Invalid"
-
-#: components/pages/Project/PayWithBank/index.tsx:181
-#: components/pages/Project/PayWithBank/index.tsx:325
-msgid "Job title"
-msgstr "Job title"
-
-#: components/Footer/index.tsx:38
-#: components/pages/Home/index.tsx:550
-msgid "KlimaDAO"
-msgstr "KlimaDAO"
-
-#: components/pages/Home/index.tsx:527
-msgid "KlimaDAO provides the transparent, neutral, and public infrastructure required to accelerate climate finance on a global scale."
-msgstr "KlimaDAO provides the transparent, neutral, and public infrastructure required to accelerate climate finance on a global scale."
-
-#: components/pages/Project/PayWithBank/index.tsx:206
-#: components/pages/Project/PayWithBank/index.tsx:337
-msgid "Last name"
-msgstr "Last name"
-
-#: components/pages/Project/PayWithBank/index.tsx:212
-msgid "Last name is required"
-msgstr "Last name is required"
-
-#: components/pages/Project/PayWithBank/index.tsx:216
-msgid "Last name should not contain numbers or special characters"
-msgstr "Last name should not contain numbers or special characters"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:67
-msgid "Latest First"
-msgstr "Latest First"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:101
-msgid "Learn More"
-msgstr "Learn More"
-
-#: components/pages/Home/index.tsx:420
-msgid "Learn more"
-msgstr "Learn more"
-
-#: components/pages/Home/index.tsx:494
-msgid "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
-msgstr "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
-
-#: components/pages/Home/index.tsx:399
-msgid "List and sell for free"
-msgstr "List and sell for free"
-
-#: components/pages/Home/index.tsx:295
-msgid "List your projects for sale in just a few clicks"
-msgstr "List your projects for sale in just a few clicks"
-
-#: components/pages/Portfolio/AssetProject/index.tsx:78
-msgid "Listed tonnes:"
-msgstr "Listed tonnes:"
-
-#: components/pages/Users/SellerConnected/index.tsx:133
-#: components/pages/Users/SellerUnconnected/index.tsx:54
-msgid "Listings"
-msgstr "Listings"
-
-#: components/pages/Portfolio/CarbonmarkAssets.tsx:57
-#: components/pages/Retire/FromPortfolio/index.tsx:60
-msgid "Loading your assets"
-msgstr "Loading your assets"
-
-#: components/Layout/NavDrawer/index.tsx:53
-#: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:285
-#: components/pages/Retire/Activity/Overview.tsx:73
-#: components/pages/Retire/Activity/Overview.tsx:84
-msgid "Loading..."
-msgstr "Loading..."
-
-#: components/Layout/NavDrawer/index.tsx:64
-#: components/LoginButton/index.tsx:13
-msgid "Log in"
-msgstr "Log in"
-
-#: components/pages/Users/Login/index.tsx:34
-msgid "Log in to create a Carbonmark profile"
-msgstr "Log in to create a Carbonmark profile"
-
-#: components/Layout/NavDrawer/index.tsx:74
-#: components/LoginButton/index.tsx:15
-msgid "Log out"
-msgstr "Log out"
-
-#: components/Layout/index.tsx:95
-#: components/LoginCard/index.tsx:32
-msgid "Login"
-msgstr "Login"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:373
-msgid "Login to pay with USDC"
-msgstr "Login to pay with USDC"
-
-#: components/shared/Navigation/index.tsx:63
-#: components/shared/Navigation/index.tsx:100
-msgid "Marketplace"
-msgstr "Marketplace"
-
-#: components/pages/Projects/index.tsx:70
-#: components/pages/Projects/index.tsx:71
-msgid "Marketplace | Carbonmark"
-msgstr "Marketplace | Carbonmark"
-
-#: components/pages/Home/index.tsx:174
-msgid "Maximize your climate impact."
-msgstr "Maximize your climate impact."
-
-#: components/pages/Project/index.tsx:146
-msgid "Methodology"
-msgstr "Methodology"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:52
-msgid "Moss"
-msgstr "Moss"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:99
-msgid "New Quantity"
-msgstr "New Quantity"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:134
-msgid "New Unit Price (USDC)"
-msgstr "New Unit Price (USDC)"
-
-#: components/CreateListing/Transaction/Approve.tsx:88
-msgid "Next"
-msgstr "Next"
-
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
-msgstr "No Activity to show."
-
-#: components/pages/Users/SellerConnected/index.tsx:196
-#: components/pages/Users/SellerUnconnected/index.tsx:90
-msgid "No active listings."
-msgstr "No active listings."
-
-#: components/pages/Retire/Activity/Quotes.tsx:38
-msgid "No activity to show"
-msgstr "No activity to show"
-
-#: components/pages/Home/index.tsx:403
-msgid "No barriers to entry for verified carbon projects"
-msgstr "No barriers to entry for verified carbon projects"
-
-#: components/pages/Retire/Activity/Overview.tsx:62
-msgid "No data to show"
-msgstr "No data to show"
-
-#: components/pages/Portfolio/CarbonmarkAssets.tsx:96
-msgid "No listable assets found."
-msgstr "No listable assets found."
-
-#: components/pages/Project/index.tsx:226
-msgid "No listings found for this project."
-msgstr "No listings found for this project."
-
-#: components/pages/Projects/GridView/GridView.tsx:38
-#: components/pages/Projects/ListView/ListView.tsx:157
-msgid "No project description found"
-msgstr "No project description found"
-
-#: components/pages/Projects/index.tsx:86
-msgid "No projects found with current filters"
-msgstr "No projects found with current filters"
-
-#: components/ProjectCard/index.tsx:64
-msgid "No props.project description found"
-msgstr "No props.project description found"
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:22
-msgid "No retirement message provided."
-msgstr "No retirement message provided."
-
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
-msgstr "Not Connected"
-
-#: components/pages/Project/PayWithBank/index.tsx:240
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:281
-msgid "Not a valid polygon address"
-msgstr "Not a valid polygon address"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:72
-msgid "Oldest First"
-msgstr "Oldest First"
-
-#: lib/getCategoryInfo.ts:41
-msgid "Other"
-msgstr "Other"
-
-#: lib/getCategoryInfo.ts:35
-msgid "Other Nature-Based"
-msgstr "Other Nature-Based"
-
-#: components/pages/Home/index.tsx:101
-msgid "Our Partners"
-msgstr "Our Partners"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:35
-msgid "Our system is taking longer than expected. The retirement should appear in your<0>retirement history</0> soon."
-msgstr "Our system is taking longer than expected. The retirement should appear in your<0>retirement history</0> soon."
-
-#: components/pages/Home/index.tsx:121
-msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
-msgstr "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
-
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr "PROJECT"
-
-#: components/pages/Project/PayWithBank/index.tsx:89
-#: components/pages/Project/PayWithBank/index.tsx:90
-msgid "Pay with Bank Transfer | Carbonmark"
-msgstr "Pay with Bank Transfer | Carbonmark"
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
-msgstr "Pay with bank transfer"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:98
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:112
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:316
-msgid "Pay with:"
-msgstr "Pay with:"
-
-#: components/pages/Purchases/index.tsx:61
-msgid "Payment Successful"
-msgstr "Payment Successful"
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:233
-msgid "Payment processing fee"
-msgstr "Payment processing fee"
-
-#: components/pages/Project/PayWithBank/index.tsx:161
-#: components/pages/Project/PayWithBank/index.tsx:313
-msgid "Phone number"
-msgstr "Phone number"
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
-msgstr "Please Log In"
-
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:30
-msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
-msgstr "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
-
-#: components/pages/Portfolio/index.tsx:66
-#: components/pages/Users/SellerConnected/index.tsx:81
-#: components/pages/Users/SellerConnected/index.tsx:107
-msgid "Please refresh the page. There was an error updating your data: {e}."
-msgstr "Please refresh the page. There was an error updating your data: {e}."
-
-#: components/pages/Portfolio/index.tsx:76
-#: components/pages/Portfolio/index.tsx:77
-msgid "Portfolio | Carbonmark"
-msgstr "Portfolio | Carbonmark"
-
-#: components/pages/Home/index.tsx:521
-msgid "Powered by"
-msgstr "Powered by"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:56
-msgid "Press Releases"
-msgstr "Press Releases"
-
-#: components/ProjectFilterModal/constants.tsx:11
-msgid "Price Highest"
-msgstr "Price Highest"
-
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr "Price Lowest"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:170
-msgid "Price includes network fees. <0>See docs to learn more.</0>"
-msgstr "Price includes network fees. <0>See docs to learn more.</0>"
-
-#: components/CreateListing/Transaction/Submit.tsx:62
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:94
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:166
-msgid "Price per tonne"
-msgstr "Price per tonne"
-
-#: components/Footer/index.tsx:26
-msgid "Privacy Policy"
-msgstr "Privacy Policy"
-
-#: components/pages/Home/index.tsx:538
-msgid "Privacy policy"
-msgstr "Privacy policy"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:384
-msgid "Processing Fee:"
-msgstr "Processing Fee:"
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:83
-msgid "Processing Purchase"
-msgstr "Processing Purchase"
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:73
-msgid "Processing Retirement"
-msgstr "Processing Retirement"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:80
-msgid "Processing retirement..."
-msgstr "Processing retirement..."
-
-#: components/shared/Navigation/index.tsx:69
-#: components/shared/Navigation/index.tsx:106
-msgid "Profile"
-msgstr "Profile"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:199
-msgid "Profile picture"
-msgstr "Profile picture"
-
-#: components/pages/Project/PayWithBank/index.tsx:253
-#: components/pages/Project/PayWithBank/index.tsx:357
-msgid "Project names of interest"
-msgstr "Project names of interest"
-
-#: components/pages/Retire/FromPortfolio/index.tsx:79
-msgid "Purchase Carbon"
-msgstr "Purchase Carbon"
-
-#: components/pages/Purchases/index.tsx:35
-#: components/pages/Purchases/index.tsx:36
-msgid "Purchase Receipt | Carbonmark"
-msgstr "Purchase Receipt | Carbonmark"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:52
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
-msgid "Purchase amount (tonnes):"
-msgstr "Purchase amount (tonnes):"
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:104
-msgid "Purchase more Carbon"
-msgstr "Purchase more Carbon"
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
-msgid "Purchase successful"
-msgstr "Purchase successful"
-
-#: components/pages/Project/Purchase/index.tsx:37
-#: components/pages/Project/Purchase/index.tsx:38
-msgid "Purchase {0} | Carbonmark"
-msgstr "Purchase {0} | Carbonmark"
-
-#: components/pages/Retire/Activity/Table.tsx:47
-msgid "QTY"
-msgstr "QTY"
-
-#: components/CreateListing/Form/index.tsx:97
-#: components/CreateListing/Transaction/Submit.tsx:53
-msgid "Quantity"
-msgstr "Quantity"
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:41
-#: components/pages/Project/BuyOptions/SellerListing.tsx:78
-msgid "Quantity Available:"
-msgstr "Quantity Available:"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:233
-msgid "Quantity is required"
-msgstr "Quantity is required"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:127
-msgid "Quantity listed: {listedQuantity}, Quantity unlisted: {unlistedQuantity}, Total available: {totalAvailableQuantity}"
-msgstr "Quantity listed: {listedQuantity}, Quantity unlisted: {unlistedQuantity}, Total available: {totalAvailableQuantity}"
-
-#: components/pages/Purchases/index.tsx:103
-msgid "Quantity purchased:"
-msgstr "Quantity purchased:"
-
-#: components/pages/Retire/index.tsx:141
-msgid "Quick Retire"
-msgstr "Quick Retire"
-
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr "RETIRE CARBON"
-
-#: components/pages/Project/index.tsx:200
-msgid "Read Less"
-msgstr "Read Less"
-
-#: components/pages/Project/index.tsx:200
-msgid "Read More"
-msgstr "Read More"
-
-#: components/pages/Home/index.tsx:448
-#: components/pages/Home/index.tsx:475
-#: components/pages/Home/index.tsx:502
-#: components/pages/Resources/BlogPostCard/index.tsx:38
-#: components/pages/Resources/FeaturedArticles/Article.tsx:45
-msgid "Read more"
-msgstr "Read more"
-
-#: components/pages/Home/index.tsx:354
-msgid "Real-time price and transaction data powered by the blockchain"
-msgstr "Real-time price and transaction data powered by the blockchain"
-
-#: components/ProjectFilterModal/constants.tsx:13
-msgid "Recently Updated"
-msgstr "Recently Updated"
-
-#: components/Stats/StatsBar.tsx:55
-msgid "Remaining Supply:"
-msgstr "Remaining Supply:"
-
-#: lib/getCategoryInfo.ts:23
-msgid "Renewable Energy"
-msgstr "Renewable Energy"
-
-#: components/pages/Home/index.tsx:304
-#: components/pages/Home/index.tsx:328
-msgid "Request Demo"
-msgstr "Request Demo"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:202
-msgid "Required Field"
-msgstr "Required Field"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:260
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:304
-msgid "Required when proceeding with Credit Card"
-msgstr "Required when proceeding with Credit Card"
-
-#: components/Footer/index.tsx:35
-#: components/pages/Home/index.tsx:511
-#: components/pages/Home/index.tsx:547
-#: components/pages/Resources/ResourcesList/index.tsx:154
-#: components/shared/Navigation/index.tsx:75
-#: components/shared/Navigation/index.tsx:112
-msgid "Resources"
-msgstr "Resources"
-
-#: components/pages/Resources/index.tsx:19
-#: components/pages/Resources/index.tsx:20
-msgid "Resources | Carbonmark"
-msgstr "Resources | Carbonmark"
-
-#: components/ProjectFilterModal/index.tsx:168
-msgid "Result"
-msgstr "Result"
-
-#: components/ProjectFilterModal/index.tsx:168
-msgid "Results"
-msgstr "Results"
-
-#: components/pages/Portfolio/AssetProject/index.tsx:85
-msgid "Retire"
-msgstr "Retire"
-
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
-msgid "Retire Carbon"
-msgstr "Retire Carbon"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:207
-msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
-msgstr "Retire carbon credits for yourself, or on behalf of another person or organization."
-
-#: components/pages/Retire/index.tsx:77
-msgid "Retire from a featured project"
-msgstr "Retire from a featured project"
-
-#: components/pages/Retire/index.tsx:114
-msgid "Retire from your portfolio"
-msgstr "Retire from your portfolio"
-
-#: components/pages/Project/Retire/index.tsx:24
-#: components/pages/Project/Retire/index.tsx:25
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr "Retire from {fullProjectid} | Carbonmark"
-
-#: components/pages/Home/index.tsx:235
-msgid "Retire instantly, or purchase and hold digital carbon"
-msgstr "Retire instantly, or purchase and hold digital carbon"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
-msgstr "Retire more Carbon"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
-msgid "Retire more carbon"
-msgstr "Retire more carbon"
-
-#: components/pages/Project/BuyOptions/PoolPrice.tsx:56
-msgid "Retire now"
-msgstr "Retire now"
-
-#: components/pages/Home/index.tsx:184
-msgid "Retire now, or acquire carbon to retire later - you decide what to do when you take ownership of your carbon assets."
-msgstr "Retire now, or acquire carbon to retire later - you decide what to do when you take ownership of your carbon assets."
-
-#: components/pages/Project/PayWithBank/index.tsx:91
-msgid "Retire your carbon via bank transfer."
-msgstr "Retire your carbon via bank transfer."
-
-#: components/pages/Portfolio/Retire/index.tsx:92
-#: components/pages/Portfolio/Retire/index.tsx:93
-#: components/pages/Retire/index.tsx:39
-#: components/pages/Retire/index.tsx:40
-msgid "Retire | Carbonmark"
-msgstr "Retire | Carbonmark"
-
-#: components/pages/Retire/Activity/Quotes.tsx:32
-msgid "Retirement Activity"
-msgstr "Retirement Activity"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:294
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:308
-msgid "Retirement Message"
-msgstr "Retirement Message"
-
-#: components/pages/Retire/Activity/Overview.tsx:60
-#: components/pages/Retire/Activity/Overview.tsx:70
-msgid "Retirement Overview"
-msgstr "Retirement Overview"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr "Retirement Successful!"
-
-#: components/pages/Project/PayWithBank/index.tsx:264
-#: components/pages/Project/PayWithBank/index.tsx:363
-msgid "Retirement message"
-msgstr "Retirement message"
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:74
-msgid "Retirement successful"
-msgstr "Retirement successful"
-
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:362
-msgid "Retiring Token"
-msgstr "Retiring Token"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:208
-msgid "Say a few words about yourself. This will be visible in your seller profile."
-msgstr "Say a few words about yourself. This will be visible in your seller profile."
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:99
-msgid "See your portfolio"
-msgstr "See your portfolio"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:104
-msgid "See your retirement receipt"
-msgstr "See your retirement receipt"
-
-#: components/pages/Portfolio/AssetProject/index.tsx:98
-#: components/pages/Portfolio/AssetProject/index.tsx:106
-msgid "Sell"
-msgstr "Sell"
-
-#: components/pages/Home/index.tsx:313
-msgid "Sell carbon"
-msgstr "Sell carbon"
-
-#: components/pages/Home/index.tsx:409
-msgid "Sell your digital carbon directly to buyers"
-msgstr "Sell your digital carbon directly to buyers"
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:58
-msgid "Seller Listing"
-msgstr "Seller Listing"
-
-#: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
-#: components/pages/Project/Purchase/Pool/SubmitButton.tsx:31
-msgid "Sign In / Connect To Buy"
-msgstr "Sign In / Connect To Buy"
-
-#: components/CreateListing/Form/index.tsx:129
-msgid "Single unit price"
-msgstr "Single unit price"
-
-#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
-msgid "Something went wrong loading the allowance"
-msgstr "Something went wrong loading the allowance"
-
-#: components/pages/Project/PayWithBank/index.tsx:75
-msgid "Something went wrong. Please try again."
-msgstr "Something went wrong. Please try again."
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:112
-msgid "Something went wrong. Please try again. {error}"
-msgstr "Something went wrong. Please try again. {error}"
-
-#: components/pages/errors/Custom404.tsx:25
-msgid "Sorry, looks like we sent you the wrong way."
-msgstr "Sorry, looks like we sent you the wrong way."
-
-#: components/pages/errors/Custom500.tsx:25
-msgid "Sorry, something went wrong."
-msgstr "Sorry, something went wrong."
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "Sorry, this handle already exists"
-msgstr "Sorry, this handle already exists"
-
-#: components/Stats/index.tsx:23
-msgid "Stats"
-msgstr "Stats"
-
-#: components/pages/Home/index.tsx:204
-#: components/pages/Home/index.tsx:262
-msgid "Step 1"
-msgstr "Step 1"
-
-#: components/pages/Home/index.tsx:217
-#: components/pages/Home/index.tsx:277
-msgid "Step 2"
-msgstr "Step 2"
-
-#: components/pages/Home/index.tsx:230
-#: components/pages/Home/index.tsx:290
-msgid "Step 3"
-msgstr "Step 3"
-
-#: components/CreateListing/Transaction/Submit.tsx:90
-#: components/pages/Project/PayWithBank/index.tsx:279
-msgid "Submit"
-msgstr "Submit"
-
-#: components/pages/Portfolio/CarbonmarkAssets.tsx:85
-msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
-msgstr "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
-
-#: components/shared/InvalidNetworkModal/index.tsx:74
-msgid "Switch to Polygon"
-msgstr "Switch to Polygon"
-
-#: components/Footer/index.tsx:29
-msgid "Terms of Use"
-msgstr "Terms of Use"
-
-#: components/pages/Home/index.tsx:541
-msgid "Terms of use"
-msgstr "Terms of use"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
-msgid "Thank you for supporting the planet!"
-msgstr "Thank you for supporting the planet!"
-
-#: components/pages/Purchases/index.tsx:72
-msgid "Thank you for supporting the planet! See purchase details below."
-msgstr "Thank you for supporting the planet! See purchase details below."
-
-#: components/pages/Project/PayWithBank/index.tsx:292
-msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
-msgstr "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
-
-#: components/pages/Home/index.tsx:68
-msgid "The Universal Carbon Marketplace"
-msgstr "The Universal Carbon Marketplace"
-
-#: components/CreateListing/Transaction/Approve.tsx:50
-msgid "The allowance below reflects the sum of all your listings for this specific token."
-msgstr "The allowance below reflects the sum of all your listings for this specific token."
-
-#: components/CreateListing/Transaction/Approve.tsx:43
-msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
-msgstr "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:34
-msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
-msgstr "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
-msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
-msgstr "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:213
-msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
-msgstr "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
-
-#: components/pages/Home/index.tsx:56
-#: components/pages/Home/index.tsx:71
-msgid "The largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading."
-msgstr "The largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading."
-
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:96
-msgid "The minimum amount to buy is 1 Tonne"
-msgstr "The minimum amount to buy is 1 Tonne"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:55
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:61
-msgid "The minimum amount to retire is 0.001 Tonnes"
-msgstr "The minimum amount to retire is 0.001 Tonnes"
-
-#: components/pages/Project/PayWithBank/index.tsx:133
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:73
-msgid "The minimum amount to retire is 1 Tonne"
-msgstr "The minimum amount to retire is 1 Tonne"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:97
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:103
-msgid "The minimum amount to retire via bank transfer is 100 Tonnes"
-msgstr "The minimum amount to retire via bank transfer is 100 Tonnes"
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:53
-msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
-msgstr "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
-msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
-msgstr "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
-
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:190
-msgid "There was an error during the checkout process. Please try again."
-msgstr "There was an error during the checkout process. Please try again."
-
-#: components/pages/Retire/Activity/List.tsx:44
-msgid "There was an error getting your retirement data. Please refresh the page to try again."
-msgstr "There was an error getting your retirement data. Please refresh the page to try again."
-
-#: components/pages/Retire/Activity/Overview.tsx:49
-msgid "There was an error getting your total retirement data"
-msgstr "There was an error getting your total retirement data"
-
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:61
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:124
-msgid "There was an error loading the total cost."
-msgstr "There was an error loading the total cost."
-
-#: components/shared/InvalidNetworkModal/index.tsx:70
-msgid "This app only works on Polygon Mainnet."
-msgstr "This app only works on Polygon Mainnet."
-
-#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
-msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
-msgstr "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
-
-#: components/pages/Users/Badge/index.tsx:17
-msgid "This listing has expired and is hidden from the marketplace. Please resubmit or delete the listing."
-msgstr "This listing has expired and is hidden from the marketplace. Please resubmit or delete the listing."
-
-#: components/pages/Users/Badge/index.tsx:12
-msgid "This listing is no longer valid and is hidden from the marketplace. Please resubmit or delete the listing."
-msgstr "This listing is no longer valid and is hidden from the marketplace. Please resubmit or delete the listing."
-
-#: components/pages/Project/Purchase/InactivePurchase.tsx:24
-msgid "This offer no longer exists."
-msgstr "This offer no longer exists."
-
-#: components/BetaBadge/index.tsx:9
-msgid "This product is still in Beta and audits have not been completed yet."
-msgstr "This product is still in Beta and audits have not been completed yet."
-
-#: components/pages/Users/ProfileHeader/index.tsx:46
-msgid "This user has not yet created a carbonmark profile."
-msgstr "This user has not yet created a carbonmark profile."
-
-#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
-msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
-msgstr "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
-
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:60
-msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
-msgstr "To finalize your retirement, verify all information is correct and then click 'submit' below."
-
-#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:25
-msgid "To get started, be sure to complete your <0>profile</0> and then head to the <1>marketplace</1> to purchase carbon assets."
-msgstr "To get started, be sure to complete your <0>profile</0> and then head to the <1>marketplace</1> to purchase carbon assets."
-
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:25
-msgid "To pay via bank transfer, we'll need to gather some information from you."
-msgstr "To pay via bank transfer, we'll need to gather some information from you."
-
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr "Toggle Select Project"
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr "Toggle Sorted by menu"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:110
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
-msgid "Toggle payment method"
-msgstr "Toggle payment method"
-
-#: components/pages/Projects/ProjectSort/index.tsx:29
-msgid "Toggle sort menu"
-msgstr "Toggle sort menu"
-
-#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
-msgid "Token you will receive"
-msgstr "Token you will receive"
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
-msgid "Tokens received:"
-msgstr "Tokens received:"
-
+#. js-lingui-explicit-id
 #: components/AssetDetails/index.tsx:54
 #: components/pages/Project/PayWithBank/index.tsx:125
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:51
@@ -1483,194 +74,917 @@ msgstr "Tokens received:"
 msgid "Tonnes"
 msgstr "Tonnes"
 
-#: components/Stats/StatsListings.tsx:42
-msgid "Tonnes listed:"
-msgstr "Tonnes listed:"
-
-#: components/Stats/StatsListings.tsx:35
-msgid "Tonnes sold:"
-msgstr "Tonnes sold:"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:462
-msgid "Total Cost is required"
-msgstr "Total Cost is required"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr "Total Price"
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr "Total Retirements:"
-
-#: components/CreateListing/Transaction/Approve.tsx:59
-msgid "Total allowance"
-msgstr "Total allowance"
-
-#: components/pages/Project/PayWithBank/index.tsx:129
-msgid "Total amount of tonnes to retire is required"
-msgstr "Total amount of tonnes to retire is required"
-
-#: components/pages/Retire/Activity/Overview.tsx:72
-msgid "Total carbon tonnes retired"
-msgstr "Total carbon tonnes retired"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:263
-msgid "Total cost"
-msgstr "Total cost"
-
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:156
-msgid "Total price"
-msgstr "Total price"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
-msgid "Total quantity to list for sale"
-msgstr "Total quantity to list for sale"
-
-#: components/pages/Retire/Activity/Overview.tsx:83
-msgid "Total retirement transactions"
-msgstr "Total retirement transactions"
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
-msgid "Total sale cost"
-msgstr "Total sale cost"
-
-#: components/CreateListing/Form/index.tsx:106
-msgid "USDC per tonne"
-msgstr "USDC per tonne"
-
-#: components/CreateListing/Form/index.tsx:111
-msgid "Unit price is required"
-msgstr "Unit price is required"
-
-#: components/pages/Portfolio/AssetProject/index.tsx:74
-msgid "Unlisted tonnes:"
-msgstr "Unlisted tonnes:"
-
-#: components/pages/Home/index.tsx:322
-msgid "Unprecedented transparency across the digital carbon market."
-msgstr "Unprecedented transparency across the digital carbon market."
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:183
-msgid "Update listing"
-msgstr "Update listing"
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:86
-msgid "Updated:"
-msgstr "Updated:"
-
-#: components/pages/Users/SellerConnected/index.tsx:190
-msgid "Updating your data..."
-msgstr "Updating your data..."
-
-#: components/pages/Resources/lib/cmsDataMap.ts:61
-msgid "User Guides"
-msgstr "User Guides"
-
-#: components/pages/Users/Login/index.tsx:32
-#: components/pages/Users/Login/index.tsx:33
-msgid "User Profile | Carbonmark"
-msgstr "User Profile | Carbonmark"
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:41
-msgid "Verify all information is correct and click 'approve' to continue."
-msgstr "Verify all information is correct and click 'approve' to continue."
-
-#: components/ViewWalletButton/index.tsx:25
-msgid "View"
-msgstr "View"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:50
-msgid "View Carbonmark Profile"
-msgstr "View Carbonmark Profile"
-
-#: components/pages/Project/index.tsx:209
-msgid "View Registry Details <0/>"
-msgstr "View Registry Details <0/>"
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
-msgstr "View Results"
-
-#: components/pages/Portfolio/index.tsx:78
-msgid "View a complete overview of the digital carbon that you own in your Portfolio."
-msgstr "View a complete overview of the digital carbon that you own in your Portfolio."
-
-#: components/pages/Portfolio/Retire/index.tsx:94
-msgid "View a complete overview of the digital carbon that you own in your Retire."
-msgstr "View a complete overview of the digital carbon that you own in your Retire."
-
-#: components/pages/Retire/index.tsx:41
-msgid "View a complete overview of the digital carbon that you retired."
-msgstr "View a complete overview of the digital carbon that you retired."
-
-#: components/pages/Retire/index.tsx:118
-msgid "View all Portfolio items"
-msgstr "View all Portfolio items"
-
-#: components/pages/Retire/index.tsx:83
-msgid "View all Projects"
-msgstr "View all Projects"
-
-#: components/pages/Retire/Activity/Quotes.tsx:85
-#: components/pages/Retire/Activity/Table.tsx:77
-msgid "View all Retirements"
-msgstr "View all Retirements"
-
-#: components/pages/Project/index.tsx:116
-msgid "View and purchase this carbon offset project on Carbonmark"
-msgstr "View and purchase this carbon offset project on Carbonmark"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:74
-msgid "View and share certificate"
-msgstr "View and share certificate"
-
+#. js-lingui-explicit-id
 #: components/AssetDetails/index.tsx:60
 msgid "View on PolygonScan"
 msgstr "View on PolygonScan"
 
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:47
-msgid "View on PolygonScan <0/>"
-msgstr "View on PolygonScan <0/>"
+#. js-lingui-explicit-id
+#: components/BetaBadge/index.tsx:9
+msgid "This product is still in Beta and audits have not been completed yet."
+msgstr "This product is still in Beta and audits have not been completed yet."
 
-#: components/pages/Purchases/index.tsx:29
-msgid "View the project details and other info for this purchase."
-msgstr "View the project details and other info for this purchase."
+#. js-lingui-explicit-id
+#: components/BetaBadge/index.tsx:13
+msgid "BETA"
+msgstr "BETA"
 
-#: components/ProjectFilterModal/index.tsx:141
-msgid "Vintage"
-msgstr "Vintage"
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:44
+#: components/shared/ChangeLanguageButton/index.tsx:48
+msgid "Change language"
+msgstr "Change language"
 
-#: components/ProjectFilterModal/constants.tsx:14
-msgid "Vintage Newest"
-msgstr "Vintage Newest"
+#. js-lingui-explicit-id
+#: components/CopyAddressButton/index.tsx:37
+msgid "Copy"
+msgstr "Copy"
 
-#: components/ProjectFilterModal/constants.tsx:15
-msgid "Vintage Oldest"
-msgstr "Vintage Oldest"
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:59
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:80
+msgid "Asset"
+msgstr "Asset"
 
-#: components/pages/Purchases/index.tsx:65
-msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
-msgstr "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:74
+msgid "How many tonnes do you want to list for sale?"
+msgstr "How many tonnes do you want to list for sale?"
 
-#: components/pages/Retire/FromPortfolio/index.tsx:74
-#: components/pages/Retire/FromPortfolio/index.tsx:89
-msgid "We couldn't find any assets in your portfolio."
-msgstr "We couldn't find any assets in your portfolio."
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:93
+msgid "Balance exceeded"
+msgstr "Balance exceeded"
 
-#: components/pages/Retire/index.tsx:89
-msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
-msgstr "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:97
+#: components/CreateListing/Transaction/Submit.tsx:53
+msgid "Quantity"
+msgstr "Quantity"
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:101
+msgid "Available to list: {0}"
+msgstr "Available to list: {0}"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:106
+msgid "USDC per tonne"
+msgstr "USDC per tonne"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:111
+msgid "Unit price is required"
+msgstr "Unit price is required"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:129
+msgid "Single unit price"
+msgstr "Single unit price"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr "Toggle Select Project"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/index.tsx:152
+msgid "Create a listing"
+msgstr "Create a listing"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:37
+msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
+msgstr "First, approve the Carbonmark system to transfer this asset on your behalf."
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:43
+msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
+msgstr "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:50
+msgid "The allowance below reflects the sum of all your listings for this specific token."
+msgstr "The allowance below reflects the sum of all your listings for this specific token."
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:59
+msgid "Total allowance"
+msgstr "Total allowance"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:81
+#: components/Transaction/Approve.tsx:101
+msgid "Approve"
+msgstr "Approve"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Approve.tsx:88
+msgid "Next"
+msgstr "Next"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:61
+msgid "{0} tonnes"
+msgstr "{0} tonnes"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:41
+msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
+msgstr "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:47
+msgid "You can delete this listing at any time."
+msgstr "You can delete this listing at any time."
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:62
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:94
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:166
+msgid "Price per tonne"
+msgstr "Price per tonne"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:90
+#: components/pages/Project/PayWithBank/index.tsx:279
+msgid "Submit"
+msgstr "Submit"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/Submit.tsx:98
+msgid "Close"
+msgstr "Close"
+
+#. js-lingui-explicit-id
+#: components/Dropdown/index.tsx:133
+msgid "Coming soon"
+msgstr "Coming soon"
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:39
+#: components/pages/Project/Purchase/Listing/SubmitButton.tsx:44
+#: components/pages/Project/Purchase/Pool/SubmitButton.tsx:44
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:38
+#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:34
+msgid "Continue"
+msgstr "Continue"
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:44
+msgid "Cancel"
+msgstr "Cancel"
+
+#. js-lingui-explicit-id
+#: components/FeatureBanner/index.tsx:31
+msgid "NEW FEATURE:"
+msgstr "NEW FEATURE:"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:26
+msgid "Privacy Policy"
+msgstr "Privacy Policy"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:29
+msgid "Terms of Use"
+msgstr "Terms of Use"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:32
+#: components/pages/Home/index.tsx:544
+#: components/shared/Navigation/index.tsx:87
+#: components/shared/Navigation/index.tsx:124
+msgid "Help"
+msgstr "Help"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:35
+#: components/pages/Home/index.tsx:511
+#: components/pages/Home/index.tsx:547
+#: components/pages/Resources/ResourcesList/index.tsx:154
+#: components/shared/Navigation/index.tsx:75
+#: components/shared/Navigation/index.tsx:112
+msgid "Resources"
+msgstr "Resources"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:38
+#: components/pages/Home/index.tsx:550
+msgid "KlimaDAO"
+msgstr "KlimaDAO"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:41
+#: components/pages/Home/index.tsx:553
+msgid "Contact"
+msgstr "Contact"
+
+#. js-lingui-explicit-id
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr "Your Wallet Address:"
+
+#. js-lingui-explicit-id
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr "Not Connected"
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:95
+#: components/LoginCard/index.tsx:32
+msgid "Login"
+msgstr "Login"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:53
+#: components/LoginButton/index.tsx:11
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:285
+#: components/pages/Retire/Activity/Overview.tsx:73
+#: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
+msgid "Loading..."
+msgstr "Loading..."
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:64
+#: components/LoginButton/index.tsx:13
+msgid "Log in"
+msgstr "Log in"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:74
+#: components/LoginButton/index.tsx:15
+msgid "Log out"
+msgstr "Log out"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:94
+msgid "Book a demo"
+msgstr "Book a demo"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavDrawer/index.tsx:102
+msgid "Built with 🌳 by <0>KlimaDAO</0>"
+msgstr "Built with 🌳 by <0>KlimaDAO</0>"
+
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr "Please Log In"
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom404.tsx:13
+#: components/pages/errors/Custom404.tsx:14
+#: components/pages/errors/Custom404.tsx:15
+#: components/pages/errors/Custom404.tsx:22
+msgid "404 - Page Not Found"
+msgstr "404 - Page Not Found"
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom404.tsx:25
+msgid "Sorry, looks like we sent you the wrong way."
+msgstr "Sorry, looks like we sent you the wrong way."
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:13
+#: components/pages/errors/Custom500.tsx:14
+#: components/pages/errors/Custom500.tsx:15
+msgid "500 - Server Error"
+msgstr "500 - Server Error"
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:22
+msgid "500 - Server error occurred"
+msgstr "500 - Server error occurred"
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:25
+msgid "Sorry, something went wrong."
+msgstr "Sorry, something went wrong."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:54
+#: components/pages/Home/index.tsx:55
+msgid "Carbonmark | The Universal Carbon Marketplace"
+msgstr "Carbonmark | The Universal Carbon Marketplace"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:56
+#: components/pages/Home/index.tsx:71
+msgid "The largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading."
+msgstr "The largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:68
+msgid "The Universal Carbon Marketplace"
+msgstr "The Universal Carbon Marketplace"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:79
+msgid "Get Started"
+msgstr "Get Started"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:101
+msgid "Our Partners"
+msgstr "Our Partners"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:121
+msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
+msgstr "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:160
+#: components/pages/Home/index.tsx:191
+#: components/pages/Home/index.tsx:244
+#: components/pages/Project/PayWithBank/index.tsx:370
+#: components/shared/Navigation/index.tsx:54
+#: components/shared/Navigation/index.tsx:133
+msgid "Browse Projects"
+msgstr "Browse Projects"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:171
+msgid "Buy or retire carbon"
+msgstr "Buy or retire carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:174
+msgid "Maximize your climate impact."
+msgstr "Maximize your climate impact."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:177
+msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
+msgstr "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:184
+msgid "Retire now, or acquire carbon to retire later - you decide what to do when you take ownership of your carbon assets."
+msgstr "Retire now, or acquire carbon to retire later - you decide what to do when you take ownership of your carbon assets."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:204
+#: components/pages/Home/index.tsx:262
+msgid "Step 1"
+msgstr "Step 1"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:209
+msgid "Choose a project and quantity"
+msgstr "Choose a project and quantity"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:217
+#: components/pages/Home/index.tsx:277
+msgid "Step 2"
+msgstr "Step 2"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:222
+msgid "Create a profile and get connected"
+msgstr "Create a profile and get connected"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:230
+#: components/pages/Home/index.tsx:290
+msgid "Step 3"
+msgstr "Step 3"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:235
+msgid "Retire instantly, or purchase and hold digital carbon"
+msgstr "Retire instantly, or purchase and hold digital carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:267
+msgid "Digitize your carbon by using a supported bridge"
+msgstr "Digitize your carbon by using a supported bridge"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:282
+msgid "Create a seller profile"
+msgstr "Create a seller profile"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:295
+msgid "List your projects for sale in just a few clicks"
+msgstr "List your projects for sale in just a few clicks"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:304
+#: components/pages/Home/index.tsx:328
+msgid "Request Demo"
+msgstr "Request Demo"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:313
+msgid "Sell carbon"
+msgstr "Sell carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:316
+msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
+msgstr "Create your own carbon storefront. Sell directly to organizations and individuals alike."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:322
+msgid "Unprecedented transparency across the digital carbon market."
+msgstr "Unprecedented transparency across the digital carbon market."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:343
+msgid "For carbon traders"
+msgstr "For carbon traders"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:348
+msgid "Compare prices across all sellers and trading pools"
+msgstr "Compare prices across all sellers and trading pools"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:354
+msgid "Real-time price and transaction data powered by the blockchain"
+msgstr "Real-time price and transaction data powered by the blockchain"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:361
+msgid "0% listing fee"
+msgstr "0% listing fee"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:365
+msgid "All assets sourced from major registries"
+msgstr "All assets sourced from major registries"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:369
+msgid "Instant settlement of all trades"
+msgstr "Instant settlement of all trades"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:388
+msgid "For project developers"
+msgstr "For project developers"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:393
+msgid "Get paid immediately: transactions are resolved in seconds"
+msgstr "Get paid immediately: transactions are resolved in seconds"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:399
+msgid "List and sell for free"
+msgstr "List and sell for free"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:403
+msgid "No barriers to entry for verified carbon projects"
+msgstr "No barriers to entry for verified carbon projects"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:409
+msgid "Sell your digital carbon directly to buyers"
+msgstr "Sell your digital carbon directly to buyers"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:420
+msgid "Learn more"
+msgstr "Learn more"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:437
+msgid "Introducing Carbonmark"
+msgstr "Introducing Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:440
+msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
+msgstr "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:448
+#: components/pages/Home/index.tsx:475
+#: components/pages/Home/index.tsx:502
+#: components/pages/Resources/BlogPostCard/index.tsx:38
+#: components/pages/Resources/FeaturedArticles/Article.tsx:45
+msgid "Read more"
+msgstr "Read more"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:464
+msgid "FAQs"
+msgstr "FAQs"
+
+#. js-lingui-explicit-id
 #: components/pages/Home/index.tsx:467
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:491
+msgid "Carbonmark's role"
+msgstr "Carbonmark's role"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:494
+msgid "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
+msgstr "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:521
+msgid "Powered by"
+msgstr "Powered by"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:527
+msgid "KlimaDAO provides the transparent, neutral, and public infrastructure required to accelerate climate finance on a global scale."
+msgstr "KlimaDAO provides the transparent, neutral, and public infrastructure required to accelerate climate finance on a global scale."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:538
+msgid "Privacy policy"
+msgstr "Privacy policy"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:541
+msgid "Terms of use"
+msgstr "Terms of use"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/AssetProject/index.tsx:74
+msgid "Unlisted tonnes:"
+msgstr "Unlisted tonnes:"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/AssetProject/index.tsx:78
+msgid "Listed tonnes:"
+msgstr "Listed tonnes:"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/AssetProject/index.tsx:85
+msgid "Retire"
+msgstr "Retire"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/AssetProject/index.tsx:98
+#: components/pages/Portfolio/AssetProject/index.tsx:106
+msgid "Sell"
+msgstr "Sell"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/CarbonmarkAssets.tsx:57
+#: components/pages/Retire/FromPortfolio/index.tsx:60
+msgid "Loading your assets"
+msgstr "Loading your assets"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/CarbonmarkAssets.tsx:85
+msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
+msgstr "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/CarbonmarkAssets.tsx:96
+msgid "No listable assets found."
+msgstr "No listable assets found."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/index.tsx:66
+#: components/pages/Users/SellerConnected/index.tsx:81
+#: components/pages/Users/SellerConnected/index.tsx:107
+msgid "Please refresh the page. There was an error updating your data: {e}."
+msgstr "Please refresh the page. There was an error updating your data: {e}."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/index.tsx:76
+#: components/pages/Portfolio/index.tsx:77
+msgid "Portfolio | Carbonmark"
+msgstr "Portfolio | Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/index.tsx:78
+msgid "View a complete overview of the digital carbon that you own in your Portfolio."
+msgstr "View a complete overview of the digital carbon that you own in your Portfolio."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/PortfolioSidebar.tsx:26
+#: components/pages/Users/SellerConnected/index.tsx:214
+msgid "Your seller data"
+msgstr "Your seller data"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/index.tsx:92
+#: components/pages/Portfolio/Retire/index.tsx:93
+#: components/pages/Retire/index.tsx:39
+#: components/pages/Retire/index.tsx:40
+msgid "Retire | Carbonmark"
+msgstr "Retire | Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/index.tsx:94
+msgid "View a complete overview of the digital carbon that you own in your Retire."
+msgstr "View a complete overview of the digital carbon that you own in your Retire."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:207
+msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
+msgstr "Retire carbon credits for yourself, or on behalf of another person or organization."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:213
+msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
+msgstr "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:221
+msgid "<0>* </0> Required Field"
+msgstr "<0>* </0> Required Field"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
+msgid "Available: {unlistedBalance}"
+msgstr "Available: {unlistedBalance}"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:299
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
+msgid "Beneficiary wallet address (optional)"
+msgstr "Beneficiary wallet address (optional)"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:21
+msgid "Asset Details"
+msgstr "Asset Details"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:25
+msgid "Asset ID"
+msgstr "Asset ID"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:29
+msgid "{tokenSymbol}"
+msgstr "{tokenSymbol}"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:34
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:363
+msgid "Available to retire"
+msgstr "Available to retire"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:37
+msgid "tonnes"
+msgstr "tonnes"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:47
+msgid "View on PolygonScan <0/>"
+msgstr "View on PolygonScan <0/>"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr "Retirement Successful!"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:48
+msgid "You can view the successful transaction now on<0> PolygonScan.</0>"
+msgstr "You can view the successful transaction now on<0> PolygonScan.</0>"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
+msgid "Retire more carbon"
+msgstr "Retire more carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:74
+msgid "View and share certificate"
+msgstr "View and share certificate"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
+msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
+msgstr "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:19
+msgid "You must have a profile created to view carbon assets you own in your Carbonmark portfolio."
+msgstr "You must have a profile created to view carbon assets you own in your Carbonmark portfolio."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:25
+msgid "To get started, be sure to complete your <0>profile</0> and then head to the <1>marketplace</1> to purchase carbon assets."
+msgstr "To get started, be sure to complete your <0>profile</0> and then head to the <1>marketplace</1> to purchase carbon assets."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:30
+msgid "Carbon Pool"
+msgstr "Carbon Pool"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:34
+#: components/pages/Project/BuyOptions/SellerListing.tsx:62
+#: components/pages/Project/index.tsx:139
+msgid "Best Price"
+msgstr "Best Price"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:41
+#: components/pages/Project/BuyOptions/SellerListing.tsx:78
+msgid "Quantity Available:"
+msgstr "Quantity Available:"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:45
+msgid "Buy"
+msgstr "Buy"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/PoolPrice.tsx:56
+msgid "Retire now"
+msgstr "Retire now"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:58
+msgid "Seller Listing"
+msgstr "Seller Listing"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:82
+msgid "Created:"
+msgstr "Created:"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:86
+msgid "Updated:"
+msgstr "Updated:"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:116
+msgid "View and purchase this carbon offset project on Carbonmark"
+msgstr "View and purchase this carbon offset project on Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:146
+msgid "Methodology"
+msgstr "Methodology"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:187
+msgid "Description"
+msgstr "Description"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:200
+msgid "Read Less"
+msgstr "Read Less"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:200
+msgid "Read More"
+msgstr "Read More"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:209
+msgid "View Registry Details <0/>"
+msgstr "View Registry Details <0/>"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:226
+msgid "No listings found for this project."
+msgstr "No listings found for this project."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/index.tsx:236
+msgid "Data for this project and vintage"
+msgstr "Data for this project and vintage"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:75
+msgid "Something went wrong. Please try again."
+msgstr "Something went wrong. Please try again."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:89
+#: components/pages/Project/PayWithBank/index.tsx:90
+msgid "Pay with Bank Transfer | Carbonmark"
+msgstr "Pay with Bank Transfer | Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:91
+msgid "Retire your carbon via bank transfer."
+msgstr "Retire your carbon via bank transfer."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
+msgstr "Pay with bank transfer"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:101
+msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
+msgstr "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:116
+msgid "Indicates required field"
+msgstr "Indicates required field"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:122
+msgid "How much would you like to retire?"
+msgstr "How much would you like to retire?"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:129
+msgid "Total amount of tonnes to retire is required"
+msgstr "Total amount of tonnes to retire is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:133
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:73
+msgid "The minimum amount to retire is 1 Tonne"
+msgstr "The minimum amount to retire is 1 Tonne"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:143
+#: components/pages/Project/PayWithBank/index.tsx:307
+msgid "Email"
+msgstr "Email"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:149
+msgid "Email address is required"
+msgstr "Email address is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:153
+msgid "A valid email address is required"
+msgstr "A valid email address is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:161
+#: components/pages/Project/PayWithBank/index.tsx:313
+msgid "Phone number"
+msgstr "Phone number"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:167
+#: components/pages/Project/PayWithBank/index.tsx:319
+msgid "Company name"
+msgstr "Company name"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:173
+msgid "Company name is required"
+msgstr "Company name is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:181
+#: components/pages/Project/PayWithBank/index.tsx:325
+msgid "Job title"
+msgstr "Job title"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:187
+#: components/pages/Project/PayWithBank/index.tsx:331
+msgid "First name"
+msgstr "First name"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:193
+msgid "First name is required"
+msgstr "First name is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:197
+msgid "First name should not contain numbers or special characters"
+msgstr "First name should not contain numbers or special characters"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:206
+#: components/pages/Project/PayWithBank/index.tsx:337
+msgid "Last name"
+msgstr "Last name"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:212
+msgid "Last name is required"
+msgstr "Last name is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:216
+msgid "Last name should not contain numbers or special characters"
+msgstr "Last name should not contain numbers or special characters"
+
+#. js-lingui-explicit-id
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:250
@@ -1678,780 +992,2072 @@ msgstr "What is Carbonmark? Answers to common questions about the Digital Carbon
 msgid "Who will this retirement be credited to?"
 msgstr "Who will this retirement be credited to?"
 
-#: components/shared/InvalidNetworkModal/index.tsx:64
-msgid "Wrong Network"
-msgstr "Wrong Network"
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:232
+#: components/pages/Project/PayWithBank/index.tsx:349
+msgid "Beneficiary wallet address"
+msgstr "Beneficiary wallet address"
 
-#: components/pages/Retire/Activity/Quotes.tsx:71
-#: lib/formatWalletAddress.ts:9
-#: lib/formatWalletAddress.ts:21
-msgid "You"
-msgstr "You"
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:240
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:281
+msgid "Not a valid polygon address"
+msgstr "Not a valid polygon address"
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
-msgid "You are about to purchase a carbon asset."
-msgstr "You are about to purchase a carbon asset."
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:253
+#: components/pages/Project/PayWithBank/index.tsx:357
+msgid "Project names of interest"
+msgstr "Project names of interest"
 
-#: components/pages/Project/Retire/Pool/RetireModal.tsx:31
-msgid "You are about to retire a carbon asset."
-msgstr "You are about to retire a carbon asset."
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:264
+#: components/pages/Project/PayWithBank/index.tsx:363
+msgid "Retirement message"
+msgstr "Retirement message"
 
-#: components/pages/Retire/index.tsx:123
-msgid "You can also retire any carbon asset in your wallet."
-msgstr "You can also retire any carbon asset in your wallet."
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:289
+msgid "Form complete"
+msgstr "Form complete"
 
-#: components/CreateListing/Transaction/Submit.tsx:47
-msgid "You can delete this listing at any time."
-msgstr "You can delete this listing at any time."
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:292
+msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
+msgstr "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:48
-msgid "You can view the successful transaction now on <0>PolygonScan.</0>"
-msgstr "You can view the successful transaction now on <0>PolygonScan.</0>"
+#. js-lingui-explicit-id
+#: components/pages/Project/PayWithBank/index.tsx:301
+msgid "How many tonnes would you like to retire?"
+msgstr "How many tonnes would you like to retire?"
 
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:48
-msgid "You can view the successful transaction now on<0> PolygonScan.</0>"
-msgstr "You can view the successful transaction now on<0> PolygonScan.</0>"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/InactivePurchase.tsx:24
+msgid "This offer no longer exists."
+msgstr "This offer no longer exists."
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:110
-msgid "You chose to reject the transaction."
-msgstr "You chose to reject the transaction."
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/index.tsx:37
+#: components/pages/Project/Purchase/index.tsx:38
+msgid "Purchase {0} | Carbonmark"
+msgstr "Purchase {0} | Carbonmark"
 
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:275
-msgid "You either need to provide a beneficiary address or login with your browser wallet."
-msgstr "You either need to provide a beneficiary address or login with your browser wallet."
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/index.tsx:49
+#: components/pages/Project/Retire/index.tsx:36
+msgid "Back to Project"
+msgstr "Back to Project"
 
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:63
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:65
-msgid "You exceeded your available amount of tokens"
-msgstr "You exceeded your available amount of tokens"
-
-#: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:19
-msgid "You must have a profile created to view carbon assets you own in your Carbonmark portfolio."
-msgstr "You must have a profile created to view carbon assets you own in your Carbonmark portfolio."
-
-#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:43
-msgid "You successfully acquired carbon!"
-msgstr "You successfully acquired carbon!"
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
-msgstr "Your Wallet Address:"
-
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:405
-msgid "Your balance must equal at least 1% more than the cost of the transaction."
-msgstr "Your balance must equal at least 1% more than the cost of the transaction."
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:129
-#: components/pages/Project/Purchase/Pool/TotalValues.tsx:172
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:292
-msgid "Your balance:"
-msgstr "Your balance:"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:178
-msgid "Your display name"
-msgstr "Your display name"
-
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
-msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
-msgstr "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
-
-#: components/pages/Portfolio/PortfolioSidebar.tsx:26
-#: components/pages/Users/SellerConnected/index.tsx:214
-msgid "Your seller data"
-msgstr "Your seller data"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:84
-msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
-msgstr "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:144
-msgid "Your unique handle"
-msgstr "Your unique handle"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:82
-msgid "Z-A"
-msgstr "Z-A"
-
-#: components/pages/Home/index.tsx:440
-msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
-msgstr "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
-
-#: components/Activities/Activity.tsx:33
-msgid "at"
-msgstr "at"
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr "The information provided in this blog post pertaining to KlimaDAO (“KlimaDAO”), its crypto-assets, business assets, strategy, and operations, is for general informational purposes only and is not a formal offer to sell or a solicitation of an offer to buy any securities, options, futures, or other derivatives related to securities in any jurisdiction and its content is not prescribed by securities laws. Information contained in this blog post should not be relied upon as advice to buy or sell or hold such securities or as an offer to sell such securities. This blog post does not take into account nor does it provide any tax, legal or investment advice or opinion regarding the specific investment objectives or financial situation of any person. KlimaDAO and its agents, advisors, directors, officers, employees and shareholders make no representation or warranties, expressed or implied, as to the accuracy of such information and KlimaDAO expressly disclaims any and all liability that may be based on such information or errors or omissions thereof. KlimaDAO reserves the right to amend or replace the information contained herein, in part or entirely, at any time, and undertakes no obligation to provide the recipient with access to the amended information or to notify the recipient thereof. The information contained in this blog post supersedes any prior blog post or conversation concerning the same, similar or related information. Any information, representations or statements not contained herein shall not be relied upon for any purpose. Neither KlimaDAO nor any of its representatives shall have any liability whatsoever, under contract, tort, trust or otherwise, to you or any person resulting from the use of the information in this blog post by you or any of your representatives or for omissions from the information in this blog post. Additionally, KlimaDAO undertakes no obligation to comment on the expectations of, or statements made by, third parties in respect of the matters discussed in this blog post."
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr "Disclaimer:"
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr "bought from"
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:104
-msgid "buy"
-msgstr "Buy"
-
-#: components/Layout/index.tsx:86
-msgid "connectModal.torus"
-msgstr "social or email"
-
-#: components/Layout/index.tsx:90
-msgid "connectModal.wallet"
-msgstr "connect a wallet"
-
-#: components/Layout/index.tsx:96
-msgid "connect_modal.connecting"
-msgstr "Connecting..."
-
-#: lib/constants.ts:80
-msgid "connect_modal.error_message_default"
-msgstr "We had some trouble connecting. Please try again."
-
-#: lib/constants.ts:84
-msgid "connect_modal.error_message_refused"
-msgstr "User refused connection."
-
-#: lib/constants.ts:88
-msgid "connect_modal.error_processing"
-msgstr "Request already processing. Please open your wallet and complete the request."
-
-#: components/Layout/index.tsx:100
-msgid "connect_modal.error_title"
-msgstr "Connection Error"
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr "created listing"
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr "deleted listing"
-
+#. js-lingui-explicit-id
 #: components/pages/Project/Purchase/Listing/Price.tsx:18
 #: components/pages/Project/Purchase/Pool/Price.tsx:17
 #: components/pages/Project/Retire/Pool/Price.tsx:17
 msgid "each"
 msgstr "each"
 
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr "After you click the button below to continue, you will be asked to connect your wallet and the project you selected here will already be selected for you on KlimaDAO.finance. From there, follow the directions on that page to complete your transaction."
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr "Carbon credits you purchase or any retirements you make on KlimaDAO.finance will also be accessible in your Carbonmark portfolio."
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr "You will be taken to KlimaDAO.finance to complete this transaction."
-
-#: components/Activities/Activity.tsx:89
-msgid "for"
-msgstr "for"
-
-#: components/pages/Retire/index.tsx:53
-msgid "for beneficiary"
-msgstr "for beneficiary"
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr "Marketplace"
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr "Portfolio"
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr "Profile"
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr "Retire"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:229
-msgid "offset.amount_in_tonnes"
-msgstr "How many tonnes of carbon would you like to offset? <0>* </0>"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:319
-msgid "offset.default_retirement_address"
-msgstr "Defaults to the connected wallet address"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:252
-msgid "offset.offset_quantity"
-msgstr "Enter quantity to offset"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:403
-msgid "offset.retire_carbon"
-msgstr "Confirm Retirement"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:282
-msgid "offset.retirement_beneficiary_name"
-msgstr "Beneficiary Name"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:270
-msgid "offset.retirement_credit"
-msgstr "Who will this retirement be credited to?"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:328
-msgid "offset.retirement_message"
-msgstr "Retirement message"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:339
-msgid "offset.retirement_retirement_message"
-msgstr "Retirement Message"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr "Thank you for supporting the planet! View transaction on <0> PolygonScan.</0>"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr "Thank you for supporting the planet!"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr "Your transaction has been successfully processed but is taking longer than normal to index. It will appear in your <0>retirements</0> soon."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:360
-msgid "offset_disclaimer"
-msgstr "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr "Balances"
-
-#: components/CreateListing/Form/index.tsx:135
-msgid "profile.addListing_modal.submit"
-msgstr "Create Listing"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:230
-msgid "profile.edit_modal.submit"
-msgstr "Save Changes"
-
-#: components/pages/Users/SellerConnected/index.tsx:220
-msgid "profile.edit_profile.title"
-msgstr "Your Profile"
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr "Edit your profile to add a description."
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:155
-msgid "profile.listing.delete.error"
-msgstr "Could not delete listing. Please try again."
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:216
-msgid "profile.listing.edit.delete_listing"
-msgstr "Delete Listing"
-
-#: components/pages/Purchases/index.tsx:48
-msgid "project.single.button.back_to_project_details"
-msgstr "Back to Project Details"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr "You are about to purchase a carbon asset."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr "Verify all information is correct and click 'approve' to continue."
-
-#: components/pages/Purchases/index.tsx:142
-msgid "purchase.button.view_assets"
-msgstr "View Your Assets"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:79
-msgid "purchase.input.amount.minimum"
-msgstr "The minimum amount to buy is 1 Tonne"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:61
-msgid "purchase.input.amount.placeholder"
-msgstr "Tonnes"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:72
-msgid "purchase.input.amount.required"
-msgstr "Amount is required"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:171
-msgid "purchase.input.price.maxAmount"
-msgstr "You exceeded your available amount of tokens"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:164
-msgid "purchase.input.price.required"
-msgstr "Price is required"
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-msgid "purchase.loading.allowance.error"
-msgstr "something went wrong loading the allowance"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:85
-msgid "purchase.transaction.modal.title.confirm"
-msgstr "Confirm Purchase"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:89
-msgid "purchase.transaction.modal.title.processing"
-msgstr "Processing Purchase"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr "Categories"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr "Select one or more"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr "Clear All"
-
-#: components/pages/Resources/ResourcesList/index.tsx:171
-msgid "resources.form.input.search.label"
-msgstr "Search"
-
-#: components/pages/Resources/ResourcesList/index.tsx:162
-msgid "resources.form.input.search.placeholder"
-msgstr "Search..."
-
-#: components/pages/Resources/ResourcesList/index.tsx:200
-msgid "resources.form.input.sort_by.label"
-msgstr "Sort by"
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:21
-msgid "resources.form.input.sort_by.select"
-msgstr "Select"
-
-#: components/pages/Resources/ResourcesList/index.tsx:301
-msgid "resources.mobile_modal.button.show_results"
-msgstr "Show Results"
-
-#: components/pages/Resources/ResourcesList/index.tsx:274
-msgid "resources.mobile_modal.title"
-msgstr "Sort By"
-
-#: components/pages/Resources/ResourcesList/index.tsx:239
-msgid "resources.page.list.no_search_results.title"
-msgstr "Sorry. We couldn't find any matching results."
-
-#: components/pages/Resources/ResourcesList/index.tsx:231
-msgid "resources.page.list.on_fetch_error"
-msgstr "Sorry! Something went wrong."
-
-#: components/pages/Resources/ResourcesList/index.tsx:252
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr "Please use a different filter combination."
-
-#: components/pages/Resources/ResourcesList/index.tsx:245
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr "Check your search for typos or try a different search term."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:381
-msgid "retire.back_button"
-msgstr "back"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:372
-msgid "retire.submit_button"
-msgstr "Retire Carbon"
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr "retired"
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr "With over 20 million verified digital carbon credits from hundreds of projects, Carbonmark offers the largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading. <0>Get started today</0>."
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr "About Carbonmark"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:128
-msgid "retirement.head.metaDescription"
-msgstr "Transparent, on-chain offsets powered by Carbonmark."
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr "{retiree} retired {formattedAmount} Tonnes of carbon"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr "Carbonmark | Carbon Retirement Receipt"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:41
-msgid "retirement.single.beneficiary.address.placeholder"
-msgstr "No beneficiary address available"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.placeholder"
-msgstr "No beneficiary name provided"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:35
-msgid "retirement.single.beneficiary.title"
-msgstr "Beneficiary:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:35
-msgid "retirement.single.beneficiary_address.title"
-msgstr "Beneficiary Address:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr "Carbon Credit Retirement"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:96
-msgid "retirement.single.country_region.title"
-msgstr "Country/Region:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:121
-msgid "retirement.single.immutable_public_records.title"
-msgstr "This represents the permanent retirement of a digital carbon asset. This retirement and the associated data are immutable public records."
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr "Retirement Message:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:82
-msgid "retirement.single.methodology.title"
-msgstr "Methodology:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:29
-msgid "retirement.single.moss_offset.description"
-msgstr "MC02 credits are generated by projects that preserve the Amazon Forest, with all sorts of positive externalities such as the creation of local jobs and preservation of local biodiversity. Explore MCO2 on <0>data.klimadao.finance</0>."
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:71
-msgid "retirement.single.moss_offset.name"
-msgstr "MOSS Earth MC02"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:114
-msgid "retirement.single.official_certificate.title"
-msgstr "Official Certificate for On-Chain Carbon Retirement Provided by <0>Carbonmark.com</0>"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.project.title"
-msgstr "Project:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:82
-msgid "retirement.single.project_description.title"
-msgstr "Description"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:42
-msgid "retirement.single.project_details.title"
-msgstr "Project Details"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:65
-msgid "retirement.single.project_name.title"
-msgstr "Project Name"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr "Proof of"
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr "QUANTITY RETIRED"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:29
-msgid "retirement.single.share_retirement.title"
-msgstr "Share this retirement"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr "No retirement timestamp provided"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:55
-msgid "retirement.single.transaction_id.placeholder"
-msgstr "No transaction id available"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:49
-msgid "retirement.single.transaction_id.title"
-msgstr "Transaction ID"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:28
-msgid "retirement.single.transaction_record.title"
-msgstr "Immutable transaction record"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.type.title"
-msgstr "Type:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr "Verified tonnes of carbon retired"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:140
-msgid "retirement.single.view_on_polygon_scan"
-msgstr "View on Polygonscan"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:109
-msgid "retirement.single.vintage.title"
-msgstr "Vintage:"
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr "No retirements found"
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr "All Retirements"
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr "Carbonmark - Carbon Retirements for beneficiary {0}"
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr "Carbonmark - Carbon Retirements for beneficiary {0}"
-
-#: components/pages/Retirements/index.tsx:64
-msgid "retirement.totals.page_headline"
-msgstr "Carbon Retirements"
-
-#: components/pages/Retirements/index.tsx:70
-msgid "retirement.totals.page_subline"
-msgstr "for beneficiary"
-
-#: components/pages/Retirements/index.tsx:94
-msgid "retirement.totals.retired_assets"
-msgstr "Retired Assets"
-
-#: components/pages/Retirements/index.tsx:110
-msgid "retirement.totals.retirements"
-msgstr "Retirements"
-
-#: components/pages/Retirements/index.tsx:102
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr "Total Carbon Tonnes Retired"
-
-#: components/pages/Retirements/index.tsx:116
-msgid "retirement.totals.total_retirement_transactions"
-msgstr "Total Retirement Transactions"
-
-#: components/pages/Users/SellerUnconnected/index.tsx:77
-msgid "seller.listing.buy"
-msgstr "Buy"
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr "Quantity Available:"
-
-#: components/pages/Project/BuyOptions/SellerListing.tsx:94
-#: components/pages/Users/SellerUnconnected/index.tsx:67
-msgid "shared.connect_to_buy"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:52
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
+msgid "Purchase amount (tonnes):"
+msgstr "Purchase amount (tonnes):"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:54
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:75
+msgid "Available: {0}"
+msgstr "Available: {0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:86
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:100
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:238
+msgid "Available supply exceeded"
+msgstr "Available supply exceeded"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:90
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:104
+msgid "How many tonnes of carbon do you want to buy?"
+msgstr "How many tonnes of carbon do you want to buy?"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:98
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:112
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:316
+msgid "Pay with:"
+msgstr "Pay with:"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:101
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:115
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:320
+msgid "Balance: {0}"
+msgstr "Balance: {0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:110
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
+msgid "Toggle payment method"
+msgstr "Toggle payment method"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:144
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
+msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
+msgstr "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
+#: components/pages/Project/Purchase/Pool/SubmitButton.tsx:31
+msgid "Sign In / Connect To Buy"
 msgstr "Sign In / Connect To Buy"
 
-#: components/pages/Retirements/index.tsx:51
-msgid "shared.head.description"
-msgstr "Drive climate action and earn rewards with a carbon-backed digital currency."
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
+msgstr "Total Price"
 
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr "Resource Center"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:49
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:86
+msgid "Amount to purchase"
+msgstr "Amount to purchase"
 
-#: components/pages/Resources/ResourcesList/index.tsx:206
-msgid "shared.resources.sort_by.header"
-msgstr "Sort by:"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:170
+msgid "Price includes network fees. <0>See docs to learn more.</0>"
+msgstr "Price includes network fees. <0>See docs to learn more.</0>"
 
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr "sold to"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:86
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:125
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:207
+msgid "Carbonmark fee"
+msgstr "Carbonmark fee"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:263
+msgid "Total cost"
+msgstr "Total cost"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:129
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:172
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:292
+msgid "Your balance:"
+msgstr "Your balance:"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
+msgid "Something went wrong loading the allowance"
+msgstr "Something went wrong loading the allowance"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
+msgid "Token you will receive"
+msgstr "Token you will receive"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:210
+msgid "Available to purchase"
+msgstr "Available to purchase"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:59
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:459
+msgid "Could not calculate Total Cost"
+msgstr "Could not calculate Total Cost"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:63
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:65
+msgid "You exceeded your available amount of tokens"
+msgstr "You exceeded your available amount of tokens"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:92
+msgid "Amount is required"
+msgstr "Amount is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:96
+msgid "The minimum amount to buy is 1 Tonne"
+msgstr "The minimum amount to buy is 1 Tonne"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:405
+msgid "Your balance must equal at least 1% more than the cost of the transaction."
+msgstr "Your balance must equal at least 1% more than the cost of the transaction."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
+msgid "You are about to purchase a carbon asset."
+msgstr "You are about to purchase a carbon asset."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
+msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
+msgstr "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:41
+msgid "Verify all information is correct and click 'approve' to continue."
+msgstr "Verify all information is correct and click 'approve' to continue."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
+msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
+msgstr "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
+msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
+msgstr "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:83
+msgid "Processing Purchase"
+msgstr "Processing Purchase"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
+msgid "Purchase successful"
+msgstr "Purchase successful"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
+#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:21
+msgid "Confirm Purchase"
+msgstr "Confirm Purchase"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:43
+msgid "You successfully acquired carbon!"
+msgstr "You successfully acquired carbon!"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
+msgid "Tokens received:"
+msgstr "Tokens received:"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
+msgid "Total sale cost"
+msgstr "Total sale cost"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:99
+msgid "See your portfolio"
+msgstr "See your portfolio"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:104
+msgid "Purchase more Carbon"
+msgstr "Purchase more Carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:61
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:124
+msgid "There was an error loading the total cost."
+msgstr "There was an error loading the total cost."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:156
+msgid "Total price"
+msgstr "Total price"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/index.tsx:24
+#: components/pages/Project/Retire/index.tsx:25
+msgid "Retire from {fullProjectid} | Carbonmark"
+msgstr "Retire from {fullProjectid} | Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:25
+msgid "To pay via bank transfer, we'll need to gather some information from you."
+msgstr "To pay via bank transfer, we'll need to gather some information from you."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:30
+msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
+msgstr "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
+msgstr "Go Back"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
+msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
+msgstr "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
+msgid "Go back"
+msgstr "Go back"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:187
+msgid "{0}"
+msgstr "{0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:190
+msgid "There was an error during the checkout process. Please try again."
+msgstr "There was an error during the checkout process. Please try again."
+
+#. js-lingui-explicit-id
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:243
 msgid "something went wrong loading the allowance"
 msgstr "something went wrong loading the allowance"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:362
+msgid "Retiring Token"
+msgstr "Retiring Token"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:55
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:61
+msgid "The minimum amount to retire is 0.001 Tonnes"
+msgstr "The minimum amount to retire is 0.001 Tonnes"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:79
+msgid "Credit card minimum purchase is {0}"
+msgstr "Credit card minimum purchase is {0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:85
+msgid ""
+"At this time, Carbonmark cannot process credit card payments\n"
+"exceeding {0}. Please adjust the\n"
+"quantity and try again later."
+msgstr ""
+"At this time, Carbonmark cannot process credit card payments\n"
+"exceeding {0}. Please adjust the\n"
+"quantity and try again later."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:97
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:103
+msgid "The minimum amount to retire via bank transfer is 100 Tonnes"
+msgstr "The minimum amount to retire via bank transfer is 100 Tonnes"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:202
+msgid "Required Field"
+msgstr "Required Field"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:207
+msgid "How many tonnes of carbon would you like to retire?"
+msgstr "How many tonnes of carbon would you like to retire?"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:211
+msgid "Available:"
+msgstr "Available:"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:233
+msgid "Quantity is required"
+msgstr "Quantity is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:242
+msgid "How many tonnes of carbon do you want to retire?"
+msgstr "How many tonnes of carbon do you want to retire?"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:256
+msgid "Beneficiary name"
+msgstr "Beneficiary name"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:260
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:304
+msgid "Required when proceeding with Credit Card"
+msgstr "Required when proceeding with Credit Card"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:275
+msgid "You either need to provide a beneficiary address or login with your browser wallet."
+msgstr "You either need to provide a beneficiary address or login with your browser wallet."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:285
+msgid "Beneficiary Address"
+msgstr "Beneficiary Address"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:289
+msgid "Defaults to the connected wallet address"
+msgstr "Defaults to the connected wallet address"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:294
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:308
+msgid "Retirement Message"
+msgstr "Retirement Message"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:300
+msgid "Describe the purpose of this retirement"
+msgstr "Describe the purpose of this retirement"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:324
+msgid "{0} maximum for credit cards"
+msgstr "{0} maximum for credit cards"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:373
+msgid "Login to pay with USDC"
+msgstr "Login to pay with USDC"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:384
+msgid "Processing Fee:"
+msgstr "Processing Fee:"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:390
+msgid "Balance"
+msgstr "Balance"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:428
+msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
+msgstr "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:443
+msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
+msgstr "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:462
+msgid "Total Cost is required"
+msgstr "Total Cost is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:31
+msgid "You are about to retire a carbon asset."
+msgstr "You are about to retire a carbon asset."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:34
+msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
+msgstr "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:53
+msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
+msgstr "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:60
+msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
+msgstr "To finalize your retirement, verify all information is correct and then click 'submit' below."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:73
+msgid "Processing Retirement"
+msgstr "Processing Retirement"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:74
+msgid "Retirement successful"
+msgstr "Retirement successful"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/RetireModal.tsx:75
+msgid "Confirm Retirement"
+msgstr "Confirm Retirement"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
+msgid "Retire Carbon"
+msgstr "Retire Carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr "RETIRE CARBON"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:35
+msgid "Our system is taking longer than expected. The retirement should appear in your<0>retirement history</0> soon."
+msgstr "Our system is taking longer than expected. The retirement should appear in your<0>retirement history</0> soon."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:48
+msgid "You can view the successful transaction now on <0>PolygonScan.</0>"
+msgstr "You can view the successful transaction now on <0>PolygonScan.</0>"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
+msgid "Thank you for supporting the planet!"
+msgstr "Thank you for supporting the planet!"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:104
+msgid "See your retirement receipt"
+msgstr "See your retirement receipt"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
+msgstr "Retire more Carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:103
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr "Credit card minimum purchase is ${formattedFiatMinimum}"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:121
+msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
+msgstr "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:158
+msgid "Amount to retire"
+msgstr "Amount to retire"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:233
+msgid "Payment processing fee"
+msgstr "Payment processing fee"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:237
+msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
+msgstr "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:51
+msgid "Pay via Bank Transfer / Wire"
+msgstr "Pay via Bank Transfer / Wire"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:56
+msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer"
+msgstr "Purchase retirements from any project on Carbonmark and pay via bank transfer"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:57
+msgid "Can we remind you about this new feature later?"
+msgstr "Can we remind you about this new feature later?"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:64
+msgid "Let's Go!"
+msgstr "Let's Go!"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:69
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:101
+msgid "Learn More"
+msgstr "Learn More"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:75
+msgid "Sure"
+msgstr "Sure"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/Banners/BankTransfer.tsx:77
+msgid "Don't Remind Me"
+msgstr "Don't Remind Me"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/GridView/GridView.tsx:38
+#: components/pages/Projects/ListView/ListView.tsx:157
+msgid "No project description found"
+msgstr "No project description found"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/index.tsx:71
+#: components/pages/Projects/index.tsx:72
+msgid "Marketplace | Carbonmark"
+msgstr "Marketplace | Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/index.tsx:73
+msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
+msgstr "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/index.tsx:88
+msgid "No projects found with current filters"
+msgstr "No projects found with current filters"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/ProjectSearch/index.tsx:45
+msgid "Filters"
+msgstr "Filters"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/ProjectSearch/index.tsx:52
+#: components/ProjectFilterModal/index.tsx:162
+msgid "Clear Filters"
+msgstr "Clear Filters"
+
+#. js-lingui-explicit-id
+#: components/pages/Projects/ProjectSort/index.tsx:29
+msgid "Toggle sort menu"
+msgstr "Toggle sort menu"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:28
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr "{amount} tonnes were purchased for project {0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:29
+msgid "View the project details and other info for this purchase."
+msgstr "View the project details and other info for this purchase."
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:35
+#: components/pages/Purchases/index.tsx:36
+msgid "Purchase Receipt | Carbonmark"
+msgstr "Purchase Receipt | Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:61
+msgid "Payment Successful"
+msgstr "Payment Successful"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:65
+msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
+msgstr "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:72
+msgid "Thank you for supporting the planet! See purchase details below."
+msgstr "Thank you for supporting the planet! See purchase details below."
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:90
+msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
+msgstr "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:103
+msgid "Quantity purchased:"
+msgstr "Quantity purchased:"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:112
+msgid "Final price"
+msgstr "Final price"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:19
+#: components/pages/Resources/index.tsx:20
+msgid "Resources | Carbonmark"
+msgstr "Resources | Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:21
+msgid "Find the latest updates, guides, and resources to help you leverage the Carbonmark platform."
+msgstr "Find the latest updates, guides, and resources to help you leverage the Carbonmark platform."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
+msgstr "Carbonmark Overview"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:51
+msgid "Digital Carbon"
+msgstr "Digital Carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:56
+msgid "Press Releases"
+msgstr "Press Releases"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:61
+msgid "User Guides"
+msgstr "User Guides"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:67
+msgid "Latest First"
+msgstr "Latest First"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:72
+msgid "Oldest First"
+msgstr "Oldest First"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:77
+msgid "A-Z"
+msgstr "A-Z"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:82
+msgid "Z-A"
+msgstr "Z-A"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
+msgstr "Toggle Sorted by menu"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/List.tsx:44
+msgid "There was an error getting your retirement data. Please refresh the page to try again."
+msgstr "There was an error getting your retirement data. Please refresh the page to try again."
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:49
+msgid "There was an error getting your total retirement data"
+msgstr "There was an error getting your total retirement data"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:60
+#: components/pages/Retire/Activity/Overview.tsx:70
+msgid "Retirement Overview"
+msgstr "Retirement Overview"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:62
+msgid "No data to show"
+msgstr "No data to show"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:72
+msgid "Total carbon tonnes retired"
+msgstr "Total carbon tonnes retired"
+
+#. js-lingui-explicit-id
 #: components/pages/Retire/Activity/Overview.tsx:77
 #: components/pages/Retire/Activity/Quotes.tsx:76
 #: components/pages/Retire/Activity/Table.tsx:65
 msgid "t"
 msgstr "t"
 
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:37
-msgid "tonnes"
-msgstr "tonnes"
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Overview.tsx:83
+msgid "Total retirement transactions"
+msgstr "Total retirement transactions"
 
-#: lib/statusMessage.ts:31
-msgid "transaction.status.done"
-msgstr "Transaction complete."
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:32
+msgid "Retirement Activity"
+msgstr "Retirement Activity"
 
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:38
+msgid "No activity to show"
+msgstr "No activity to show"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:71
+#: lib/formatWalletAddress.ts:9
+#: lib/formatWalletAddress.ts:21
+msgid "You"
+msgstr "You"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
+msgstr "retired"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Quotes.tsx:85
+#: components/pages/Retire/Activity/Table.tsx:77
+msgid "View all Retirements"
+msgstr "View all Retirements"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr "PROJECT"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Table.tsx:47
+msgid "QTY"
+msgstr "QTY"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr "DATE"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
+msgstr "No Activity to show."
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr "Available Tonnes:"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/FromPortfolio/index.tsx:74
+#: components/pages/Retire/FromPortfolio/index.tsx:89
+msgid "We couldn't find any assets in your portfolio."
+msgstr "We couldn't find any assets in your portfolio."
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/FromPortfolio/index.tsx:79
+msgid "Purchase Carbon"
+msgstr "Purchase Carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/FromPortfolio/index.tsx:94
+msgid "Create Carbonmark Profile"
+msgstr "Create Carbonmark Profile"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:41
+msgid "View a complete overview of the digital carbon that you retired."
+msgstr "View a complete overview of the digital carbon that you retired."
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:48
+msgid "Carbon Retirements"
+msgstr "Carbon Retirements"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:53
+msgid "for beneficiary"
+msgstr "for beneficiary"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:77
+msgid "Retire from a featured project"
+msgstr "Retire from a featured project"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:83
+msgid "View all Projects"
+msgstr "View all Projects"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:89
+msgid "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
+msgstr "We’ve hand-curated some of the best projects based on strict criteria, such as price, veracity, and global environmental impact."
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:114
+msgid "Retire from your portfolio"
+msgstr "Retire from your portfolio"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:118
+msgid "View all Portfolio items"
+msgstr "View all Portfolio items"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:123
+msgid "You can also retire any carbon asset in your wallet."
+msgstr "You can also retire any carbon asset in your wallet."
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:141
+msgid "Quick Retire"
+msgstr "Quick Retire"
+
+#. js-lingui-explicit-id
+#: components/pages/Retire/index.tsx:146
+msgid "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
+msgstr "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:50
+msgid "View Carbonmark Profile"
+msgstr "View Carbonmark Profile"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:80
+msgid "Processing retirement..."
+msgstr "Processing retirement..."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:84
+msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
+msgstr "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:52
+msgid "Moss"
+msgstr "Moss"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:22
+msgid "No retirement message provided."
+msgstr "No retirement message provided."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:36
+msgid "Downloading ..."
+msgstr "Downloading ..."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:36
+msgid "Download PDF"
+msgstr "Download PDF"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:67
+msgid "Create your own retirement"
+msgstr "Create your own retirement"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Badge/index.tsx:10
+msgid "Invalid"
+msgstr "Invalid"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Badge/index.tsx:12
+msgid "This listing is no longer valid and is hidden from the marketplace. Please resubmit or delete the listing."
+msgstr "This listing is no longer valid and is hidden from the marketplace. Please resubmit or delete the listing."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Badge/index.tsx:15
+msgid "Expired"
+msgstr "Expired"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Badge/index.tsx:17
+msgid "This listing has expired and is hidden from the marketplace. Please resubmit or delete the listing."
+msgstr "This listing has expired and is hidden from the marketplace. Please resubmit or delete the listing."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr "{0} | Profile | Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/index.tsx:36
+msgid "Create and edit listings, and track your activity with your Carbonmark profile."
+msgstr "Create and edit listings, and track your activity with your Carbonmark profile."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Login/index.tsx:32
+#: components/pages/Users/Login/index.tsx:33
+msgid "User Profile | Carbonmark"
+msgstr "User Profile | Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Login/index.tsx:34
+msgid "Log in to create a Carbonmark profile"
+msgstr "Log in to create a Carbonmark profile"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Login/index.tsx:47
+#: components/pages/Users/SellerUnconnected/index.tsx:96
+msgid "Data for this seller"
+msgstr "Data for this seller"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:38
+msgid "Click the 'create profile' button to customize this page and get started."
+msgstr "Click the 'create profile' button to customize this page and get started."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:46
+msgid "This user has not yet created a carbonmark profile."
+msgstr "This user has not yet created a carbonmark profile."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:99
+msgid "New Quantity"
+msgstr "New Quantity"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
+msgid "Total quantity to list for sale"
+msgstr "Total quantity to list for sale"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:120
+msgid "Available balance exceeded"
+msgstr "Available balance exceeded"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:127
+msgid "Quantity listed: {listedQuantity}, Quantity unlisted: {unlistedQuantity}, Total available: {totalAvailableQuantity}"
+msgstr "Quantity listed: {listedQuantity}, Quantity unlisted: {unlistedQuantity}, Total available: {totalAvailableQuantity}"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:134
+msgid "New Unit Price (USDC)"
+msgstr "New Unit Price (USDC)"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:169
+msgid "Expiration"
+msgstr "Expiration"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:173
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:183
+msgid "Update listing"
+msgstr "Update listing"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:110
+msgid "You chose to reject the transaction."
+msgstr "You chose to reject the transaction."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:112
+msgid "Something went wrong. Please try again. {error}"
+msgstr "Something went wrong. Please try again. {error}"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:144
+msgid "Your unique handle"
+msgstr "Your unique handle"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:152
+msgid "Handle is required"
+msgstr "Handle is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:156
+msgid "Handle should not contain any special characters"
+msgstr "Handle should not contain any special characters"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:161
+msgid "Handle should not be an address"
+msgstr "Handle should not be an address"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "Sorry, this handle already exists"
+msgstr "Sorry, this handle already exists"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:171
+msgid "@Username (note: this can not be changed!)"
+msgstr "@Username (note: this can not be changed!)"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:178
+msgid "Your display name"
+msgstr "Your display name"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:183
+msgid "Display name is required"
+msgstr "Display name is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:188
+msgid "Display name"
+msgstr "Display name"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:199
+msgid "Profile picture"
+msgstr "Profile picture"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:200
+msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
+msgstr "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:208
+msgid "Say a few words about yourself. This will be visible in your seller profile."
+msgstr "Say a few words about yourself. This will be visible in your seller profile."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:211
+#: components/shared/Navigation/index.tsx:81
+#: components/shared/Navigation/index.tsx:118
+msgid "About"
+msgstr "About"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:118
+msgid "Edit Profile"
+msgstr "Edit Profile"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:118
+msgid "Create Profile"
+msgstr "Create Profile"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:133
+#: components/pages/Users/SellerUnconnected/index.tsx:54
+msgid "Listings"
+msgstr "Listings"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr "Create New Listing"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:190
+msgid "Updating your data..."
+msgstr "Updating your data..."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:196
+#: components/pages/Users/SellerUnconnected/index.tsx:90
+msgid "No active listings."
+msgstr "No active listings."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:189
+msgid "Edit"
+msgstr "Edit"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:201
+msgid "Edit listing"
+msgstr "Edit listing"
+
+#. js-lingui-explicit-id
+#: components/ProjectCard/index.tsx:64
+msgid "No props.project description found"
+msgstr "No props.project description found"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:11
+msgid "Price Highest"
+msgstr "Price Highest"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
+msgstr "Price Lowest"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:13
+msgid "Recently Updated"
+msgstr "Recently Updated"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:14
+msgid "Vintage Newest"
+msgstr "Vintage Newest"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/constants.tsx:15
+msgid "Vintage Oldest"
+msgstr "Vintage Oldest"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:119
+msgid "Country"
+msgstr "Country"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:130
+msgid "Category"
+msgstr "Category"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:141
+msgid "Vintage"
+msgstr "Vintage"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
+msgstr "View Results"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:168
+msgid "Result"
+msgstr "Result"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:168
+msgid "Results"
+msgstr "Results"
+
+#. js-lingui-explicit-id
+#: components/ProjectFilterModal/index.tsx:170
+msgid "Compiling Results ..."
+msgstr "Compiling Results ..."
+
+#. js-lingui-explicit-id
+#: components/shared/InvalidNetworkModal/index.tsx:64
+msgid "Wrong Network"
+msgstr "Wrong Network"
+
+#. js-lingui-explicit-id
+#: components/shared/InvalidNetworkModal/index.tsx:70
+msgid "This app only works on Polygon Mainnet."
+msgstr "This app only works on Polygon Mainnet."
+
+#. js-lingui-explicit-id
+#: components/shared/InvalidNetworkModal/index.tsx:74
+msgid "Switch to Polygon"
+msgstr "Switch to Polygon"
+
+#. js-lingui-explicit-id
+#: components/shared/Navigation/index.tsx:63
+#: components/shared/Navigation/index.tsx:100
+msgid "Marketplace"
+msgstr "Marketplace"
+
+#. js-lingui-explicit-id
+#: components/shared/Navigation/index.tsx:69
+#: components/shared/Navigation/index.tsx:106
+msgid "Profile"
+msgstr "Profile"
+
+#. js-lingui-explicit-id
+#: components/Stats/index.tsx:23
+msgid "Stats"
+msgstr "Stats"
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
+msgstr "Total Retirements:"
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsBar.tsx:41
+msgid "Amount of credits from this project/vintage combination that have been retired."
+msgstr "Amount of credits from this project/vintage combination that have been retired."
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsBar.tsx:55
+msgid "Remaining Supply:"
+msgstr "Remaining Supply:"
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsBar.tsx:61
+msgid "Amount of credits that have been bridged from this project/vintage combination but not yet retired."
+msgstr "Amount of credits that have been bridged from this project/vintage combination but not yet retired."
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsListings.tsx:35
+msgid "Tonnes sold:"
+msgstr "Tonnes sold:"
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsListings.tsx:42
+msgid "Tonnes listed:"
+msgstr "Tonnes listed:"
+
+#. js-lingui-explicit-id
+#: components/Stats/StatsListings.tsx:49
+msgid "Active listings:"
+msgstr "Active listings:"
+
+#. js-lingui-explicit-id
+#: components/ViewWalletButton/index.tsx:25
+msgid "View"
+msgstr "View"
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:23
+msgid "Renewable Energy"
+msgstr "Renewable Energy"
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:29
+msgid "Forestry"
+msgstr "Forestry"
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:35
+msgid "Other Nature-Based"
+msgstr "Other Nature-Based"
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:41
+msgid "Other"
+msgstr "Other"
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:47
+msgid "Energy Efficiency"
+msgstr "Energy Efficiency"
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:53
+msgid "Agriculture"
+msgstr "Agriculture"
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:59
+msgid "Industrial Processing"
+msgstr "Industrial Processing"
+
+#. js-lingui-explicit-id
+#: lib/getCategoryInfo.ts:65
+msgid "Blue Carbon"
+msgstr "Blue Carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr "{retiree} retired {formattedAmount} Tonnes of carbon"
+
+#. js-lingui-explicit-id
 #: lib/statusMessage.ts:26
 msgid "transaction.status.error"
 msgstr "❌ Error: something went wrong..."
 
-#: lib/statusMessage.ts:41
-msgid "transaction.status.network_confirmation"
-msgstr "Transaction initiated. Waiting for network confirmation."
-
-#: lib/statusMessage.ts:36
-msgid "transaction.status.user_confirmation"
-msgstr "Please click 'confirm' in your wallet to continue."
-
-#: lib/statusMessage.ts:20
-msgid "transaction.status.user_rejected"
-msgstr "You chose to reject the transaction"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr "You are about to retire a carbon asset."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr "Verify all information is correct and click 'approve' to continue."
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr "Confirm amount"
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr "Contract address"
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr "Confirm price per tonne"
-
-#: components/CreateListing/Transaction/index.tsx:81
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr "Go back"
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr "Close"
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr "Next"
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr "Submit amount"
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr "Submit"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr "To finalize your retirement, verify all information is correct and then click 'submit' below."
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr "Contract address"
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr "Submit price per tonne:"
-
+#. js-lingui-explicit-id
 #: components/CreateListing/Transaction/index.tsx:46
 #: components/Transaction/index.tsx:45
 msgid "transaction_modal.view.approve.title"
 msgstr "1. Approve"
 
+#. js-lingui-explicit-id
 #: components/CreateListing/Transaction/index.tsx:56
 #: components/Transaction/index.tsx:55
 msgid "transaction_modal.view.submit.title"
 msgstr "2. Submit"
 
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr "updated price"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr "About Carbonmark"
 
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr "updated quantity"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr "After you click the button below to continue, you will be asked to connect your wallet and the project you selected here will already be selected for you on KlimaDAO.finance. From there, follow the directions on that page to complete your transaction."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr "All Retirements"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:72
+msgid "purchase.input.amount.required"
+msgstr "Amount is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:381
+msgid "retire.back_button"
+msgstr "back"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:48
+msgid "project.single.button.back_to_project_details"
+msgstr "Back to Project Details"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr "Balances"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:360
+msgid "offset_disclaimer"
+msgstr "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:35
+msgid "retirement.single.beneficiary_address.title"
+msgstr "Beneficiary Address:"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:282
+msgid "offset.retirement_beneficiary_name"
+msgstr "Beneficiary Name"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:35
+msgid "retirement.single.beneficiary.title"
+msgstr "Beneficiary:"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:104
+msgid "buy"
+msgstr "Buy"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:77
+msgid "seller.listing.buy"
+msgstr "Buy"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr "Carbon Credit Retirement"
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr "Carbon credits you purchase or any retirements you make on KlimaDAO.finance will also be accessible in your Carbonmark portfolio."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:64
+msgid "retirement.totals.page_headline"
+msgstr "Carbon Retirements"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
+msgstr "Carbonmark - Carbon Retirements for beneficiary {0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr "Carbonmark - Carbon Retirements for beneficiary {0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr "Carbonmark | Carbon Retirement Receipt"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
+msgstr "Categories"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:245
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr "Check your search for typos or try a different search term."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr "Clear All"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
+msgstr "Close"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr "Confirm amount"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr "Confirm price per tonne"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:85
+msgid "purchase.transaction.modal.title.confirm"
+msgstr "Confirm Purchase"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:403
+msgid "offset.retire_carbon"
+msgstr "Confirm Retirement"
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:90
+msgid "connectModal.wallet"
+msgstr "connect a wallet"
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:96
+msgid "connect_modal.connecting"
+msgstr "Connecting..."
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:100
+msgid "connect_modal.error_title"
+msgstr "Connection Error"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr "Contract address"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr "Contract address"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:155
+msgid "profile.listing.delete.error"
+msgstr "Could not delete listing. Please try again."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:96
+msgid "retirement.single.country_region.title"
+msgstr "Country/Region:"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:135
+msgid "profile.addListing_modal.submit"
+msgstr "Create Listing"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:319
+msgid "offset.default_retirement_address"
+msgstr "Defaults to the connected wallet address"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:216
+msgid "profile.listing.edit.delete_listing"
+msgstr "Delete Listing"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:82
+msgid "retirement.single.project_description.title"
+msgstr "Description"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
+msgstr "Disclaimer:"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:51
+msgid "shared.head.description"
+msgstr "Drive climate action and earn rewards with a carbon-backed digital currency."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
+msgstr "Edit your profile to add a description."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:252
+msgid "offset.offset_quantity"
+msgstr "Enter quantity to offset"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:70
+msgid "retirement.totals.page_subline"
+msgstr "for beneficiary"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:81
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
+msgstr "Go back"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:229
+msgid "offset.amount_in_tonnes"
+msgstr "How many tonnes of carbon would you like to offset? <0>* </0>"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:28
+msgid "retirement.single.transaction_record.title"
+msgstr "Immutable transaction record"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr "Marketplace"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:29
+msgid "retirement.single.moss_offset.description"
+msgstr "MC02 credits are generated by projects that preserve the Amazon Forest, with all sorts of positive externalities such as the creation of local jobs and preservation of local biodiversity. Explore MCO2 on <0>data.klimadao.finance</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:82
+msgid "retirement.single.methodology.title"
+msgstr "Methodology:"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:71
+msgid "retirement.single.moss_offset.name"
+msgstr "MOSS Earth MC02"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
+msgstr "Next"
+
+#. js-lingui-explicit-id
 #: components/Activities/index.tsx:29
 msgid "user.activities.empty_state"
 msgstr "No activity to show"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "user.edit.form.edit.price.placeholder"
-msgstr "USDC per ton"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:41
+msgid "retirement.single.beneficiary.address.placeholder"
+msgstr "No beneficiary address available"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:113
-msgid "user.listing.edit.input.quantity.minimum"
-msgstr "The minimum quantity to sell is 1 tonne"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.placeholder"
+msgstr "No beneficiary name provided"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
+msgstr "No retirement timestamp provided"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr "No retirements found"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:55
+msgid "retirement.single.transaction_id.placeholder"
+msgstr "No transaction id available"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:114
+msgid "retirement.single.official_certificate.title"
+msgstr "Official Certificate for On-Chain Carbon Retirement Provided by <0>Carbonmark.com</0>"
+
+#. js-lingui-explicit-id
+#: lib/statusMessage.ts:36
+msgid "transaction.status.user_confirmation"
+msgstr "Please click 'confirm' in your wallet to continue."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:252
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr "Please use a different filter combination."
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
+msgstr "Portfolio"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:164
+msgid "purchase.input.price.required"
+msgstr "Price is required"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:89
+msgid "purchase.transaction.modal.title.processing"
+msgstr "Processing Purchase"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr "Profile"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:42
+msgid "retirement.single.project_details.title"
+msgstr "Project Details"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:65
+msgid "retirement.single.project_name.title"
+msgstr "Project Name"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.project.title"
+msgstr "Project:"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr "Proof of"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr "Quantity Available:"
+
+#. js-lingui-explicit-id
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:106
 msgid "user.listing.edit.input.quantity.required"
 msgstr "Quantity is required"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr "QUANTITY RETIRED"
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:88
+msgid "connect_modal.error_processing"
+msgstr "Request already processing. Please open your wallet and complete the request."
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
+msgstr "Resource Center"
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr "Retire"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:372
+msgid "retire.submit_button"
+msgstr "Retire Carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:94
+msgid "retirement.totals.retired_assets"
+msgstr "Retired Assets"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:328
+msgid "offset.retirement_message"
+msgstr "Retirement message"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:339
+msgid "offset.retirement_retirement_message"
+msgstr "Retirement Message"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr "Retirement Message:"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:110
+msgid "retirement.totals.retirements"
+msgstr "Retirements"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:230
+msgid "profile.edit_modal.submit"
+msgstr "Save Changes"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:171
+msgid "resources.form.input.search.label"
+msgstr "Search"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:162
+msgid "resources.form.input.search.placeholder"
+msgstr "Search..."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/SortyByDropDown/index.tsx:21
+msgid "resources.form.input.sort_by.select"
+msgstr "Select"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr "Select one or more"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:29
+msgid "retirement.single.share_retirement.title"
+msgstr "Share this retirement"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:301
+msgid "resources.mobile_modal.button.show_results"
+msgstr "Show Results"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/BuyOptions/SellerListing.tsx:94
+#: components/pages/Users/SellerUnconnected/index.tsx:67
+msgid "shared.connect_to_buy"
+msgstr "Sign In / Connect To Buy"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:144
+msgid "user.listing.form.input.singleUnitPrice.required"
+msgstr "Single Price is required"
+
+#. js-lingui-explicit-id
+#: components/Layout/index.tsx:86
+msgid "connectModal.torus"
+msgstr "social or email"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+msgid "purchase.loading.allowance.error"
+msgstr "something went wrong loading the allowance"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:231
+msgid "resources.page.list.on_fetch_error"
+msgstr "Sorry! Something went wrong."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:239
+msgid "resources.page.list.no_search_results.title"
+msgstr "Sorry. We couldn't find any matching results."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:200
+msgid "resources.form.input.sort_by.label"
+msgstr "Sort by"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:274
+msgid "resources.mobile_modal.title"
+msgstr "Sort By"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:206
+msgid "shared.resources.sort_by.header"
+msgstr "Sort by:"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr "Submit"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr "Submit amount"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr "Submit price per tonne:"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
+msgstr "Thank you for supporting the planet!"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
+msgstr "Thank you for supporting the planet! View transaction on <0> PolygonScan.</0>"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
+msgstr "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
+msgstr "The information provided in this blog post pertaining to KlimaDAO (“KlimaDAO”), its crypto-assets, business assets, strategy, and operations, is for general informational purposes only and is not a formal offer to sell or a solicitation of an offer to buy any securities, options, futures, or other derivatives related to securities in any jurisdiction and its content is not prescribed by securities laws. Information contained in this blog post should not be relied upon as advice to buy or sell or hold such securities or as an offer to sell such securities. This blog post does not take into account nor does it provide any tax, legal or investment advice or opinion regarding the specific investment objectives or financial situation of any person. KlimaDAO and its agents, advisors, directors, officers, employees and shareholders make no representation or warranties, expressed or implied, as to the accuracy of such information and KlimaDAO expressly disclaims any and all liability that may be based on such information or errors or omissions thereof. KlimaDAO reserves the right to amend or replace the information contained herein, in part or entirely, at any time, and undertakes no obligation to provide the recipient with access to the amended information or to notify the recipient thereof. The information contained in this blog post supersedes any prior blog post or conversation concerning the same, similar or related information. Any information, representations or statements not contained herein shall not be relied upon for any purpose. Neither KlimaDAO nor any of its representatives shall have any liability whatsoever, under contract, tort, trust or otherwise, to you or any person resulting from the use of the information in this blog post by you or any of your representatives or for omissions from the information in this blog post. Additionally, KlimaDAO undertakes no obligation to comment on the expectations of, or statements made by, third parties in respect of the matters discussed in this blog post."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:79
+msgid "purchase.input.amount.minimum"
+msgstr "The minimum amount to buy is 1 Tonne"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:86
+msgid "user.listing.form.input.totalAmountToSell.minimum"
+msgstr "The minimum amount to sell is 1 Tonne"
+
+#. js-lingui-explicit-id
 #: components/CreateListing/Form/index.tsx:120
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:151
 msgid "user.listing.form.input.singleUnitPrice.minimum"
 msgstr "The minimum price per tonne is {0}"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:144
-msgid "user.listing.form.input.singleUnitPrice.required"
-msgstr "Single Price is required"
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:113
+msgid "user.listing.edit.input.quantity.minimum"
+msgstr "The minimum quantity to sell is 1 tonne"
 
-#: components/CreateListing/Form/index.tsx:86
-msgid "user.listing.form.input.totalAmountToSell.minimum"
-msgstr "The minimum amount to sell is 1 Tonne"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 
-#: components/CreateListing/Form/index.tsx:79
-msgid "user.listing.form.input.totalAmountToSell.required"
-msgstr "Total Amount to Sell is required"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
 
+#. js-lingui-explicit-id
 #: components/LoginCard/index.tsx:24
 msgid "user.login.description"
 msgstr "This feature is available only to users who are logged in. You can log in or create an account via the button below."
 
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:187
-msgid "{0}"
-msgstr "{0}"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:121
+msgid "retirement.single.immutable_public_records.title"
+msgstr "This represents the permanent retirement of a digital carbon asset. This retirement and the associated data are immutable public records."
 
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:324
-msgid "{0} maximum for credit cards"
-msgstr "{0} maximum for credit cards"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
+msgstr "To finalize your retirement, verify all information is correct and then click 'submit' below."
 
-#: components/CreateListing/Transaction/index.tsx:61
-msgid "{0} tonnes"
-msgstr "{0} tonnes"
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:61
+msgid "purchase.input.amount.placeholder"
+msgstr "Tonnes"
 
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr "{0} | Profile | Carbonmark"
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:79
+msgid "user.listing.form.input.totalAmountToSell.required"
+msgstr "Total Amount to Sell is required"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:173
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:102
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr "Total Carbon Tonnes Retired"
 
-#: components/pages/Purchases/index.tsx:28
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr "{amount} tonnes were purchased for project {0}"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:116
+msgid "retirement.totals.total_retirement_transactions"
+msgstr "Total Retirement Transactions"
 
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:29
-msgid "{tokenSymbol}"
-msgstr "{tokenSymbol}"
+#. js-lingui-explicit-id
+#: lib/statusMessage.ts:31
+msgid "transaction.status.done"
+msgstr "Transaction complete."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:49
+msgid "retirement.single.transaction_id.title"
+msgstr "Transaction ID"
+
+#. js-lingui-explicit-id
+#: lib/statusMessage.ts:41
+msgid "transaction.status.network_confirmation"
+msgstr "Transaction initiated. Waiting for network confirmation."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:128
+msgid "retirement.head.metaDescription"
+msgstr "Transparent, on-chain offsets powered by Carbonmark."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.type.title"
+msgstr "Type:"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "user.edit.form.edit.price.placeholder"
+msgstr "USDC per ton"
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:84
+msgid "connect_modal.error_message_refused"
+msgstr "User refused connection."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr "Verified tonnes of carbon retired"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr "Verify all information is correct and click 'approve' to continue."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr "Verify all information is correct and click 'approve' to continue."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:140
+msgid "retirement.single.view_on_polygon_scan"
+msgstr "View on Polygonscan"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:142
+msgid "purchase.button.view_assets"
+msgstr "View Your Assets"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:109
+msgid "retirement.single.vintage.title"
+msgstr "Vintage:"
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:80
+msgid "connect_modal.error_message_default"
+msgstr "We had some trouble connecting. Please try again."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:270
+msgid "offset.retirement_credit"
+msgstr "Who will this retirement be credited to?"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
+msgstr "With over 20 million verified digital carbon credits from hundreds of projects, Carbonmark offers the largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading. <0>Get started today</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr "You are about to purchase a carbon asset."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
+msgstr "You are about to retire a carbon asset."
+
+#. js-lingui-explicit-id
+#: lib/statusMessage.ts:20
+msgid "transaction.status.user_rejected"
+msgstr "You chose to reject the transaction"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:171
+msgid "purchase.input.price.maxAmount"
+msgstr "You exceeded your available amount of tokens"
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
+msgstr "You will be taken to KlimaDAO.finance to complete this transaction."
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/index.tsx:220
+msgid "profile.edit_profile.title"
+msgstr "Your Profile"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
+msgstr "Your transaction has been successfully processed but is taking longer than normal to index. It will appear in your <0>retirements</0> soon."

--- a/site/locale/en-pseudo/messages.po
+++ b/site/locale/en-pseudo/messages.po
@@ -6,57 +6,104 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
-#: components/pages/Buy/index.tsx:100
-msgid "<0>Swap for KLIMA.</0> Sushi is a Decentralized Exchange where you can trade some of your MATIC tokens for KLIMA tokens at the lowest possible price."
-msgstr ""
-
-#: components/Footer/index.tsx:43
-msgid "App"
-msgstr ""
-
-#: components/Navigation/index.tsx:122
-#: components/Navigation/index.tsx:251
-msgid "Bond Klima"
-msgstr ""
-
-#: components/Footer/index.tsx:37
-msgid "Buy"
-msgstr ""
-
-#: components/Navigation/index.tsx:112
-msgid "Buy Klima"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:37
+msgid "Buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:40
+msgid "Stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:43
+msgid "App"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:46
+msgid "Docs"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Footer/index.tsx:52
 #: components/pages/About/AboutHeader/index.tsx:67
 msgid "Contact"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:65
+msgid "Wrong Network"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:75
+msgid "This app only works on Polygon Mainnet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:80
+msgid "Switch to Polygon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:112
+msgid "Buy Klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:117
+#: components/Navigation/index.tsx:246
+msgid "Stake Klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:122
+#: components/Navigation/index.tsx:251
+msgid "Bond Klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:193
+#: components/Navigation/index.tsx:325
+msgid "Official Docs"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:220
 msgid "Contact Us"
 msgstr ""
 
-#: components/Footer/index.tsx:46
-msgid "Docs"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:100
+msgid "<0>Swap for KLIMA.</0> Sushi is a Decentralized Exchange where you can trade some of your MATIC tokens for KLIMA tokens at the lowest possible price."
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:33
-msgid "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:68
-msgid "Explore MCO2 on data.klimadao.finance"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:530
 msgid "Frequently Asked Questions"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:113
+#: components/pages/Pledge/PledgeDashboard/index.tsx:171
+msgid "Login"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:53
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:48
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/TokenRow/index.tsx:41
@@ -65,1721 +112,281 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:47
-msgid "Location: {0}"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:171
-#: components/pages/Pledge/index.tsx:113
-msgid "Login"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:50
-msgid "MCO2 Token"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:52
-msgid "Methodology: {0}"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:23
-msgid "No retirement message provided."
-msgstr ""
-
-#: components/Navigation/index.tsx:193
-#: components/Navigation/index.tsx:325
-msgid "Official Docs"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:159
-msgid "Processing data..."
-msgstr ""
-
-#: components/Footer/index.tsx:40
-msgid "Stake"
-msgstr ""
-
-#: components/Navigation/index.tsx:117
-#: components/Navigation/index.tsx:246
-msgid "Stake Klima"
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:80
-msgid "Switch to Polygon"
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:75
-msgid "This app only works on Polygon Mainnet."
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/Resources/SortyByDropDown/index.tsx:62
 msgid "Toggle Sorted by menu"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:74
-msgid "View on Polygonscan"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:159
+msgid "Processing data..."
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/pages/Retirements/SingleRetirement/index.tsx:163
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 msgstr ""
 
-#: components/InvalidNetworkModal/index.tsx:65
-msgid "Wrong Network"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:33
+msgid "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
 msgstr ""
 
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:93
-msgid "blog.disclaimer.description"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:50
+msgid "MCO2 Token"
 msgstr ""
 
-#: components/pages/Blog/Post/index.tsx:90
-msgid "blog.disclaimer.title"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:47
+msgid "Location: {0}"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:434
-msgid "buy.answer_exchange"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:52
+msgid "Methodology: {0}"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:391
-msgid "buy.bond_answer_cedit_card"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:57
+msgid "{trimTotalRetired} Tonnes retired in total"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:409
-msgid "buy.bond_answer_cex1"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:62
+msgid "{trimCurrentSupply} Tonnes remaining"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:417
-msgid "buy.bond_answer_cex2"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:68
+msgid "Explore MCO2 on data.klimadao.finance"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:372
-msgid "buy.bond_description1"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:74
+msgid "View on Polygonscan"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:381
-msgid "buy.bond_description_capacity"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:23
+msgid "No retirement message provided."
 msgstr ""
 
-#: components/pages/Buy/index.tsx:402
-msgid "buy.bond_question_cex"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:110
+msgid "pledges.dashboard.footprint.tooltip.quantity"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:386
-msgid "buy.bond_question_credit_card"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
+msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:189
-msgid "buy.connect_advanced"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:104
+msgid "pledges.dashboard.footprint.tooltip.category_percent"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:184
-msgid "buy.connect_torus_sushi"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:73
+msgid "pledges.dashboard.profile.pledge_progress"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:211
-msgid "buy.connect_torus_sushi_description2"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:137
+msgid "pledges.dashboard.head.metaDescription"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:228
-msgid "buy.connect_torus_sushi_description3"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:133
+msgid "pledges.dashboard.head.metaTitle"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:236
-msgid "buy.connect_torus_sushi_description4"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:129
+msgid "pledges.dashboard.head.title"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:242
-msgid "buy.connect_torus_sushi_description5"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:131
+msgid "retirement.head.metaTitle"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:72
-msgid "buy.create_wallet_description"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:99
+msgid "pledge.invitation.join_message"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:113
-msgid "buy.create_wallet_description1"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:119
-msgid "buy.create_wallet_description2"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:128
-msgid "buy.create_wallet_description3"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:134
-msgid "buy.create_wallet_description4"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:110
-msgid "buy.create_wallet_item"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:320
-msgid "buy.faq_title"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:27
-#: components/pages/Buy/index.tsx:28
-msgid "buy.head.title"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:41
-msgid "buy.how_to_buy"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:44
-msgid "buy.how_to_paragraph_part_1"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:51
-msgid "buy.how_to_paragraph_part_2"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:142
-msgid "buy.load_wallet"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:85
-msgid "buy.load_wallet_description"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:147
-msgid "buy.load_wallet_description1"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/Buy/index.tsx:157
 msgid "buy.load_wallet_description2"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/pages/Buy/index.tsx:167
 msgid "buy.load_wallet_description3"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:428
-msgid "buy.question_exchange"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:72
+msgid "buy.create_wallet_description"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:323
-msgid "buy.question_why_matic"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:328
-msgid "buy.question_why_matic_answer"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:339
-msgid "buy.question_why_matic_answer_bullet1"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:346
-msgid "buy.question_why_matic_answer_bullet2"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:353
-msgid "buy.question_why_matic_answer_bullet3"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:360
-msgid "buy.question_why_matic_answer_bullet4"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:291
-msgid "buy.staking_cta"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:294
-msgid "buy.staking_description1"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:302
-msgid "buy.staking_description2"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:311
-msgid "buy.staking_description3"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:69
-msgid "buy.step_1"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:82
-msgid "buy.step_2"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:97
-msgid "buy.step_3"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:62
-msgid "buy.summary_steps_title"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:59
-msgid "buy.summary_title"
-msgstr ""
-
-#: components/pages/Buy/index.tsx:252
-msgid "buy.swap_description1"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/Buy/index.tsx:258
 msgid "buy.swap_description2"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:274
-msgid "buy.swap_description3"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:85
+msgid "buy.load_wallet_description"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:281
-msgid "buy.swap_description4"
+#. <0>WELCOME TO</0><1>KlimaDAO</1>
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:92
+msgid "home.welcome_to_klimadao"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:249
-msgid "buy.swap_subtitle"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:64
+msgid "pledges.dashboard.profile.pledge_met"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:178
-msgid "buy.swap_wallet"
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:81
+msgid "home.latest_news"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:195
-msgid "buy.torus_login_description"
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:469
+msgid "infinity.mission_card2_number"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:204
-msgid "buy.wallet_connect_example"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:372
+msgid "pledges.form.input.walletAddress.placeholder"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:221
-#: components/pages/Buy/index.tsx:267
-msgid "buy.wallet_connect_example_qr_code"
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:258
+msgid "infinity.getStarted_1"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:367
-msgid "buy.what_are_bonds"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:116
-msgid "community.become_a_partner"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:180
-msgid "community.bigcowg_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:172
-msgid "community.blockchainforclimatefondation_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:314
-msgid "community.come_on_in"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:228
-msgid "community.deltawave_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:265
-msgid "community.digitalcharityart_logo"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:69
+msgid "buy.step_1"
 msgstr ""
 
 #. Long sentence
-#: components/pages/About/Community/index.tsx:329
-msgid "community.discord_is_where_we_share"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:244
-msgid "community.dovu_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:249
-msgid "community.eco_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:236
-msgid "community.etcgroup_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:361
-msgid "community.get_in_touch"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:204
-msgid "community.gitcoin_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:95
-msgid "community.head.headline"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:102
-msgid "community.head.metadescription"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:96
-msgid "community.head.subline"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:94
-#: components/pages/About/Community/index.tsx:101
-msgid "community.head.title"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Community/index.tsx:364
-msgid "community.if_you_ve_got_questions"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:317
-msgid "community.join_our_discord"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:304
-msgid "community.join_the_klima_community"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:281
-msgid "community.landx_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:113
-#: components/pages/About/Community/index.tsx:358
-msgid "community.lets_work_together"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:156
-msgid "community.moss_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:196
-msgid "community.oceandrop_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:257
-msgid "community.offsetra_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:212
-msgid "community.olympusdao_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:220
-msgid "community.openearth_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:151
-msgid "community.our_partners"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:188
-msgid "community.polygon_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:164
-msgid "community.toucan_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:273
-msgid "community.toughtforfood_logo"
-msgstr ""
-
-#: components/pages/About/Community/index.tsx:132
-msgid "community.tree_grove"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Community/index.tsx:119
-msgid "community.we_work_with_traditionnal"
-msgstr ""
-
-#: components/pages/About/Contact/index.tsx:63
-msgid "concat.careers"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:162
-#: components/pages/Pledge/index.tsx:104
-msgid "connectModal.torus"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:166
-#: components/pages/Pledge/index.tsx:108
-msgid "connectModal.wallet"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:172
-#: components/pages/Pledge/index.tsx:114
-msgid "connect_modal.connecting"
-msgstr ""
-
-#: lib/constants.ts:16
-msgid "connect_modal.error_message_default"
-msgstr ""
-
-#: lib/constants.ts:20
-msgid "connect_modal.error_message_refused"
-msgstr ""
-
-#: lib/constants.ts:24
-msgid "connect_modal.error_processing"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:176
-#: components/pages/Pledge/index.tsx:118
-msgid "connect_modal.error_title"
-msgstr ""
-
-#: components/pages/About/Contact/index.tsx:140
-msgid "contact.bug_reports"
-msgstr ""
-
-#. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
-#: components/pages/About/Contact/index.tsx:143
-msgid "contact.bug_reports.to_file_a_bug_report"
-msgstr ""
-
-#. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
-#: components/pages/About/Contact/index.tsx:66
-msgid "contact.careers.we_re_hiring"
-msgstr ""
-
-#: components/pages/About/Contact/index.tsx:25
-msgid "contact.head.description"
-msgstr ""
-
-#: components/pages/About/Contact/index.tsx:18
-msgid "contact.head.headline"
-msgstr ""
-
-#: components/pages/About/Contact/index.tsx:19
-msgid "contact.head.subline"
-msgstr ""
-
-#: components/pages/About/Contact/index.tsx:17
-#: components/pages/About/Contact/index.tsx:24
-msgid "contact.head.title"
-msgstr ""
-
-#: components/pages/About/Contact/index.tsx:105
-msgid "contact.media"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Contact/index.tsx:108
-msgid "contact.media.if_you_are_a_journalist"
-msgstr ""
-
-#. Use this <0>Media Request Form</0>.
-#: components/pages/About/Contact/index.tsx:117
-msgid "contact.media.use_this_media_request_form"
-msgstr ""
-
-#: components/pages/About/Contact/index.tsx:85
-msgid "contact.partnerships"
-msgstr ""
-
-#. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
-#: components/pages/About/Contact/index.tsx:88
-msgid "contact.partnerships.until_we_finish_building"
-msgstr ""
-
-#: components/pages/About/Contact/index.tsx:35
-msgid "contact.quest_and_support"
-msgstr ""
-
-#. Join our <0>community</0>
-#: components/pages/About/Contact/index.tsx:38
-msgid "contact.quest_and_support.join_our_community"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Contact/index.tsx:46
-msgid "contact.quest_and_support.join_our_discord_server"
-msgstr ""
-
-#. Long sentence
+#. js-lingui-explicit-id
 #: components/pages/About/Disclaimer/index.tsx:64
 msgid "disclaimer.1_an_offer_or_sollicitation"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:110
+msgid "buy.create_wallet_item"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/About/Disclaimer/index.tsx:111
 msgid "disclaimer.1_meet_your_requirements"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:543
+msgid "infinity.faq_question1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:418
+msgid "infinity.box_amount_104k"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:404
+msgid "infinity.box_amount_11k"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:491
+msgid "infinity.mission_card3_number"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:447
+msgid "infinity.mission_card1_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:272
+msgid "infinity.getStarted_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:82
+msgid "buy.step_2"
+msgstr ""
+
 #. Long sentence
+#. js-lingui-explicit-id
 #: components/pages/About/Disclaimer/index.tsx:116
 msgid "disclaimer.2_be_available_on_an_uninterrupted"
 msgstr ""
 
 #. Long sentence
+#. js-lingui-explicit-id
 #: components/pages/About/Disclaimer/index.tsx:74
 msgid "disclaimer.2_financial_investment_or_trading_advice"
 msgstr ""
 
-#: components/pages/About/Disclaimer/index.tsx:125
-msgid "disclaimer.3_be_reliable_complete_legal_or_safe"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:32
-msgid "disclaimer.all_information_on_this_website"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:159
-msgid "disclaimer.any_action_you_take_upon_the_information"
-msgstr ""
-
-#: components/pages/About/Disclaimer/index.tsx:19
-msgid "disclaimer.disclaimer"
-msgstr ""
-
-#: components/pages/About/Disclaimer/index.tsx:21
-msgid "disclaimer.head.description"
-msgstr ""
-
-#: components/pages/About/Disclaimer/index.tsx:15
-#: components/pages/About/Disclaimer/index.tsx:25
-msgid "disclaimer.head.title"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:102
-msgid "disclaimer.klimadao_and_its_suppliers"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:43
-msgid "disclaimer.klimadao_is_a_platform"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:130
-msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:178
-msgid "disclaimer.nothing_in_this_disclaimer"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:56
-msgid "disclaimer.nothing_in_this_platform"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:83
-msgid "disclaimer.the_service_available"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:189
-msgid "disclaimer.we_recommend_that_you_visit"
-msgstr ""
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:144
-msgid "disclaimer.you_bear_full_responsibility"
-msgstr ""
-
-#: components/pages/errors/Custom404.tsx:41
-msgid "error.404.page.text"
-msgstr ""
-
-#: components/pages/errors/Custom500.tsx:39
-msgid "error.500.page.text"
-msgstr ""
-
-#: components/pages/errors/Custom500.tsx:34
-msgid "error.500.page.title"
-msgstr ""
-
-#: components/pages/errors/Custom500.tsx:19
-msgid "error.page.500.head.title"
-msgstr ""
-
-#: components/pages/errors/Custom500.tsx:15
-msgid "error.page.500.title"
-msgstr ""
-
-#: components/pages/Home/index.tsx:209
-msgid "home.benefits"
-msgstr ""
-
-#: components/pages/Home/index.tsx:330
-msgid "home.cars_annual"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Home/index.tsx:162
-msgid "home.developed_by_klima"
-msgstr ""
-
-#: components/pages/Home/index.tsx:299
-msgid "home.equivalent_to"
-msgstr ""
-
-#: components/SocialProof/index.tsx:19
-msgid "home.featured_on"
-msgstr ""
-
-#: components/pages/Home/index.tsx:444
-msgid "home.get_exposure_to_the_growing_carbon_economy"
-msgstr ""
-
-#: components/pages/Home/index.tsx:441
-msgid "home.get_klima"
-msgstr ""
-
-#: components/pages/Home/index.tsx:387
-msgid "home.govern_the_market"
-msgstr ""
-
-#: components/pages/Home/index.tsx:313
-msgid "home.hectares_of_forest"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Home/index.tsx:405
-msgid "home.join_over_100k_members"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Home/index.tsx:212
-msgid "home.klima_is_creating"
-msgstr ""
-
-#: components/pages/Home/index.tsx:81
-msgid "home.latest_news"
-msgstr ""
-
-#: components/pages/Home/index.tsx:137
-msgid "home.learn_more"
-msgstr ""
-
-#: components/pages/Home/index.tsx:345
-msgid "home.liters_if_gasoline"
-msgstr ""
-
-#: components/pages/Home/index.tsx:253
-msgid "home.neutral_and_trusted"
-msgstr ""
-
-#: components/pages/Home/index.tsx:473
-msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Home/index.tsx:481
-msgid "home.newletter.get_the_latest_updates"
-msgstr ""
-
-#: components/pages/Home/index.tsx:498
-msgid "home.newletter.never_shared_never_spammed"
-msgstr ""
-
-#: components/pages/Home/index.tsx:492
-msgid "home.newletter.sign_up"
-msgstr ""
-
-#: components/pages/Home/index.tsx:478
-msgid "home.newsletter"
-msgstr ""
-
-#: components/pages/Home/index.tsx:273
-msgid "home.public_and_open-source"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Home/index.tsx:152
-msgid "home.public_good_for_the_planet"
-msgstr ""
-
-#: components/pages/Home/index.tsx:451
-msgid "home.see_tutorial"
-msgstr ""
-
-#: components/pages/Home/index.tsx:360
-msgid "home.source"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Home/index.tsx:422
-msgid "home.take_climate_action_now"
-msgstr ""
-
-#. TONNES OF <0>CARBON HELD</0> BY KLIMADAO
-#: components/pages/Home/index.tsx:286
-msgid "home.tonnes_of_carbon_held_by_klimadao"
-msgstr ""
-
-#: components/pages/Home/index.tsx:233
-msgid "home.transparent_and_efficient"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Home/index.tsx:105
-msgid "home.transparent_neutral"
-msgstr ""
-
-#. <0>WELCOME TO</0><1>KlimaDAO</1>
-#: components/pages/Home/index.tsx:92
-msgid "home.welcome_to_klimadao"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:162
-msgid "infinity.affordable_subtitle"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:157
-msgid "infinity.affordable_title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:418
-msgid "infinity.box_amount_104k"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:404
-msgid "infinity.box_amount_11k"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:400
-msgid "infinity.box_title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:414
-msgid "infinity.box_title2"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:665
-msgid "infinity.button.read_blog_faq"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:368
-msgid "infinity.button.read_blog_polygon"
-msgstr ""
-
-#: components/pages/Infinity/Cards/CardsSlider.tsx:89
-msgid "infinity.cards_slider.title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:331
-msgid "infinity.carousel_image_description"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:343
-msgid "infinity.carousel_info_subtitle"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:338
-msgid "infinity.carousel_info_title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:685
-msgid "infinity.cta_title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:557
-msgid "infinity.faq_answer1"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:593
-msgid "infinity.faq_answer2_paragraph1"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:603
-msgid "infinity.faq_answer2_paragraph2"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:611
-msgid "infinity.faq_answer2_paragraph3"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:648
-msgid "infinity.faq_answer3"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:543
-msgid "infinity.faq_question1"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:577
 msgid "infinity.faq_question2"
 msgstr ""
 
-#: components/pages/Infinity/index.tsx:634
-msgid "infinity.faq_question3"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:142
+msgid "buy.load_wallet"
 msgstr ""
 
-#: components/pages/Infinity/index.tsx:137
-msgid "infinity.fast_subtitle"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:142
-msgid "infinity.fast_title"
-msgstr ""
-
-#: components/pages/Infinity/GetStartedModal.tsx:47
-msgid "infinity.getStartedModal_business"
-msgstr ""
-
-#: components/pages/Infinity/GetStartedModal.tsx:70
-msgid "infinity.getStartedModal_individual"
-msgstr ""
-
-#: components/pages/Infinity/GetStartedModal.tsx:104
-msgid "infinity.getStartedModal_needAssistance"
-msgstr ""
-
-#: components/pages/Infinity/GetStartedModal.tsx:94
-msgid "infinity.getStartedModal_offsetCrypto"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:258
-msgid "infinity.getStarted_1"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:272
-msgid "infinity.getStarted_2"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:261
-msgid "infinity.getStarted_calculate"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:264
-msgid "infinity.getStarted_calculate_subtitle"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:301
-msgid "infinity.getStarted_cta"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:278
-msgid "infinity.getStarted_second_subtitle"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:275
-msgid "infinity.getStarted_second_title"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:286
 msgid "infinity.getStarted_third"
 msgstr ""
 
-#: components/pages/Infinity/index.tsx:292
-msgid "infinity.getStarted_third_subtitle"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:97
+msgid "buy.step_3"
 msgstr ""
 
-#: components/pages/Infinity/index.tsx:289
-msgid "infinity.getStarted_third_title"
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:125
+msgid "disclaimer.3_be_reliable_complete_legal_or_safe"
 msgstr ""
 
-#: components/pages/Infinity/index.tsx:67
-msgid "infinity.head.metaDescription"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:178
+msgid "buy.swap_wallet"
 msgstr ""
 
-#: components/pages/Infinity/index.tsx:63
-msgid "infinity.head.metaTitle"
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:634
+msgid "infinity.faq_question3"
 msgstr ""
 
-#: components/pages/Infinity/index.tsx:59
-msgid "infinity.head.title"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:184
+msgid "buy.connect_torus_sushi"
 msgstr ""
 
-#: components/pages/Infinity/index.tsx:178
-msgid "infinity.info_subtitle1"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:249
+msgid "buy.swap_subtitle"
 msgstr ""
 
-#: components/pages/Infinity/index.tsx:183
-msgid "infinity.info_subtitle2"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:450
-msgid "infinity.mission_card1_subtitle"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:447
-msgid "infinity.mission_card1_title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:472
-msgid "infinity.mission_card2_description"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:469
-msgid "infinity.mission_card2_number"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:494
-msgid "infinity.mission_card3_description"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:491
-msgid "infinity.mission_card3_number"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:387
-msgid "infinity.polygon_manifesto_description"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:381
-msgid "infinity.polygon_manifesto_title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:361
-msgid "infinity.polygon_story_description"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:356
-msgid "infinity.polygon_story_title"
-msgstr ""
-
-#: components/pages/Infinity/Cards/Card.tsx:66
-#: components/pages/Infinity/index.tsx:407
-#: components/pages/Infinity/index.tsx:421
-msgid "infinity.tonnes"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:196
-msgid "infinity.transparent_subtitle"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:191
-msgid "infinity.transparent_title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:98
-msgid "infinity.welcome_subtitle"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:93
-msgid "infinity.welcome_title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:224
-msgid "infinity.why_description"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:219
-msgid "infinity.why_subtitle"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:216
-msgid "infinity.why_title"
-msgstr ""
-
-#: components/pages/Infinity/index.tsx:439
-msgid "mission.header"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:79
-#: components/pages/Pledge/PledgeForm/index.tsx:83
-#: components/pages/Pledge/PledgeForm/index.tsx:99
-msgid "pledge.errors.default"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:91
-msgid "pledge.errors.method_not_allowed"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:75
-msgid "pledge.errors.pledge_not_found"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:87
-msgid "pledge.errors.unknown_error"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:191
-msgid "pledge.form.error.cannot_add_yourself"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:227
-msgid "pledge.form.error.default_error_message"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:175
-msgid "pledge.form.error.duplicate_wallets"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:616
-msgid "pledge.form.wallets.confirm_remove_wallet"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:340
-msgid "pledge.form.wallets.tooltip"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:41
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:108
-msgid "pledge.invitation.accept"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:70
-msgid "pledge.invitation.error.wallet_already_pinned"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:49
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:44
-msgid "pledge.invitation.error_title"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:99
-msgid "pledge.invitation.join_message"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:127
-msgid "pledge.invitation.later"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:115
-msgid "pledge.invitation.reject"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:54
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:49
-msgid "pledge.invitation.signing"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:190
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:176
-msgid "pledge.invitations.awaiting_signature"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:196
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:182
-msgid "pledge.invitations.signature_instructions"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:126
-msgid "pledge.modal.are_you_sure"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:150
-msgid "pledge.modal.confirm"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:40
-msgid "pledge.modal.confirm_remove"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:39
-msgid "pledge.modal.edit_pledge"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:98
-msgid "pledge.modal.unable_to_edit"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:107
-msgid "pledge.modal.unpin_wallet"
-msgstr ""
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:141
-msgid "pledge.modal.wallet_add_confirm"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:110
-msgid "pledges.dashboard.assets.emptyBalance"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:87
-msgid "pledges.dashboard.assets.title"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
-msgid "pledges.dashboard.footprint.title"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
-msgid "pledges.dashboard.footprint.tonnes"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:104
-msgid "pledges.dashboard.footprint.tooltip.category_percent"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:110
-msgid "pledges.dashboard.footprint.tooltip.quantity"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:137
-msgid "pledges.dashboard.head.metaDescription"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:133
-msgid "pledges.dashboard.head.metaTitle"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:129
-msgid "pledges.dashboard.head.title"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:14
-msgid "pledges.dashboard.metholodogy.default_text"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:21
-msgid "pledges.dashboard.metholodogy.title"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:14
-msgid "pledges.dashboard.pledge.default_text"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:21
-msgid "pledges.dashboard.pledge.title"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:64
-msgid "pledges.dashboard.profile.pledge_met"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:73
-msgid "pledges.dashboard.profile.pledge_progress"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:106
-msgid "pledges.dashboard.profile.pledged_to_offset"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:104
-msgid "pledges.dashboard.retirements.title"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
-msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:123
-msgid "pledges.dashboard.retirements.total_tonnes_retired"
-msgstr ""
-
-#: components/pages/Pledge/HeaderDesktop/index.tsx:37
-msgid "pledges.edit_pledge"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:562
-msgid "pledges.form.add_footprint_category_button"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:446
-msgid "pledges.form.add_wallet_button"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:242
-msgid "pledges.form.awaiting_signature"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:190
-msgid "pledges.form.confirm_delete"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:622
-msgid "pledges.form.confirm_remove"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:635
-msgid "pledges.form.confirm_remove_cancel"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:205
-msgid "pledges.form.error"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:74
-msgid "pledges.form.errors.categoryName.max"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:70
-msgid "pledges.form.errors.categoryName.required"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:78
-msgid "pledges.form.errors.categoryQuantity.min"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:50
-msgid "pledges.form.errors.description.max"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:46
-msgid "pledges.form.errors.description.required"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:62
-msgid "pledges.form.errors.footprint.generic_error"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:66
-msgid "pledges.form.errors.footprint.min"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:58
-msgid "pledges.form.errors.methodology.max"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:54
-msgid "pledges.form.errors.methodology.required"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:34
-msgid "pledges.form.errors.name.required"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:38
-msgid "pledges.form.errors.profileImageUrl.url"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:42
-msgid "pledges.form.errors.profileWebsiteUrl.url"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:86
-msgid "pledges.form.errors.walletAddress.isAddress"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:90
-msgid "pledges.form.errors.walletAddress.isOwner"
-msgstr ""
-
-#: components/pages/Pledge/lib/formSchema.ts:82
-msgid "pledges.form.errors.walletAddress.required"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:489
-msgid "pledges.form.footprint.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:497
-msgid "pledges.form.footprint.prompt"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:260
-msgid "pledges.form.generic_error"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:518
-msgid "pledges.form.input.categoryName.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:510
-msgid "pledges.form.input.categoryName.placeholder"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:538
-msgid "pledges.form.input.categoryQuantity.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:530
-msgid "pledges.form.input.categoryQuantity.placeholder"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:323
-msgid "pledges.form.input.description.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:316
-msgid "pledges.form.input.description.placeholder"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:476
-msgid "pledges.form.input.methodology.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:468
-msgid "pledges.form.input.methodology.placeholder"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:280
-msgid "pledges.form.input.name.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:273
-msgid "pledges.form.input.name.placeholder"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:291
-msgid "pledges.form.input.profileImageUrl.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:305
-msgid "pledges.form.input.profileWebsiteUrl.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:579
-msgid "pledges.form.input.totalFootprint.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:380
-msgid "pledges.form.input.walletAddress.label"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:372
-msgid "pledges.form.input.walletAddress.placeholder"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:595
-msgid "pledges.form.submit_button"
-msgstr ""
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:186
-msgid "pledges.form.title"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:52
-msgid "pledges.form.total_footprint_summary"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:607
-msgid "pledges.form.use_your_wallet"
-msgstr ""
-
-#: components/pages/Pledge/PledgeForm/index.tsx:332
-msgid "pledges.form.wallets.label"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:94
-msgid "pledges.head.metaDescription"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:90
-msgid "pledges.head.metaTitle"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:86
-msgid "pledges.head.title"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:66
-msgid "pledges.home.hero.connecting"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:77
-msgid "pledges.home.hero.create"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:163
-msgid "pledges.home.hero.learn_more"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:72
-msgid "pledges.home.hero.view"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:199
-msgid "pledges.home.search.label"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:193
-msgid "pledges.home.search.placeholder"
-msgstr ""
-
-#: components/pages/Pledge/index.tsx:219
-msgid "pledges.home.search.submit"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:24
-msgid "resources.form.categories.header"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:27
-msgid "resources.form.categories.subheader"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:66
-msgid "resources.form.filters.clear_all"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:185
-msgid "resources.form.input.search.label"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:176
-msgid "resources.form.input.search.placeholder"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:210
-msgid "resources.form.input.sort_by.label"
-msgstr ""
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:21
-msgid "resources.form.input.sort_by.select"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:53
-msgid "resources.form.medium.header"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:41
-msgid "resources.form.sub_topics.header"
-msgstr ""
-
-#: components/pages/Resources/index.tsx:31
-msgid "resources.head.metaDescription"
-msgstr ""
-
-#: components/pages/Resources/index.tsx:27
-msgid "resources.head.metaTitle"
-msgstr ""
-
-#: components/pages/Resources/index.tsx:23
-msgid "resources.head.title"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:71
-msgid "resources.list.filter.tag.basics"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:111
-msgid "resources.list.filter.tag.carbon_footprint"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:79
-msgid "resources.list.filter.tag.deep_dives"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:52
-msgid "resources.list.filter.tag.klima_infinity"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:44
-msgid "resources.list.filter.tag.klima_overview"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:60
-msgid "resources.list.filter.tag.partnerships"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:103
-msgid "resources.list.filter.tag.policy"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:95
-msgid "resources.list.filter.tag.press_releases"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:87
-msgid "resources.list.filter.tag.user_guides"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:121
-msgid "resources.list.filter.type.blog"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:129
-msgid "resources.list.filter.type.podcast"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:155
-msgid "resources.list.sort_by.a-z"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:139
-msgid "resources.list.sort_by.latest_first"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:147
-msgid "resources.list.sort_by.oldest_first"
-msgstr ""
-
-#: components/pages/Resources/lib/cmsDataMap.ts:163
-msgid "resources.list.sort_by.z-a"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:311
-msgid "resources.mobile_modal.button.show_results"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:284
-msgid "resources.mobile_modal.title"
-msgstr ""
-
-#: components/pages/Resources/index.tsx:46
-msgid "resources.page.header.subline"
-msgstr ""
-
-#: components/pages/Resources/index.tsx:43
-msgid "resources.page.header.title"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:167
-msgid "resources.page.list.header"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:249
-msgid "resources.page.list.no_search_results.title"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:241
-msgid "resources.page.list.on_fetch_error"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:262
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:255
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr ""
-
-#: components/pages/Retirements/Footer/index.tsx:18
-msgid "retirement.footer.aboutKlima.left"
-msgstr ""
-
-#: components/pages/Retirements/Footer/index.tsx:28
-msgid "retirement.footer.aboutKlima.right"
-msgstr ""
-
-#: components/pages/Retirements/Footer/index.tsx:13
-msgid "retirement.footer.aboutKlima.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:37
-msgid "retirement.footer.buy_klima.button.buy"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:44
-msgid "retirement.footer.buy_klima.button.offset"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:30
-msgid "retirement.footer.buy_klima.text"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:25
-msgid "retirement.footer.buy_klima.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:135
-msgid "retirement.head.metaDescription"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:131
-msgid "retirement.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:127
-msgid "retirement.head.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:279
-msgid "retirement.share.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:189
-msgid "retirement.single.beneficiary.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:183
-msgid "retirement.single.beneficiary.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:197
-msgid "retirement.single.beneficiaryAddress.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:258
-msgid "retirement.single.create_a_pledge"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:244
-msgid "retirement.single.disclaimer"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:30
-msgid "retirement.single.download_certificate_button"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:147
-msgid "retirement.single.header.subline"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:254
-msgid "retirement.single.is_this_your_retirement"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
-msgid "retirement.single.message.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:30
-msgid "retirement.single.no_pledge"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
-msgid "retirement.single.project_details.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
-msgid "retirement.single.quantity"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:218
-msgid "retirement.single.retirementCertificate.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:21
-msgid "retirement.single.retirementDate.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:24
-msgid "retirement.single.timestamp.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:315
-msgid "retirement.single.view_on_polygon_scan"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:18
-msgid "retirement.single.view_pledge"
-msgstr ""
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr ""
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:46
-msgid "retirement.totals.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:40
-msgid "retirement.totals.head.title"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:65
-msgid "retirement.totals.page_headline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:71
-msgid "retirement.totals.page_subline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:95
-msgid "retirement.totals.retired_assets"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:111
-msgid "retirement.totals.retirements"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:103
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:117
-msgid "retirement.totals.total_retirement_transactions"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/errors/Custom404.tsx:20
 #: components/pages/errors/Custom404.tsx:24
 #: components/pages/errors/Custom404.tsx:28
@@ -1787,52 +394,409 @@ msgstr ""
 msgid "shared.404"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:15
+msgid "error.page.500.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:19
+msgid "error.page.500.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:34
+msgid "error.500.page.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:557
+msgid "infinity.faq_answer1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:67
+msgid "infinity.head.metaDescription"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:75
+msgid "pledge.errors.pledge_not_found"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:155
+msgid "resources.list.sort_by.a-z"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:78
 #: components/Navigation/index.tsx:206
 msgid "shared.about"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:13
+msgid "retirement.footer.aboutKlima.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:301
+msgid "infinity.getStarted_cta"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:41
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:108
+msgid "pledge.invitation.accept"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:25
+msgid "retirement.footer.buy_klima.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:497
+msgid "pledges.form.footprint.prompt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:562
+msgid "pledges.form.add_footprint_category_button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:340
+msgid "pledge.form.wallets.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:446
+msgid "pledges.form.add_wallet_button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:380
+msgid "pledges.form.input.walletAddress.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:82
+msgid "pledges.form.errors.walletAddress.required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:434
+msgid "buy.answer_exchange"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:134
+msgid "buy.create_wallet_description4"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:162
+msgid "infinity.affordable_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:252
+msgid "buy.swap_description1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:473
+msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:32
+msgid "disclaimer.all_information_on_this_website"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:289
+msgid "infinity.getStarted_third_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:79
+#: components/pages/Pledge/PledgeForm/index.tsx:83
+#: components/pages/Pledge/PledgeForm/index.tsx:99
+msgid "pledge.errors.default"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:21
+msgid "disclaimer.head.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:87
+msgid "pledge.errors.unknown_error"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:159
+msgid "disclaimer.any_action_you_take_upon_the_information"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:110
 #: components/Navigation/index.tsx:237
 msgid "shared.app"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:367
+msgid "buy.what_are_bonds"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:616
+msgid "pledge.form.wallets.confirm_remove_wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:126
+msgid "pledge.modal.are_you_sure"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:242
+msgid "pledges.form.awaiting_signature"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:190
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:176
+msgid "pledge.invitations.awaiting_signature"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:71
+msgid "resources.list.filter.tag.basics"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:116
+msgid "community.become_a_partner"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:183
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:197
+msgid "retirement.single.beneficiaryAddress.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:209
+msgid "home.benefits"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:180
+msgid "community.bigcowg_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:172
+msgid "community.blockchainforclimatefondation_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Footer/index.tsx:49
 msgid "shared.blog"
 msgstr ""
 
-#: components/Navigation/index.tsx:241
-msgid "shared.buy"
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:121
+msgid "resources.list.filter.type.blog"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:381
+msgid "buy.bond_description_capacity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:140
+msgid "contact.bug_reports"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:37
+msgid "retirement.footer.buy_klima.button.buy"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:143
 #: components/Navigation/index.tsx:272
 msgid "shared.buy_carbon"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:241
+msgid "shared.buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:387
+msgid "infinity.polygon_manifesto_description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:261
+msgid "infinity.getStarted_calculate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:264
+msgid "infinity.getStarted_calculate_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:386
+msgid "buy.bond_question_credit_card"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:635
+msgid "pledges.form.confirm_remove_cancel"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:158
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:115
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:144
 msgid "shared.cancel"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:87
+msgid "pledges.dashboard.assets.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:593
+msgid "infinity.faq_answer2_paragraph1"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:317
 msgid "shared.carbon_dashboard"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:185
 msgid "shared.carbon_dashboards"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:111
+msgid "resources.list.filter.tag.carbon_footprint"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:472
+msgid "infinity.mission_card2_description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:65
+msgid "retirement.totals.page_headline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:530
+msgid "pledges.form.input.categoryQuantity.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:450
+msgid "infinity.mission_card1_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:494
+msgid "infinity.mission_card3_description"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:160
 #: components/Navigation/index.tsx:291
 msgid "shared.carbonmark"
 msgstr ""
 
-#: components/pages/Home/index.tsx:192
-msgid "shared.carbonmark_cta"
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:63
+msgid "concat.careers"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:330
+msgid "home.cars_annual"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:24
+msgid "resources.form.categories.header"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:518
+msgid "pledges.form.input.categoryName.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:510
+msgid "pledges.form.input.categoryName.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:218
+msgid "retirement.single.retirementCertificate.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:255
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:119
+msgid "buy.create_wallet_description2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:66
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:147
+msgid "retirement.single.header.subline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:314
+msgid "community.come_on_in"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:82
 #: components/Navigation/index.tsx:211
 #: components/pages/About/AboutHeader/index.tsx:31
@@ -1840,16 +804,83 @@ msgstr ""
 msgid "shared.community"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:95
+msgid "community.head.headline"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:45
 msgid "shared.confirm"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:150
+msgid "pledge.modal.confirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:190
+msgid "pledges.form.confirm_delete"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:40
+msgid "pledge.modal.confirm_remove"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:294
+msgid "buy.staking_description1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:108
+#: components/pages/Pledge/PledgeDashboard/index.tsx:166
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:66
+msgid "pledges.home.hero.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:114
+#: components/pages/Pledge/PledgeDashboard/index.tsx:172
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:118
+#: components/pages/Pledge/PledgeDashboard/index.tsx:176
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:18
+msgid "contact.head.headline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:17
+#: components/pages/About/Contact/index.tsx:24
+msgid "contact.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:66
 #: components/pages/Infinity/index.tsx:117
 #: components/pages/Infinity/index.tsx:701
 msgid "shared.contact_sales"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:91
 #: components/pages/About/AboutHeader/index.tsx:40
 #: components/pages/About/Community/index.tsx:129
@@ -1857,10 +888,58 @@ msgstr ""
 msgid "shared.contact_us"
 msgstr ""
 
-#: components/pages/Home/index.tsx:185
-msgid "shared.dcm_cta"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:90
+msgid "pledges.head.metaTitle"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:77
+msgid "pledges.home.hero.create"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:258
+msgid "retirement.single.create_a_pledge"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:21
+msgid "retirement.single.retirementDate.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:79
+msgid "resources.list.filter.tag.deep_dives"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:219
+msgid "infinity.why_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:228
+msgid "community.deltawave_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:94
+msgid "pledges.head.metaDescription"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:162
+msgid "home.developed_by_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:265
+msgid "community.digitalcharityart_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Footer/index.tsx:55
 #: components/Navigation/index.tsx:100
 #: components/Navigation/index.tsx:226
@@ -1869,117 +948,1514 @@ msgstr ""
 msgid "shared.disclaimer"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:19
+msgid "disclaimer.disclaimer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:90
+msgid "blog.disclaimer.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:329
+msgid "community.discord_is_where_we_share"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:244
+msgid "community.dovu_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:30
+msgid "retirement.single.download_certificate_button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/Cards/CardsSlider.tsx:89
+msgid "infinity.cards_slider.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:29
+#: components/pages/errors/Custom500.tsx:23
+#: components/pages/Home/index.tsx:67
+#: components/pages/Retirements/index.tsx:52
+msgid "shared.head.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:343
+msgid "infinity.carousel_info_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:249
+msgid "community.eco_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:39
+msgid "pledge.modal.edit_pledge"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/HeaderDesktop/index.tsx:37
+msgid "pledges.edit_pledge"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:199
+msgid "pledges.home.search.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:62
+msgid "pledges.form.errors.footprint.generic_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:70
+msgid "pledges.form.errors.categoryName.required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:54
+msgid "pledges.form.errors.methodology.required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:34
+msgid "pledges.form.errors.name.required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:46
+msgid "pledges.form.errors.description.required"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:38
+msgid "pledges.form.errors.profileImageUrl.url"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:42
+msgid "pledges.form.errors.profileWebsiteUrl.url"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:66
+msgid "pledges.form.errors.footprint.min"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:78
+msgid "pledges.form.errors.categoryQuantity.min"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:205
+msgid "pledges.form.error"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:58
 #: components/pages/Home/index.tsx:113
 msgid "shared.enter_app"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:193
+msgid "pledges.home.search.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:58
+msgid "pledges.form.errors.methodology.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:74
+msgid "pledges.form.errors.categoryName.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:50
+msgid "pledges.form.errors.description.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:299
+msgid "home.equivalent_to"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:154
 msgid "shared.error"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:236
+msgid "community.etcgroup_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:372
+msgid "buy.bond_description1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:167
+msgid "resources.page.list.header"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:185
+msgid "shared.dcm_cta"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:320
+msgid "buy.faq_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:142
+msgid "infinity.fast_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:43
+msgid "resources.page.header.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:311
+msgid "buy.staking_description3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:242
+msgid "buy.connect_torus_sushi_description5"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
+msgid "pledges.dashboard.footprint.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:489
+msgid "pledges.form.footprint.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:71
+msgid "retirement.totals.page_subline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:178
+msgid "infinity.info_subtitle1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:444
+msgid "home.get_exposure_to_the_growing_carbon_economy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:25
+msgid "contact.head.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:361
+msgid "community.get_in_touch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:441
+msgid "home.get_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Infinity/GetStartedModal.tsx:25
 msgid "shared.get_started"
 msgstr ""
 
-#: components/pages/Buy/index.tsx:29
-#: components/pages/Home/index.tsx:67
-#: components/pages/Retirements/index.tsx:52
-#: components/pages/errors/Custom500.tsx:23
-msgid "shared.head.description"
-msgstr ""
-
-#: components/Footer/index.tsx:34
-msgid "shared.home"
-msgstr ""
-
-#: components/Navigation/index.tsx:176
-#: components/Navigation/index.tsx:308
-msgid "shared.how_to_buy"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:108
 #: components/pages/Infinity/index.tsx:309
 #: components/pages/Infinity/index.tsx:692
 msgid "shared.infinity.get_started"
 msgstr ""
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:481
+msgid "home.newletter.get_the_latest_updates"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:204
+msgid "community.gitcoin_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:387
+msgid "home.govern_the_market"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:113
+msgid "buy.create_wallet_description1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:313
+msgid "home.hectares_of_forest"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:34
+msgid "shared.home"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:27
+#: components/pages/Buy/index.tsx:28
+msgid "buy.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:41
+msgid "buy.how_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:176
+#: components/Navigation/index.tsx:308
+msgid "shared.how_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:14
+msgid "pledges.dashboard.metholodogy.default_text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/GetStartedModal.tsx:94
+msgid "infinity.getStartedModal_offsetCrypto"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/GetStartedModal.tsx:104
+msgid "infinity.getStartedModal_needAssistance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/GetStartedModal.tsx:47
+msgid "infinity.getStartedModal_business"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/GetStartedModal.tsx:70
+msgid "infinity.getStartedModal_individual"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:108
+msgid "contact.media.if_you_are_a_journalist"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:274
+msgid "buy.swap_description3"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:364
+msgid "community.if_you_ve_got_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:191
+msgid "infinity.transparent_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:275
+msgid "infinity.getStarted_second_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:278
+msgid "infinity.getStarted_second_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:195
+msgid "buy.torus_login_description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:211
+msgid "buy.connect_torus_sushi_description2"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:151
 #: components/Navigation/index.tsx:280
 msgid "shared.info"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:417
+msgid "buy.bond_answer_cex2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:254
+msgid "retirement.single.is_this_your_retirement"
+msgstr ""
+
+#. Join our <0>community</0>
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:38
+msgid "contact.quest_and_support.join_our_community"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:317
+msgid "community.join_our_discord"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:46
+msgid "contact.quest_and_support.join_our_discord_server"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:405
+msgid "home.join_over_100k_members"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:304
+msgid "community.join_the_klima_community"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:52
+msgid "resources.list.filter.tag.klima_infinity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:63
+msgid "infinity.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:98
+msgid "infinity.welcome_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:44
+msgid "buy.how_to_paragraph_part_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:409
+msgid "buy.bond_answer_cex1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:44
+msgid "resources.list.filter.tag.klima_overview"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:28
+msgid "retirement.footer.aboutKlima.right"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:40
+msgid "retirement.totals.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:46
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:127
+msgid "retirement.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:59
+msgid "infinity.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:86
+msgid "pledges.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:23
+msgid "resources.head.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:102
+msgid "disclaimer.klimadao_and_its_suppliers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:94
+#: components/pages/About/Community/index.tsx:101
+msgid "community.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:15
+#: components/pages/About/Disclaimer/index.tsx:25
+msgid "disclaimer.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/SocialProof/index.tsx:19
+msgid "home.featured_on"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:96
+msgid "community.head.subline"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:43
+msgid "disclaimer.klimadao_is_a_platform"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:212
+msgid "home.klima_is_creating"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:18
+msgid "retirement.footer.aboutKlima.left"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:224
+msgid "infinity.why_description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:27
+msgid "resources.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:439
+msgid "mission.header"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:281
+msgid "community.landx_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:400
+msgid "infinity.box_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:139
+msgid "resources.list.sort_by.latest_first"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:102
+msgid "community.head.metadescription"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:163
+msgid "pledges.home.hero.learn_more"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:137
+msgid "home.learn_more"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:113
+#: components/pages/About/Community/index.tsx:358
+msgid "community.lets_work_together"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:345
+msgid "home.liters_if_gasoline"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/HeaderDesktop/index.tsx:43
 #: components/pages/Pledge/HeaderMobile/index.tsx:46
 msgid "shared.login_connect"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:105
+msgid "contact.media"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:53
+msgid "resources.form.medium.header"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:91
+msgid "pledge.errors.method_not_allowed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:21
+msgid "pledges.dashboard.metholodogy.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:476
+msgid "pledges.form.input.methodology.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:156
+msgid "community.moss_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:280
+msgid "pledges.form.input.name.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:273
+msgid "pledges.form.input.name.placeholder"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:130
+msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:253
+msgid "home.neutral_and_trusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:498
+msgid "home.newletter.never_shared_never_spammed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:478
+msgid "home.newsletter"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:189
+msgid "retirement.single.beneficiary.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:110
+msgid "pledges.dashboard.assets.emptyBalance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:24
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:189
+msgid "buy.connect_advanced"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:178
+msgid "disclaimer.nothing_in_this_disclaimer"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:56
+msgid "disclaimer.nothing_in_this_platform"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:196
+msgid "community.oceandrop_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:135
 #: components/Navigation/index.tsx:264
 msgid "shared.offset"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:44
+msgid "retirement.footer.buy_klima.button.offset"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:137
+msgid "infinity.fast_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:192
+msgid "shared.carbonmark_cta"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:257
+msgid "community.offsetra_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:172
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:158
 msgid "shared.okay"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:147
+msgid "resources.list.sort_by.oldest_first"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:212
+msgid "community.olympusdao_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:220
+msgid "community.openearth_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:281
+msgid "buy.swap_description4"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:151
+msgid "community.our_partners"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:85
+msgid "contact.partnerships"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:60
+msgid "resources.list.filter.tag.partnerships"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/PledgeForm/index.tsx:421
 msgid "shared.pending"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:86
+msgid "pledges.form.errors.walletAddress.isAddress"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:175
+msgid "pledge.form.error.duplicate_wallets"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:262
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:21
+msgid "pledges.dashboard.pledge.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:323
+msgid "pledges.form.input.description.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:106
+msgid "pledges.dashboard.profile.pledged_to_offset"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:129
+msgid "resources.list.filter.type.podcast"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:103
+msgid "resources.list.filter.tag.policy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:356
+msgid "infinity.polygon_story_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:188
+msgid "community.polygon_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:361
+msgid "infinity.polygon_story_description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:95
+msgid "resources.list.filter.tag.press_releases"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:291
+msgid "pledges.form.input.profileImageUrl.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:273
+msgid "home.public_and_open-source"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:152
+msgid "home.public_good_for_the_planet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:611
+msgid "infinity.faq_answer2_paragraph3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:538
+msgid "pledges.form.input.categoryQuantity.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
+msgid "retirement.single.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:35
+msgid "contact.quest_and_support"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:19
+msgid "contact.head.subline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:665
+msgid "infinity.button.read_blog_faq"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:368
+msgid "infinity.button.read_blog_polygon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:157
+msgid "infinity.affordable_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:115
+msgid "pledge.invitation.reject"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:127
+msgid "pledge.invitation.later"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:132
 msgid "shared.remove"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:622
+msgid "pledges.form.confirm_remove"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:24
+msgid "connect_modal.error_processing"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:167
 #: components/Navigation/index.tsx:299
 #: components/pages/Blog/Post/index.tsx:76
 msgid "shared.resourcecenter"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:164
 #: components/Navigation/index.tsx:295
 msgid "shared.resources"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:95
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
+msgid "retirement.single.message.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:104
+msgid "pledges.dashboard.retirements.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:111
+msgid "retirement.totals.retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:228
+msgid "buy.connect_torus_sushi_description3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:595
+msgid "pledges.form.submit_button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:219
+msgid "pledges.home.search.submit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:185
+msgid "resources.form.input.search.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:176
+msgid "resources.form.input.search.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:332
+msgid "pledges.form.wallets.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:451
+msgid "home.see_tutorial"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/SortyByDropDown/index.tsx:21
+msgid "resources.form.input.sort_by.select"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:27
+msgid "resources.form.categories.subheader"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:353
+msgid "buy.question_why_matic_answer_bullet3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:49
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:44
+msgid "pledge.invitation.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:279
+msgid "retirement.share.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:311
+msgid "resources.mobile_modal.button.show_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:492
+msgid "home.newletter.sign_up"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:54
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:49
+msgid "pledge.invitation.signing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:104
+#: components/pages/Pledge/PledgeDashboard/index.tsx:162
+msgid "connectModal.torus"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:227
+msgid "pledge.form.error.default_error_message"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:260
+msgid "pledges.form.generic_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom404.tsx:41
+msgid "error.404.page.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:39
+msgid "error.500.page.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:241
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:249
+msgid "resources.page.list.no_search_results.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:210
+msgid "resources.form.input.sort_by.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:284
+msgid "resources.mobile_modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Resources/ResourcesList/index.tsx:216
 msgid "shared.resources.sort_by.header"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:360
+msgid "home.source"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:291
+msgid "buy.staking_cta"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:339
+msgid "buy.question_why_matic_answer_bullet1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:41
+msgid "resources.form.sub_topics.header"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:59
+msgid "buy.summary_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:338
+msgid "infinity.carousel_info_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:346
+msgid "buy.question_why_matic_answer_bullet2"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:422
+msgid "home.take_climate_action_now"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:62
+msgid "buy.summary_steps_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:93
+msgid "infinity.welcome_title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:93
+msgid "blog.disclaimer.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:328
+msgid "buy.question_why_matic_answer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:685
+msgid "infinity.cta_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:648
+msgid "infinity.faq_answer3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:381
+msgid "infinity.polygon_manifesto_title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:83
+msgid "disclaimer.the_service_available"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:183
+msgid "infinity.info_subtitle2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:51
+msgid "buy.how_to_paragraph_part_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:244
+msgid "retirement.single.disclaimer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:30
+msgid "retirement.single.no_pledge"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:98
+msgid "pledge.modal.unable_to_edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:70
+msgid "pledge.invitation.error.wallet_already_pinned"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:273
+msgid "community.toughtforfood_logo"
+msgstr ""
+
+#. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:143
+msgid "contact.bug_reports.to_file_a_bug_report"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/Cards/Card.tsx:66
+#: components/pages/Infinity/index.tsx:407
+#: components/pages/Infinity/index.tsx:421
+msgid "infinity.tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
+msgid "pledges.dashboard.footprint.tonnes"
+msgstr ""
+
+#. TONNES OF <0>CARBON HELD</0> BY KLIMADAO
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:286
+msgid "home.tonnes_of_carbon_held_by_klimadao"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:414
+msgid "infinity.box_title2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:123
+msgid "pledges.dashboard.retirements.total_tonnes_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:103
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:579
+msgid "pledges.form.input.totalFootprint.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:52
+msgid "pledges.form.total_footprint_summary"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:117
+msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:164
+msgid "community.toucan_logo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:292
+msgid "infinity.getStarted_third_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:196
+msgid "infinity.transparent_subtitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:233
+msgid "home.transparent_and_efficient"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:105
+msgid "home.transparent_neutral"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:135
+msgid "retirement.head.metaDescription"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:132
+msgid "community.tree_grove"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:107
+msgid "pledge.modal.unpin_wallet"
+msgstr ""
+
+#. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:88
+msgid "contact.partnerships.until_we_finish_building"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:31
+msgid "resources.head.metaDescription"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:46
+msgid "resources.page.header.subline"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:147
+msgid "buy.load_wallet_description1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:30
+msgid "retirement.footer.buy_klima.text"
+msgstr ""
+
+#. Use this <0>Media Request Form</0>.
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:117
+msgid "contact.media.use_this_media_request_form"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:196
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:182
+msgid "pledge.invitations.signature_instructions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:607
+msgid "pledges.form.use_your_wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:87
+msgid "resources.list.filter.tag.user_guides"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:20
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:360
+msgid "buy.question_why_matic_answer_bullet4"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:315
+msgid "retirement.single.view_on_polygon_scan"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:18
+msgid "retirement.single.view_pledge"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:72
+msgid "pledges.home.hero.view"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:512
 msgid "shared.visit_klimadao_blog"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:204
+msgid "buy.wallet_connect_example"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:221
+#: components/pages/Buy/index.tsx:267
+msgid "buy.wallet_connect_example_qr_code"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:16
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:189
+msgid "disclaimer.we_recommend_that_you_visit"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:119
+msgid "community.we_work_with_traditionnal"
+msgstr ""
+
+#. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:66
+msgid "contact.careers.we_re_hiring"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:305
+msgid "pledges.form.input.profileWebsiteUrl.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:428
+msgid "buy.question_exchange"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:316
+msgid "pledges.form.input.description.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:468
+msgid "pledges.form.input.methodology.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:128
+msgid "buy.create_wallet_description3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:603
+msgid "infinity.faq_answer2_paragraph2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:236
+msgid "buy.connect_torus_sushi_description4"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:402
+msgid "buy.bond_question_cex"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:323
+msgid "buy.question_why_matic"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:216
+msgid "infinity.why_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:331
+msgid "infinity.carousel_image_description"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:127
 #: components/Navigation/index.tsx:256
 msgid "shared.wrap"
 msgstr ""
 
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:14
+msgid "pledges.dashboard.pledge.default_text"
 msgstr ""
 
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:391
+msgid "buy.bond_answer_cedit_card"
 msgstr ""
 
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:144
+msgid "disclaimer.you_bear_full_responsibility"
 msgstr ""
 
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:302
+msgid "buy.staking_description2"
 msgstr ""
 
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:90
+msgid "pledges.form.errors.walletAddress.isOwner"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:62
-msgid "{trimCurrentSupply} Tonnes remaining"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:191
+msgid "pledge.form.error.cannot_add_yourself"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:57
-msgid "{trimTotalRetired} Tonnes retired in total"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:141
+msgid "pledge.modal.wallet_add_confirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:186
+msgid "pledges.form.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:163
+msgid "resources.list.sort_by.z-a"
 msgstr ""

--- a/site/locale/en/messages.po
+++ b/site/locale/en/messages.po
@@ -13,56 +13,97 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: components/pages/Buy/index.tsx:100
-msgid "<0>Swap for KLIMA.</0> Sushi is a Decentralized Exchange where you can trade some of your MATIC tokens for KLIMA tokens at the lowest possible price."
-msgstr "<0>Swap for KLIMA.</0> Sushi is a Decentralized Exchange where you can trade some of your MATIC tokens for KLIMA tokens at the lowest possible price."
-
-#: components/Footer/index.tsx:43
-msgid "App"
-msgstr "App"
-
-#: components/Navigation/index.tsx:122
-#: components/Navigation/index.tsx:251
-msgid "Bond Klima"
-msgstr "Bond Klima"
-
-#: components/Footer/index.tsx:37
-msgid "Buy"
-msgstr "Buy"
-
-#: components/Navigation/index.tsx:112
-msgid "Buy Klima"
-msgstr "Buy Klima"
-
+#. js-lingui-explicit-id
 #: components/ChangeLanguageButton/index.tsx:48
 msgid "Change language"
 msgstr "Change language"
 
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:37
+msgid "Buy"
+msgstr "Buy"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:40
+msgid "Stake"
+msgstr "Stake"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:43
+msgid "App"
+msgstr "App"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:46
+msgid "Docs"
+msgstr "Docs"
+
+#. js-lingui-explicit-id
 #: components/Footer/index.tsx:52
 #: components/pages/About/AboutHeader/index.tsx:67
 msgid "Contact"
 msgstr "Contact"
 
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:65
+msgid "Wrong Network"
+msgstr "Wrong Network"
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:75
+msgid "This app only works on Polygon Mainnet."
+msgstr "This app only works on Polygon Mainnet."
+
+#. js-lingui-explicit-id
+#: components/InvalidNetworkModal/index.tsx:80
+msgid "Switch to Polygon"
+msgstr "Switch to Polygon"
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:112
+msgid "Buy Klima"
+msgstr "Buy Klima"
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:117
+#: components/Navigation/index.tsx:246
+msgid "Stake Klima"
+msgstr "Stake Klima"
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:122
+#: components/Navigation/index.tsx:251
+msgid "Bond Klima"
+msgstr "Bond Klima"
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:193
+#: components/Navigation/index.tsx:325
+msgid "Official Docs"
+msgstr "Official Docs"
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:220
 msgid "Contact Us"
 msgstr "Contact Us"
 
-#: components/Footer/index.tsx:46
-msgid "Docs"
-msgstr "Docs"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:100
+msgid "<0>Swap for KLIMA.</0> Sushi is a Decentralized Exchange where you can trade some of your MATIC tokens for KLIMA tokens at the lowest possible price."
+msgstr "<0>Swap for KLIMA.</0> Sushi is a Decentralized Exchange where you can trade some of your MATIC tokens for KLIMA tokens at the lowest possible price."
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:33
-msgid "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
-msgstr "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:68
-msgid "Explore MCO2 on data.klimadao.finance"
-msgstr "Explore MCO2 on data.klimadao.finance"
-
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:530
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:113
+#: components/pages/Pledge/PledgeDashboard/index.tsx:171
+msgid "Login"
+msgstr "Login"
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:53
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:48
 #: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/TokenRow/index.tsx:41
@@ -71,1721 +112,281 @@ msgstr "Frequently Asked Questions"
 msgid "Loading..."
 msgstr "Loading..."
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:47
-msgid "Location: {0}"
-msgstr "Location: {0}"
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:171
-#: components/pages/Pledge/index.tsx:113
-msgid "Login"
-msgstr "Login"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:50
-msgid "MCO2 Token"
-msgstr "MCO2 Token"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:52
-msgid "Methodology: {0}"
-msgstr "Methodology: {0}"
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:23
-msgid "No retirement message provided."
-msgstr "No retirement message provided."
-
-#: components/Navigation/index.tsx:193
-#: components/Navigation/index.tsx:325
-msgid "Official Docs"
-msgstr "Official Docs"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:159
-msgid "Processing data..."
-msgstr "Processing data..."
-
-#: components/Footer/index.tsx:40
-msgid "Stake"
-msgstr "Stake"
-
-#: components/Navigation/index.tsx:117
-#: components/Navigation/index.tsx:246
-msgid "Stake Klima"
-msgstr "Stake Klima"
-
-#: components/InvalidNetworkModal/index.tsx:80
-msgid "Switch to Polygon"
-msgstr "Switch to Polygon"
-
-#: components/InvalidNetworkModal/index.tsx:75
-msgid "This app only works on Polygon Mainnet."
-msgstr "This app only works on Polygon Mainnet."
-
+#. js-lingui-explicit-id
 #: components/pages/Resources/SortyByDropDown/index.tsx:62
 msgid "Toggle Sorted by menu"
 msgstr "Toggle Sorted by menu"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:74
-msgid "View on Polygonscan"
-msgstr "View on Polygonscan"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:159
+msgid "Processing data..."
+msgstr "Processing data..."
 
+#. js-lingui-explicit-id
 #: components/pages/Retirements/SingleRetirement/index.tsx:163
 msgid "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 msgstr "We haven't finished processing the blockchain data for this retirement. This usually takes a few seconds, but might take longer if the network is congested."
 
-#: components/InvalidNetworkModal/index.tsx:65
-msgid "Wrong Network"
-msgstr "Wrong Network"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:33
+msgid "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
+msgstr "Every KlimaDAO retirement is tied to a verified offset project. Click to learn more about the project."
 
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:93
-msgid "blog.disclaimer.description"
-msgstr "The information provided in this blog post pertaining to KlimaDAO (“KlimaDAO”), its crypto-assets, business assets, strategy, and operations, is for general informational purposes only and is not a formal offer to sell or a solicitation of an offer to buy any securities, options, futures, or other derivatives related to securities in any jurisdiction and its content is not prescribed by securities laws. Information contained in this blog post should not be relied upon as advice to buy or sell or hold such securities or as an offer to sell such securities. This blog post does not take into account nor does it provide any tax, legal or investment advice or opinion regarding the specific investment objectives or financial situation of any person. KlimaDAO and its agents, advisors, directors, officers, employees and shareholders make no representation or warranties, expressed or implied, as to the accuracy of such information and KlimaDAO expressly disclaims any and all liability that may be based on such information or errors or omissions thereof. KlimaDAO reserves the right to amend or replace the information contained herein, in part or entirely, at any time, and undertakes no obligation to provide the recipient with access to the amended information or to notify the recipient thereof. The information contained in this blog post supersedes any prior blog post or conversation concerning the same, similar or related information. Any information, representations or statements not contained herein shall not be relied upon for any purpose. Neither KlimaDAO nor any of its representatives shall have any liability whatsoever, under contract, tort, trust or otherwise, to you or any person resulting from the use of the information in this blog post by you or any of your representatives or for omissions from the information in this blog post. Additionally, KlimaDAO undertakes no obligation to comment on the expectations of, or statements made by, third parties in respect of the matters discussed in this blog post."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:50
+msgid "MCO2 Token"
+msgstr "MCO2 Token"
 
-#: components/pages/Blog/Post/index.tsx:90
-msgid "blog.disclaimer.title"
-msgstr "Disclaimer:"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:47
+msgid "Location: {0}"
+msgstr "Location: {0}"
 
-#: components/pages/Buy/index.tsx:434
-msgid "buy.answer_exchange"
-msgstr "Advanced users can use the <0>Polygon Bridge</0> to move any asset from Ethereum to Polygon, and/or the <1>Polygon Gas Swap</1> to swap assets like USDC for MATIC."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:52
+msgid "Methodology: {0}"
+msgstr "Methodology: {0}"
 
-#: components/pages/Buy/index.tsx:391
-msgid "buy.bond_answer_cedit_card"
-msgstr "Yes, some on-ramp providers like <0>Transak</0> allow you to buy KLIMA directly with a credit card, for a fee. However, if your wallet doesn't have MATIC, you won't be able to transfer or perform other actions. For this reason, and to guarantee the best market rate, we recommend buying MATIC directly instead, and swapping your MATIC for KLIMA on Sushi.com."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:57
+msgid "{trimTotalRetired} Tonnes retired in total"
+msgstr "{trimTotalRetired} Tonnes retired in total"
 
-#: components/pages/Buy/index.tsx:409
-msgid "buy.bond_answer_cex1"
-msgstr "KLIMA is not traded on a centralized exchange like Coinbase, Binance, or Crypto.com as these exchanges typically charge very high listing fees and require financing from expensive market makers."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:62
+msgid "{trimCurrentSupply} Tonnes remaining"
+msgstr "{trimCurrentSupply} Tonnes remaining"
 
-#: components/pages/Buy/index.tsx:417
-msgid "buy.bond_answer_cex2"
-msgstr "Instead, KLIMA tokens are traded on a \"Decentralized Exchange\" (DEX) that is powered by smart contracts and runs directly on the blockchain. DEXs have some major advantages. DEXs made it possible for the DAO to own the majority of liquidity, so it can maintain full autonomy and generate revenue to pay contributors. We chose to use Sushi's DEX technology as it already facilitates tens of millions of dollars in transactions per day."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:68
+msgid "Explore MCO2 on data.klimadao.finance"
+msgstr "Explore MCO2 on data.klimadao.finance"
 
-#: components/pages/Buy/index.tsx:372
-msgid "buy.bond_description1"
-msgstr "Experienced crypto users can buy KLIMA directly from the protocol via bonds. To acquire KLIMA via bonds, you provide a carbon token or liquidity token and get discounted KLIMA tokens in return. This is the mechanism that the DAO uses to grow its treasury of digital carbon."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:74
+msgid "View on Polygonscan"
+msgstr "View on Polygonscan"
 
-#: components/pages/Buy/index.tsx:381
-msgid "buy.bond_description_capacity"
-msgstr "Bond capacity is limited and bonds are not always available."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:23
+msgid "No retirement message provided."
+msgstr "No retirement message provided."
 
-#: components/pages/Buy/index.tsx:402
-msgid "buy.bond_question_cex"
-msgstr "Why can't I find KLIMA on Coinbase or other centralized exchanges? Why do I have to use <0>Sushi.com</0>?"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:110
+msgid "pledges.dashboard.footprint.tooltip.quantity"
+msgstr "{0} Carbon Tonne(s)"
 
-#: components/pages/Buy/index.tsx:386
-msgid "buy.bond_question_credit_card"
-msgstr "Can I buy KLIMA directly with a credit card?"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
+msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
+msgstr "{0} Carbon Tonne(s) Retired"
 
-#: components/pages/Buy/index.tsx:189
-msgid "buy.connect_advanced"
-msgstr "Note: these instructions are for Torus wallet users only. Sushi supports a variety of different wallets."
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:104
+msgid "pledges.dashboard.footprint.tooltip.category_percent"
+msgstr "{0}% of footprint"
 
-#: components/pages/Buy/index.tsx:184
-msgid "buy.connect_torus_sushi"
-msgstr "3A. Connect Torus to Sushi.com using WalletConnect"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:73
+msgid "pledges.dashboard.profile.pledge_progress"
+msgstr "{0}% of Pledge Met"
 
-#: components/pages/Buy/index.tsx:211
-msgid "buy.connect_torus_sushi_description2"
-msgstr "In a separate browser tab, visit <0>Sushi.com</0> and click \"Connect\" at the top-right corner. You will be presented with a few wallet options. Choose WalletConnect. After you choose WalletConnect you will see a QR code—click \"Copy to Clipboard\"."
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:137
+msgid "pledges.dashboard.head.metaDescription"
+msgstr "{pledgeOwnerTitle} pledges to Offset {currentTotalFootprint} Carbon Tonnes. View their carbon offset history and read more about their commitment."
 
-#: components/pages/Buy/index.tsx:228
-msgid "buy.connect_torus_sushi_description3"
-msgstr "Return to the Torus wallet app and paste this code into the WalletConnect widget. This will create a temporary connection between your wallet and <0>Sushi.com</0>."
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:133
+msgid "pledges.dashboard.head.metaTitle"
+msgstr "{pledgeOwnerTitle}'s Pledge"
 
-#: components/pages/Buy/index.tsx:236
-msgid "buy.connect_torus_sushi_description4"
-msgstr "When you return to the Sushi tab in your browser, you should see that your Torus address is now visible in the top-right corner."
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:129
+msgid "pledges.dashboard.head.title"
+msgstr "{pledgeOwnerTitle}'s Pledge | KlimaDAO"
 
-#: components/pages/Buy/index.tsx:242
-msgid "buy.connect_torus_sushi_description5"
-msgstr "Finally, use the drop-down menu on <0>Sushi.com</0> to switch to the Polygon network."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:131
+msgid "retirement.head.metaTitle"
+msgstr "{retiree} retired {formattedAmount} Tonnes of carbon"
 
-#: components/pages/Buy/index.tsx:72
-msgid "buy.create_wallet_description"
-msgstr "<0>Create a wallet.</0> We recommend Torus Wallet, but our app supports most Web3 wallets (Metamask, Coinbase Wallet, Brave, MyEtherWallet, and many more)."
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:99
+msgid "pledge.invitation.join_message"
+msgstr "{shortenedAddress} has invited you to add your wallet to this pledge. If you accept, then your carbon retirements will count toward {shortenedAddress}'s pledge. You may remove your wallet from this pledge at any time."
 
-#: components/pages/Buy/index.tsx:113
-msgid "buy.create_wallet_description1"
-msgstr "Head to <0>app.klimadao.finance</0> and click \"Connect\" at the top-right corner."
-
-#: components/pages/Buy/index.tsx:119
-msgid "buy.create_wallet_description2"
-msgstr "Choose the “Email or Social” sign-in option, which will direct you to log in with Torus. Torus is a technology that generates a secure wallet using your existing email or social login. You will be able to use this new Torus wallet across hundreds of other Web3 and DeFi apps."
-
-#: components/pages/Buy/index.tsx:128
-msgid "buy.create_wallet_description3"
-msgstr "When you are connected, you should see your new wallet address in the top left corner of the app."
-
-#: components/pages/Buy/index.tsx:134
-msgid "buy.create_wallet_description4"
-msgstr "Advanced: if you don't want to use Torus, feel free to use any Polygon-compatible Web3 wallet."
-
-#: components/pages/Buy/index.tsx:110
-msgid "buy.create_wallet_item"
-msgstr "1. Create a Wallet"
-
-#: components/pages/Buy/index.tsx:320
-msgid "buy.faq_title"
-msgstr "FAQ"
-
-#: components/pages/Buy/index.tsx:27
-#: components/pages/Buy/index.tsx:28
-msgid "buy.head.title"
-msgstr "How to buy KLIMA"
-
-#: components/pages/Buy/index.tsx:41
-msgid "buy.how_to_buy"
-msgstr "How to buy KLIMA"
-
-#: components/pages/Buy/index.tsx:44
-msgid "buy.how_to_paragraph_part_1"
-msgstr "KLIMA is a carbon-backed digital asset and can be staked for rewards or used to offset digital carbon. Holding KLIMA also empowers you to vote and help govern the Digital Carbon Market."
-
-#: components/pages/Buy/index.tsx:51
-msgid "buy.how_to_paragraph_part_2"
-msgstr "This is a short tutorial for beginners who are new to Web3 and DeFi"
-
-#: components/pages/Buy/index.tsx:142
-msgid "buy.load_wallet"
-msgstr "2. Load your wallet with MATIC tokens"
-
-#: components/pages/Buy/index.tsx:85
-msgid "buy.load_wallet_description"
-msgstr "<0>Load your new wallet with MATIC tokens.</0> MATIC is the gas that powers the Polygon network. Every transaction you execute on Polygon will require a few cents worth of MATIC to pay the network fee."
-
-#: components/pages/Buy/index.tsx:147
-msgid "buy.load_wallet_description1"
-msgstr "Use a service like <0>MoonPay</0> or <1>Transak</1> or a centralized exchange like <2>Coinbase</2> to buy Polygon MATIC and send it to your newly created wallet."
-
+#. js-lingui-explicit-id
 #: components/pages/Buy/index.tsx:157
 msgid "buy.load_wallet_description2"
 msgstr "<0>Be sure that the MATIC tokens are sent to your new wallet address!</0> You can copy the address to your clipboard by connecting to our app and clicking the address in the navigation menu."
 
+#. js-lingui-explicit-id
 #: components/pages/Buy/index.tsx:167
 msgid "buy.load_wallet_description3"
 msgstr "<0>Be sure to buy and send the MATIC through the Polygon network!</0> Some exchanges like Coinbase will ask you which network to send the MATIC tokens on. Make sure to always choose Polygon."
 
-#: components/pages/Buy/index.tsx:428
-msgid "buy.question_exchange"
-msgstr "What if I want to use a different exchange, but they don't sell Polygon MATIC?"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:72
+msgid "buy.create_wallet_description"
+msgstr "<0>Create a wallet.</0> We recommend Torus Wallet, but our app supports most Web3 wallets (Metamask, Coinbase Wallet, Brave, MyEtherWallet, and many more)."
 
-#: components/pages/Buy/index.tsx:323
-msgid "buy.question_why_matic"
-msgstr "Why do I have to buy MATIC first?"
-
-#: components/pages/Buy/index.tsx:328
-msgid "buy.question_why_matic_answer"
-msgstr "The KLIMA token and protocol lives on the Polygon blockchain. MATIC is the “gas” that powers every transaction on Polygon. It is not possible to execute a transaction without paying the transaction fee. This means you will need to pay a few cents worth of MATIC for the following actions:"
-
-#: components/pages/Buy/index.tsx:339
-msgid "buy.question_why_matic_answer_bullet1"
-msgstr "Staking KLIMA for sKLIMA"
-
-#: components/pages/Buy/index.tsx:346
-msgid "buy.question_why_matic_answer_bullet2"
-msgstr "Swapping between different tokens"
-
-#: components/pages/Buy/index.tsx:353
-msgid "buy.question_why_matic_answer_bullet3"
-msgstr "Sending tokens to another wallet"
-
-#: components/pages/Buy/index.tsx:360
-msgid "buy.question_why_matic_answer_bullet4"
-msgstr "Using KLIMA or other tokens to offset carbon"
-
-#: components/pages/Buy/index.tsx:291
-msgid "buy.staking_cta"
-msgstr "Stake, earn, vote, and offset!"
-
-#: components/pages/Buy/index.tsx:294
-msgid "buy.staking_description1"
-msgstr "Congrats! Now that you have some KLIMA in your wallet, we highly recommend <0>staking</0> that KLIMA for sKLIMA, which accrues rewards over time as the protocol grows."
-
-#: components/pages/Buy/index.tsx:302
-msgid "buy.staking_description2"
-msgstr "You can also use the app to spend KLIMA and <0>retire digital carbon</0> on the blockchain."
-
-#: components/pages/Buy/index.tsx:311
-msgid "buy.staking_description3"
-msgstr "Finally, keep an eye out for <0>ongoing votes</0> and help guide the protocol in the right direction."
-
-#: components/pages/Buy/index.tsx:69
-msgid "buy.step_1"
-msgstr "1."
-
-#: components/pages/Buy/index.tsx:82
-msgid "buy.step_2"
-msgstr "2."
-
-#: components/pages/Buy/index.tsx:97
-msgid "buy.step_3"
-msgstr "3."
-
-#: components/pages/Buy/index.tsx:62
-msgid "buy.summary_steps_title"
-msgstr "The best and easiest way to get KLIMA is to follow these three steps:"
-
-#: components/pages/Buy/index.tsx:59
-msgid "buy.summary_title"
-msgstr "Summary"
-
-#: components/pages/Buy/index.tsx:252
-msgid "buy.swap_description1"
-msgstr "After connecting your wallet and switching to the Polygon network, you should now be able to swap from MATIC to KLIMA."
-
+#. js-lingui-explicit-id
 #: components/pages/Buy/index.tsx:258
 msgid "buy.swap_description2"
 msgstr "<0>Important note: don't swap all your MATIC for KLIMA!</0> Save at least 0.5 MATIC to pay for future transaction fees."
 
-#: components/pages/Buy/index.tsx:274
-msgid "buy.swap_description3"
-msgstr "If you are using Torus, keep the browser tab with the Torus app open. You will need to return to your wallet to approve and authorize the transactions."
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:85
+msgid "buy.load_wallet_description"
+msgstr "<0>Load your new wallet with MATIC tokens.</0> MATIC is the gas that powers the Polygon network. Every transaction you execute on Polygon will require a few cents worth of MATIC to pay the network fee."
 
-#: components/pages/Buy/index.tsx:281
-msgid "buy.swap_description4"
-msgstr "Optional: If you'd like your Sushi transactions themselves to be climate positive, you should enable the Sushi 'Green Fee', powered by KlimaDAO. This will spend 0.02 MATIC per transaction to purchase and retire digital carbon automatically!"
+#. <0>WELCOME TO</0><1>KlimaDAO</1>
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:92
+msgid "home.welcome_to_klimadao"
+msgstr "<0>WELCOME TO</0><1>KlimaDAO</1>"
 
-#: components/pages/Buy/index.tsx:249
-msgid "buy.swap_subtitle"
-msgstr "3B. Swap MATIC for KLIMA"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:64
+msgid "pledges.dashboard.profile.pledge_met"
+msgstr "≥ 100% of Pledge Met"
 
-#: components/pages/Buy/index.tsx:178
-msgid "buy.swap_wallet"
-msgstr "3. Swap for KLIMA on <0>Sushi.com</0>"
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:81
+msgid "home.latest_news"
+msgstr "📰 Latest News:"
 
-#: components/pages/Buy/index.tsx:195
-msgid "buy.torus_login_description"
-msgstr "In a new browser tab, go to the <0>Torus Polygon webapp</0> and log in with your new Torus account. When you log in, you should see a WalletConnect widget."
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:469
+msgid "infinity.mission_card2_number"
+msgstr "$10m+"
 
-#: components/pages/Buy/index.tsx:204
-msgid "buy.wallet_connect_example"
-msgstr "wallet connect input example"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:372
+msgid "pledges.form.input.walletAddress.placeholder"
+msgstr "0x..."
 
-#: components/pages/Buy/index.tsx:221
-#: components/pages/Buy/index.tsx:267
-msgid "buy.wallet_connect_example_qr_code"
-msgstr "wallet connect qr code example"
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:258
+msgid "infinity.getStarted_1"
+msgstr "1"
 
-#: components/pages/Buy/index.tsx:367
-msgid "buy.what_are_bonds"
-msgstr "Are there other ways to get KLIMA? What are bonds?"
-
-#: components/pages/About/Community/index.tsx:116
-msgid "community.become_a_partner"
-msgstr "BECOME A PARTNER"
-
-#: components/pages/About/Community/index.tsx:180
-msgid "community.bigcowg_logo"
-msgstr "BICOWG logo"
-
-#: components/pages/About/Community/index.tsx:172
-msgid "community.blockchainforclimatefondation_logo"
-msgstr "Blockchain for Climate Foundation logo"
-
-#: components/pages/About/Community/index.tsx:314
-msgid "community.come_on_in"
-msgstr "Come On In"
-
-#: components/pages/About/Community/index.tsx:228
-msgid "community.deltawave_logo"
-msgstr "Delta Wave logo"
-
-#: components/pages/About/Community/index.tsx:265
-msgid "community.digitalcharityart_logo"
-msgstr "Digital Charity Art logo"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:69
+msgid "buy.step_1"
+msgstr "1."
 
 #. Long sentence
-#: components/pages/About/Community/index.tsx:329
-msgid "community.discord_is_where_we_share"
-msgstr "Discord is where we share important announcements, hold office-hours, answer questions, and trade memes. Our Discord server is extremely active and moderated around-the-clock. We've got channels for everything from trading to sustainability and carbon markets."
-
-#: components/pages/About/Community/index.tsx:244
-msgid "community.dovu_logo"
-msgstr "Dovu logo"
-
-#: components/pages/About/Community/index.tsx:249
-msgid "community.eco_logo"
-msgstr "Eco logo"
-
-#: components/pages/About/Community/index.tsx:236
-msgid "community.etcgroup_logo"
-msgstr "Etc Group logo"
-
-#: components/pages/About/Community/index.tsx:361
-msgid "community.get_in_touch"
-msgstr "Get in touch?"
-
-#: components/pages/About/Community/index.tsx:204
-msgid "community.gitcoin_logo"
-msgstr "Gitcoin logo"
-
-#: components/pages/About/Community/index.tsx:95
-msgid "community.head.headline"
-msgstr "Community"
-
-#: components/pages/About/Community/index.tsx:102
-msgid "community.head.metadescription"
-msgstr "Learn about our community of passionate Klimates"
-
-#: components/pages/About/Community/index.tsx:96
-msgid "community.head.subline"
-msgstr "KlimaDAO is a Decentralized Autonomous Organization for Change. We are governed and built by a community of passionate Klimates."
-
-#: components/pages/About/Community/index.tsx:94
-#: components/pages/About/Community/index.tsx:101
-msgid "community.head.title"
-msgstr "KlimaDAO Community"
-
-#. Long sentence
-#: components/pages/About/Community/index.tsx:364
-msgid "community.if_you_ve_got_questions"
-msgstr "If you've got questions, ideas, advice or anything else: we can help you find the right person to talk to."
-
-#: components/pages/About/Community/index.tsx:317
-msgid "community.join_our_discord"
-msgstr "Join Our Discord"
-
-#: components/pages/About/Community/index.tsx:304
-msgid "community.join_the_klima_community"
-msgstr "Join the Klima Community"
-
-#: components/pages/About/Community/index.tsx:281
-msgid "community.landx_logo"
-msgstr "LandX logo"
-
-#: components/pages/About/Community/index.tsx:113
-#: components/pages/About/Community/index.tsx:358
-msgid "community.lets_work_together"
-msgstr "Let's Work Together"
-
-#: components/pages/About/Community/index.tsx:156
-msgid "community.moss_logo"
-msgstr "Moss logo"
-
-#: components/pages/About/Community/index.tsx:196
-msgid "community.oceandrop_logo"
-msgstr "Oceandrop logo"
-
-#: components/pages/About/Community/index.tsx:257
-msgid "community.offsetra_logo"
-msgstr "Offsetra logo"
-
-#: components/pages/About/Community/index.tsx:212
-msgid "community.olympusdao_logo"
-msgstr "OlympusDAO logo"
-
-#: components/pages/About/Community/index.tsx:220
-msgid "community.openearth_logo"
-msgstr "Open Earth logo"
-
-#: components/pages/About/Community/index.tsx:151
-msgid "community.our_partners"
-msgstr "OUR PARTNERS"
-
-#: components/pages/About/Community/index.tsx:188
-msgid "community.polygon_logo"
-msgstr "Polygon logo"
-
-#: components/pages/About/Community/index.tsx:164
-msgid "community.toucan_logo"
-msgstr "Toucan logo"
-
-#: components/pages/About/Community/index.tsx:273
-msgid "community.toughtforfood_logo"
-msgstr "Thought for Food logo"
-
-#: components/pages/About/Community/index.tsx:132
-msgid "community.tree_grove"
-msgstr "Tree grove"
-
-#. Long sentence
-#: components/pages/About/Community/index.tsx:119
-msgid "community.we_work_with_traditionnal"
-msgstr "We work with traditional carbon market players, crypto platforms, corporations and everyone in-between."
-
-#: components/pages/About/Contact/index.tsx:63
-msgid "concat.careers"
-msgstr "Careers"
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:162
-#: components/pages/Pledge/index.tsx:104
-msgid "connectModal.torus"
-msgstr "social or email"
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:166
-#: components/pages/Pledge/index.tsx:108
-msgid "connectModal.wallet"
-msgstr "connect a wallet"
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:172
-#: components/pages/Pledge/index.tsx:114
-msgid "connect_modal.connecting"
-msgstr "Connecting..."
-
-#: lib/constants.ts:16
-msgid "connect_modal.error_message_default"
-msgstr "We had some trouble connecting. Please try again."
-
-#: lib/constants.ts:20
-msgid "connect_modal.error_message_refused"
-msgstr "User refused connection."
-
-#: lib/constants.ts:24
-msgid "connect_modal.error_processing"
-msgstr "Request already processing. Please open your wallet and complete the request."
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:176
-#: components/pages/Pledge/index.tsx:118
-msgid "connect_modal.error_title"
-msgstr "Connection Error"
-
-#: components/pages/About/Contact/index.tsx:140
-msgid "contact.bug_reports"
-msgstr "Bug Reports"
-
-#. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
-#: components/pages/About/Contact/index.tsx:143
-msgid "contact.bug_reports.to_file_a_bug_report"
-msgstr "To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you."
-
-#. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
-#: components/pages/About/Contact/index.tsx:66
-msgid "contact.careers.we_re_hiring"
-msgstr "We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!"
-
-#: components/pages/About/Contact/index.tsx:25
-msgid "contact.head.description"
-msgstr "Get in touch with someone from KlimaDAO."
-
-#: components/pages/About/Contact/index.tsx:18
-msgid "contact.head.headline"
-msgstr "Contact"
-
-#: components/pages/About/Contact/index.tsx:19
-msgid "contact.head.subline"
-msgstr "Questions, concerns, ideas? Here are a few ways you can get in touch. We love meeting institutions and individuals alike."
-
-#: components/pages/About/Contact/index.tsx:17
-#: components/pages/About/Contact/index.tsx:24
-msgid "contact.head.title"
-msgstr "Contact KlimaDAO"
-
-#: components/pages/About/Contact/index.tsx:105
-msgid "contact.media"
-msgstr "Media"
-
-#. Long sentence
-#: components/pages/About/Contact/index.tsx:108
-msgid "contact.media.if_you_are_a_journalist"
-msgstr "If you are a journalist or content creator, our marketing team would love to meet you."
-
-#. Use this <0>Media Request Form</0>.
-#: components/pages/About/Contact/index.tsx:117
-msgid "contact.media.use_this_media_request_form"
-msgstr "Use this <0>Media Request Form</0> or send an email to <1>press@klimadao.finance</1>"
-
-#: components/pages/About/Contact/index.tsx:85
-msgid "contact.partnerships"
-msgstr "Partnerships"
-
-#. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
-#: components/pages/About/Contact/index.tsx:88
-msgid "contact.partnerships.until_we_finish_building"
-msgstr "Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>."
-
-#: components/pages/About/Contact/index.tsx:35
-msgid "contact.quest_and_support"
-msgstr "Questions & Support"
-
-#. Join our <0>community</0>
-#: components/pages/About/Contact/index.tsx:38
-msgid "contact.quest_and_support.join_our_community"
-msgstr "Join our <0>community</0>"
-
-#. Long sentence
-#: components/pages/About/Contact/index.tsx:46
-msgid "contact.quest_and_support.join_our_discord_server"
-msgstr "Join our Discord server and ask in the #questions channel. We have thousands of friendly, knowledgeable community members ready and willing to help you out."
-
-#. Long sentence
+#. js-lingui-explicit-id
 #: components/pages/About/Disclaimer/index.tsx:64
 msgid "disclaimer.1_an_offer_or_sollicitation"
 msgstr "1. An offer, or solicitation of an offer to hold or control any security, other asset or service, which are connected with intangible benefits;"
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:110
+msgid "buy.create_wallet_item"
+msgstr "1. Create a Wallet"
+
+#. js-lingui-explicit-id
 #: components/pages/About/Disclaimer/index.tsx:111
 msgid "disclaimer.1_meet_your_requirements"
 msgstr "1. Meet your requirements;"
 
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:543
+msgid "infinity.faq_question1"
+msgstr "1. What is a carbon offset?"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:418
+msgid "infinity.box_amount_104k"
+msgstr "104k"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:404
+msgid "infinity.box_amount_11k"
+msgstr "11k"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:491
+msgid "infinity.mission_card3_number"
+msgstr "150,000+"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:447
+msgid "infinity.mission_card1_title"
+msgstr "18.1 million"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:272
+msgid "infinity.getStarted_2"
+msgstr "2"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:82
+msgid "buy.step_2"
+msgstr "2."
+
 #. Long sentence
+#. js-lingui-explicit-id
 #: components/pages/About/Disclaimer/index.tsx:116
 msgid "disclaimer.2_be_available_on_an_uninterrupted"
 msgstr "2. Be available on an uninterrupted, timely, secure, or error-free basis;"
 
 #. Long sentence
+#. js-lingui-explicit-id
 #: components/pages/About/Disclaimer/index.tsx:74
 msgid "disclaimer.2_financial_investment_or_trading_advice"
 msgstr "2. Financial, investment or trading advice or an offer to provide such advice and/or service."
 
-#: components/pages/About/Disclaimer/index.tsx:125
-msgid "disclaimer.3_be_reliable_complete_legal_or_safe"
-msgstr "3. Be reliable, complete, legal or safe."
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:32
-msgid "disclaimer.all_information_on_this_website"
-msgstr "All the information on this website is published in good faith and for general information purpose only. KlimaDAO is distributed on a basis that it will be useful and serve only within grounds and limits described on above mentioned website."
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:159
-msgid "disclaimer.any_action_you_take_upon_the_information"
-msgstr "Any action you take upon the information you find on this website is strictly at your own risk. Decisions based on information contained on this website are the sole responsibility of the visitor. KlimaDAO will not be liable for any losses and/or damages in connection with the use of the website, the loss of your password/seed phrase, a bad trade, sending an asset to the wrong address, losing your asset and events related to damage caused by scammers. KlimaDAO cannot assume any responsibility or liability connected with market changing and its volatility. You must conduct your own research and satisfy yourself of your own situation, familiarity and knowledge of information or service provided by this platform."
-
-#: components/pages/About/Disclaimer/index.tsx:19
-msgid "disclaimer.disclaimer"
-msgstr "Disclaimer"
-
-#: components/pages/About/Disclaimer/index.tsx:21
-msgid "disclaimer.head.description"
-msgstr "An important disclaimer from the KlimaDAO legal team."
-
-#: components/pages/About/Disclaimer/index.tsx:15
-#: components/pages/About/Disclaimer/index.tsx:25
-msgid "disclaimer.head.title"
-msgstr "KlimaDAO Disclaimer"
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:102
-msgid "disclaimer.klimadao_and_its_suppliers"
-msgstr "KlimaDAO and its suppliers make no warranty that the platform will:"
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:43
-msgid "disclaimer.klimadao_is_a_platform"
-msgstr "KlimaDAO is a platform. We are not a broker, financial institution, or creditor. Services provided on this website do not include an offer to hold or control your securities, options, assets, futures or other derivatives related to securities in any jurisdiction and its content is not prescribed by securities laws."
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:130
-msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
-msgstr "Neither KlimaDAO nor any of its representatives will not liable for any loss of any kind from any action taken or taken in reliance on material or information, contained on the service. KlimaDAO is making the use of the service and content safe, nevertheless it does not represent or warrant that the service and content on our platform are free of viruses or other harmful components."
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:178
-msgid "disclaimer.nothing_in_this_disclaimer"
-msgstr "Nothing in this disclaimer, any information content or material shall or shall be constructed to create any legal relations between us and you nor grant any rights or obligations to either of us."
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:56
-msgid "disclaimer.nothing_in_this_platform"
-msgstr "Nothing in this platform constitutes or be construed as:"
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:83
-msgid "disclaimer.the_service_available"
-msgstr "The service available in or accessible through the service are provided “As is” and, to the fullest extent permissible pursuant to applicable law. KlimaDAO and its agents, advisors, directors, officers, employees and shareholders disclaim all warranties, express or implied, including, but not limited to, implied warranties of merchantability, fitness for a particular purpose and non-infrigement, and warranties implied from a course of performance or course of dealing. KlimaDAO does not make any warranties about the completeness, reliability and accuracy of this information, warranty of merchantability or fitness for a particular purpose. This platform does not make any warranties about the completeness and accuracy of this information."
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:189
-msgid "disclaimer.we_recommend_that_you_visit"
-msgstr "We recommend that you visit our Crypto Security 101 page for safety instructions before the use of the website. Please, take into consideration: never share your private key or seed phrase with anyone – neither our members nor our app will ever ask for or request this from you."
-
-#. Long sentence
-#: components/pages/About/Disclaimer/index.tsx:144
-msgid "disclaimer.you_bear_full_responsibility"
-msgstr "You bear full responsibility for providing of private information, verifying the identity and legitimacy. Notwithstanding indicators and messages that suggest providing the private information and verification, KlimaDAO makes no claims about the identity on the platform. We cannot guarantee the security of any data that disclose online, and for sustained casualties due to vulnerability or any kind of failure, abnormal behavior of software."
-
-#: components/pages/errors/Custom404.tsx:41
-msgid "error.404.page.text"
-msgstr "Sorry, looks like we sent you the wrong way. <0/>Let us guide you back to the home page:"
-
-#: components/pages/errors/Custom500.tsx:39
-msgid "error.500.page.text"
-msgstr "Sorry, something bad happened.<0/>Try to go back to the Start Page:"
-
-#: components/pages/errors/Custom500.tsx:34
-msgid "error.500.page.title"
-msgstr "500 - Server-side error occurred"
-
-#: components/pages/errors/Custom500.tsx:19
-msgid "error.page.500.head.title"
-msgstr "500 - Page Not Found"
-
-#: components/pages/errors/Custom500.tsx:15
-msgid "error.page.500.title"
-msgstr "500 - Page Not Found"
-
-#: components/pages/Home/index.tsx:209
-msgid "home.benefits"
-msgstr "BENEFITS"
-
-#: components/pages/Home/index.tsx:330
-msgid "home.cars_annual"
-msgstr "Cars (annual)"
-
-#. Long sentence
-#: components/pages/Home/index.tsx:162
-msgid "home.developed_by_klima"
-msgstr "Developed by KlimaDAO, the Digital Carbon Market (DCM) enables the scale-up of climate finance - with over $4 billion traded to date. Explore the DCM via <0>Carbonmark.com</0> - the universal marketplace - and the <1>Carbon Dashboard</1>."
-
-#: components/pages/Home/index.tsx:299
-msgid "home.equivalent_to"
-msgstr "EQUIVALENT TO"
-
-#: components/SocialProof/index.tsx:19
-msgid "home.featured_on"
-msgstr "KlimaDAO featured on"
-
-#: components/pages/Home/index.tsx:444
-msgid "home.get_exposure_to_the_growing_carbon_economy"
-msgstr "Get exposure to the growing carbon economy today. Acquire, stake, and get rewarded. Financial activism for the climate."
-
-#: components/pages/Home/index.tsx:441
-msgid "home.get_klima"
-msgstr "GET KLIMA"
-
-#: components/pages/Home/index.tsx:387
-msgid "home.govern_the_market"
-msgstr "Govern the market, for the planet"
-
-#: components/pages/Home/index.tsx:313
-msgid "home.hectares_of_forest"
-msgstr "Hectares of forest"
-
-#. Long sentence
-#: components/pages/Home/index.tsx:405
-msgid "home.join_over_100k_members"
-msgstr "Join over 100,000 members who hold the $KLIMA token, using it to steward KlimaDAO's resources and grow the Digital Carbon Market."
-
-#. Long sentence
-#: components/pages/Home/index.tsx:212
-msgid "home.klima_is_creating"
-msgstr "KlimaDAO is creating a public and open-source social and technology layer to shape the future of the carbon markets."
-
-#: components/pages/Home/index.tsx:81
-msgid "home.latest_news"
-msgstr "📰 Latest News:"
-
-#: components/pages/Home/index.tsx:137
-msgid "home.learn_more"
-msgstr "LEARN MORE"
-
-#: components/pages/Home/index.tsx:345
-msgid "home.liters_if_gasoline"
-msgstr "Liters of gasoline"
-
-#: components/pages/Home/index.tsx:253
-msgid "home.neutral_and_trusted"
-msgstr "Neutral and trusted"
-
-#: components/pages/Home/index.tsx:473
-msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
-msgstr "All the Alpha, straight to your inbox"
-
-#. Long sentence
-#: components/pages/Home/index.tsx:481
-msgid "home.newletter.get_the_latest_updates"
-msgstr "Get the latest updates on KlimaDAO, as we build the future of the carbon economy."
-
-#: components/pages/Home/index.tsx:498
-msgid "home.newletter.never_shared_never_spammed"
-msgstr "Never shared. Never spammed."
-
-#: components/pages/Home/index.tsx:492
-msgid "home.newletter.sign_up"
-msgstr "Sign up"
-
-#: components/pages/Home/index.tsx:478
-msgid "home.newsletter"
-msgstr "Newsletter"
-
-#: components/pages/Home/index.tsx:273
-msgid "home.public_and_open-source"
-msgstr "Public and open-source"
-
-#. Long sentence
-#: components/pages/Home/index.tsx:152
-msgid "home.public_good_for_the_planet"
-msgstr "Public good for the planet"
-
-#: components/pages/Home/index.tsx:451
-msgid "home.see_tutorial"
-msgstr "See Tutorial"
-
-#: components/pages/Home/index.tsx:360
-msgid "home.source"
-msgstr "Source"
-
-#. Long sentence
-#: components/pages/Home/index.tsx:422
-msgid "home.take_climate_action_now"
-msgstr "Take climate action now by using <0>Carbonmark</0> to buy, sell, or retire digital carbon."
-
-#. TONNES OF <0>CARBON HELD</0> BY KLIMADAO
-#: components/pages/Home/index.tsx:286
-msgid "home.tonnes_of_carbon_held_by_klimadao"
-msgstr "TONNES OF <0>CARBON HELD</0> BY KLIMADAO"
-
-#: components/pages/Home/index.tsx:233
-msgid "home.transparent_and_efficient"
-msgstr "Transparent and efficient"
-
-#. Long sentence
-#: components/pages/Home/index.tsx:105
-msgid "home.transparent_neutral"
-msgstr "Transparent, neutral, public resources to accelerate climate finance on a global scale."
-
-#. <0>WELCOME TO</0><1>KlimaDAO</1>
-#: components/pages/Home/index.tsx:92
-msgid "home.welcome_to_klimadao"
-msgstr "<0>WELCOME TO</0><1>KlimaDAO</1>"
-
-#: components/pages/Infinity/index.tsx:162
-msgid "infinity.affordable_subtitle"
-msgstr "Affordable"
-
-#: components/pages/Infinity/index.tsx:157
-msgid "infinity.affordable_title"
-msgstr "Real-time pricing, low transaction costs"
-
-#: components/pages/Infinity/index.tsx:418
-msgid "infinity.box_amount_104k"
-msgstr "104k"
-
-#: components/pages/Infinity/index.tsx:404
-msgid "infinity.box_amount_11k"
-msgstr "11k"
-
-#: components/pages/Infinity/index.tsx:400
-msgid "infinity.box_title"
-msgstr "Last Carbon Offset"
-
-#: components/pages/Infinity/index.tsx:414
-msgid "infinity.box_title2"
-msgstr "Total Carbon Retired"
-
-#: components/pages/Infinity/index.tsx:665
-msgid "infinity.button.read_blog_faq"
-msgstr "Read in-depth FAQs for KI Clients"
-
-#: components/pages/Infinity/index.tsx:368
-msgid "infinity.button.read_blog_polygon"
-msgstr "Read Polygon's Story"
-
-#: components/pages/Infinity/Cards/CardsSlider.tsx:89
-msgid "infinity.cards_slider.title"
-msgstr "Dozens of organizations have offset over 150,000 carbon tonnes with Klima Infinity"
-
-#: components/pages/Infinity/index.tsx:331
-msgid "infinity.carousel_image_description"
-msgstr "Wind power project at Jaibhim, India"
-
-#: components/pages/Infinity/index.tsx:343
-msgid "infinity.carousel_info_subtitle"
-msgstr "Drive funding to projects that move the needle on climate change mitigation"
-
-#: components/pages/Infinity/index.tsx:338
-msgid "infinity.carousel_info_title"
-msgstr "Support high quality projects"
-
-#: components/pages/Infinity/index.tsx:685
-msgid "infinity.cta_title"
-msgstr "The next-generation carbon toolkit for your organization"
-
-#: components/pages/Infinity/index.tsx:557
-msgid "infinity.faq_answer1"
-msgstr "A carbon offset unit represents the removal of one tonne of carbon dioxide equivalent (tCO2e) from the atmosphere, or the avoidance of one tonne of emissions."
-
-#: components/pages/Infinity/index.tsx:593
-msgid "infinity.faq_answer2_paragraph1"
-msgstr "Carbon credits are a high-integrity mechanism that allow carbon finance to flow from those who pollute, to projects across the globe that help to mitigate or remove carbon from the atmosphere. They are a valuable tool to cover hard-to-abate emissions that may be costly or technically challenging to eliminate today."
-
-#: components/pages/Infinity/index.tsx:603
-msgid "infinity.faq_answer2_paragraph2"
-msgstr "When you purchase a carbon credit, Klima Infinity enables you to retire this carbon credit, permanently removing it from circulation. This retirement is the point at which you can claim the benefit of the carbon offset."
-
-#: components/pages/Infinity/index.tsx:611
-msgid "infinity.faq_answer2_paragraph3"
-msgstr "Purchased offsets lead to measurable and accountable emissions reductions elsewhere in the economy, and can be used to ‘offset’ an unavoidable carbon footprint. The trade and retirement of carbon credits enables a market mechanism to emerge that puts a price on carbon."
-
-#: components/pages/Infinity/index.tsx:648
-msgid "infinity.faq_answer3"
-msgstr "The objective of carbon markets is to reduce greenhouse gas (GHG, or “carbon”) emissions cost-effectively by setting limits on emissions and enabling the trading of emission units, which are financial instruments representing emission reductions. Trading enables entities that can reduce emissions at lower cost to be paid to do so by higher-cost emitters, thus lowering the economic cost of reducing emissions."
-
-#: components/pages/Infinity/index.tsx:543
-msgid "infinity.faq_question1"
-msgstr "1. What is a carbon offset?"
-
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:577
 msgid "infinity.faq_question2"
 msgstr "2. How does offsetting help in the fight against climate change?"
 
-#: components/pages/Infinity/index.tsx:634
-msgid "infinity.faq_question3"
-msgstr "3. What are carbon markets?"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:142
+msgid "buy.load_wallet"
+msgstr "2. Load your wallet with MATIC tokens"
 
-#: components/pages/Infinity/index.tsx:137
-msgid "infinity.fast_subtitle"
-msgstr "Offset in seconds, with no red tape"
-
-#: components/pages/Infinity/index.tsx:142
-msgid "infinity.fast_title"
-msgstr "Fast"
-
-#: components/pages/Infinity/GetStartedModal.tsx:47
-msgid "infinity.getStartedModal_business"
-msgstr "I'm a <0/>business."
-
-#: components/pages/Infinity/GetStartedModal.tsx:70
-msgid "infinity.getStartedModal_individual"
-msgstr "I'm an<0/>individual."
-
-#: components/pages/Infinity/GetStartedModal.tsx:104
-msgid "infinity.getStartedModal_needAssistance"
-msgstr "I'd like assistance with my organization's carbon footprint."
-
-#: components/pages/Infinity/GetStartedModal.tsx:94
-msgid "infinity.getStartedModal_offsetCrypto"
-msgstr "I want to<0/>offset crypto."
-
-#: components/pages/Infinity/index.tsx:258
-msgid "infinity.getStarted_1"
-msgstr "1"
-
-#: components/pages/Infinity/index.tsx:272
-msgid "infinity.getStarted_2"
-msgstr "2"
-
-#: components/pages/Infinity/index.tsx:261
-msgid "infinity.getStarted_calculate"
-msgstr "Calculate"
-
-#: components/pages/Infinity/index.tsx:264
-msgid "infinity.getStarted_calculate_subtitle"
-msgstr "Calculate your organization's carbon footprint and define the scope of your offset with Klima Infinity."
-
-#: components/pages/Infinity/index.tsx:301
-msgid "infinity.getStarted_cta"
-msgstr "Accelerate your path to carbon neutral - and beyond"
-
-#: components/pages/Infinity/index.tsx:278
-msgid "infinity.getStarted_second_subtitle"
-msgstr "Implement your offset with just a few clicks, and with near-instant transaction time."
-
-#: components/pages/Infinity/index.tsx:275
-msgid "infinity.getStarted_second_title"
-msgstr "Implement"
-
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:286
 msgid "infinity.getStarted_third"
 msgstr "3"
 
-#: components/pages/Infinity/index.tsx:292
-msgid "infinity.getStarted_third_subtitle"
-msgstr "Track your commitment, and amplify awareness around your Climate Positive actions."
-
-#: components/pages/Infinity/index.tsx:289
-msgid "infinity.getStarted_third_title"
-msgstr "Amplify"
-
-#: components/pages/Infinity/index.tsx:67
-msgid "infinity.head.metaDescription"
-msgstr "A next-generation carbon toolkit for your organization."
-
-#: components/pages/Infinity/index.tsx:63
-msgid "infinity.head.metaTitle"
-msgstr "Klima Infinity - Go carbon neutral"
-
-#: components/pages/Infinity/index.tsx:59
-msgid "infinity.head.title"
-msgstr "KlimaDAO | Klima Infinity"
-
-#: components/pages/Infinity/index.tsx:178
-msgid "infinity.info_subtitle1"
-msgstr "For the planet's pioneering organizations"
-
-#: components/pages/Infinity/index.tsx:183
-msgid "infinity.info_subtitle2"
-msgstr "The world's most powerful and easy-to-use offsetting solution"
-
-#: components/pages/Infinity/index.tsx:450
-msgid "infinity.mission_card1_subtitle"
-msgstr "Carbon tonnes held by KlimaDAO"
-
-#: components/pages/Infinity/index.tsx:447
-msgid "infinity.mission_card1_title"
-msgstr "18.1 million"
-
-#: components/pages/Infinity/index.tsx:472
-msgid "infinity.mission_card2_description"
-msgstr "Carbon liquidity held by KlimaDAO"
-
-#: components/pages/Infinity/index.tsx:469
-msgid "infinity.mission_card2_number"
-msgstr "$10m+"
-
-#: components/pages/Infinity/index.tsx:494
-msgid "infinity.mission_card3_description"
-msgstr "Carbon tonnes offset via KlimaDAO"
-
-#: components/pages/Infinity/index.tsx:491
-msgid "infinity.mission_card3_number"
-msgstr "150,000+"
-
-#: components/pages/Infinity/index.tsx:387
-msgid "infinity.polygon_manifesto_description"
-msgstr "By offsetting the historical emissions of their entire network, Polygon has ensured that every interaction within its network - whether an NFT mint or a DeFi transaction - is taken into account. This is a key reason why Meta chose Polygon to issue its NFTs."
-
-#: components/pages/Infinity/index.tsx:381
-msgid "infinity.polygon_manifesto_title"
-msgstr "The offset is part of Polygon's Green Manifesto"
-
-#: components/pages/Infinity/index.tsx:361
-msgid "infinity.polygon_story_description"
-msgstr "Polygon offset the network's carbon emissions since inception - roughly 90,000 tonnes - and pledged to go climate positive for all of the network's future transactions."
-
-#: components/pages/Infinity/index.tsx:356
-msgid "infinity.polygon_story_title"
-msgstr "Polygon chose Klima Infinity to offset their blockchain network"
-
-#: components/pages/Infinity/Cards/Card.tsx:66
-#: components/pages/Infinity/index.tsx:407
-#: components/pages/Infinity/index.tsx:421
-msgid "infinity.tonnes"
-msgstr "Tonnes"
-
-#: components/pages/Infinity/index.tsx:196
-msgid "infinity.transparent_subtitle"
-msgstr "Transparent"
-
-#: components/pages/Infinity/index.tsx:191
-msgid "infinity.transparent_title"
-msgstr "Immutably recorded on the blockchain"
-
-#: components/pages/Infinity/index.tsx:98
-msgid "infinity.welcome_subtitle"
-msgstr "Klima Infinity is a next-generation carbon toolkit for your organization"
-
-#: components/pages/Infinity/index.tsx:93
-msgid "infinity.welcome_title"
-msgstr "The easiest way to go carbon neutral"
-
-#: components/pages/Infinity/index.tsx:224
-msgid "infinity.why_description"
-msgstr "KlimaDAO is leveraging a stack of DeFi technologies to reduce market fragmentation and accelerate the delivery of climate finance to sustainability projects worldwide."
-
-#: components/pages/Infinity/index.tsx:219
-msgid "infinity.why_subtitle"
-msgstr "DeFi that defies climate change"
-
-#: components/pages/Infinity/index.tsx:216
-msgid "infinity.why_title"
-msgstr "Why KlimaDAO?"
-
-#: components/pages/Infinity/index.tsx:439
-msgid "mission.header"
-msgstr "KlimaDAO's mission is to democratize climate action"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:79
-#: components/pages/Pledge/PledgeForm/index.tsx:83
-#: components/pages/Pledge/PledgeForm/index.tsx:99
-msgid "pledge.errors.default"
-msgstr "An error has occured"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:91
-msgid "pledge.errors.method_not_allowed"
-msgstr "Method not allowed."
-
-#: components/pages/Pledge/PledgeForm/index.tsx:75
-msgid "pledge.errors.pledge_not_found"
-msgstr "A pledge was not found for this address."
-
-#: components/pages/Pledge/PledgeForm/index.tsx:87
-msgid "pledge.errors.unknown_error"
-msgstr "An unknown error has occured."
-
-#: components/pages/Pledge/PledgeForm/index.tsx:191
-msgid "pledge.form.error.cannot_add_yourself"
-msgstr "You cannot add your own wallet as a secondary wallet"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:227
-msgid "pledge.form.error.default_error_message"
-msgstr "Something went wrong. Please try again shortly."
-
-#: components/pages/Pledge/PledgeForm/index.tsx:175
-msgid "pledge.form.error.duplicate_wallets"
-msgstr "Please remove the duplicate wallet(s)"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:616
-msgid "pledge.form.wallets.confirm_remove_wallet"
-msgstr "Are you sure you want to remove {0} from your pledge?"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:340
-msgid "pledge.form.wallets.tooltip"
-msgstr "Add other wallets to contribute to your pledge. If the owner of the wallet accepts your invitation, their wallet will appear on your pledge dashboard. Any retirements made by a secondary wallet will contribute toward your pledge. You'll retain sole ownership and editing access to this pledge."
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:41
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:108
-msgid "pledge.invitation.accept"
-msgstr "Accept Invitation"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:70
-msgid "pledge.invitation.error.wallet_already_pinned"
-msgstr "This wallet is already pinned to another pledge. Please unpin your wallet and try again."
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:49
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:44
-msgid "pledge.invitation.error_title"
-msgstr "Server Error"
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:99
-msgid "pledge.invitation.join_message"
-msgstr "{shortenedAddress} has invited you to add your wallet to this pledge. If you accept, then your carbon retirements will count toward {shortenedAddress}'s pledge. You may remove your wallet from this pledge at any time."
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:127
-msgid "pledge.invitation.later"
-msgstr "Remind me later"
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:115
-msgid "pledge.invitation.reject"
-msgstr "Reject Invitation"
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:54
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:49
-msgid "pledge.invitation.signing"
-msgstr "Signing"
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:190
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:176
-msgid "pledge.invitations.awaiting_signature"
-msgstr "Awaiting Signature..."
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:196
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:182
-msgid "pledge.invitations.signature_instructions"
-msgstr "Use your wallet to sign and confirm this edit."
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:126
-msgid "pledge.modal.are_you_sure"
-msgstr "Are you sure you want to remove your wallet from this pledge?"
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:150
-msgid "pledge.modal.confirm"
-msgstr "Confirm"
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:40
-msgid "pledge.modal.confirm_remove"
-msgstr "Confirm Removal"
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:39
-msgid "pledge.modal.edit_pledge"
-msgstr "Edit pledge"
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:98
-msgid "pledge.modal.unable_to_edit"
-msgstr "This wallet does not have permission to edit this pledge. To edit, you must reconnect with the original author wallet ({0})."
-
-#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:107
-msgid "pledge.modal.unpin_wallet"
-msgstr "unpin my wallet"
-
-#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:141
-msgid "pledge.modal.wallet_add_confirm"
-msgstr "You may only have one pledge page per wallet address. If you have already created a pledge page with this wallet, visitors will be redirected to this pledge instead. You can remove this wallet at any time."
-
-#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:110
-msgid "pledges.dashboard.assets.emptyBalance"
-msgstr "No carbon assets to show."
-
-#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:87
-msgid "pledges.dashboard.assets.title"
-msgstr "Carbon Assets"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
-msgid "pledges.dashboard.footprint.title"
-msgstr "Footprint"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
-msgid "pledges.dashboard.footprint.tonnes"
-msgstr "Tonnes"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:104
-msgid "pledges.dashboard.footprint.tooltip.category_percent"
-msgstr "{0}% of footprint"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/FootprintCharts.tsx:110
-msgid "pledges.dashboard.footprint.tooltip.quantity"
-msgstr "{0} Carbon Tonne(s)"
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:137
-msgid "pledges.dashboard.head.metaDescription"
-msgstr "{pledgeOwnerTitle} pledges to Offset {currentTotalFootprint} Carbon Tonnes. View their carbon offset history and read more about their commitment."
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:133
-msgid "pledges.dashboard.head.metaTitle"
-msgstr "{pledgeOwnerTitle}'s Pledge"
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:129
-msgid "pledges.dashboard.head.title"
-msgstr "{pledgeOwnerTitle}'s Pledge | KlimaDAO"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:14
-msgid "pledges.dashboard.metholodogy.default_text"
-msgstr "How will you meet your pledge?"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:21
-msgid "pledges.dashboard.metholodogy.title"
-msgstr "Methodology"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:14
-msgid "pledges.dashboard.pledge.default_text"
-msgstr "Write your pledge today!"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:21
-msgid "pledges.dashboard.pledge.title"
-msgstr "Pledge"
-
-#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:64
-msgid "pledges.dashboard.profile.pledge_met"
-msgstr "≥ 100% of Pledge Met"
-
-#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:73
-msgid "pledges.dashboard.profile.pledge_progress"
-msgstr "{0}% of Pledge Met"
-
-#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:106
-msgid "pledges.dashboard.profile.pledged_to_offset"
-msgstr "Pledged to Offset <0>{0}</0> Carbon Tonnes"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:104
-msgid "pledges.dashboard.retirements.title"
-msgstr "Retirements"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/RetirementsChart.tsx:141
-msgid "pledges.dashboard.retirements.tooltip.tonnes_retired"
-msgstr "{0} Carbon Tonne(s) Retired"
-
-#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:123
-msgid "pledges.dashboard.retirements.total_tonnes_retired"
-msgstr "Total Carbon Tonnes Retired"
-
-#: components/pages/Pledge/HeaderDesktop/index.tsx:37
-msgid "pledges.edit_pledge"
-msgstr "Edit Pledge"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:562
-msgid "pledges.form.add_footprint_category_button"
-msgstr "Add category"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:446
-msgid "pledges.form.add_wallet_button"
-msgstr "Add wallet"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:242
-msgid "pledges.form.awaiting_signature"
-msgstr "Awaiting signature..."
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:190
-msgid "pledges.form.confirm_delete"
-msgstr "confirm removal"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:622
-msgid "pledges.form.confirm_remove"
-msgstr "remove"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:635
-msgid "pledges.form.confirm_remove_cancel"
-msgstr "cancel"
-
-#: components/pages/Pledge/index.tsx:205
-msgid "pledges.form.error"
-msgstr "Enter a wallet address, .klima or .eth domain"
-
-#: components/pages/Pledge/lib/formSchema.ts:74
-msgid "pledges.form.errors.categoryName.max"
-msgstr "Enter less than 32 characters"
-
-#: components/pages/Pledge/lib/formSchema.ts:70
-msgid "pledges.form.errors.categoryName.required"
-msgstr "Enter a category"
-
-#: components/pages/Pledge/lib/formSchema.ts:78
-msgid "pledges.form.errors.categoryQuantity.min"
-msgstr "Enter a value greater than 0"
-
-#: components/pages/Pledge/lib/formSchema.ts:50
-msgid "pledges.form.errors.description.max"
-msgstr "Enter less than 500 characters"
-
-#: components/pages/Pledge/lib/formSchema.ts:46
-msgid "pledges.form.errors.description.required"
-msgstr "Enter a pledge"
-
-#: components/pages/Pledge/lib/formSchema.ts:62
-msgid "pledges.form.errors.footprint.generic_error"
-msgstr "Enter a carbon tonne estimate"
-
-#: components/pages/Pledge/lib/formSchema.ts:66
-msgid "pledges.form.errors.footprint.min"
-msgstr "Enter a value greater than 0"
-
-#: components/pages/Pledge/lib/formSchema.ts:58
-msgid "pledges.form.errors.methodology.max"
-msgstr "Enter less than 1000 characters"
-
-#: components/pages/Pledge/lib/formSchema.ts:54
-msgid "pledges.form.errors.methodology.required"
-msgstr "Enter a methodology"
-
-#: components/pages/Pledge/lib/formSchema.ts:34
-msgid "pledges.form.errors.name.required"
-msgstr "Enter a name"
-
-#: components/pages/Pledge/lib/formSchema.ts:38
-msgid "pledges.form.errors.profileImageUrl.url"
-msgstr "Enter a valid url"
-
-#: components/pages/Pledge/lib/formSchema.ts:42
-msgid "pledges.form.errors.profileWebsiteUrl.url"
-msgstr "Enter a valid url"
-
-#: components/pages/Pledge/lib/formSchema.ts:86
-msgid "pledges.form.errors.walletAddress.isAddress"
-msgstr "Please enter a valid address"
-
-#: components/pages/Pledge/lib/formSchema.ts:90
-msgid "pledges.form.errors.walletAddress.isOwner"
-msgstr "You cannot add the pledge owner"
-
-#: components/pages/Pledge/lib/formSchema.ts:82
-msgid "pledges.form.errors.walletAddress.required"
-msgstr "Address required"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:489
-msgid "pledges.form.footprint.label"
-msgstr "Footprint"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:497
-msgid "pledges.form.footprint.prompt"
-msgstr "Add a category and start calculating your carbon footprint"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:260
-msgid "pledges.form.generic_error"
-msgstr "Something went wrong. Please try again."
-
-#: components/pages/Pledge/PledgeForm/index.tsx:518
-msgid "pledges.form.input.categoryName.label"
-msgstr "Category"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:510
-msgid "pledges.form.input.categoryName.placeholder"
-msgstr "Category name"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:538
-msgid "pledges.form.input.categoryQuantity.label"
-msgstr "Quantity"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:530
-msgid "pledges.form.input.categoryQuantity.placeholder"
-msgstr "Carbon tonnes"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:323
-msgid "pledges.form.input.description.label"
-msgstr "Pledge"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:316
-msgid "pledges.form.input.description.placeholder"
-msgstr "What is your pledge?"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:476
-msgid "pledges.form.input.methodology.label"
-msgstr "Methodology"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:468
-msgid "pledges.form.input.methodology.placeholder"
-msgstr "What tools or methodologies did you use to calculate your carbon footprint?"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:280
-msgid "pledges.form.input.name.label"
-msgstr "Name"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:273
-msgid "pledges.form.input.name.placeholder"
-msgstr "Name or company name"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:291
-msgid "pledges.form.input.profileImageUrl.label"
-msgstr "Profile image url (optional)"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:305
-msgid "pledges.form.input.profileWebsiteUrl.label"
-msgstr "Website (Optional)"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:579
-msgid "pledges.form.input.totalFootprint.label"
-msgstr "Total footprint"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:380
-msgid "pledges.form.input.walletAddress.label"
-msgstr "Address"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:372
-msgid "pledges.form.input.walletAddress.placeholder"
-msgstr "0x..."
-
-#: components/pages/Pledge/PledgeForm/index.tsx:595
-msgid "pledges.form.submit_button"
-msgstr "Save pledge"
-
-#: components/pages/Pledge/PledgeDashboard/index.tsx:186
-msgid "pledges.form.title"
-msgstr "Your pledge"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:52
-msgid "pledges.form.total_footprint_summary"
-msgstr "Total Footprint: {0} Carbon Tonnes"
-
-#: components/pages/Pledge/PledgeForm/index.tsx:607
-msgid "pledges.form.use_your_wallet"
-msgstr "Use your wallet to sign and confirm this edit."
-
-#: components/pages/Pledge/PledgeForm/index.tsx:332
-msgid "pledges.form.wallets.label"
-msgstr "Secondary Wallet(s)"
-
-#: components/pages/Pledge/index.tsx:94
-msgid "pledges.head.metaDescription"
-msgstr "Demonstrate your commitment to climate positivity by claiming your pledge dashboard to highlight all of your carbon offsetting activity"
-
-#: components/pages/Pledge/index.tsx:90
-msgid "pledges.head.metaTitle"
-msgstr "Create a carbon pledge and showcase your impact"
-
-#: components/pages/Pledge/index.tsx:86
-msgid "pledges.head.title"
-msgstr "KlimaDAO | Pledges"
-
-#: components/pages/Pledge/index.tsx:66
-msgid "pledges.home.hero.connecting"
-msgstr "Connecting..."
-
-#: components/pages/Pledge/index.tsx:77
-msgid "pledges.home.hero.create"
-msgstr "Create a pledge"
-
-#: components/pages/Pledge/index.tsx:163
-msgid "pledges.home.hero.learn_more"
-msgstr "Learn more"
-
-#: components/pages/Pledge/index.tsx:72
-msgid "pledges.home.hero.view"
-msgstr "View your pledge"
-
-#: components/pages/Pledge/index.tsx:199
-msgid "pledges.home.search.label"
-msgstr "ENS or 0x address"
-
-#: components/pages/Pledge/index.tsx:193
-msgid "pledges.home.search.placeholder"
-msgstr "Enter ENS, KNS or 0x address"
-
-#: components/pages/Pledge/index.tsx:219
-msgid "pledges.home.search.submit"
-msgstr "Search"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:24
-msgid "resources.form.categories.header"
-msgstr "Categories"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:27
-msgid "resources.form.categories.subheader"
-msgstr "Select one or more"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:66
-msgid "resources.form.filters.clear_all"
-msgstr "Clear All"
-
-#: components/pages/Resources/ResourcesList/index.tsx:185
-msgid "resources.form.input.search.label"
-msgstr "Search"
-
-#: components/pages/Resources/ResourcesList/index.tsx:176
-msgid "resources.form.input.search.placeholder"
-msgstr "Search..."
-
-#: components/pages/Resources/ResourcesList/index.tsx:210
-msgid "resources.form.input.sort_by.label"
-msgstr "Sort by"
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:21
-msgid "resources.form.input.sort_by.select"
-msgstr "Select"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:53
-msgid "resources.form.medium.header"
-msgstr "Medium"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:41
-msgid "resources.form.sub_topics.header"
-msgstr "Sub-topics"
-
-#: components/pages/Resources/index.tsx:31
-msgid "resources.head.metaDescription"
-msgstr "Updates and thought leadership from the founders, DAO contributors, advisors and community."
-
-#: components/pages/Resources/index.tsx:27
-msgid "resources.head.metaTitle"
-msgstr "KlimaDAO Resources - Go beyond Carbon neutral"
-
-#: components/pages/Resources/index.tsx:23
-msgid "resources.head.title"
-msgstr "KlimaDAO | Resources"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:71
-msgid "resources.list.filter.tag.basics"
-msgstr "Basics"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:111
-msgid "resources.list.filter.tag.carbon_footprint"
-msgstr "Carbon Footprint"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:79
-msgid "resources.list.filter.tag.deep_dives"
-msgstr "Deep Dives"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:52
-msgid "resources.list.filter.tag.klima_infinity"
-msgstr "Klima Infinity"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:44
-msgid "resources.list.filter.tag.klima_overview"
-msgstr "Klima Overview"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:60
-msgid "resources.list.filter.tag.partnerships"
-msgstr "Partnerships"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:103
-msgid "resources.list.filter.tag.policy"
-msgstr "Policy"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:95
-msgid "resources.list.filter.tag.press_releases"
-msgstr "Press Releases"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:87
-msgid "resources.list.filter.tag.user_guides"
-msgstr "User Guides"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:121
-msgid "resources.list.filter.type.blog"
-msgstr "Blog"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:129
-msgid "resources.list.filter.type.podcast"
-msgstr "Podcast"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:155
-msgid "resources.list.sort_by.a-z"
-msgstr "A-Z"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:139
-msgid "resources.list.sort_by.latest_first"
-msgstr "Latest First"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:147
-msgid "resources.list.sort_by.oldest_first"
-msgstr "Oldest First"
-
-#: components/pages/Resources/lib/cmsDataMap.ts:163
-msgid "resources.list.sort_by.z-a"
-msgstr "Z-A"
-
-#: components/pages/Resources/ResourcesList/index.tsx:311
-msgid "resources.mobile_modal.button.show_results"
-msgstr "Show Results"
-
-#: components/pages/Resources/ResourcesList/index.tsx:284
-msgid "resources.mobile_modal.title"
-msgstr "Sort By"
-
-#: components/pages/Resources/index.tsx:46
-msgid "resources.page.header.subline"
-msgstr "Updates and thought leadership from the founders, DAO contributors, advisors and community."
-
-#: components/pages/Resources/index.tsx:43
-msgid "resources.page.header.title"
-msgstr "Featured Articles"
-
-#: components/pages/Resources/ResourcesList/index.tsx:167
-msgid "resources.page.list.header"
-msgstr "Explore All"
-
-#: components/pages/Resources/ResourcesList/index.tsx:249
-msgid "resources.page.list.no_search_results.title"
-msgstr "Sorry. We couldn't find any matching results."
-
-#: components/pages/Resources/ResourcesList/index.tsx:241
-msgid "resources.page.list.on_fetch_error"
-msgstr "Sorry! Something went wrong."
-
-#: components/pages/Resources/ResourcesList/index.tsx:262
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr "Please use a different filter combination."
-
-#: components/pages/Resources/ResourcesList/index.tsx:255
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr "Check your search for typos or try a different search term."
-
-#: components/pages/Retirements/Footer/index.tsx:18
-msgid "retirement.footer.aboutKlima.left"
-msgstr "KlimaDAO is incentivizing sustainability and catalyzing a more transparent and liquid carbon market. Our tools make it possible for any individual or businesses to trade and retire quality carbon assets on the blockchain."
-
-#: components/pages/Retirements/Footer/index.tsx:28
-msgid "retirement.footer.aboutKlima.right"
-msgstr "KLIMA tokens are at the center of a burgeoning on-chain carbon economy. Visit our <0>knowledge base</0> to learn more about KLIMA, carbon offsetting, carbon markets, and the underlying carbon assets."
-
-#: components/pages/Retirements/Footer/index.tsx:13
-msgid "retirement.footer.aboutKlima.title"
-msgstr "About Klima"
-
-#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:37
-msgid "retirement.footer.buy_klima.button.buy"
-msgstr "Buy"
-
-#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:44
-msgid "retirement.footer.buy_klima.button.offset"
-msgstr "Offset"
-
-#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:30
-msgid "retirement.footer.buy_klima.text"
-msgstr "Use carbon-backed KLIMA tokens to govern, swap, and earn staking rewards— then use those rewards to offset your emissions!"
-
-#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:25
-msgid "retirement.footer.buy_klima.title"
-msgstr "Acquire, stake, and get rewarded."
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:135
-msgid "retirement.head.metaDescription"
-msgstr "Transparent, on-chain offsets powered by KlimaDAO."
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:131
-msgid "retirement.head.metaTitle"
-msgstr "{retiree} retired {formattedAmount} Tonnes of carbon"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:127
-msgid "retirement.head.title"
-msgstr "KlimaDAO | Carbon Retirement Receipt"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:279
-msgid "retirement.share.title"
-msgstr "Share your impact"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:189
-msgid "retirement.single.beneficiary.placeholder"
-msgstr "No beneficiary name provided"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:183
-msgid "retirement.single.beneficiary.title"
-msgstr "Beneficiary"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:197
-msgid "retirement.single.beneficiaryAddress.title"
-msgstr "Beneficiary Address"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:258
-msgid "retirement.single.create_a_pledge"
-msgstr "Create a pledge now."
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:244
-msgid "retirement.single.disclaimer"
-msgstr "This represents the permanent retirement of tokenized carbon assets on the Polygon blockchain. This retirement and the associated data are immutable public records."
-
-#: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:30
-msgid "retirement.single.download_certificate_button"
-msgstr "Download PDF"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:147
-msgid "retirement.single.header.subline"
-msgstr "CO2-Equivalent Emissions Offset (Metric Tonnes)"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:254
-msgid "retirement.single.is_this_your_retirement"
-msgstr "Is this your retirement?"
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
-msgid "retirement.single.message.title"
-msgstr "Retirement Message"
-
-#: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:30
-msgid "retirement.single.no_pledge"
-msgstr "This user has not created a pledge"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
-msgid "retirement.single.project_details.title"
-msgstr "Project Details"
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
-msgid "retirement.single.quantity"
-msgstr "QUANTITY RETIRED"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:218
-msgid "retirement.single.retirementCertificate.title"
-msgstr "Certificate"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:21
-msgid "retirement.single.retirementDate.title"
-msgstr "Date"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:24
-msgid "retirement.single.timestamp.placeholder"
-msgstr "No retirement timestamp provided"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:315
-msgid "retirement.single.view_on_polygon_scan"
-msgstr "View on Polygonscan"
-
-#: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:18
-msgid "retirement.single.view_pledge"
-msgstr "View Pledge"
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr "No retirements found"
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr "All Retirements"
-
-#: components/pages/Retirements/index.tsx:46
-msgid "retirement.totals.head.metaTitle"
-msgstr "KlimaDAO - Carbon Retirements for beneficiary {0}"
-
-#: components/pages/Retirements/index.tsx:40
-msgid "retirement.totals.head.title"
-msgstr "KlimaDAO - Carbon Retirements for beneficiary {0}"
-
-#: components/pages/Retirements/index.tsx:65
-msgid "retirement.totals.page_headline"
-msgstr "Carbon Retirements"
-
-#: components/pages/Retirements/index.tsx:71
-msgid "retirement.totals.page_subline"
-msgstr "for beneficiary"
-
-#: components/pages/Retirements/index.tsx:95
-msgid "retirement.totals.retired_assets"
-msgstr "Retired Assets"
-
-#: components/pages/Retirements/index.tsx:111
-msgid "retirement.totals.retirements"
-msgstr "Retirements"
-
-#: components/pages/Retirements/index.tsx:103
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr "Total Carbon Tonnes Retired"
-
-#: components/pages/Retirements/index.tsx:117
-msgid "retirement.totals.total_retirement_transactions"
-msgstr "Total Retirement Transactions"
-
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:97
+msgid "buy.step_3"
+msgstr "3."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:125
+msgid "disclaimer.3_be_reliable_complete_legal_or_safe"
+msgstr "3. Be reliable, complete, legal or safe."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:178
+msgid "buy.swap_wallet"
+msgstr "3. Swap for KLIMA on <0>Sushi.com</0>"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:634
+msgid "infinity.faq_question3"
+msgstr "3. What are carbon markets?"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:184
+msgid "buy.connect_torus_sushi"
+msgstr "3A. Connect Torus to Sushi.com using WalletConnect"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:249
+msgid "buy.swap_subtitle"
+msgstr "3B. Swap MATIC for KLIMA"
+
+#. js-lingui-explicit-id
 #: components/pages/errors/Custom404.tsx:20
 #: components/pages/errors/Custom404.tsx:24
 #: components/pages/errors/Custom404.tsx:28
@@ -1793,52 +394,409 @@ msgstr "Total Retirement Transactions"
 msgid "shared.404"
 msgstr "404 - Page Not Found"
 
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:15
+msgid "error.page.500.title"
+msgstr "500 - Page Not Found"
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:19
+msgid "error.page.500.head.title"
+msgstr "500 - Page Not Found"
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:34
+msgid "error.500.page.title"
+msgstr "500 - Server-side error occurred"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:557
+msgid "infinity.faq_answer1"
+msgstr "A carbon offset unit represents the removal of one tonne of carbon dioxide equivalent (tCO2e) from the atmosphere, or the avoidance of one tonne of emissions."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:67
+msgid "infinity.head.metaDescription"
+msgstr "A next-generation carbon toolkit for your organization."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:75
+msgid "pledge.errors.pledge_not_found"
+msgstr "A pledge was not found for this address."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:155
+msgid "resources.list.sort_by.a-z"
+msgstr "A-Z"
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:78
 #: components/Navigation/index.tsx:206
 msgid "shared.about"
 msgstr "About"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:13
+msgid "retirement.footer.aboutKlima.title"
+msgstr "About Klima"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:301
+msgid "infinity.getStarted_cta"
+msgstr "Accelerate your path to carbon neutral - and beyond"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:41
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:108
+msgid "pledge.invitation.accept"
+msgstr "Accept Invitation"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:25
+msgid "retirement.footer.buy_klima.title"
+msgstr "Acquire, stake, and get rewarded."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:497
+msgid "pledges.form.footprint.prompt"
+msgstr "Add a category and start calculating your carbon footprint"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:562
+msgid "pledges.form.add_footprint_category_button"
+msgstr "Add category"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:340
+msgid "pledge.form.wallets.tooltip"
+msgstr "Add other wallets to contribute to your pledge. If the owner of the wallet accepts your invitation, their wallet will appear on your pledge dashboard. Any retirements made by a secondary wallet will contribute toward your pledge. You'll retain sole ownership and editing access to this pledge."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:446
+msgid "pledges.form.add_wallet_button"
+msgstr "Add wallet"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:380
+msgid "pledges.form.input.walletAddress.label"
+msgstr "Address"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:82
+msgid "pledges.form.errors.walletAddress.required"
+msgstr "Address required"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:434
+msgid "buy.answer_exchange"
+msgstr "Advanced users can use the <0>Polygon Bridge</0> to move any asset from Ethereum to Polygon, and/or the <1>Polygon Gas Swap</1> to swap assets like USDC for MATIC."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:134
+msgid "buy.create_wallet_description4"
+msgstr "Advanced: if you don't want to use Torus, feel free to use any Polygon-compatible Web3 wallet."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:162
+msgid "infinity.affordable_subtitle"
+msgstr "Affordable"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:252
+msgid "buy.swap_description1"
+msgstr "After connecting your wallet and switching to the Polygon network, you should now be able to swap from MATIC to KLIMA."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr "All Retirements"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:473
+msgid "home.newletter.all_the_alpha_straight_to_your_inbox"
+msgstr "All the Alpha, straight to your inbox"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:32
+msgid "disclaimer.all_information_on_this_website"
+msgstr "All the information on this website is published in good faith and for general information purpose only. KlimaDAO is distributed on a basis that it will be useful and serve only within grounds and limits described on above mentioned website."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:289
+msgid "infinity.getStarted_third_title"
+msgstr "Amplify"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:79
+#: components/pages/Pledge/PledgeForm/index.tsx:83
+#: components/pages/Pledge/PledgeForm/index.tsx:99
+msgid "pledge.errors.default"
+msgstr "An error has occured"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:21
+msgid "disclaimer.head.description"
+msgstr "An important disclaimer from the KlimaDAO legal team."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:87
+msgid "pledge.errors.unknown_error"
+msgstr "An unknown error has occured."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:159
+msgid "disclaimer.any_action_you_take_upon_the_information"
+msgstr "Any action you take upon the information you find on this website is strictly at your own risk. Decisions based on information contained on this website are the sole responsibility of the visitor. KlimaDAO will not be liable for any losses and/or damages in connection with the use of the website, the loss of your password/seed phrase, a bad trade, sending an asset to the wrong address, losing your asset and events related to damage caused by scammers. KlimaDAO cannot assume any responsibility or liability connected with market changing and its volatility. You must conduct your own research and satisfy yourself of your own situation, familiarity and knowledge of information or service provided by this platform."
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:110
 #: components/Navigation/index.tsx:237
 msgid "shared.app"
 msgstr "App"
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:367
+msgid "buy.what_are_bonds"
+msgstr "Are there other ways to get KLIMA? What are bonds?"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:616
+msgid "pledge.form.wallets.confirm_remove_wallet"
+msgstr "Are you sure you want to remove {0} from your pledge?"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:126
+msgid "pledge.modal.are_you_sure"
+msgstr "Are you sure you want to remove your wallet from this pledge?"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:242
+msgid "pledges.form.awaiting_signature"
+msgstr "Awaiting signature..."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:190
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:176
+msgid "pledge.invitations.awaiting_signature"
+msgstr "Awaiting Signature..."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:71
+msgid "resources.list.filter.tag.basics"
+msgstr "Basics"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:116
+msgid "community.become_a_partner"
+msgstr "BECOME A PARTNER"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:183
+msgid "retirement.single.beneficiary.title"
+msgstr "Beneficiary"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:197
+msgid "retirement.single.beneficiaryAddress.title"
+msgstr "Beneficiary Address"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:209
+msgid "home.benefits"
+msgstr "BENEFITS"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:180
+msgid "community.bigcowg_logo"
+msgstr "BICOWG logo"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:172
+msgid "community.blockchainforclimatefondation_logo"
+msgstr "Blockchain for Climate Foundation logo"
+
+#. js-lingui-explicit-id
 #: components/Footer/index.tsx:49
 msgid "shared.blog"
 msgstr "Blog"
 
-#: components/Navigation/index.tsx:241
-msgid "shared.buy"
-msgstr "Buy Klima"
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:121
+msgid "resources.list.filter.type.blog"
+msgstr "Blog"
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:381
+msgid "buy.bond_description_capacity"
+msgstr "Bond capacity is limited and bonds are not always available."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:140
+msgid "contact.bug_reports"
+msgstr "Bug Reports"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:37
+msgid "retirement.footer.buy_klima.button.buy"
+msgstr "Buy"
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:143
 #: components/Navigation/index.tsx:272
 msgid "shared.buy_carbon"
 msgstr "Buy Carbon"
 
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:241
+msgid "shared.buy"
+msgstr "Buy Klima"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:387
+msgid "infinity.polygon_manifesto_description"
+msgstr "By offsetting the historical emissions of their entire network, Polygon has ensured that every interaction within its network - whether an NFT mint or a DeFi transaction - is taken into account. This is a key reason why Meta chose Polygon to issue its NFTs."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:261
+msgid "infinity.getStarted_calculate"
+msgstr "Calculate"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:264
+msgid "infinity.getStarted_calculate_subtitle"
+msgstr "Calculate your organization's carbon footprint and define the scope of your offset with Klima Infinity."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:386
+msgid "buy.bond_question_credit_card"
+msgstr "Can I buy KLIMA directly with a credit card?"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:635
+msgid "pledges.form.confirm_remove_cancel"
+msgstr "cancel"
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:158
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:115
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:144
 msgid "shared.cancel"
 msgstr "Cancel"
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:87
+msgid "pledges.dashboard.assets.title"
+msgstr "Carbon Assets"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:593
+msgid "infinity.faq_answer2_paragraph1"
+msgstr "Carbon credits are a high-integrity mechanism that allow carbon finance to flow from those who pollute, to projects across the globe that help to mitigate or remove carbon from the atmosphere. They are a valuable tool to cover hard-to-abate emissions that may be costly or technically challenging to eliminate today."
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:317
 msgid "shared.carbon_dashboard"
 msgstr "Carbon Dashboard"
 
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:185
 msgid "shared.carbon_dashboards"
 msgstr "Carbon Dashboards"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:111
+msgid "resources.list.filter.tag.carbon_footprint"
+msgstr "Carbon Footprint"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:472
+msgid "infinity.mission_card2_description"
+msgstr "Carbon liquidity held by KlimaDAO"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:65
+msgid "retirement.totals.page_headline"
+msgstr "Carbon Retirements"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:530
+msgid "pledges.form.input.categoryQuantity.placeholder"
+msgstr "Carbon tonnes"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:450
+msgid "infinity.mission_card1_subtitle"
+msgstr "Carbon tonnes held by KlimaDAO"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:494
+msgid "infinity.mission_card3_description"
+msgstr "Carbon tonnes offset via KlimaDAO"
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:160
 #: components/Navigation/index.tsx:291
 msgid "shared.carbonmark"
 msgstr "Carbonmark"
 
-#: components/pages/Home/index.tsx:192
-msgid "shared.carbonmark_cta"
-msgstr "OFFSET YOUR FOOTPRINT"
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:63
+msgid "concat.careers"
+msgstr "Careers"
 
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:330
+msgid "home.cars_annual"
+msgstr "Cars (annual)"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:24
+msgid "resources.form.categories.header"
+msgstr "Categories"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:518
+msgid "pledges.form.input.categoryName.label"
+msgstr "Category"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:510
+msgid "pledges.form.input.categoryName.placeholder"
+msgstr "Category name"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:218
+msgid "retirement.single.retirementCertificate.title"
+msgstr "Certificate"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:255
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr "Check your search for typos or try a different search term."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:119
+msgid "buy.create_wallet_description2"
+msgstr "Choose the “Email or Social” sign-in option, which will direct you to log in with Torus. Torus is a technology that generates a secure wallet using your existing email or social login. You will be able to use this new Torus wallet across hundreds of other Web3 and DeFi apps."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:66
+msgid "resources.form.filters.clear_all"
+msgstr "Clear All"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:147
+msgid "retirement.single.header.subline"
+msgstr "CO2-Equivalent Emissions Offset (Metric Tonnes)"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:314
+msgid "community.come_on_in"
+msgstr "Come On In"
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:82
 #: components/Navigation/index.tsx:211
 #: components/pages/About/AboutHeader/index.tsx:31
@@ -1846,16 +804,83 @@ msgstr "OFFSET YOUR FOOTPRINT"
 msgid "shared.community"
 msgstr "Community"
 
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:95
+msgid "community.head.headline"
+msgstr "Community"
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:45
 msgid "shared.confirm"
 msgstr "Confirm"
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:150
+msgid "pledge.modal.confirm"
+msgstr "Confirm"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:190
+msgid "pledges.form.confirm_delete"
+msgstr "confirm removal"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:40
+msgid "pledge.modal.confirm_remove"
+msgstr "Confirm Removal"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:294
+msgid "buy.staking_description1"
+msgstr "Congrats! Now that you have some KLIMA in your wallet, we highly recommend <0>staking</0> that KLIMA for sKLIMA, which accrues rewards over time as the protocol grows."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:108
+#: components/pages/Pledge/PledgeDashboard/index.tsx:166
+msgid "connectModal.wallet"
+msgstr "connect a wallet"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr "Connect with your browser web3 provider"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:66
+msgid "pledges.home.hero.connecting"
+msgstr "Connecting..."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:114
+#: components/pages/Pledge/PledgeDashboard/index.tsx:172
+msgid "connect_modal.connecting"
+msgstr "Connecting..."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:118
+#: components/pages/Pledge/PledgeDashboard/index.tsx:176
+msgid "connect_modal.error_title"
+msgstr "Connection Error"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:18
+msgid "contact.head.headline"
+msgstr "Contact"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:17
+#: components/pages/About/Contact/index.tsx:24
+msgid "contact.head.title"
+msgstr "Contact KlimaDAO"
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:66
 #: components/pages/Infinity/index.tsx:117
 #: components/pages/Infinity/index.tsx:701
 msgid "shared.contact_sales"
 msgstr "Contact Sales"
 
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:91
 #: components/pages/About/AboutHeader/index.tsx:40
 #: components/pages/About/Community/index.tsx:129
@@ -1863,10 +888,58 @@ msgstr "Contact Sales"
 msgid "shared.contact_us"
 msgstr "Contact Us"
 
-#: components/pages/Home/index.tsx:185
-msgid "shared.dcm_cta"
-msgstr "EXPLORE THE DCM"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:90
+msgid "pledges.head.metaTitle"
+msgstr "Create a carbon pledge and showcase your impact"
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:77
+msgid "pledges.home.hero.create"
+msgstr "Create a pledge"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:258
+msgid "retirement.single.create_a_pledge"
+msgstr "Create a pledge now."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:21
+msgid "retirement.single.retirementDate.title"
+msgstr "Date"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:79
+msgid "resources.list.filter.tag.deep_dives"
+msgstr "Deep Dives"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:219
+msgid "infinity.why_subtitle"
+msgstr "DeFi that defies climate change"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:228
+msgid "community.deltawave_logo"
+msgstr "Delta Wave logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:94
+msgid "pledges.head.metaDescription"
+msgstr "Demonstrate your commitment to climate positivity by claiming your pledge dashboard to highlight all of your carbon offsetting activity"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:162
+msgid "home.developed_by_klima"
+msgstr "Developed by KlimaDAO, the Digital Carbon Market (DCM) enables the scale-up of climate finance - with over $4 billion traded to date. Explore the DCM via <0>Carbonmark.com</0> - the universal marketplace - and the <1>Carbon Dashboard</1>."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:265
+msgid "community.digitalcharityart_logo"
+msgstr "Digital Charity Art logo"
+
+#. js-lingui-explicit-id
 #: components/Footer/index.tsx:55
 #: components/Navigation/index.tsx:100
 #: components/Navigation/index.tsx:226
@@ -1875,117 +948,1514 @@ msgstr "EXPLORE THE DCM"
 msgid "shared.disclaimer"
 msgstr "Disclaimer"
 
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:19
+msgid "disclaimer.disclaimer"
+msgstr "Disclaimer"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:90
+msgid "blog.disclaimer.title"
+msgstr "Disclaimer:"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:329
+msgid "community.discord_is_where_we_share"
+msgstr "Discord is where we share important announcements, hold office-hours, answer questions, and trade memes. Our Discord server is extremely active and moderated around-the-clock. We've got channels for everything from trading to sustainability and carbon markets."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:244
+msgid "community.dovu_logo"
+msgstr "Dovu logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/DownloadCertificateButton/index.tsx:30
+msgid "retirement.single.download_certificate_button"
+msgstr "Download PDF"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/Cards/CardsSlider.tsx:89
+msgid "infinity.cards_slider.title"
+msgstr "Dozens of organizations have offset over 150,000 carbon tonnes with Klima Infinity"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:29
+#: components/pages/errors/Custom500.tsx:23
+#: components/pages/Home/index.tsx:67
+#: components/pages/Retirements/index.tsx:52
+msgid "shared.head.description"
+msgstr "Drive climate action and earn rewards with a carbon-backed digital currency."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:343
+msgid "infinity.carousel_info_subtitle"
+msgstr "Drive funding to projects that move the needle on climate change mitigation"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr "Easy one-click wallet by Torus"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:249
+msgid "community.eco_logo"
+msgstr "Eco logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:39
+msgid "pledge.modal.edit_pledge"
+msgstr "Edit pledge"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/HeaderDesktop/index.tsx:37
+msgid "pledges.edit_pledge"
+msgstr "Edit Pledge"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr "Email or Social"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:199
+msgid "pledges.home.search.label"
+msgstr "ENS or 0x address"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:62
+msgid "pledges.form.errors.footprint.generic_error"
+msgstr "Enter a carbon tonne estimate"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:70
+msgid "pledges.form.errors.categoryName.required"
+msgstr "Enter a category"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:54
+msgid "pledges.form.errors.methodology.required"
+msgstr "Enter a methodology"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:34
+msgid "pledges.form.errors.name.required"
+msgstr "Enter a name"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:46
+msgid "pledges.form.errors.description.required"
+msgstr "Enter a pledge"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:38
+msgid "pledges.form.errors.profileImageUrl.url"
+msgstr "Enter a valid url"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:42
+msgid "pledges.form.errors.profileWebsiteUrl.url"
+msgstr "Enter a valid url"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:66
+msgid "pledges.form.errors.footprint.min"
+msgstr "Enter a value greater than 0"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:78
+msgid "pledges.form.errors.categoryQuantity.min"
+msgstr "Enter a value greater than 0"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:205
+msgid "pledges.form.error"
+msgstr "Enter a wallet address, .klima or .eth domain"
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:58
 #: components/pages/Home/index.tsx:113
 msgid "shared.enter_app"
 msgstr "Enter App"
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:193
+msgid "pledges.home.search.placeholder"
+msgstr "Enter ENS, KNS or 0x address"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:58
+msgid "pledges.form.errors.methodology.max"
+msgstr "Enter less than 1000 characters"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:74
+msgid "pledges.form.errors.categoryName.max"
+msgstr "Enter less than 32 characters"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:50
+msgid "pledges.form.errors.description.max"
+msgstr "Enter less than 500 characters"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:299
+msgid "home.equivalent_to"
+msgstr "EQUIVALENT TO"
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:154
 msgid "shared.error"
 msgstr "Error"
 
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:236
+msgid "community.etcgroup_logo"
+msgstr "Etc Group logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:372
+msgid "buy.bond_description1"
+msgstr "Experienced crypto users can buy KLIMA directly from the protocol via bonds. To acquire KLIMA via bonds, you provide a carbon token or liquidity token and get discounted KLIMA tokens in return. This is the mechanism that the DAO uses to grow its treasury of digital carbon."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:167
+msgid "resources.page.list.header"
+msgstr "Explore All"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:185
+msgid "shared.dcm_cta"
+msgstr "EXPLORE THE DCM"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:320
+msgid "buy.faq_title"
+msgstr "FAQ"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:142
+msgid "infinity.fast_title"
+msgstr "Fast"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:43
+msgid "resources.page.header.title"
+msgstr "Featured Articles"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:311
+msgid "buy.staking_description3"
+msgstr "Finally, keep an eye out for <0>ongoing votes</0> and help guide the protocol in the right direction."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:242
+msgid "buy.connect_torus_sushi_description5"
+msgstr "Finally, use the drop-down menu on <0>Sushi.com</0> to switch to the Polygon network."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:77
+msgid "pledges.dashboard.footprint.title"
+msgstr "Footprint"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:489
+msgid "pledges.form.footprint.label"
+msgstr "Footprint"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:71
+msgid "retirement.totals.page_subline"
+msgstr "for beneficiary"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:178
+msgid "infinity.info_subtitle1"
+msgstr "For the planet's pioneering organizations"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:444
+msgid "home.get_exposure_to_the_growing_carbon_economy"
+msgstr "Get exposure to the growing carbon economy today. Acquire, stake, and get rewarded. Financial activism for the climate."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:25
+msgid "contact.head.description"
+msgstr "Get in touch with someone from KlimaDAO."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:361
+msgid "community.get_in_touch"
+msgstr "Get in touch?"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:441
+msgid "home.get_klima"
+msgstr "GET KLIMA"
+
+#. js-lingui-explicit-id
 #: components/pages/Infinity/GetStartedModal.tsx:25
 msgid "shared.get_started"
 msgstr "Get Started"
 
-#: components/pages/Buy/index.tsx:29
-#: components/pages/Home/index.tsx:67
-#: components/pages/Retirements/index.tsx:52
-#: components/pages/errors/Custom500.tsx:23
-msgid "shared.head.description"
-msgstr "Drive climate action and earn rewards with a carbon-backed digital currency."
-
-#: components/Footer/index.tsx:34
-msgid "shared.home"
-msgstr "Home"
-
-#: components/Navigation/index.tsx:176
-#: components/Navigation/index.tsx:308
-msgid "shared.how_to_buy"
-msgstr "How To Buy Klima"
-
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:108
 #: components/pages/Infinity/index.tsx:309
 #: components/pages/Infinity/index.tsx:692
 msgid "shared.infinity.get_started"
 msgstr "Get Started"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:481
+msgid "home.newletter.get_the_latest_updates"
+msgstr "Get the latest updates on KlimaDAO, as we build the future of the carbon economy."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:204
+msgid "community.gitcoin_logo"
+msgstr "Gitcoin logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:387
+msgid "home.govern_the_market"
+msgstr "Govern the market, for the planet"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:113
+msgid "buy.create_wallet_description1"
+msgstr "Head to <0>app.klimadao.finance</0> and click \"Connect\" at the top-right corner."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:313
+msgid "home.hectares_of_forest"
+msgstr "Hectares of forest"
+
+#. js-lingui-explicit-id
+#: components/Footer/index.tsx:34
+msgid "shared.home"
+msgstr "Home"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:27
+#: components/pages/Buy/index.tsx:28
+msgid "buy.head.title"
+msgstr "How to buy KLIMA"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:41
+msgid "buy.how_to_buy"
+msgstr "How to buy KLIMA"
+
+#. js-lingui-explicit-id
+#: components/Navigation/index.tsx:176
+#: components/Navigation/index.tsx:308
+msgid "shared.how_to_buy"
+msgstr "How To Buy Klima"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:14
+msgid "pledges.dashboard.metholodogy.default_text"
+msgstr "How will you meet your pledge?"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/GetStartedModal.tsx:94
+msgid "infinity.getStartedModal_offsetCrypto"
+msgstr "I want to<0/>offset crypto."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/GetStartedModal.tsx:104
+msgid "infinity.getStartedModal_needAssistance"
+msgstr "I'd like assistance with my organization's carbon footprint."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/GetStartedModal.tsx:47
+msgid "infinity.getStartedModal_business"
+msgstr "I'm a <0/>business."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/GetStartedModal.tsx:70
+msgid "infinity.getStartedModal_individual"
+msgstr "I'm an<0/>individual."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:108
+msgid "contact.media.if_you_are_a_journalist"
+msgstr "If you are a journalist or content creator, our marketing team would love to meet you."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:274
+msgid "buy.swap_description3"
+msgstr "If you are using Torus, keep the browser tab with the Torus app open. You will need to return to your wallet to approve and authorize the transactions."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:364
+msgid "community.if_you_ve_got_questions"
+msgstr "If you've got questions, ideas, advice or anything else: we can help you find the right person to talk to."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:191
+msgid "infinity.transparent_title"
+msgstr "Immutably recorded on the blockchain"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:275
+msgid "infinity.getStarted_second_title"
+msgstr "Implement"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:278
+msgid "infinity.getStarted_second_subtitle"
+msgstr "Implement your offset with just a few clicks, and with near-instant transaction time."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:195
+msgid "buy.torus_login_description"
+msgstr "In a new browser tab, go to the <0>Torus Polygon webapp</0> and log in with your new Torus account. When you log in, you should see a WalletConnect widget."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:211
+msgid "buy.connect_torus_sushi_description2"
+msgstr "In a separate browser tab, visit <0>Sushi.com</0> and click \"Connect\" at the top-right corner. You will be presented with a few wallet options. Choose WalletConnect. After you choose WalletConnect you will see a QR code—click \"Copy to Clipboard\"."
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:151
 #: components/Navigation/index.tsx:280
 msgid "shared.info"
 msgstr "Info"
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:417
+msgid "buy.bond_answer_cex2"
+msgstr "Instead, KLIMA tokens are traded on a \"Decentralized Exchange\" (DEX) that is powered by smart contracts and runs directly on the blockchain. DEXs have some major advantages. DEXs made it possible for the DAO to own the majority of liquidity, so it can maintain full autonomy and generate revenue to pay contributors. We chose to use Sushi's DEX technology as it already facilitates tens of millions of dollars in transactions per day."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:254
+msgid "retirement.single.is_this_your_retirement"
+msgstr "Is this your retirement?"
+
+#. Join our <0>community</0>
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:38
+msgid "contact.quest_and_support.join_our_community"
+msgstr "Join our <0>community</0>"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:317
+msgid "community.join_our_discord"
+msgstr "Join Our Discord"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:46
+msgid "contact.quest_and_support.join_our_discord_server"
+msgstr "Join our Discord server and ask in the #questions channel. We have thousands of friendly, knowledgeable community members ready and willing to help you out."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:405
+msgid "home.join_over_100k_members"
+msgstr "Join over 100,000 members who hold the $KLIMA token, using it to steward KlimaDAO's resources and grow the Digital Carbon Market."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:304
+msgid "community.join_the_klima_community"
+msgstr "Join the Klima Community"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:52
+msgid "resources.list.filter.tag.klima_infinity"
+msgstr "Klima Infinity"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:63
+msgid "infinity.head.metaTitle"
+msgstr "Klima Infinity - Go carbon neutral"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:98
+msgid "infinity.welcome_subtitle"
+msgstr "Klima Infinity is a next-generation carbon toolkit for your organization"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:44
+msgid "buy.how_to_paragraph_part_1"
+msgstr "KLIMA is a carbon-backed digital asset and can be staked for rewards or used to offset digital carbon. Holding KLIMA also empowers you to vote and help govern the Digital Carbon Market."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:409
+msgid "buy.bond_answer_cex1"
+msgstr "KLIMA is not traded on a centralized exchange like Coinbase, Binance, or Crypto.com as these exchanges typically charge very high listing fees and require financing from expensive market makers."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:44
+msgid "resources.list.filter.tag.klima_overview"
+msgstr "Klima Overview"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:28
+msgid "retirement.footer.aboutKlima.right"
+msgstr "KLIMA tokens are at the center of a burgeoning on-chain carbon economy. Visit our <0>knowledge base</0> to learn more about KLIMA, carbon offsetting, carbon markets, and the underlying carbon assets."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:40
+msgid "retirement.totals.head.title"
+msgstr "KlimaDAO - Carbon Retirements for beneficiary {0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:46
+msgid "retirement.totals.head.metaTitle"
+msgstr "KlimaDAO - Carbon Retirements for beneficiary {0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:127
+msgid "retirement.head.title"
+msgstr "KlimaDAO | Carbon Retirement Receipt"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:59
+msgid "infinity.head.title"
+msgstr "KlimaDAO | Klima Infinity"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:86
+msgid "pledges.head.title"
+msgstr "KlimaDAO | Pledges"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:23
+msgid "resources.head.title"
+msgstr "KlimaDAO | Resources"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:102
+msgid "disclaimer.klimadao_and_its_suppliers"
+msgstr "KlimaDAO and its suppliers make no warranty that the platform will:"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:94
+#: components/pages/About/Community/index.tsx:101
+msgid "community.head.title"
+msgstr "KlimaDAO Community"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:15
+#: components/pages/About/Disclaimer/index.tsx:25
+msgid "disclaimer.head.title"
+msgstr "KlimaDAO Disclaimer"
+
+#. js-lingui-explicit-id
+#: components/SocialProof/index.tsx:19
+msgid "home.featured_on"
+msgstr "KlimaDAO featured on"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:96
+msgid "community.head.subline"
+msgstr "KlimaDAO is a Decentralized Autonomous Organization for Change. We are governed and built by a community of passionate Klimates."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:43
+msgid "disclaimer.klimadao_is_a_platform"
+msgstr "KlimaDAO is a platform. We are not a broker, financial institution, or creditor. Services provided on this website do not include an offer to hold or control your securities, options, assets, futures or other derivatives related to securities in any jurisdiction and its content is not prescribed by securities laws."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:212
+msgid "home.klima_is_creating"
+msgstr "KlimaDAO is creating a public and open-source social and technology layer to shape the future of the carbon markets."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:18
+msgid "retirement.footer.aboutKlima.left"
+msgstr "KlimaDAO is incentivizing sustainability and catalyzing a more transparent and liquid carbon market. Our tools make it possible for any individual or businesses to trade and retire quality carbon assets on the blockchain."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:224
+msgid "infinity.why_description"
+msgstr "KlimaDAO is leveraging a stack of DeFi technologies to reduce market fragmentation and accelerate the delivery of climate finance to sustainability projects worldwide."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:27
+msgid "resources.head.metaTitle"
+msgstr "KlimaDAO Resources - Go beyond Carbon neutral"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:439
+msgid "mission.header"
+msgstr "KlimaDAO's mission is to democratize climate action"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:281
+msgid "community.landx_logo"
+msgstr "LandX logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:400
+msgid "infinity.box_title"
+msgstr "Last Carbon Offset"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:139
+msgid "resources.list.sort_by.latest_first"
+msgstr "Latest First"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:102
+msgid "community.head.metadescription"
+msgstr "Learn about our community of passionate Klimates"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:163
+msgid "pledges.home.hero.learn_more"
+msgstr "Learn more"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:137
+msgid "home.learn_more"
+msgstr "LEARN MORE"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:113
+#: components/pages/About/Community/index.tsx:358
+msgid "community.lets_work_together"
+msgstr "Let's Work Together"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:345
+msgid "home.liters_if_gasoline"
+msgstr "Liters of gasoline"
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/HeaderDesktop/index.tsx:43
 #: components/pages/Pledge/HeaderMobile/index.tsx:46
 msgid "shared.login_connect"
 msgstr "Login / Connect"
 
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:105
+msgid "contact.media"
+msgstr "Media"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:53
+msgid "resources.form.medium.header"
+msgstr "Medium"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:91
+msgid "pledge.errors.method_not_allowed"
+msgstr "Method not allowed."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/MethodologyCard/index.tsx:21
+msgid "pledges.dashboard.metholodogy.title"
+msgstr "Methodology"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:476
+msgid "pledges.form.input.methodology.label"
+msgstr "Methodology"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:156
+msgid "community.moss_logo"
+msgstr "Moss logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:280
+msgid "pledges.form.input.name.label"
+msgstr "Name"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:273
+msgid "pledges.form.input.name.placeholder"
+msgstr "Name or company name"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:130
+msgid "disclaimer.neither_klimadao_nor_any_of_its_representatives"
+msgstr "Neither KlimaDAO nor any of its representatives will not liable for any loss of any kind from any action taken or taken in reliance on material or information, contained on the service. KlimaDAO is making the use of the service and content safe, nevertheless it does not represent or warrant that the service and content on our platform are free of viruses or other harmful components."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:253
+msgid "home.neutral_and_trusted"
+msgstr "Neutral and trusted"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:498
+msgid "home.newletter.never_shared_never_spammed"
+msgstr "Never shared. Never spammed."
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:478
+msgid "home.newsletter"
+msgstr "Newsletter"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:189
+msgid "retirement.single.beneficiary.placeholder"
+msgstr "No beneficiary name provided"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/AssetBalanceCard/index.tsx:110
+msgid "pledges.dashboard.assets.emptyBalance"
+msgstr "No carbon assets to show."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:24
+msgid "retirement.single.timestamp.placeholder"
+msgstr "No retirement timestamp provided"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr "No retirements found"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:189
+msgid "buy.connect_advanced"
+msgstr "Note: these instructions are for Torus wallet users only. Sushi supports a variety of different wallets."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:178
+msgid "disclaimer.nothing_in_this_disclaimer"
+msgstr "Nothing in this disclaimer, any information content or material shall or shall be constructed to create any legal relations between us and you nor grant any rights or obligations to either of us."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:56
+msgid "disclaimer.nothing_in_this_platform"
+msgstr "Nothing in this platform constitutes or be construed as:"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:196
+msgid "community.oceandrop_logo"
+msgstr "Oceandrop logo"
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:135
 #: components/Navigation/index.tsx:264
 msgid "shared.offset"
 msgstr "Offset"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:44
+msgid "retirement.footer.buy_klima.button.offset"
+msgstr "Offset"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:137
+msgid "infinity.fast_subtitle"
+msgstr "Offset in seconds, with no red tape"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:192
+msgid "shared.carbonmark_cta"
+msgstr "OFFSET YOUR FOOTPRINT"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:257
+msgid "community.offsetra_logo"
+msgstr "Offsetra logo"
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:172
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:158
 msgid "shared.okay"
 msgstr "Okay"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:147
+msgid "resources.list.sort_by.oldest_first"
+msgstr "Oldest First"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:212
+msgid "community.olympusdao_logo"
+msgstr "OlympusDAO logo"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:220
+msgid "community.openearth_logo"
+msgstr "Open Earth logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:281
+msgid "buy.swap_description4"
+msgstr "Optional: If you'd like your Sushi transactions themselves to be climate positive, you should enable the Sushi 'Green Fee', powered by KlimaDAO. This will spend 0.02 MATIC per transaction to purchase and retire digital carbon automatically!"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:151
+msgid "community.our_partners"
+msgstr "OUR PARTNERS"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:85
+msgid "contact.partnerships"
+msgstr "Partnerships"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:60
+msgid "resources.list.filter.tag.partnerships"
+msgstr "Partnerships"
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/PledgeForm/index.tsx:421
 msgid "shared.pending"
 msgstr "Pending"
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:86
+msgid "pledges.form.errors.walletAddress.isAddress"
+msgstr "Please enter a valid address"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:175
+msgid "pledge.form.error.duplicate_wallets"
+msgstr "Please remove the duplicate wallet(s)"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:262
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr "Please use a different filter combination."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:21
+msgid "pledges.dashboard.pledge.title"
+msgstr "Pledge"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:323
+msgid "pledges.form.input.description.label"
+msgstr "Pledge"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Profile/index.tsx:106
+msgid "pledges.dashboard.profile.pledged_to_offset"
+msgstr "Pledged to Offset <0>{0}</0> Carbon Tonnes"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:129
+msgid "resources.list.filter.type.podcast"
+msgstr "Podcast"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:103
+msgid "resources.list.filter.tag.policy"
+msgstr "Policy"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:356
+msgid "infinity.polygon_story_title"
+msgstr "Polygon chose Klima Infinity to offset their blockchain network"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:188
+msgid "community.polygon_logo"
+msgstr "Polygon logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:361
+msgid "infinity.polygon_story_description"
+msgstr "Polygon offset the network's carbon emissions since inception - roughly 90,000 tonnes - and pledged to go climate positive for all of the network's future transactions."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:95
+msgid "resources.list.filter.tag.press_releases"
+msgstr "Press Releases"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:291
+msgid "pledges.form.input.profileImageUrl.label"
+msgstr "Profile image url (optional)"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:27
+msgid "retirement.single.project_details.title"
+msgstr "Project Details"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:273
+msgid "home.public_and_open-source"
+msgstr "Public and open-source"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:152
+msgid "home.public_good_for_the_planet"
+msgstr "Public good for the planet"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:611
+msgid "infinity.faq_answer2_paragraph3"
+msgstr "Purchased offsets lead to measurable and accountable emissions reductions elsewhere in the economy, and can be used to ‘offset’ an unavoidable carbon footprint. The trade and retirement of carbon credits enables a market mechanism to emerge that puts a price on carbon."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:538
+msgid "pledges.form.input.categoryQuantity.label"
+msgstr "Quantity"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:18
+msgid "retirement.single.quantity"
+msgstr "QUANTITY RETIRED"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:35
+msgid "contact.quest_and_support"
+msgstr "Questions & Support"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:19
+msgid "contact.head.subline"
+msgstr "Questions, concerns, ideas? Here are a few ways you can get in touch. We love meeting institutions and individuals alike."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:665
+msgid "infinity.button.read_blog_faq"
+msgstr "Read in-depth FAQs for KI Clients"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:368
+msgid "infinity.button.read_blog_polygon"
+msgstr "Read Polygon's Story"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:157
+msgid "infinity.affordable_title"
+msgstr "Real-time pricing, low transaction costs"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:115
+msgid "pledge.invitation.reject"
+msgstr "Reject Invitation"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:127
+msgid "pledge.invitation.later"
+msgstr "Remind me later"
+
+#. js-lingui-explicit-id
 #: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:132
 msgid "shared.remove"
 msgstr "remove"
 
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:622
+msgid "pledges.form.confirm_remove"
+msgstr "remove"
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:24
+msgid "connect_modal.error_processing"
+msgstr "Request already processing. Please open your wallet and complete the request."
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:167
 #: components/Navigation/index.tsx:299
 #: components/pages/Blog/Post/index.tsx:76
 msgid "shared.resourcecenter"
 msgstr "Resource Center"
 
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:164
 #: components/Navigation/index.tsx:295
 msgid "shared.resources"
 msgstr "Resources"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:95
+msgid "retirement.totals.retired_assets"
+msgstr "Retired Assets"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:14
+msgid "retirement.single.message.title"
+msgstr "Retirement Message"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:104
+msgid "pledges.dashboard.retirements.title"
+msgstr "Retirements"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:111
+msgid "retirement.totals.retirements"
+msgstr "Retirements"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:228
+msgid "buy.connect_torus_sushi_description3"
+msgstr "Return to the Torus wallet app and paste this code into the WalletConnect widget. This will create a temporary connection between your wallet and <0>Sushi.com</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:595
+msgid "pledges.form.submit_button"
+msgstr "Save pledge"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr "Scan with Coinbase to connect"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr "Scan with WalletConnect to connect"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:219
+msgid "pledges.home.search.submit"
+msgstr "Search"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:185
+msgid "resources.form.input.search.label"
+msgstr "Search"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:176
+msgid "resources.form.input.search.placeholder"
+msgstr "Search..."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:332
+msgid "pledges.form.wallets.label"
+msgstr "Secondary Wallet(s)"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:451
+msgid "home.see_tutorial"
+msgstr "See Tutorial"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/SortyByDropDown/index.tsx:21
+msgid "resources.form.input.sort_by.select"
+msgstr "Select"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:27
+msgid "resources.form.categories.subheader"
+msgstr "Select one or more"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:353
+msgid "buy.question_why_matic_answer_bullet3"
+msgstr "Sending tokens to another wallet"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:49
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:44
+msgid "pledge.invitation.error_title"
+msgstr "Server Error"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:279
+msgid "retirement.share.title"
+msgstr "Share your impact"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:311
+msgid "resources.mobile_modal.button.show_results"
+msgstr "Show Results"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:492
+msgid "home.newletter.sign_up"
+msgstr "Sign up"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:54
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:49
+msgid "pledge.invitation.signing"
+msgstr "Signing"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:104
+#: components/pages/Pledge/PledgeDashboard/index.tsx:162
+msgid "connectModal.torus"
+msgstr "social or email"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:227
+msgid "pledge.form.error.default_error_message"
+msgstr "Something went wrong. Please try again shortly."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:260
+msgid "pledges.form.generic_error"
+msgstr "Something went wrong. Please try again."
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom404.tsx:41
+msgid "error.404.page.text"
+msgstr "Sorry, looks like we sent you the wrong way. <0/>Let us guide you back to the home page:"
+
+#. js-lingui-explicit-id
+#: components/pages/errors/Custom500.tsx:39
+msgid "error.500.page.text"
+msgstr "Sorry, something bad happened.<0/>Try to go back to the Start Page:"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:241
+msgid "resources.page.list.on_fetch_error"
+msgstr "Sorry! Something went wrong."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:249
+msgid "resources.page.list.no_search_results.title"
+msgstr "Sorry. We couldn't find any matching results."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:210
+msgid "resources.form.input.sort_by.label"
+msgstr "Sort by"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:284
+msgid "resources.mobile_modal.title"
+msgstr "Sort By"
+
+#. js-lingui-explicit-id
 #: components/pages/Resources/ResourcesList/index.tsx:216
 msgid "shared.resources.sort_by.header"
 msgstr "Sort by:"
 
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:360
+msgid "home.source"
+msgstr "Source"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:291
+msgid "buy.staking_cta"
+msgstr "Stake, earn, vote, and offset!"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:339
+msgid "buy.question_why_matic_answer_bullet1"
+msgstr "Staking KLIMA for sKLIMA"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:41
+msgid "resources.form.sub_topics.header"
+msgstr "Sub-topics"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:59
+msgid "buy.summary_title"
+msgstr "Summary"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:338
+msgid "infinity.carousel_info_title"
+msgstr "Support high quality projects"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:346
+msgid "buy.question_why_matic_answer_bullet2"
+msgstr "Swapping between different tokens"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:422
+msgid "home.take_climate_action_now"
+msgstr "Take climate action now by using <0>Carbonmark</0> to buy, sell, or retire digital carbon."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:62
+msgid "buy.summary_steps_title"
+msgstr "The best and easiest way to get KLIMA is to follow these three steps:"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:93
+msgid "infinity.welcome_title"
+msgstr "The easiest way to go carbon neutral"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:93
+msgid "blog.disclaimer.description"
+msgstr "The information provided in this blog post pertaining to KlimaDAO (“KlimaDAO”), its crypto-assets, business assets, strategy, and operations, is for general informational purposes only and is not a formal offer to sell or a solicitation of an offer to buy any securities, options, futures, or other derivatives related to securities in any jurisdiction and its content is not prescribed by securities laws. Information contained in this blog post should not be relied upon as advice to buy or sell or hold such securities or as an offer to sell such securities. This blog post does not take into account nor does it provide any tax, legal or investment advice or opinion regarding the specific investment objectives or financial situation of any person. KlimaDAO and its agents, advisors, directors, officers, employees and shareholders make no representation or warranties, expressed or implied, as to the accuracy of such information and KlimaDAO expressly disclaims any and all liability that may be based on such information or errors or omissions thereof. KlimaDAO reserves the right to amend or replace the information contained herein, in part or entirely, at any time, and undertakes no obligation to provide the recipient with access to the amended information or to notify the recipient thereof. The information contained in this blog post supersedes any prior blog post or conversation concerning the same, similar or related information. Any information, representations or statements not contained herein shall not be relied upon for any purpose. Neither KlimaDAO nor any of its representatives shall have any liability whatsoever, under contract, tort, trust or otherwise, to you or any person resulting from the use of the information in this blog post by you or any of your representatives or for omissions from the information in this blog post. Additionally, KlimaDAO undertakes no obligation to comment on the expectations of, or statements made by, third parties in respect of the matters discussed in this blog post."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:328
+msgid "buy.question_why_matic_answer"
+msgstr "The KLIMA token and protocol lives on the Polygon blockchain. MATIC is the “gas” that powers every transaction on Polygon. It is not possible to execute a transaction without paying the transaction fee. This means you will need to pay a few cents worth of MATIC for the following actions:"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:685
+msgid "infinity.cta_title"
+msgstr "The next-generation carbon toolkit for your organization"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:648
+msgid "infinity.faq_answer3"
+msgstr "The objective of carbon markets is to reduce greenhouse gas (GHG, or “carbon”) emissions cost-effectively by setting limits on emissions and enabling the trading of emission units, which are financial instruments representing emission reductions. Trading enables entities that can reduce emissions at lower cost to be paid to do so by higher-cost emitters, thus lowering the economic cost of reducing emissions."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:381
+msgid "infinity.polygon_manifesto_title"
+msgstr "The offset is part of Polygon's Green Manifesto"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:83
+msgid "disclaimer.the_service_available"
+msgstr "The service available in or accessible through the service are provided “As is” and, to the fullest extent permissible pursuant to applicable law. KlimaDAO and its agents, advisors, directors, officers, employees and shareholders disclaim all warranties, express or implied, including, but not limited to, implied warranties of merchantability, fitness for a particular purpose and non-infrigement, and warranties implied from a course of performance or course of dealing. KlimaDAO does not make any warranties about the completeness, reliability and accuracy of this information, warranty of merchantability or fitness for a particular purpose. This platform does not make any warranties about the completeness and accuracy of this information."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:183
+msgid "infinity.info_subtitle2"
+msgstr "The world's most powerful and easy-to-use offsetting solution"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:51
+msgid "buy.how_to_paragraph_part_2"
+msgstr "This is a short tutorial for beginners who are new to Web3 and DeFi"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:244
+msgid "retirement.single.disclaimer"
+msgstr "This represents the permanent retirement of tokenized carbon assets on the Polygon blockchain. This retirement and the associated data are immutable public records."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:30
+msgid "retirement.single.no_pledge"
+msgstr "This user has not created a pledge"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:98
+msgid "pledge.modal.unable_to_edit"
+msgstr "This wallet does not have permission to edit this pledge. To edit, you must reconnect with the original author wallet ({0})."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:70
+msgid "pledge.invitation.error.wallet_already_pinned"
+msgstr "This wallet is already pinned to another pledge. Please unpin your wallet and try again."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:273
+msgid "community.toughtforfood_logo"
+msgstr "Thought for Food logo"
+
+#. To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you.
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:143
+msgid "contact.bug_reports.to_file_a_bug_report"
+msgstr "To file a bug report, join our community Discord server and ask your question in the #bug-reports channel. Someone in our <0>community</0> will be happy to investigate and find a solution for you."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/Cards/Card.tsx:66
+#: components/pages/Infinity/index.tsx:407
+#: components/pages/Infinity/index.tsx:421
+msgid "infinity.tonnes"
+msgstr "Tonnes"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/FootprintCard/index.tsx:94
+msgid "pledges.dashboard.footprint.tonnes"
+msgstr "Tonnes"
+
+#. TONNES OF <0>CARBON HELD</0> BY KLIMADAO
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:286
+msgid "home.tonnes_of_carbon_held_by_klimadao"
+msgstr "TONNES OF <0>CARBON HELD</0> BY KLIMADAO"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:414
+msgid "infinity.box_title2"
+msgstr "Total Carbon Retired"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/RetirementsCard/index.tsx:123
+msgid "pledges.dashboard.retirements.total_tonnes_retired"
+msgstr "Total Carbon Tonnes Retired"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:103
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr "Total Carbon Tonnes Retired"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:579
+msgid "pledges.form.input.totalFootprint.label"
+msgstr "Total footprint"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:52
+msgid "pledges.form.total_footprint_summary"
+msgstr "Total Footprint: {0} Carbon Tonnes"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:117
+msgid "retirement.totals.total_retirement_transactions"
+msgstr "Total Retirement Transactions"
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:164
+msgid "community.toucan_logo"
+msgstr "Toucan logo"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:292
+msgid "infinity.getStarted_third_subtitle"
+msgstr "Track your commitment, and amplify awareness around your Climate Positive actions."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:196
+msgid "infinity.transparent_subtitle"
+msgstr "Transparent"
+
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:233
+msgid "home.transparent_and_efficient"
+msgstr "Transparent and efficient"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Home/index.tsx:105
+msgid "home.transparent_neutral"
+msgstr "Transparent, neutral, public resources to accelerate climate finance on a global scale."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:135
+msgid "retirement.head.metaDescription"
+msgstr "Transparent, on-chain offsets powered by KlimaDAO."
+
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:132
+msgid "community.tree_grove"
+msgstr "Tree grove"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:107
+msgid "pledge.modal.unpin_wallet"
+msgstr "unpin my wallet"
+
+#. Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>.
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:88
+msgid "contact.partnerships.until_we_finish_building"
+msgstr "Until we finish building out our partnerships page, we are directing potential partnership and collaboration inquiries to <0>this contact form</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:31
+msgid "resources.head.metaDescription"
+msgstr "Updates and thought leadership from the founders, DAO contributors, advisors and community."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/index.tsx:46
+msgid "resources.page.header.subline"
+msgstr "Updates and thought leadership from the founders, DAO contributors, advisors and community."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:147
+msgid "buy.load_wallet_description1"
+msgstr "Use a service like <0>MoonPay</0> or <1>Transak</1> or a centralized exchange like <2>Coinbase</2> to buy Polygon MATIC and send it to your newly created wallet."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BuyKlima/index.tsx:30
+msgid "retirement.footer.buy_klima.text"
+msgstr "Use carbon-backed KLIMA tokens to govern, swap, and earn staking rewards— then use those rewards to offset your emissions!"
+
+#. Use this <0>Media Request Form</0>.
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:117
+msgid "contact.media.use_this_media_request_form"
+msgstr "Use this <0>Media Request Form</0> or send an email to <1>press@klimadao.finance</1>"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:196
+#: components/pages/Pledge/InvitationModals/RemoveModal/index.tsx:182
+msgid "pledge.invitations.signature_instructions"
+msgstr "Use your wallet to sign and confirm this edit."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:607
+msgid "pledges.form.use_your_wallet"
+msgstr "Use your wallet to sign and confirm this edit."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:87
+msgid "resources.list.filter.tag.user_guides"
+msgstr "User Guides"
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:20
+msgid "connect_modal.error_message_refused"
+msgstr "User refused connection."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:360
+msgid "buy.question_why_matic_answer_bullet4"
+msgstr "Using KLIMA or other tokens to offset carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:315
+msgid "retirement.single.view_on_polygon_scan"
+msgstr "View on Polygonscan"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ViewPledgeButton/index.tsx:18
+msgid "retirement.single.view_pledge"
+msgstr "View Pledge"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/index.tsx:72
+msgid "pledges.home.hero.view"
+msgstr "View your pledge"
+
+#. js-lingui-explicit-id
 #: components/pages/Infinity/index.tsx:512
 msgid "shared.visit_klimadao_blog"
 msgstr "Visit the KlimaDAO Blog"
 
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:204
+msgid "buy.wallet_connect_example"
+msgstr "wallet connect input example"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:221
+#: components/pages/Buy/index.tsx:267
+msgid "buy.wallet_connect_example_qr_code"
+msgstr "wallet connect qr code example"
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:16
+msgid "connect_modal.error_message_default"
+msgstr "We had some trouble connecting. Please try again."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:189
+msgid "disclaimer.we_recommend_that_you_visit"
+msgstr "We recommend that you visit our Crypto Security 101 page for safety instructions before the use of the website. Please, take into consideration: never share your private key or seed phrase with anyone – neither our members nor our app will ever ask for or request this from you."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Community/index.tsx:119
+msgid "community.we_work_with_traditionnal"
+msgstr "We work with traditional carbon market players, crypto platforms, corporations and everyone in-between."
+
+#. Long We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!
+#. js-lingui-explicit-id
+#: components/pages/About/Contact/index.tsx:66
+msgid "contact.careers.we_re_hiring"
+msgstr "We're a fully remote team hiring across all time zones. We regularly post roles and bounties in our <0>Community Discord Server</0>. If you’re a self-starter who's motivated to join a purpose driven DAO, we'd love to hear from you!"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:305
+msgid "pledges.form.input.profileWebsiteUrl.label"
+msgstr "Website (Optional)"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:428
+msgid "buy.question_exchange"
+msgstr "What if I want to use a different exchange, but they don't sell Polygon MATIC?"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:316
+msgid "pledges.form.input.description.placeholder"
+msgstr "What is your pledge?"
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:468
+msgid "pledges.form.input.methodology.placeholder"
+msgstr "What tools or methodologies did you use to calculate your carbon footprint?"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:128
+msgid "buy.create_wallet_description3"
+msgstr "When you are connected, you should see your new wallet address in the top left corner of the app."
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:603
+msgid "infinity.faq_answer2_paragraph2"
+msgstr "When you purchase a carbon credit, Klima Infinity enables you to retire this carbon credit, permanently removing it from circulation. This retirement is the point at which you can claim the benefit of the carbon offset."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:236
+msgid "buy.connect_torus_sushi_description4"
+msgstr "When you return to the Sushi tab in your browser, you should see that your Torus address is now visible in the top-right corner."
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:402
+msgid "buy.bond_question_cex"
+msgstr "Why can't I find KLIMA on Coinbase or other centralized exchanges? Why do I have to use <0>Sushi.com</0>?"
+
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:323
+msgid "buy.question_why_matic"
+msgstr "Why do I have to buy MATIC first?"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:216
+msgid "infinity.why_title"
+msgstr "Why KlimaDAO?"
+
+#. js-lingui-explicit-id
+#: components/pages/Infinity/index.tsx:331
+msgid "infinity.carousel_image_description"
+msgstr "Wind power project at Jaibhim, India"
+
+#. js-lingui-explicit-id
 #: components/Navigation/index.tsx:127
 #: components/Navigation/index.tsx:256
 msgid "shared.wrap"
 msgstr "Wrap sKlima"
 
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr "Connect with your browser web3 provider"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/Cards/PledgeCard/index.tsx:14
+msgid "pledges.dashboard.pledge.default_text"
+msgstr "Write your pledge today!"
 
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr "Easy one-click wallet by Torus"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:391
+msgid "buy.bond_answer_cedit_card"
+msgstr "Yes, some on-ramp providers like <0>Transak</0> allow you to buy KLIMA directly with a credit card, for a fee. However, if your wallet doesn't have MATIC, you won't be able to transfer or perform other actions. For this reason, and to guarantee the best market rate, we recommend buying MATIC directly instead, and swapping your MATIC for KLIMA on Sushi.com."
 
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr "Email or Social"
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/About/Disclaimer/index.tsx:144
+msgid "disclaimer.you_bear_full_responsibility"
+msgstr "You bear full responsibility for providing of private information, verifying the identity and legitimacy. Notwithstanding indicators and messages that suggest providing the private information and verification, KlimaDAO makes no claims about the identity on the platform. We cannot guarantee the security of any data that disclose online, and for sustained casualties due to vulnerability or any kind of failure, abnormal behavior of software."
 
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr "Scan with WalletConnect to connect"
+#. js-lingui-explicit-id
+#: components/pages/Buy/index.tsx:302
+msgid "buy.staking_description2"
+msgstr "You can also use the app to spend KLIMA and <0>retire digital carbon</0> on the blockchain."
 
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr "Scan with Coinbase to connect"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/lib/formSchema.ts:90
+msgid "pledges.form.errors.walletAddress.isOwner"
+msgstr "You cannot add the pledge owner"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:62
-msgid "{trimCurrentSupply} Tonnes remaining"
-msgstr "{trimCurrentSupply} Tonnes remaining"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeForm/index.tsx:191
+msgid "pledge.form.error.cannot_add_yourself"
+msgstr "You cannot add your own wallet as a secondary wallet"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/List/index.tsx:57
-msgid "{trimTotalRetired} Tonnes retired in total"
-msgstr "{trimTotalRetired} Tonnes retired in total"
+#. js-lingui-explicit-id
+#: components/pages/Pledge/InvitationModals/AcceptModal/index.tsx:141
+msgid "pledge.modal.wallet_add_confirm"
+msgstr "You may only have one pledge page per wallet address. If you have already created a pledge page with this wallet, visitors will be redirected to this pledge instead. You can remove this wallet at any time."
+
+#. js-lingui-explicit-id
+#: components/pages/Pledge/PledgeDashboard/index.tsx:186
+msgid "pledges.form.title"
+msgstr "Your pledge"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/lib/cmsDataMap.ts:163
+msgid "resources.list.sort_by.z-a"
+msgstr "Z-A"


### PR DESCRIPTION
## Description

This PR introduces a new feature banner which should only be visible on the marketplace homepage - `/projects`. The main functionality is described in the main #1993 ticket.

## Related Ticket

Closes #1993 

## Notes For QA

* [x] On load of the marketplace, a new feature banner should slide down from the top and show the initial banner
       - QA should test that the banner matches the figma designs
       - QA should test that clicking "Let's Go" brings the user to the retire via bank transfer form.
       - QA should test that clicking on "Learn More" brings the user to the following blog [post](https://carbonmark-git-makka-1993-new-feature-banner-klimadao.vercel.app/blog/carbonmark-now-accepts-bank-transfer-as-a-payment-method)
       - QA should test that clicking on the close (x) button should show the updated banner i.e. the banner containing the text and two buttons - "Sure" and "Don't Remind Me".
* [x] After navigating to the retire via bank transfer form and returning to the marketplace, the user should be presented with an updated banner which contains updated text and two buttons - "Sure" and "Don't Remind Me".
       - QA should test that when clicking "Sure" the banner slides up and is hidden for the current session. The user should be able to navigate around the site and the banner shouldn't appear. However, if the user opens a new tab and navigates to the marketplace, they should be presented with the initial banner in the new tab session.
       - QA should test that when clicking "Don't Remind Me" that the banner slides up and is completely hidden. Upon opening a new tab and navigating to the marketplace, the user shouldn't be presented with the banner again.

Specific pages, components or journeys that might be affected:
- Projects View