### PR TITLE
[provenance] fix layout issues with GridContainer

### DIFF
--- a/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx
@@ -60,7 +60,7 @@ export const ProvenanceComponent = (props: ProvenanceComponentProps) => {
             <BalanceOutlined fontSize="large" />
             <Trans>Amount</Trans>
           </Text>
-          <Text t="h5">
+          <Text t="h5" align="end">
             <Trans>{formattedAmount} Tonnes</Trans>
           </Text>
         </div>

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/styles.ts
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@emotion/css";
+import breakpoints from "@klimadao/lib/theme/breakpoints";
 
 export const timeline = css`
   max-width: 56rem;
@@ -10,8 +11,12 @@ export const timeline = css`
 export const timelineItem = css`
   overflow: hidden;
   min-height: auto;
-  min-width: 56rem;
   transition: max-height 0.2s;
+  min-width: max-content;
+
+  ${breakpoints.desktop} {
+    min-width: 56rem;
+  }
 `;
 
 export const timelineItemVisible = css`
@@ -29,7 +34,11 @@ export const content = css`
   flex-direction: column;
   gap: 1.2rem;
   white-space: nowrap;
-  min-width: 48rem;
+  min-width: max-content;
+
+  ${breakpoints.desktop} {
+    min-width: 48rem;
+  }
 `;
 
 export const contentHeader = css`

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/styles.ts
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/styles.ts
@@ -6,6 +6,12 @@ export const timeline = css`
   position: relative;
   left: -5rem;
   oveflow: visible;
+
+  li {
+    &:before {
+      flex: unset;
+    }
+  }
 `;
 
 export const timelineItem = css`
@@ -34,7 +40,7 @@ export const content = css`
   flex-direction: column;
   gap: 1.2rem;
   white-space: nowrap;
-  min-width: max-content;
+  max-width: 48rem;
 
   ${breakpoints.desktop} {
     min-width: 48rem;

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/index.tsx
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/index.tsx
@@ -37,7 +37,7 @@ export const RetirementProvenancePage: NextPage<
   const provenanceList = splitProvenance(props.provenance);
 
   return (
-    <GridContainer>
+    <GridContainer className={styles.pageWrapper}>
       <PageHead
         title={t({
           id: "retirement.provenance.head.title",

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/styles.ts
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/styles.ts
@@ -1,6 +1,10 @@
 import { css } from "@emotion/css";
 import breakpoints from "@klimadao/lib/theme/breakpoints";
 
+export const pageWrapper = css`
+  display: unset;
+`;
+
 export const section = css`
   padding-bottom: 3.6rem;
   display: flex;

--- a/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/index.tsx
@@ -70,7 +70,7 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
 
   if (!retirement) {
     return (
-      <GridContainer>
+      <GridContainer className={styles.pageWrapper}>
         <Navigation activePage="Home" />
         <Section className={styles.section}>
           <div className={styles.pending}>
@@ -115,7 +115,7 @@ export const SingleRetirementPage: NextPage<SingleRetirementPageProps> = ({
   const tokenData = carbonTokenInfoMap[carbonTokenName];
 
   return (
-    <GridContainer>
+    <GridContainer className={styles.pageWrapper}>
       <PageHead
         title={t({
           id: "retirement.head.title",

--- a/carbonmark/components/pages/Retirements/SingleRetirement/styles.ts
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/styles.ts
@@ -1,6 +1,10 @@
 import { css } from "@emotion/css";
 import breakpoints from "@klimadao/lib/theme/breakpoints";
 
+export const pageWrapper = css`
+  display: unset;
+`;
+
 export const section = css`
   padding-bottom: 3.6rem;
   ${breakpoints.desktop} {

--- a/carbonmark/components/pages/Retirements/index.tsx
+++ b/carbonmark/components/pages/Retirements/index.tsx
@@ -34,7 +34,7 @@ export const RetirementPage: NextPage<Props> = (props) => {
   const concattedAddress = concatAddress(beneficiaryAddress);
 
   return (
-    <GridContainer>
+    <GridContainer className={styles.pageWrapper}>
       <PageHead
         title={t({
           id: "retirement.totals.head.title",

--- a/carbonmark/components/pages/Retirements/styles.ts
+++ b/carbonmark/components/pages/Retirements/styles.ts
@@ -2,6 +2,10 @@ import { css } from "@emotion/css";
 import breakpoints from "@klimadao/lib/theme/breakpoints";
 import * as typography from "@klimadao/lib/theme/typography";
 
+export const pageWrapper = css`
+  display: unset;
+`;
+
 export const section = css`
   padding-bottom: 0;
   ${breakpoints.medium} {


### PR DESCRIPTION
## Description

`GridContainer` is used for the page layouts and after the recent navigation changes, the page layout has changed. Grid container by default is setting `display: grid`, in this instance using `display: unset` resolves the page issues. 

Note: I'd like to relook at these pages that use GridContainer in a follow up ticket and see can they now be replaced with the `Container` component from material-ui. I've briefly checked if it works, it does apart from the footer needs some work to  span the full screen.

## Related Ticket

Closes #2273

## How to Test

1. Ensure the layout isn't breaking on desktop/mobile.
2. Ensure the retirements page layout is also working as expected.

## Screenshots:

<img width="1512" alt="Screenshot 2024-02-15 at 15 33 20" src="https://github.com/KlimaDAO/klimadao/assets/92357475/b30012ad-5954-4fe3-b3db-cc7ac23014b2">

<img width="367" alt="Screenshot 2024-02-15 at 15 33 34" src="https://github.com/KlimaDAO/klimadao/assets/92357475/91690b2b-69d3-447a-8712-5fff1560360c">


