### PR TITLE
Make the carbonmark use API version 5.2.1

### DIFF
--- a/carbonmark/.generated/carbonmark-api-sdk/clients/getListingsId.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/clients/getListingsId.ts
@@ -1,0 +1,25 @@
+import type { ResponseConfig } from "../client";
+import client from "../client";
+import type {
+  GetListingsIdPathParams,
+  GetListingsIdQueryParams,
+  GetListingsIdQueryResponse,
+} from "../types/GetListingsId";
+
+/**
+ * @description Get a listing by its identifier
+ * @summary Listing
+ * @link /listings/:id */
+export async function getListingsId(
+  id: GetListingsIdPathParams["id"],
+  params?: GetListingsIdQueryParams,
+  options: Partial<Parameters<typeof client>[0]> = {}
+): Promise<ResponseConfig<GetListingsIdQueryResponse>["data"]> {
+  const res = await client<GetListingsIdQueryResponse>({
+    method: "get",
+    url: `/listings/${id}`,
+    params,
+    ...options,
+  });
+  return res.data;
+}

--- a/carbonmark/.generated/carbonmark-api-sdk/clients/getPurchases.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/clients/getPurchases.ts
@@ -8,18 +8,16 @@ import type {
 /**
  * @description Retrieve a list of recent purchases
  * @summary Recent purchases
- * @link /purchases
- */
-export async function getPurchases<TData = GetPurchasesQueryResponse>(
+ * @link /purchases */
+export async function getPurchases(
   params?: GetPurchasesQueryParams,
   options: Partial<Parameters<typeof client>[0]> = {}
-): Promise<ResponseConfig<TData>["data"]> {
-  const { data: resData } = await client<TData>({
+): Promise<ResponseConfig<GetPurchasesQueryResponse>["data"]> {
+  const res = await client<GetPurchasesQueryResponse>({
     method: "get",
     url: `/purchases`,
     params,
     ...options,
   });
-
-  return resData;
+  return res.data;
 }

--- a/carbonmark/.generated/carbonmark-api-sdk/clients/index.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/clients/index.ts
@@ -1,6 +1,7 @@
 export * from "./getActivities";
 export * from "./getCategories";
 export * from "./getCountries";
+export * from "./getListingsId";
 export * from "./getProjects";
 export * from "./getProjectsId";
 export * from "./getProjectsIdActivity";

--- a/carbonmark/.generated/carbonmark-api-sdk/clients/operations.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/clients/operations.ts
@@ -7,6 +7,7 @@ export const operations = {
   get_purchases: { path: "/purchases", method: "get" },
   post_users: { path: "/users", method: "post" },
   get_vintages: { path: "/vintages", method: "get" },
+  "get_listings-id": { path: "/listings/:id", method: "get" },
   "post_login-verify": { path: "/login/verify", method: "post" },
   "get_projects-id": { path: "/projects/:id", method: "get" },
   "get_purchases-id": { path: "/purchases/:id", method: "get" },

--- a/carbonmark/.generated/carbonmark-api-sdk/hooks/index.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from "./useGetActivities";
 export * from "./useGetCategories";
 export * from "./useGetCountries";
+export * from "./useGetListingsId";
 export * from "./useGetProjects";
 export * from "./useGetProjectsId";
 export * from "./useGetProjectsIdActivity";

--- a/carbonmark/.generated/carbonmark-api-sdk/hooks/useGetListingsId.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/hooks/useGetListingsId.ts
@@ -1,0 +1,78 @@
+import type { SWRConfiguration, SWRResponse } from "swr";
+import useSWR from "swr";
+import client from "../client";
+import type {
+  GetListingsIdPathParams,
+  GetListingsIdQueryParams,
+  GetListingsIdQueryResponse,
+} from "../types/GetListingsId";
+
+type GetListingsIdClient = typeof client<
+  GetListingsIdQueryResponse,
+  never,
+  never
+>;
+type GetListingsId = {
+  data: GetListingsIdQueryResponse;
+  error: never;
+  request: never;
+  pathParams: GetListingsIdPathParams;
+  queryParams: GetListingsIdQueryParams;
+  headerParams: never;
+  response: GetListingsIdQueryResponse;
+  client: {
+    parameters: Partial<Parameters<GetListingsIdClient>[0]>;
+    return: Awaited<ReturnType<GetListingsIdClient>>;
+  };
+};
+export function getListingsIdQueryOptions<
+  TData extends GetListingsId["response"] = GetListingsId["response"],
+  TError = GetListingsId["error"],
+>(
+  id: GetListingsIdPathParams["id"],
+  params?: GetListingsId["queryParams"],
+  options: GetListingsId["client"]["parameters"] = {}
+): SWRConfiguration<TData, TError> {
+  return {
+    fetcher: async () => {
+      const res = await client<TData, TError>({
+        method: "get",
+        url: `/listings/${id}`,
+        params,
+        ...options,
+      });
+      return res.data;
+    },
+  };
+}
+/**
+ * @description Get a listing by its identifier
+ * @summary Listing
+ * @link /listings/:id */
+export function useGetListingsId<
+  TData extends GetListingsId["response"] = GetListingsId["response"],
+  TError = GetListingsId["error"],
+>(
+  id: GetListingsIdPathParams["id"],
+  params?: GetListingsId["queryParams"],
+  options?: {
+    query?: SWRConfiguration<TData, TError>;
+    client?: GetListingsId["client"]["parameters"];
+    shouldFetch?: boolean;
+  }
+): SWRResponse<TData, TError> {
+  const {
+    query: queryOptions,
+    client: clientOptions = {},
+    shouldFetch = true,
+  } = options ?? {};
+  const url = `/listings/${id}` as const;
+  const query = useSWR<TData, TError, [typeof url, typeof params] | null>(
+    shouldFetch ? [url, params] : null,
+    {
+      ...getListingsIdQueryOptions<TData, TError>(id, params, clientOptions),
+      ...queryOptions,
+    }
+  );
+  return query;
+}

--- a/carbonmark/.generated/carbonmark-api-sdk/schemas/Listing.json
+++ b/carbonmark/.generated/carbonmark-api-sdk/schemas/Listing.json
@@ -73,7 +73,8 @@
         "country",
         "methodology"
       ]
-    }
+    },
+    "symbol": { "description": "Symbol of the token", "type": "string" }
   },
   "required": [
     "id",

--- a/carbonmark/.generated/carbonmark-api-sdk/schemas/Project.json
+++ b/carbonmark/.generated/carbonmark-api-sdk/schemas/Project.json
@@ -207,6 +207,10 @@
                   "country",
                   "methodology"
                 ]
+              },
+              "symbol": {
+                "description": "Symbol of the token",
+                "type": "string"
               }
             },
             "required": [

--- a/carbonmark/.generated/carbonmark-api-sdk/schemas/User.json
+++ b/carbonmark/.generated/carbonmark-api-sdk/schemas/User.json
@@ -92,7 +92,8 @@
               "country",
               "methodology"
             ]
-          }
+          },
+          "symbol": { "description": "Symbol of the token", "type": "string" }
         },
         "required": [
           "id",

--- a/carbonmark/.generated/carbonmark-api-sdk/types/GetListingsId.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/types/GetListingsId.ts
@@ -1,4 +1,17 @@
-export type Listing = {
+import type { Def1 } from "./Def1";
+
+export type GetListingsIdPathParams = {
+  /**
+   * @description The listing id
+   * @type string
+   */
+  id: string;
+};
+
+/**
+ * @description Successful response
+ */
+export type GetListingsIdQueryResponse = {
   /**
    * @description Unique listing identifier
    * @type string
@@ -91,3 +104,12 @@ export type Listing = {
    */
   symbol?: string;
 };
+
+export type GetListingsIdQueryParams = {
+  network?: Def1;
+};
+export namespace GetListingsIdQuery {
+  export type Response = GetListingsIdQueryResponse;
+  export type PathParams = GetListingsIdPathParams;
+  export type QueryParams = GetListingsIdQueryParams;
+}

--- a/carbonmark/.generated/carbonmark-api-sdk/types/GetProjects.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/types/GetProjects.ts
@@ -228,6 +228,11 @@ export type GetProjectsQueryResponse = {
            */
           methodology: string;
         };
+        /**
+         * @description Symbol of the token
+         * @type string | undefined
+         */
+        symbol?: string;
       }[]
     | null;
   /**

--- a/carbonmark/.generated/carbonmark-api-sdk/types/GetProjectsId.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/types/GetProjectsId.ts
@@ -236,6 +236,11 @@ export type GetProjectsIdQueryResponse = {
            */
           methodology: string;
         };
+        /**
+         * @description Symbol of the token
+         * @type string | undefined
+         */
+        symbol?: string;
       }[]
     | null;
   /**

--- a/carbonmark/.generated/carbonmark-api-sdk/types/GetPurchases.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/types/GetPurchases.ts
@@ -78,3 +78,7 @@ export type GetPurchasesQueryResponse = {
 export type GetPurchasesQueryParams = {
   network?: Def1;
 };
+export namespace GetPurchasesQuery {
+  export type Response = GetPurchasesQueryResponse;
+  export type QueryParams = GetPurchasesQueryParams;
+}

--- a/carbonmark/.generated/carbonmark-api-sdk/types/GetUsersWalletorhandle.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/types/GetUsersWalletorhandle.ts
@@ -121,6 +121,11 @@ export type GetUsersWalletorhandleQueryResponse = {
        */
       methodology: string;
     };
+    /**
+     * @description Symbol of the token
+     * @type string | undefined
+     */
+    symbol?: string;
   }[];
   /**
    * @type array | undefined

--- a/carbonmark/.generated/carbonmark-api-sdk/types/Project.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/types/Project.ts
@@ -221,6 +221,11 @@ export type Project = {
            */
           methodology: string;
         };
+        /**
+         * @description Symbol of the token
+         * @type string | undefined
+         */
+        symbol?: string;
       }[]
     | null;
   /**

--- a/carbonmark/.generated/carbonmark-api-sdk/types/User.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/types/User.ts
@@ -108,6 +108,11 @@ export type User = {
        */
       methodology: string;
     };
+    /**
+     * @description Symbol of the token
+     * @type string | undefined
+     */
+    symbol?: string;
   }[];
   /**
    * @type array | undefined

--- a/carbonmark/.generated/carbonmark-api-sdk/types/index.ts
+++ b/carbonmark/.generated/carbonmark-api-sdk/types/index.ts
@@ -7,6 +7,7 @@ export * from "./Def1";
 export * from "./GetActivities";
 export * from "./GetCategories";
 export * from "./GetCountries";
+export * from "./GetListingsId";
 export * from "./GetProjects";
 export * from "./GetProjectsId";
 export * from "./GetProjectsIdActivity";

--- a/carbonmark/.generated/carbonmark-api.schema.json
+++ b/carbonmark/.generated/carbonmark-api.schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Carbonmark REST API",
-    "description": "\nWelcome to the API Reference docs for **version 5.0.2** of the Carbonmark REST API.\n\nUse this API to view assets, prices, supply, activity and more.\n\nLooking for the latest version? Visit our [GitHub Releases page](https://github.com/KlimaDAO/klimadao/releases).\n\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v5.0.2.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
+    "description": "\nWelcome to the API Reference docs for **version 5.2.1** of the Carbonmark REST API.\n\nUse this API to view assets, prices, supply, activity and more.\n\nLooking for the latest version? Visit our [GitHub Releases page](https://github.com/KlimaDAO/klimadao/releases).\n\n## Quick start\nBe sure to prefix a version number, otherwise your application will be exposed to breaking changes.\n\n~~~ts\nconst res = await fetch(\"https://v5.2.1.api.carbonmark.com/projects\");\nconst projects = await res.json();\n~~~\n\nFor a developer guides and example implementations, or to learn more about Carbonmark and Digital Carbon Market, view our product knowledge base at <a href=\"https://docs.carbonmark.com\">docs.carbonmark.com</a>.\n## \n",
     "termsOfService": "https://www.carbonmark.com/blog/terms-of-use",
     "contact": {
       "name": "Support",
@@ -12,7 +12,7 @@
       "name": "MIT",
       "url": "https://github.com/KlimaDAO/klimadao/blob/main/LICENSE"
     },
-    "version": "5.0.2"
+    "version": "5.2.1"
   },
   "components": {
     "schemas": {
@@ -444,6 +444,10 @@
                         "country",
                         "methodology"
                       ]
+                    },
+                    "symbol": {
+                      "description": "Symbol of the token",
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -850,6 +854,10 @@
               "country",
               "methodology"
             ]
+          },
+          "symbol": {
+            "description": "Symbol of the token",
+            "type": "string"
           }
         },
         "required": [
@@ -1265,6 +1273,10 @@
                     "country",
                     "methodology"
                   ]
+                },
+                "symbol": {
+                  "description": "Symbol of the token",
+                  "type": "string"
                 }
               },
               "required": [
@@ -2536,6 +2548,10 @@
                                     "country",
                                     "methodology"
                                   ]
+                                },
+                                "symbol": {
+                                  "description": "Symbol of the token",
+                                  "type": "string"
                                 }
                               },
                               "required": [
@@ -2921,6 +2937,244 @@
                     "2020"
                   ]
                 ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/listings/{id}": {
+      "get": {
+        "summary": "Listing",
+        "tags": [
+          "Listing"
+        ],
+        "description": "Get a listing by its identifier",
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/def-1"
+            },
+            "in": "query",
+            "name": "network",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "example": "0xde5c717958a9a80f2dee8ebcc6f411a8d860ac7b0042e45487f4ad2afaf46d5a",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "The listing id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Marketplace listing with per-tonne price and project info.",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "description": "Unique listing identifier",
+                      "type": "string"
+                    },
+                    "leftToSell": {
+                      "description": "Remaining supply. Unformatted 18 decimal string",
+                      "type": "string"
+                    },
+                    "tokenAddress": {
+                      "description": "Address of the asset being sold",
+                      "type": "string"
+                    },
+                    "singleUnitPrice": {
+                      "description": "USDC price per tonne. Unformatted 6 decimal string. e.g. 1000000",
+                      "type": "string"
+                    },
+                    "totalAmountToSell": {
+                      "type": "string"
+                    },
+                    "active": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deleted": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "batches": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "batchPrices": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "createdAt": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "updatedAt": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "seller": {
+                      "type": "object",
+                      "properties": {
+                        "handle": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "username": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "profileImgUrl": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    "expiration": {
+                      "description": "Unix Timestamp (seconds) when the listing expires.",
+                      "type": "number"
+                    },
+                    "minFillAmount": {
+                      "description": "Minimum quantity for purchase transaction to succeed.",
+                      "type": "string"
+                    },
+                    "project": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "vintage": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "category": {
+                          "type": "string"
+                        },
+                        "country": {
+                          "type": "string"
+                        },
+                        "methodology": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "key",
+                        "vintage",
+                        "name",
+                        "category",
+                        "country",
+                        "methodology"
+                      ]
+                    },
+                    "symbol": {
+                      "description": "Symbol of the token",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "leftToSell",
+                    "tokenAddress",
+                    "singleUnitPrice",
+                    "totalAmountToSell",
+                    "seller",
+                    "expiration",
+                    "minFillAmount",
+                    "project"
+                  ]
+                }
               }
             }
           }
@@ -3462,6 +3716,10 @@
                                   "country",
                                   "methodology"
                                 ]
+                              },
+                              "symbol": {
+                                "description": "Symbol of the token",
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -3966,6 +4224,10 @@
                               "country",
                               "methodology"
                             ]
+                          },
+                          "symbol": {
+                            "description": "Symbol of the token",
+                            "type": "string"
                           }
                         },
                         "required": [
@@ -4529,7 +4791,7 @@
   },
   "servers": [
     {
-      "url": "https://v5.0.2.api.carbonmark.com"
+      "url": "https://v5.2.1.api.carbonmark.com"
     }
   ],
   "externalDocs": {

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -28,7 +28,7 @@ const SHORT_COMMIT_HASH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(
 );
 
 /** When incrementing this API version, be sure to update TypeScript types to reflect API changes */
-export const API_PROD_URL = "https://v5.0.0.api.carbonmark.com";
+export const API_PROD_URL = "https://v5.2.1.api.carbonmark.com";
 
 /**
  * Optional preview URL can be provided via env var.


### PR DESCRIPTION
## Description

Makes the carbonmark use API version 5.2.1

## Related Ticket

Partialy solves
#2129

## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->
Specific pages, components or journeys that might be affected:
- Search the marketplace for projects by vintage

Relevant preview URLs:
- https://carbonmark-git-biwano-carbonmarkuseapi521-klimadao.vercel.app/fr/projects?layout=grid&sort=recently-updated
