### PR TITLE
[api] Remove ICR artifacts 

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/carbonmark-api/src/.generated/types/icr.types.ts
+++ b/carbonmark-api/src/.generated/types/icr.types.ts
@@ -1656,13 +1656,6 @@ export type ExPostAmountsFragmentFragment = { __typename?: 'ExPostHolder', id: a
 
 export type ExPostFragmentFragment = { __typename?: 'ExPost', tokenId: string, vintage: string, serialization: string, project: { __typename?: 'Project', id: any, projectName: string } };
 
-export type GetExPostInfoViaSerializationQueryVariables = Exact<{
-  serialization: Scalars['String'];
-}>;
-
-
-export type GetExPostInfoViaSerializationQuery = { __typename?: 'Query', exPosts: Array<{ __typename?: 'ExPost', serialization: string, supply: string, retiredAmount: string, estimatedAmount: string, cancelledAmount: string, id: any, lastVerificationTimestamp: string, tokenId: string, verificationPeriodEnd: string, verificationPeriodStart: string, vintage: string, project: { __typename?: 'Project', id: any, projectAddress: any, projectName: string, transactionHash: any } }> };
-
 export type GetHoldingsByAddressQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
@@ -1700,26 +1693,6 @@ export const ExPostAmountsFragmentFragmentDoc = gql`
   }
 }
     ${ExPostFragmentFragmentDoc}`;
-export const GetExPostInfoViaSerializationDocument = gql`
-    query getExPostInfoViaSerialization($serialization: String!) {
-  exPosts(where: {serialization: $serialization}) {
-    serialization
-    supply
-    retiredAmount
-    estimatedAmount
-    cancelledAmount
-    id
-    lastVerificationTimestamp
-    project {
-      ...ICRProjectFragment
-    }
-    tokenId
-    verificationPeriodEnd
-    verificationPeriodStart
-    vintage
-  }
-}
-    ${IcrProjectFragmentFragmentDoc}`;
 export const GetHoldingsByAddressDocument = gql`
     query getHoldingsByAddress($id: ID!) {
   holder(id: $id) {
@@ -1738,9 +1711,6 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    getExPostInfoViaSerialization(variables: GetExPostInfoViaSerializationQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetExPostInfoViaSerializationQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetExPostInfoViaSerializationQuery>(GetExPostInfoViaSerializationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getExPostInfoViaSerialization', 'query');
-    },
     getHoldingsByAddress(variables: GetHoldingsByAddressQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetHoldingsByAddressQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetHoldingsByAddressQuery>(GetHoldingsByAddressDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getHoldingsByAddress', 'query');
     }

--- a/carbonmark-api/src/graphql/icr.gql
+++ b/carbonmark-api/src/graphql/icr.gql
@@ -1,22 +1,3 @@
-query getExPostInfoViaSerialization($serialization: String!) {
-  exPosts(where: { serialization: $serialization }) {
-    serialization
-    supply
-    retiredAmount
-    estimatedAmount
-    cancelledAmount
-    id
-    lastVerificationTimestamp
-    project {
-      ...ICRProjectFragment
-    }
-    tokenId
-    verificationPeriodEnd
-    verificationPeriodStart
-    vintage
-  }
-}
-
 query getHoldingsByAddress($id: ID!) {
   holder(id: $id) {
     id

--- a/carbonmark-api/src/models/Project.model.ts
+++ b/carbonmark-api/src/models/Project.model.ts
@@ -42,7 +42,6 @@ export const ProjectModel = Type.Object({
   ),
   hasSupply: Type.Boolean(),
   tokenId: Type.Optional(Type.String()),
-  serialization: Type.Optional(Type.String()),
 });
 
 export type Project = Static<typeof ProjectModel>;

--- a/carbonmark-api/src/models/Purchase.model.ts
+++ b/carbonmark-api/src/models/Purchase.model.ts
@@ -43,9 +43,6 @@ export const PurchaseModel = Type.Object({
       vintage: Type.String({
         examples: ["2008"],
       }),
-      serialization: Type.Optional(
-        Type.String({ examples: ["ICR-ISL-354-78040-14-R-0-2021"] })
-      ),
     }),
   }),
   price: Type.String({


### PR DESCRIPTION
## Description

In the original version of the ICR integration, ICR's project credit`serialization` was the only reliable way to query the ICR api for a specific project.

After the refactor to use the cms for project data, the serialization is only needed to create the `registry-registryProjectID` format to identify the project when querying the ICR subgraph for ICR holdings. The serialization can be removed everywhere else.

In the app, besides generated files, the serialization only exists as a prop in carbonmark/lib/createUrls and will be deleted there for the APP PR for this api version. 

The end goal is not to use the serialization anywhere in the CM codebase. Once we can query ICR holdings from a CM subgraph this last requirement can be removed.

## Related Ticket

related to [2093](https://github.com/KlimaDAO/klimadao/issues/2093)

