### PR TITLE
[APP] Incrementing PROD_URL api version to 5.2.0

### DIFF
--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -28,7 +28,7 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-export const API_PROD_URL = "https://v5.0.0.api.carbonmark.com";
+export const API_PROD_URL = "https://v5.2.0.api.carbonmark.com";
 
 /**
  * Optional preview URL can be provided via env var.


### PR DESCRIPTION
## Description

Increments Carbonmark prod url version to 5.2.0

This version has an updated marketplace subgraph id

NOTE: currently failing the carbonmark check as I believe the front end can't find the deployed 5.2.0 version. Will undraft when this is resolved.


## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->
Specific pages, components or journeys that might be affected:
-  Profile/Portfolio

