### PR TITLE
[api] Fix `listings` endpoint for ICR

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "5.3.1",
+  "version": "5.3.4",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "5.3.3",
+  "version": "5.3.1",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/carbonmark-api/src/utils/helpers/listings.utils.ts
+++ b/carbonmark-api/src/utils/helpers/listings.utils.ts
@@ -44,7 +44,14 @@ export const getListingById = async (sdk: GQL_SDK, id: string) => {
     return null;
   }
 
-  const symbol = (await getTokenById(sdk, listing.tokenAddress)).symbol;
+  let symbol;
+
+  if (listing.project.id.startsWith("ICR")) {
+    symbol = listing.project.id;
+  } else {
+    symbol = (await getTokenById(sdk, listing.tokenAddress)).symbol;
+  }
+
   const formattedListing = formatListing(listing);
   return { ...formattedListing, symbol };
 };


### PR DESCRIPTION
## Description

Fixes listings endpoint for ICR listings.

The core issue is that the listings endpoint queried the `digital-carbon` subgraph for the token symbol on `Token` entity. Currently no ICR tokens are listed in the subgraph as `Tokens`. Ideally, unless ICR token don't qualify as `Tokens`, these should be added so there is no conditional logic in the endpoint.

## Related Ticket

Closes #2177

### Test preview ICR listing

https://carbonmark-api-git-fix-listings-endpoint-fetche-c1b9ef-klimadao.vercel.app/listings/0xe2d23df10da8679d3a0af644a4778d66c7d78c5c9c1540805ae1b3c6bf208e09
