### PR TITLE
Add asset detail component to listing purchase pages

### DIFF
--- a/carbonmark/components/pages/Project/Purchase/Listing/PurchaseForm.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Listing/PurchaseForm.tsx
@@ -1,5 +1,6 @@
 import { useWeb3 } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
+import { AssetDetails } from "components/AssetDetails";
 import { Card } from "components/Card";
 import { Text } from "components/Text";
 import { Col, TwoColLayout } from "components/TwoColLayout";
@@ -204,6 +205,14 @@ export const PurchaseForm: FC<Props> = (props) => {
             <TotalValues
               singleUnitPrice={props.listing.singleUnitPrice}
               balance={balance}
+            />
+          </Card>
+          <Card>
+            <AssetDetails
+              product={{ ...props.listing, type: "listing" }}
+              project={props.project}
+              actionLabel={t`Token you will receive`}
+              availableLabel={t`Available to purchase`}
             />
           </Card>
           <SubmitButton


### PR DESCRIPTION
## Description

Adds the asset component to listing purchase pages.

## Related Ticket

Closes #2018

## How to Test

1. _step1_
2. _step2_
3. _step3_

## Notes For QA
<!--

* [x] This PR is low-risk or narrow in scope, QA is not needed.

-->
Specific pages, components or journeys that might be affected:
- 

Relevant preview URLs:
- 

Other notes:
- 
