### PR TITLE
[Carbonmark] Fix retire from listing quantites

### DIFF
--- a/carbonmark/lib/actions.retire.ts
+++ b/carbonmark/lib/actions.retire.ts
@@ -216,17 +216,24 @@ export const retireCarbonTransaction = async (params: {
 
     let txn;
     if (params.product.type === "listing") {
+      const isICR = params.product.project.id.startsWith("ICR");
+      const leftToSell = isICR
+        ? params.product.leftToSell
+        : parseUnits(params.product.leftToSell, 18);
+      const quantity = isICR
+        ? params.quantity
+        : parseUnits(params.quantity, 18);
+
       txn = await retireContract.retireCarbonmarkListing(
         [
           params.product.id,
           params.product.seller.id,
           params.product.tokenAddress,
-          parseUnits(params.product.leftToSell, 18),
+          leftToSell,
           parseUnits(params.product.singleUnitPrice, getTokenDecimals("usdc")),
         ],
         parsedMaxAmountIn,
-        // TODO: ICR tokens have zero decimal places
-        parseUnits(params.quantity, 18),
+        quantity,
         "",
         params.beneficiaryAddress || params.address,
         params.beneficiaryName,


### PR DESCRIPTION
## Description

The original values for ICR were passing parsed values which led to the contract rejecting the quantities.

These values have been adjusted for ICR credits.


## How to Test
<!--
 Pleas eprovide a shrot description of how a reviewer can confirm the changes
-->

1. `Retire Now` from one of these listings: https://www.carbonmark.com/projects/ICR-112-2019
2.  The txn should complete successfully