### PR TITLE
cm: web3 hook returns lowercase address

### DIFF
--- a/lib/utils/useProvider/index.tsx
+++ b/lib/utils/useProvider/index.tsx
@@ -150,7 +150,7 @@ export const useProvider = (
       const newState: ConnectedWeb3State = {
         provider,
         signer,
-        address,
+        address: address.toLowerCase(),
         network,
         networkLabel: isTestnetChainId(network.chainId) ? "mumbai" : "polygon",
         isConnected: true,


### PR DESCRIPTION
## Description

The useWeb3 hook is returning a checksum address while the subgraph returns only lowercase addresses.

This is causing a mismatch in several areas where hooks are not returning the correct listings, which leads to allowance errors etc.

There should either be consistency to checksum or lowercase.  Given the subgraph only uses lowercase it would probably be better to have that be the st

## Related Ticket

Closes <issue-number>
Also related to <issue-number>

## How to Test
<!--
 Pleas eprovide a shrot description of how a reviewer can confirm the changes
-->

1. _step1_
2. _step2_
3. _step3_

## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->
Specific pages, components or journeys that might be affected:
- 

Relevant preview URLs:
- 

Other notes:
- 
