### PR TITLE
[ICR listing] Fix update listing minFillAmount for different decimals

### DIFF
--- a/carbonmark/lib/actions.ts
+++ b/carbonmark/lib/actions.ts
@@ -274,6 +274,9 @@ export const updateListingTransaction = async (params: {
     const amount = params.projectId.startsWith("ICR")
       ? params.newAmount
       : parseUnits(params.newAmount, 18);
+    const minFillAmount = params.projectId.startsWith("ICR")
+      ? DEFAULT_MIN_FILL_AMOUNT.toString()
+      : parseUnits(DEFAULT_MIN_FILL_AMOUNT.toString(), 18);
     const listingTxn = await carbonmarkContract.updateListing(
       params.listingId,
       amount,
@@ -281,7 +284,7 @@ export const updateListingTransaction = async (params: {
         trimWithLocale(params.singleUnitPrice, 6),
         getTokenDecimals("usdc")
       ),
-      parseUnits(DEFAULT_MIN_FILL_AMOUNT.toString(), 18), // minFillAmount
+      minFillAmount, // minFillAmount
       getExpirationTimestamp(DEFAULT_EXPIRATION_DAYS) // deadline (aka expiration)
     );
 


### PR DESCRIPTION
## Description

The updateListing function was parsing the default min fill amount (1) for every update. This is correct for ERC20s but incorrect for ICR credits. 

This issue has now been addressed on the contract level as well and breaking minFillAmounts (if a min fill is > than the actual amount) will revert.  To correct this issue on the frontend so that the correct params are passed the default min fill needs to be adjusted for different decimal amounts.

The next iteration will format these amounts by registry similar to #2237 for the api versus using ternaries.

## How to Test

1. Update an ICR credit listing with either a price or quantity change
2. The update transaction should successfully update without any contract errors or reverts


