### PR TITLE
[klima data] make sort icons visible

### DIFF
--- a/carbon/components/charts/helpers/DataTable/VerticalTableHeader/index.tsx
+++ b/carbon/components/charts/helpers/DataTable/VerticalTableHeader/index.tsx
@@ -52,7 +52,14 @@ export default function VerticalTableHeader<P>(props: {
       Element =
         props.sortParams.sort_order == "asc" ? ExpandLessIcon : ExpandMoreIcon;
     }
-    return <Element onClick={() => setSortParamsWrapper(key)} />;
+
+    return (
+      <Element
+        role="button"
+        className={styles.sortIcon}
+        onClick={() => setSortParamsWrapper(key)}
+      />
+    );
   }
 
   return (
@@ -61,7 +68,7 @@ export default function VerticalTableHeader<P>(props: {
         {columnKeys.map((key) => (
           <th key={key} className={columns[key].cellStyle}>
             <span className={styles.cell}>
-              {columns[key].header}
+              <span>{columns[key].header}</span>
               {(columns[key].sortable === undefined || columns[key].sortable) &&
                 sortButtonComponent(key)}
             </span>

--- a/carbon/components/charts/helpers/DataTable/VerticalTableHeader/styles.module.scss
+++ b/carbon/components/charts/helpers/DataTable/VerticalTableHeader/styles.module.scss
@@ -1,5 +1,9 @@
 .cell {
   display: flex;
   align-items: center;
-  width: fit-content;
+  gap: 0.8rem;
+}
+
+.sortIcon {
+  cursor: pointer;
 }


### PR DESCRIPTION
## Description

This PR makes the sort icons in the table headers on klima data visible.

<!--
  The original ticket should describe what is being fixed or changed.
  If the original ticket is not descriptive enough, please update it.

  The PR description should provide more context and help the reviewer understand the reasoning behind your changes.

  Screenshots highly encouraged!
-->

## Related Ticket

Closes #2196 

See https://carbon-git-2196-make-sort-icons-visible-klimadao.vercel.app/de/retirement-trends