### PR TITLE
Fix Filters credits for vintage discovery for polygon-digital-carbon subgraph

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
+++ b/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
@@ -4385,7 +4385,7 @@ export const PoolFragmentFragmentDoc = gql`
 export const GetDigitalCarbonProjectsVintagesDocument = gql`
     query getDigitalCarbonProjectsVintages {
   carbonProjects(first: 1000) {
-    carbonCredits {
+    carbonCredits(where: {currentSupply_not: "0"}) {
       vintage
     }
   }

--- a/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
+++ b/carbonmark-api/src/.generated/types/digitalCarbon.types.ts
@@ -4385,7 +4385,7 @@ export const PoolFragmentFragmentDoc = gql`
 export const GetDigitalCarbonProjectsVintagesDocument = gql`
     query getDigitalCarbonProjectsVintages {
   carbonProjects(first: 1000) {
-    carbonCredits(where: {currentSupply_not: "0"}) {
+    carbonCredits(where: {currentSupply_not: "0", isExAnte: false}) {
       vintage
     }
   }

--- a/carbonmark-api/src/app.constants.ts
+++ b/carbonmark-api/src/app.constants.ts
@@ -10,7 +10,7 @@ const GRAPH_API_ROOT_ID = "https://api.thegraph.com/subgraphs/id";
  * This is also the case for SANITY_URLS
  */
 const POLYGON_URLS = {
-  marketplace: `${GRAPH_API_ROOT_ID}/QmdDsUGwLLkzsFmXneaNc13BS43v8wFZL7vDTqWK4YZp1Z`,
+  marketplace: `${GRAPH_API_ROOT_ID}/QmXrzcwG5b31hE1nDzT5NCAiHfM9stwMLqs8uk9enJiyPf`,
   assets: `${GRAPH_API_ROOT}/cujowolf/klima-refi-current-holdings`,
   tokens: `${GRAPH_API_ROOT}/klimadao/klimadao-pairs`,
   digitalCarbon: `${GRAPH_API_ROOT}/klimadao/polygon-digital-carbon`,
@@ -18,7 +18,7 @@ const POLYGON_URLS = {
 
 const MUMBAI_URLS = {
   ...POLYGON_URLS,
-  marketplace: `${GRAPH_API_ROOT_ID}/QmdrYranfueu9Ann3kYCkEKTmTRReusybzFZ2nYz8YM6WF`,
+  marketplace: `${GRAPH_API_ROOT_ID}/QmUUnZTeRnfsJsQaTwLeiHmAQ5xvtk2jBW7VeP3AEW5bnv`,
 };
 
 /** Sanity URLS */

--- a/carbonmark-api/src/graphql/digitalCarbon.gql
+++ b/carbonmark-api/src/graphql/digitalCarbon.gql
@@ -1,6 +1,6 @@
 query getDigitalCarbonProjectsVintages {
   carbonProjects(first: 1000) {
-    carbonCredits(where: { currentSupply_not: "0" }) {
+    carbonCredits(where: { currentSupply_not: "0", isExAnte: false }) {
       vintage
     }
   }

--- a/carbonmark-api/src/graphql/digitalCarbon.gql
+++ b/carbonmark-api/src/graphql/digitalCarbon.gql
@@ -1,6 +1,6 @@
 query getDigitalCarbonProjectsVintages {
   carbonProjects(first: 1000) {
-    carbonCredits {
+    carbonCredits(where: { currentSupply_not: "0" }) {
       vintage
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -589,7 +589,7 @@
     },
     "carbonmark-api": {
       "name": "@klimadao/carbonmark-api",
-      "version": "5.0.0",
+      "version": "5.2.1",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",


### PR DESCRIPTION
## Description

Filters credits on currentsupply > 0 and exAnte=false  for polygon-digital-carbon subgraph for vintage discovery

See https://discord.com/channels/1135827610434289727/1135829064465264650/1196817534675066950

I could add these filters to the projects filters queries but I prefered to be cautious.

## Related Ticket

Also related to #2129 

## Notes For QA

* [x] This PR is low-risk or narrow in scope, QA is not needed.

Specific pages, components or journeys that might be affected:
- 