### PR TITLE
Conditional Copy for 1155 Approvals

### DIFF
--- a/carbonmark/components/CreateListing/Transaction/Approve.tsx
+++ b/carbonmark/components/CreateListing/Transaction/Approve.tsx
@@ -13,6 +13,7 @@ interface Props {
   amount: string;
   onApproval: () => void;
   onSuccess: () => void;
+  isERC1155: boolean;
   status: TransactionStatusMessage | null;
 }
 
@@ -48,9 +49,9 @@ export const Approve: FC<Props> = (props) => {
         <Text t="body1">
           <strong>
             <Trans>
-              The allowance below reflects the sum of all your listings for this
-              specific token. For ICR credit tokens, the allowance will reflect
-              the sum of all your ICR token listings.
+              {props.isERC1155
+                ? "For ICR credit tokens, the allowance allows Carbonmark to transact any of your ICR credits."
+                : "The allowance below reflects the sum of all your listings for this specific token."}
             </Trans>
           </strong>
         </Text>

--- a/carbonmark/components/CreateListing/Transaction/Approve.tsx
+++ b/carbonmark/components/CreateListing/Transaction/Approve.tsx
@@ -50,7 +50,7 @@ export const Approve: FC<Props> = (props) => {
           <strong>
             <Trans>
               {props.isERC1155
-                ? "For ICR credit tokens, the allowance allows Carbonmark to transact any of your ICR credits."
+                ? "This allowance enables Carbonmark to transact with any of your ICR credits."
                 : "The allowance below reflects the sum of all your listings for this specific token."}
             </Trans>
           </strong>

--- a/carbonmark/components/CreateListing/Transaction/index.tsx
+++ b/carbonmark/components/CreateListing/Transaction/index.tsx
@@ -22,6 +22,7 @@ interface Props {
   allowance: string;
   /** Quantity to list for */
   quantity: string;
+  isERC1155: boolean;
 }
 
 export const Transaction: FC<Props> = (props) => {
@@ -64,6 +65,7 @@ export const Transaction: FC<Props> = (props) => {
             props.onResetStatus();
             setView("submit");
           }}
+          isERC1155={props.isERC1155}
           status={props.status}
         />
       )}

--- a/carbonmark/components/CreateListing/index.tsx
+++ b/carbonmark/components/CreateListing/index.tsx
@@ -197,6 +197,7 @@ export const CreateListing: FC<Props> = (props) => {
             setStatus(null);
             setCurrentAllowance(null); // this will hide the Transaction View and re-checks the allowance again
           }}
+          isERC1155={!!inputValues?.tokenId}
         />
       )}
 

--- a/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/ListingEditable.tsx
@@ -207,7 +207,6 @@ export const ListingEditable: FC<Props> = (props) => {
           </Listing>
         </div>
       ))}
-
       <Modal
         title={t`Edit listing`}
         showModal={!!listingToEdit}
@@ -265,6 +264,8 @@ export const ListingEditable: FC<Props> = (props) => {
               setStatus(null);
               setCurrentAllowance(null); // this will hide the Transaction View and re-checks the allowance again
             }}
+            // @todo change to !!listingToEdit?.tokenStandard === "ERC1155" when marketplace subgraph with tokenStandard is merged
+            isERC1155={!!listingToEdit?.project.id.startsWith("ICR")}
           />
         )}
       </Modal>


### PR DESCRIPTION
## Description

Approvals for 1155 tokens work on an all-or-nothing basis, all tokens and balances or none.  The copy for approvals now reflects this. It does not show for ERC20 approvals.

## Related Ticket

Closes #1989 

## How to Test

Create a listing with an ICR credit

## Notes For QA
The previous copy was actually incorrect. It's not the sum of your ICR credit listings, it's the max allowance for all tokens.

