### PR TITLE
Explicitly set the tag on creation of a release

### DIFF
--- a/.github/workflows/release_carbonmark_api.yml
+++ b/.github/workflows/release_carbonmark_api.yml
@@ -98,7 +98,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: carbonmark-api/${{ env.RELEASE_VERSION }}
           release_name: carbonmark-api-${{ env.RELEASE_VERSION }}
           body: ${{ env.RELEASE_NOTES }}
           draft: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "prettier.requireConfig": true,


### PR DESCRIPTION
## Description
There is a `staging` tag being created sporadically which is causing conflicts when git is looking up the `staging` branch.

I believe it is being cause by teh `deploy-carbonmark-api.yml` workflow.

Possible explanation:
1. introduced the ability to create releases by incrementing package.json version
2. the release action was setup assuming that it was always triggered by creation of a tag
3. it was using ${{ github.ref }} to identify the tag, which in the case of changing the package.json it was just staging

This PR uses the RELEASE_VERSION rather than github.ref

Last PR that created a `staging` tag: https://github.com/KlimaDAO/klimadao/actions/runs/7612748363/job/20731019927

![image](https://github.com/KlimaDAO/klimadao/assets/7104689/c60a7902-7adc-4856-931b-e82c0a3cf85e)
