### PR TITLE
[api] Support both images and externalMedia media from cms projects

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/carbonmark-api/src/.generated/types/cms.types.ts
+++ b/carbonmark-api/src/.generated/types/cms.types.ts
@@ -990,7 +990,7 @@ export type StringFilter = {
   nin: InputMaybe<Array<Scalars['String']>>;
 };
 
-export type CmsProjectFragmentFragment = { __typename?: 'Project', country: string | null, description: string | null, name: string | null, region: string | null, registry: string | null, url: string | null, registryProjectId: string | null, id: string | null, geolocation: { __typename?: 'Geopoint', lat: number | null, lng: number | null, alt: number | null } | null, methodologies: Array<{ __typename?: 'Methodology', category: string | null, name: string | null, id: string | null } | null> | null };
+export type CmsProjectFragmentFragment = { __typename?: 'Project', country: string | null, description: string | null, name: string | null, region: string | null, registry: string | null, url: string | null, registryProjectId: string | null, id: string | null, geolocation: { __typename?: 'Geopoint', lat: number | null, lng: number | null, alt: number | null } | null, methodologies: Array<{ __typename?: 'Methodology', category: string | null, name: string | null, id: string | null } | null> | null, externalMedia: Array<{ __typename?: 'ExternalFile', uri: string | null, description: string | null } | null> | null };
 
 export type CmsProjectContentFragmentFragment = { __typename?: 'ProjectContent', shortDescription: string | null, longDescription: string | null, project: { __typename?: 'Project', registry: string | null, registryProjectId: string | null } | null, coverImage: { __typename?: 'Image', asset: { __typename?: 'SanityImageAsset', url: string | null } | null } | null, images: Array<{ __typename?: 'Image', asset: { __typename?: 'SanityImageAsset', url: string | null, label: string | null, title: string | null, altText: string | null } | null } | null> | null };
 
@@ -1000,7 +1000,7 @@ export type GetCmsProjectQueryVariables = Exact<{
 }>;
 
 
-export type GetCmsProjectQuery = { __typename?: 'RootQuery', allProject: Array<{ __typename?: 'Project', country: string | null, description: string | null, name: string | null, region: string | null, registry: string | null, url: string | null, registryProjectId: string | null, id: string | null, geolocation: { __typename?: 'Geopoint', lat: number | null, lng: number | null, alt: number | null } | null, methodologies: Array<{ __typename?: 'Methodology', category: string | null, name: string | null, id: string | null } | null> | null }> };
+export type GetCmsProjectQuery = { __typename?: 'RootQuery', allProject: Array<{ __typename?: 'Project', country: string | null, description: string | null, name: string | null, region: string | null, registry: string | null, url: string | null, registryProjectId: string | null, id: string | null, geolocation: { __typename?: 'Geopoint', lat: number | null, lng: number | null, alt: number | null } | null, methodologies: Array<{ __typename?: 'Methodology', category: string | null, name: string | null, id: string | null } | null> | null, externalMedia: Array<{ __typename?: 'ExternalFile', uri: string | null, description: string | null } | null> | null }> };
 
 export type GetCmsProjectContentQueryVariables = Exact<{
   registry: Scalars['String'];
@@ -1013,7 +1013,7 @@ export type GetCmsProjectContentQuery = { __typename?: 'RootQuery', allProjectCo
 export type GetAllCmsProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAllCmsProjectsQuery = { __typename?: 'RootQuery', allProject: Array<{ __typename?: 'Project', country: string | null, description: string | null, name: string | null, region: string | null, registry: string | null, url: string | null, registryProjectId: string | null, id: string | null, geolocation: { __typename?: 'Geopoint', lat: number | null, lng: number | null, alt: number | null } | null, methodologies: Array<{ __typename?: 'Methodology', category: string | null, name: string | null, id: string | null } | null> | null }> };
+export type GetAllCmsProjectsQuery = { __typename?: 'RootQuery', allProject: Array<{ __typename?: 'Project', country: string | null, description: string | null, name: string | null, region: string | null, registry: string | null, url: string | null, registryProjectId: string | null, id: string | null, geolocation: { __typename?: 'Geopoint', lat: number | null, lng: number | null, alt: number | null } | null, methodologies: Array<{ __typename?: 'Methodology', category: string | null, name: string | null, id: string | null } | null> | null, externalMedia: Array<{ __typename?: 'ExternalFile', uri: string | null, description: string | null } | null> | null }> };
 
 export type GetAllCmsProjectContentQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1040,6 +1040,10 @@ export const CmsProjectFragmentFragmentDoc = gql`
   registry
   url
   registryProjectId
+  externalMedia {
+    uri
+    description
+  }
 }
     `;
 export const CmsProjectContentFragmentFragmentDoc = gql`

--- a/carbonmark-api/src/graphql/cms.fragments.gql
+++ b/carbonmark-api/src/graphql/cms.fragments.gql
@@ -17,6 +17,10 @@ fragment CMSProjectFragment on Project {
   registry
   url
   registryProjectId
+  externalMedia {
+    uri
+    description
+  }
 }
 
 fragment CMSProjectContentFragment on ProjectContent {

--- a/carbonmark-api/src/routes/projects/get.utils.ts
+++ b/carbonmark-api/src/routes/projects/get.utils.ts
@@ -98,6 +98,28 @@ const getActivePoolPrices = (prices: TokenPriceT[], minSupply?: number) => {
   return prices.filter((price) => Number(price.supply) > (minSupply || 0));
 };
 
+// Filter out video links as CM currently does not support
+
+type CarbonProjectImage = {
+  caption: string;
+  url: string;
+};
+
+type CarbonProjectExternalMedia = {
+  caption: string;
+  url: string;
+};
+
+type MediaItem = CarbonProjectImage | CarbonProjectExternalMedia;
+
+const filterVideo = (media: MediaItem) => {
+  return (
+    !media.url.includes("youtube") &&
+    !media.url.includes("youtu.be") &&
+    !media.url.includes("vimeo")
+  );
+};
+
 /**
  * Builds a project entry given data fetched from various sources
  * project data:
@@ -194,10 +216,19 @@ export const buildProjectEntry = (props: {
     long_description: c?.longDescription,
     url: c?.url,
     images:
-      c?.images?.map((image) => ({
-        caption: image?.asset?.altText || "",
-        url: image?.asset?.url || "",
-      })) ?? [],
+      c?.images
+        ?.map((image) => ({
+          caption: image?.asset?.altText || "",
+          url: image?.asset?.url || "",
+        }))
+        .filter(filterVideo) ||
+      c?.externalMedia
+        ?.map((image) => ({
+          caption: image?.description || "",
+          url: image?.uri || "",
+        }))
+        .filter(filterVideo) ||
+      [],
     location: toGeoJSON(c?.geolocation),
     // Pool specific data
     prices: activePoolPrices,


### PR DESCRIPTION
## Description

Project media can appear in two different sources from the cms. 

In order of preference, from `images` on the allProject query. 

The second option is from `externalMedia` on allProjectContent. This PR fetches from both in that order of preference. 

**This PR also filters out any youtube or video links as CM does currently not support them.**

ICR project page with images:

<img width="697" alt="Screen Shot 2024-01-22 at 2 04 33 PM" src="https://github.com/KlimaDAO/klimadao/assets/72105234/33d4ae37-b17d-4069-9a45-5436350cbe1e">

## Notes For QA
Specific pages, components or journeys that might be affected:
- Individual project pages