### PR TITLE
Fix NBO default pool project in the API

### DIFF
--- a/carbonmark-api/package.json
+++ b/carbonmark-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klimadao/carbonmark-api",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "An API for exploring Carbonmark project data, prices and activity.",
   "main": "app.ts",
   "scripts": {

--- a/carbonmark-api/src/routes/projects/get.constants.ts
+++ b/carbonmark-api/src/routes/projects/get.constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_POOL_PROJECT_TOKENS = {
-  nbo: "0xb6ea7a53fc048d6d3b80b968d696e39482b7e578",
+  nbo: "0xd28dfeba8fb9e44b715156162c8b6076d7a95ad1",
   ubo: "0xd6ed6fae5b6535cae8d92f40f5ff653db807a4ea",
   bct: "0xb139c4cc9d20a3618e9a2268d73eff18c496b991",
   nct: "0x6362364a37f34d39a1f4993fb595dab4116daf0d",

--- a/carbonmark/lib/api/client.ts
+++ b/carbonmark/lib/api/client.ts
@@ -46,14 +46,21 @@ export const fetchClient = async <
 ): Promise<ResponseConfig<TData>> => {
   const params = request.params as ParamsObject;
   const url = `${urls.api.base}${request.url}${serializeParams(params)}`;
-  const response = await fetch(url, {
-    method: request.method,
-    body: JSON.stringify(request.data),
-    headers: {
-      "Content-Type": "application/json",
-      ...request.headers,
-    },
-  });
+  let response;
+  try {
+    response = await fetch(url, {
+      method: request.method,
+      body: JSON.stringify(request.data),
+      headers: {
+        "Content-Type": "application/json",
+        ...request.headers,
+      },
+    });
+  } catch (e) {
+    console.error(`Fetch error: ${url}`);
+    throw e;
+  }
+
   if (!response.ok) {
     const errorData = await response.json();
     throw {

--- a/package-lock.json
+++ b/package-lock.json
@@ -588,7 +588,7 @@
     },
     "carbonmark-api": {
       "name": "@klimadao/carbonmark-api",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",


### PR DESCRIPTION
## Description

- Changes NBO default pool project in the API
- Also adds logging on fetch errors to troubleshoot Vercel deployment issues

<!--
  The original ticket should describe what is being fixed or changed.
  If the original ticket is not descriptive enough, please update it.

  The PR description should provide more context and help the reviewer understand the reasoning behind your changes.

  Screenshots highly encouraged!
-->

## Related Ticket

Related to #2091 
Related to #2224

## How to Test
<!--
 Please provide a short description of how a reviewer can confirm the changes
-->

1.  curl https://carbonmark-api-git-biwano-fix2091apipoolproject-klimadao.vercel.app/projects/VCS-875-2015
2. Check isPoolDefault is true for nbo

## Notes For QA

* [x] This PR is low-risk or narrow in scope, QA is not needed.

