### PR TITLE
API release 5.3.6

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -588,7 +588,7 @@
     },
     "carbonmark-api": {
       "name": "@klimadao/carbonmark-api",
-      "version": "5.3.5",
+      "version": "5.3.6",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",


### PR DESCRIPTION
## Description

Release version 5.3.6 of the API. This is because my last update went through without a PR and did not trigger a release

## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->
Specific pages, components or journeys that might be affected:
- 

Relevant preview URLs:
- 

Other notes:
- 
