### PR TITLE
2159 reenable fiat for icr

### DIFF
--- a/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
@@ -76,8 +76,7 @@ export const RetireForm: FC<Props> = (props) => {
   const [costs, setCosts] = useState("");
 
   const { product } = props;
-  const defaultPaymentMethod: CarbonmarkPaymentMethod =
-    props.project.registry.startsWith("ICR") ? "usdc" : "fiat";
+  const defaultPaymentMethod: CarbonmarkPaymentMethod = "fiat";
 
   const methods = useForm<FormValues>({
     mode: "onChange",
@@ -339,11 +338,6 @@ export const RetireForm: FC<Props> = (props) => {
     }
   }, [retirementBlockNumber]);
 
-  const permittedPaymentMethods: Array<CarbonmarkPaymentMethod> =
-    props.project.registry.startsWith("ICR")
-      ? CarbonmarkPaymentMethods.filter((method) => method !== "fiat")
-      : Array.from(CarbonmarkPaymentMethods);
-
   return (
     <FormProvider {...methods}>
       <TwoColLayout>
@@ -362,7 +356,7 @@ export const RetireForm: FC<Props> = (props) => {
                 address={address}
                 fiatAmountError={fiatAmountError}
                 approvalValue={getApprovalValue()}
-                enabledPaymentMethods={permittedPaymentMethods}
+                enabledPaymentMethods={Array.from(CarbonmarkPaymentMethods)}
               />
               <SubmitButton
                 onSubmit={onContinue}

--- a/carbonmark/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx
@@ -97,7 +97,7 @@ export const ProjectDetails: FC<Props> = (props) => {
             href={
               isMossOffset
                 ? "https://mco2token.moss.earth/"
-                : `${carbonmarkUrls.projects}/${props.retirement.retire?.credit.project.projectID}-${props.retirement.retire?.credit.vintage}`
+                : `${carbonmarkUrls.projects}/${props.retirement.retire?.credit.project.id}-${props.retirement.retire?.credit.vintage}`
             }
           >
             {t`Learn More`}

--- a/carbonmark/components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx
+++ b/carbonmark/components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx
@@ -57,7 +57,7 @@ export const TransactionDetails: FC<Props> = (props) => (
               <Text t="button" color="lightest" uppercase>
                 <Trans id="retirement.single.project.title">Project:</Trans>
               </Text>
-              <Text>{props.retirement.retire.credit.project.projectID}</Text>
+              <Text>{props.retirement.retire.credit.project.id}</Text>
             </div>
           )}
           {props.retirement?.retire?.credit?.project && (


### PR DESCRIPTION
## Description

Fiat payments were disabled for ICR projects. Now that offsetra supports ICR, we can re-enable fiat payments for ICR projects with this PR.

## Related Ticket

Closes #2159 

## How to Test
<!--
 Pleas eprovide a shrot description of how a reviewer can confirm the changes
-->

1. Open an ICR listing
2. Choose 1 tonne
3. Choose credit card payment
4. Use this card: `4242 4242 4242 4242`, expiry `02/22`, CVC: `222`