### PR TITLE
Fix/Hydration Error with Profile Logo

### DIFF
--- a/carbonmark/components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx
@@ -36,10 +36,13 @@ const RetirementCardItem = (props: {
       <Text t="body3" color="lightest" uppercase={true}>
         {props.title}
       </Text>
-      <Text t="body1" color="lightest" className={styles.iconAndText}>
+      <div className={styles.iconAndText}>
+        {" "}
         {props.icon}
-        {props.text}
-      </Text>
+        <Text t="body1" color="lightest">
+          {props.text}
+        </Text>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Noticed while working on another issue, the profile logo was placed inside a `<Text>` component which caused a hydration error