### PR TITLE
[provenance] 2281 Fix provenance page bugs

### DIFF
--- a/app/locale/de/messages.po
+++ b/app/locale/de/messages.po
@@ -6,10 +6,156 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:239
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:170
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:16
+msgid "shared.404"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:84
 msgid "Acknowledge and Accept"
 msgstr "Bestätigen und akzeptieren"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
+msgstr ""
 
 #: components/TransactionModal/Approve.tsx:93
 #: components/views/Bond/index.tsx:454
@@ -18,9 +164,90 @@ msgstr "Bestätigen und akzeptieren"
 msgid "Approve"
 msgstr "Genehmigen"
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:47
+msgid "shared.balances"
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
 msgstr "Guthaben"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
+msgstr ""
 
 #: components/views/Redeem/index.tsx:25
 msgid "Buy & Redeem Carbon"
@@ -30,27 +257,303 @@ msgstr "CO2-Tokens kaufen und freistellen"
 msgid "Buy Carbon"
 msgstr "CO2 kaufen"
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr ""
+
 #: components/views/Bond/index.tsx:697
 msgid "Capacity"
 msgstr "Kapazität"
 
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
-msgstr "Menge angeben"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:56
+msgid "shared.change_language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:432
+#: components/views/PKlima/index.tsx:165
+#: components/views/Wrap/index.tsx:220
+msgid "shared.confirming"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:259
+#: components/views/Stake/index.tsx:268
+msgid "shared.enter_amount"
+msgstr ""
 
 #: components/views/Stake/index.tsx:242
 #: components/views/Wrap/index.tsx:212
 msgid "Enter quantity"
 msgstr "Menge eingeben"
 
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr "Menge angeben"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:475
+#: components/views/Bond/index.tsx:494
+#: components/views/Stake/index.tsx:276
+#: components/views/Wrap/index.tsx:247
+msgid "shared.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
 #: components/views/Offset/index.tsx:45
 msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
 msgstr "Nutzerinnen und Nutzer, die ihren CO2-Fußabdruck mit einem Pool-Token ausgleichen möchten, können <0>diese Seite</0> verwenden."
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
+msgstr ""
 
 #: components/views/Stake/index.tsx:247
 #: components/views/Wrap/index.tsx:225
 msgid "Insufficient balance"
 msgstr "Unzureichendes Guthaben"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:47
 msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
@@ -75,26 +578,119 @@ msgstr "Guthaben wird geladen..."
 msgid "Loading..."
 msgstr "Lade..."
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr ""
+
 #: components/views/Home/index.tsx:178
 msgid "Login"
 msgstr "Login"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:397
+#: components/views/Buy/index.tsx:65
+#: components/views/Home/index.tsx:154
+#: components/views/PKlima/index.tsx:149
+#: components/views/Stake/index.tsx:229
+#: components/views/Wrap/index.tsx:199
+msgid "shared.login_connect"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:39
 msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 msgstr "Investitionsverlust: Der Wert von $KLIMA und anderen Kryptowährungen kann jederzeit schnell steigen oder fallen. Infolgedessen könnten Sie erhebliche und schnelle Verluste erleiden, einschließlich des Verlusts des gesamten investierten Geldes."
 
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
-msgstr "Keine Garantien: Es gibt keine Garantie dafür, dass die KlimaDAO-Plattform oder der $KLIMA-Token ihre Ziele erreichen oder dass irgendein Wert im Protokoll erhalten bleibt."
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:605
+#: components/views/PKlima/index.tsx:239
+#: components/views/Stake/index.tsx:372
+#: components/views/Wrap/index.tsx:346
+msgid "shared.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:168
 msgid "No balances found."
 msgstr "Kein Guthaben gefunden."
 
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr "Keine Garantien: Es gibt keine Garantie dafür, dass die KlimaDAO-Plattform oder der $KLIMA-Token ihre Ziele erreichen oder dass irgendein Wert im Protokoll erhalten bleibt."
+
 #: components/CarbonBalancesCard/index.tsx:131
 #: components/CarbonTonnesRetiredCard/index.tsx:29
 msgid "Not Connected"
 msgstr "Nicht verbunden"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
+msgstr ""
 
 #: components/views/Offset/index.tsx:27
 msgid "Offset"
@@ -108,847 +704,441 @@ msgstr "Am 12. April haben wir unsere URL von \"dapp\" auf \"app\" geändert. Ak
 msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 msgstr "Betriebsrisiken: Die KlimaDAO-Plattform basiert auf verschiedenen Technologien im Zusammenhang mit dem Polygon-Netzwerk und anderen digitalen Assets. Diese Technologien unterliegen Änderungen und solche Änderungen könnten sich negativ auf Ihre Investition auswirken."
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:32
 msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
 msgstr "Der Kauf von Kryptowährungen, einschließlich des $KLIMA-Tokens, birgt ein hohes Risiko und sollte als äußerst spekulativ betrachtet werden. Hier sind einige wichtige Punkte, die Sie beachten sollten:"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:53
 msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
 msgstr "Regulatorische Maßnahmen und Änderungen: Das regulatorische Umfeld für Kryptowährungen entwickelt sich weiter und Änderungen in der Regulierung könnten sich negativ auf Ihre Investition auswirken."
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:924
+msgid "bond.unredeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:40
+msgid "connect_modal.error_processing"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:29
 msgid "Risk Disclaimer"
 msgstr "Haftungsausschluss"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:405
+msgid "shared.sold_out"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:335
+msgid "stake.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:258
+#: components/views/Stake/index.tsx:306
+#: components/views/Stake/index.tsx:471
+msgid "stake.stake_klima"
+msgstr ""
+
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
+msgstr ""
 
 #: components/InvalidNetworkModal/index.tsx:72
 msgid "Switch to Polygon"
 msgstr "Zu Polygon wechseln"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:68
 msgid "This app only works on Polygon Mainnet."
 msgstr "Die App funktioniert nur im Polygon-Mainnet."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:75
 msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
 msgstr "In dieser zusammenfassenden Risikowarnung werden nicht alle Risiken offengelegt, die mit einer Investition in $KLIMA verbunden sind. Sie sollten selbst eine sorgfältige Prüfung durchführen und einen Finanzberater konsultieren, bevor Sie Anlageentscheidungen treffen."
 
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:347
+msgid "stake.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:267
+#: components/views/Stake/index.tsx:473
+msgid "stake.unstake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:324
+msgid "wrap.unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:313
+msgid "wrap.wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:279
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:282
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:63
 msgid "Wrong Network"
 msgstr "Falsches Netzwerk"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:55
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:171
 msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
 msgstr "Sie müssen USDC, KLIMA oder CO2-Tokens in Ihre Wallet übertragen. Die Unterstützung für Kreditkarten ist demnächst verfügbar."
 
-#. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr "AUSVERKAUFT! Der Bedarf nach diesen Bonds ist aktuell erschöpft. Vielen Dank!"
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr "Guthaben"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr "Für Bonds bereitstehendes Guthaben"
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr "Bond"
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr "Bondpreis"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr "Reduzierter Preis. Komplette Menge, um 1 KLIMA durch Bonds zu erhalten (kleinere Bondmengen sind möglich)"
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr "Aktueller Marktpreis von KLIMA"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr "Bond {0}"
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr "KAPAZITÄT ERSCHÖPFT"
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr "Ende der vollständigen Wartefrist"
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr "Zeitpunkt, an dem der gesamte Bondwert ausgezahlt werden kann"
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr "Schuldenquote"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr "Aktuelles Verhältnis zwischen Angebot und ausstehenden Bonds"
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr "Bonding-Rabatt"
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr "Prozentualer Rabatt (oder Aufschlag, falls negativ) relativ zum aktuellen Marktpreis von KLIMA."
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr "Zu bondende Menge"
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr "Einzulösende Menge"
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr "Preisaufschlag"
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr "Preisaufschlag relativ zum aktuellen Marktpreis von KLIMA."
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr "Marktpreis"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr "Aktueller Marktpreis von KLIMA ohne Bondingrabatt"
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr "MAXIMUM ÜBERSCHRITTEN"
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr "Maximum"
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr "Maximale durch Bonding erhaltbare Menge"
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr "Nicht einlösbar"
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr "Auszahlung pro KLIMA"
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr "Wenn du 1 KLIMA bondest, bekommst du diese Menge USDC."
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr "Einlösen"
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr "Einlösbar"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr "Menge an KLIMA, die bereits garantiert ist und eingelöst werden kann."
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr "Automatisch für sKLIMA staken"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr "⚠️ Achtung: Dieser Bondpreis ist überhöht, da die Rabattrate negativ ist."
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr "Bond {0}"
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr "Klima einlösen"
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr "Nicht eingelöst"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:924
-msgid "bond.unredeemed.tooltip"
-msgstr "Verbleibender, einlösbarer Wert (zugesichert und noch nicht zugesichert)"
-
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr "Ende der Wartefrist"
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr "Wenn du jetzt CO2 bondest, endet die Wartefrist zu diesem Zeitpunkt. KLIMA-Tokens werden während dieses Zeitraums langsam für dich freigestellt."
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:746
 #: components/views/Bond/index.tsx:890
 msgid "bond.you_will_get"
-msgstr "Du erhältst"
-
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr "Menge, die du für die eingegebene Eingangssumme erhältst"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr "Menge an gebondetem KLIMA, die du für die angegebene Eingangsmenge bekommst"
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr "KLIMA kaufen"
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr "Diese Funktion steht nur für eingeloggte Nutzer zur Verfügung. Loggen Sie sich bitte ein oder erstellen Sie über den Button einen Account."
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr "Bist du Anfänger, empfehlen wir dir unser Schritt-für-Schritt-Tutorial: <0>So kaufst du KLIMA</0>."
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr "Andernfalls kannst du KLIMA über <0>Sushi.com</0> kaufen, wenn du eine Wallet mit etwas MATIC auf dem Polygon-Netzwerk hast. Bezahlst du lieber direkt mit einer Kreditkarte, kannst du KLIMA über <1>Transak</1> kaufen."
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr "Logge dich bitte ein oder verbinde eine Wallet"
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr "Diese Menge USDC steht im Smart-Contract für Bonds bereit."
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr "Nicht wieder erinnern"
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
 msgstr ""
-"Ich verstehe\n"
-""
 
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr "<0>app.klimadao.finance</0> ist die einzige offizielle Domain."
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr "⚠️ Überprüfe diese URL und richte sie dir als Lesezeichen ein!"
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr "Toucan Base Carbon Tonne"
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr "CO2 bonden"
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr "Der beste Weg, KLIMA zu kaufen. Übertrage CO2-Tokens in unsere Schatzkammer und bekomme dafür vergünstigtes KLIMA. Alle Bonds (außer Inverse Bonds) haben eine obligatorische Sperrfrist von fünf Tagen."
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr "Bond auswählen"
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr "KLIMA überweisen, USDC bekommen"
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr "KLIMA/BCT Sushiswap-Liquidität"
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr "KLIMA/USDC Sushiswap-Liquidität"
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr "MOSS Carbon Credit Token"
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr "KLIMA/MCO2 Quickswap-Liquidität"
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr "C3 Nature Based Offset"
-
-#: components/views/ChooseBond/index.tsx:239
-msgid "choose_bond.percent_discount"
-msgstr "% Rabatt"
-
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr "AUSVERKAUFT"
-
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr "Schatzkammerguthaben"
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr "C3 Universal Basic Offset"
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr "Social oder E-Mail"
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr "Wallet verbinden"
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr "Verbinde..."
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr "Wir hatten einige Verbindungsprobleme. Bitte versuche es erneut."
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr "Benutzer verweigerte Verbindung."
-
-#: lib/constants.ts:40
-msgid "connect_modal.error_processing"
-msgstr "Anfrage ist bereits in Bearbeitung. Bitte öffnen Sie Ihre Wallet und schließen Sie die Anfrage ab."
-
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
-msgstr "Verbindungsfehler"
-
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
-msgstr "Entschuldigung, sieht so aus, als hätten wir dich in die falsche Richtung geschickt. <0/>Bitte wähle einen Zielort aus dem Menü aus."
-
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
-msgstr "So funktioniert's"
-
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
-msgstr "Neu bei KLIMA?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
-msgstr "1. Metamask öffnen und zu Ethereum Mainnet wechseln"
-
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr "2. Gehe nach Einstellungen -> Netzwerke -> Polygon und klicke \"Löschen\"."
-
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr "Gehe zurück nach app.klimadao.finance und klicke auf \"Wechsel zum Mainnet\"."
-
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr "Falls die App \"Laden...\" anzeigt, liegt wahrscheinlich ein Problem der Netzwerkkonfiguration in Metamask vor. Löse dies wie folgt:"
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr "Metamask sollte dich dazu auffordern, Polygon mit der korrekten RPC-Konfiguration hinzuzufügen."
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr "Warum lädt die App nicht?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr "Häufige Fragen zur App und nützliche Links. Umfassende Informationen zu KlimaDAO findest du in unserer <0>offiziellen Dokumentation</0>."
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr "Info & FAQ"
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr "Offizielle Vertragsadressen"
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr "Netzwerk konnte nicht erreicht werden. Die Ursache ist wahrscheinlich eine veraltete Polygon-RPC-Konfiguration in deiner Wallet. Mit <0>diesem Guide</0> behebst du den Fehler. Sollte das Problem noch immer auftreten, helfen wir dir gerne bei <1>Discord</1>."
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr "Überprüfe deine Netzwerkeinstellungen"
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr "CO2 bonden"
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr "KLIMA kaufen"
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr "Info"
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr "NUR FÜR DICH"
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr "NICHT VERBUNDEN"
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr "Ausgleichen"
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr "KLIMA staken"
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr "Deine Walletadresse"
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr "sKLIMA wrappen"
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr "ERFOLGREICH!"
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr "FEHLER!"
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr "AUSSTEHEND"
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr "BESTÄTIGUNG"
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr "ZURÜCK"
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
-msgstr "KlimaDAOs Retirement Aggregator ist quelloffene Software, welche den CO2-Ausgleich durch digitale CO2-Zertifikate ermöglicht."
-
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr "Besuchen Sie unsere <0>Dokumentation</0>, um die Software in Ihre Anwendung zu integrieren, oder besuchen Sie <1>Carbonmark</1>, um eine funktionsfähige Implementierung zu nutzen."
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr "Insgesamt ausgeglichen"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr "CO2-Tonnen"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr "CO2-Ausgleiche ansehen"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr "Bislang ausgeglichen"
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr "2. BCT genehmigen"
-
-#: components/views/PKlima/index.tsx:170
-msgid "pklima.approve_pklima"
-msgstr ""
-"1. pKLIMA genehmigen\n"
-""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr "Stelle sicher, dass du dein eingelöstes pKLIMA stakest, bis die globalen Treibhausgasemissionen stagnieren."
-
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr "AUSÜBEN"
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr "1 pKLIMA und 1 BCT ausüben, um 1 KLIMA zu erhalten."
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr "Indexbereinigt"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr "Beanspruchtes sKLIMA-Äquivalent, vorausgesetzt, du hast dein eingelöstes KLIMA bis heute vollständig gestaket."
-
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr "Ausübbares pKLIMA"
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr "Du hast dein Supply-Share-Limit überschritten und zu viel KLIMA beansprucht. Dies liegt wahrscheinlich an einem Bugfix, der am 24. November am pKLIMA-Einlösungsvertrag vorgenommen wurde."
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr "pKLIMA einlösen"
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
-msgstr "Eingelöst"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr "Gesamtmenge KLIMA, die du bislang eingelöst hast."
-
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr "Angebotslimit"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr "Ein Prozentwert des gesamten Tokenangebotes. Deine indexbereinigte Anforderung darf diesen Wert nicht überschreiten."
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr "Der aktualisierte Vertrag geht davon aus, dass pKLIMA-Besitzer ehemals beanspruchte Tokens gestakt und Belohnungen dafür erhalten haben. Vor dem November-Fix wurden diese Staking-Belohnungen nicht gegen dein Supply-Share-Limit aufgerechnet, was bedeutet, dass dein Anteil am totalen KLIMA-Supply das in deinen Bedingungen angegebene Limit überschreiten konnte."
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr "KlimaDAOs CO2-Liquiditätspools sind gemeinsam genutzte Ressourcen, die positive Umweltauswirkungen fördern sollen."
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr "Besuchen Sie unsere<0>Dokumentation</0>, um die LP-Contractadressen zu finden, oder besuchen Sie <1>Carbonmark</1>, um digitales CO2 über eine einfache Benutzeroberfläche zu kaufen."
-
-#: components/views/errors/Custom404.tsx:16
-msgid "shared.404"
-msgstr "404 - Seite nicht gefunden"
-
-#: components/BalancesCard/index.tsx:47
-msgid "shared.balances"
-msgstr "Guthaben"
-
-#: components/ChangeLanguageButton/index.tsx:56
-msgid "shared.change_language"
-msgstr "Sprache wechseln"
-
-#: components/views/Bond/index.tsx:432
-#: components/views/PKlima/index.tsx:165
-#: components/views/Wrap/index.tsx:220
-msgid "shared.confirming"
-msgstr "Bestätigen..."
-
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr "Lade..."
-
-#: components/views/Stake/index.tsx:259
-#: components/views/Stake/index.tsx:268
-msgid "shared.enter_amount"
-msgstr "Menge eingeben"
-
-#: components/views/Bond/index.tsx:475
-#: components/views/Bond/index.tsx:494
-#: components/views/Stake/index.tsx:276
-#: components/views/Wrap/index.tsx:247
-msgid "shared.error"
-msgstr "FEHLER"
-
-#: components/views/Bond/index.tsx:397
-#: components/views/Buy/index.tsx:65
-#: components/views/Home/index.tsx:154
-#: components/views/PKlima/index.tsx:149
-#: components/views/Stake/index.tsx:229
-#: components/views/Wrap/index.tsx:199
-msgid "shared.login_connect"
-msgstr "Anmelden / Verbinden"
-
-#: components/views/Bond/index.tsx:605
-#: components/views/PKlima/index.tsx:239
-#: components/views/Stake/index.tsx:372
-#: components/views/Wrap/index.tsx:346
-msgid "shared.max"
-msgstr "Max"
-
-#: components/views/Bond/index.tsx:405
-msgid "shared.sold_out"
-msgstr "Ausverkauft"
-
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
-msgstr "ROI über fünf Tage"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr "Ungefähre Belohnungen inklusive Zinseszinseffekt, falls du über fünf Tage gestaket bleibst."
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
-msgstr "AKR"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
-msgstr "Jährliche KLIMA-Belohnungen, Zinseszinseffekte inbegriffen, sofern die aktuelle Belohnungsrate über zwölf Monate identisch bleibt (Rate kann sich ändern)."
-
-#. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
-msgstr "Stake deine KLIMA-Tokens, um sKLIMA zu erhalten. Nach jedem Rebase wird dein sKLIMA um die angegebene Prozentwahl wachsen."
-
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr "Geschätzte Auszahlung (sKLIMA)"
-
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr "Index"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr "Menge an KLIMA, die du heute hättest, wenn du 1 KLIMA am Starttag gestaket hättest. Nützlich für Buchführungszwecke."
-
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr "Zu stakende Menge"
-
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr "Zu unstakende Menge"
-
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr "Cross-Chain-CO2-Ausgleich wird durch <0>LI.FI und Etherspot</0> ermöglicht. Zahlreiche Blockchains und Tokens werden unterstützt."
-
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr "Ungefährer nächster Rebase"
-
-#: components/RebaseCard/index.tsx:73
-msgid "stake.percent_payout"
-msgstr "Prozentuale Auszahlung"
-
-#: components/RebaseCard/index.tsx:44
-msgid "stake.rebase"
-msgstr "Rebase"
-
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr "Das Protokoll generiert und verteilt automatisch Belohnungen. Deine Auszahlung wird als Prozentsatz deines sKLIMA-Guthabens berechnet."
-
-#: components/views/Stake/index.tsx:335
-msgid "stake.stake"
-msgstr "Staken"
-
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
-msgstr "Stake, behalte und verdiene automatisch verzinstes sKLIMA."
-
-#: components/views/Stake/index.tsx:258
-#: components/views/Stake/index.tsx:306
-#: components/views/Stake/index.tsx:471
-msgid "stake.stake_klima"
-msgstr "KLIMA staken"
-
-#: components/views/Stake/index.tsx:347
-msgid "stake.unstake"
-msgstr "Unstaken"
-
-#: components/views/Stake/index.tsx:267
-#: components/views/Stake/index.tsx:473
-msgid "stake.unstake_klima"
-msgstr "KLIMA unstaken"
-
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr "Transaktion abgeschlossen."
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr "❌ Fehler: etwas ist schiefgelaufen..."
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr "Transaktion eingeleitet. Warte auf Netzwerkbestätigung."
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr "Bitte klicke \"Bestätigen\" in deiner Wallet, um fortzufahren."
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr "Du hast die Transaktion abgebrochen"
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr "pKLIMA"
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr "Du musst unserem Smart Contract zuerst erlauben, Tokens für dich zu transferieren."
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr "Vertragsadresse"
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr "Zu genehmigende Menge"
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr "Schließen"
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr "Weiter"
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr "Menge bestätigen"
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr "Absenden"
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr "Bitte sende die Transaktion ab."
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr "Vertragsadresse"
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Genehmigen"
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Absenden"
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr "Mit deiner Web3-Browserwallet verbinden"
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr "Einfache One-Klick-Wallet von Torus"
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr "E-Mail oder Social-Media"
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr "Mit WalletConnect scannen, um dich zu verbinden"
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr "Mit Coinbase scannen, um dich zu verbinden"
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr "Guthaben"
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr "sKLIMA wrappen, um indexbereinigstes wsKLIMA zu erhalten"
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr "Index"
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr "Menge an KLIMA, die du heute besitzen würdest, wenn du 1 KLIMA am Starttag gestaket hättest. Wird zur Berechnung des wsKLIMA-Wertes genutzt."
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr "Zu wrappendes sKLIMA"
-
-#: components/views/Wrap/index.tsx:324
-msgid "wrap.unwrap"
-msgstr "Unwrappen"
-
-#: components/views/Wrap/index.tsx:313
-msgid "wrap.wrap"
-msgstr "Wrappen"
-
-#: components/views/Wrap/index.tsx:279
-msgid "wrap.wrap_sklima"
-msgstr "sKLIMA wrappen"
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
-msgstr "Manche finden dies für Buchhaltungszwecke nützlich, die Belohnungen unterscheiden sich jedoch nicht. Der aktuelle Index wird herangezogen, um die Wrap- und Unwrap-Werte zu berechnen."
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:282
-msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
-msgstr "sKLIMA wrappen, um wsKLIMA zu erhalten. Anders als bei sKLIMA wird dein wsKLIMA-Guthaben konstant bleiben, der Gewinn ist jedoch identisch."
-
-#: components/views/Wrap/index.tsx:55
-msgid "wrap.wsklima_to_unwrap"
-msgstr "Zu unwrappendes wsKLIMA"
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
-msgstr "Du erhältst"
+msgstr ""
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
-msgstr "Unwrapped"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
+msgstr ""

--- a/app/locale/en-pseudo/messages.po
+++ b/app/locale/en-pseudo/messages.po
@@ -6,9 +6,155 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:239
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:170
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:16
+msgid "shared.404"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:84
 msgid "Acknowledge and Accept"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
 msgstr ""
 
 #: components/TransactionModal/Approve.tsx:93
@@ -18,8 +164,89 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:47
+msgid "shared.balances"
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
 msgstr ""
 
 #: components/views/Redeem/index.tsx:25
@@ -30,12 +257,164 @@ msgstr ""
 msgid "Buy Carbon"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr ""
+
 #: components/views/Bond/index.tsx:697
 msgid "Capacity"
 msgstr ""
 
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:56
+msgid "shared.change_language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:432
+#: components/views/PKlima/index.tsx:165
+#: components/views/Wrap/index.tsx:220
+msgid "shared.confirming"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:259
+#: components/views/Stake/index.tsx:268
+msgid "shared.enter_amount"
 msgstr ""
 
 #: components/views/Stake/index.tsx:242
@@ -43,13 +422,137 @@ msgstr ""
 msgid "Enter quantity"
 msgstr ""
 
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:475
+#: components/views/Bond/index.tsx:494
+#: components/views/Stake/index.tsx:276
+#: components/views/Wrap/index.tsx:247
+msgid "shared.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
 #: components/views/Offset/index.tsx:45
 msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
 msgstr ""
 
 #: components/views/Stake/index.tsx:247
 #: components/views/Wrap/index.tsx:225
 msgid "Insufficient balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
 msgstr ""
 
 #: components/DisclaimerModal/index.tsx:47
@@ -75,25 +578,118 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr ""
+
 #: components/views/Home/index.tsx:178
 msgid "Login"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:397
+#: components/views/Buy/index.tsx:65
+#: components/views/Home/index.tsx:154
+#: components/views/PKlima/index.tsx:149
+#: components/views/Stake/index.tsx:229
+#: components/views/Wrap/index.tsx:199
+msgid "shared.login_connect"
 msgstr ""
 
 #: components/DisclaimerModal/index.tsx:39
 msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:605
+#: components/views/PKlima/index.tsx:239
+#: components/views/Stake/index.tsx:372
+#: components/views/Wrap/index.tsx:346
+msgid "shared.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
 msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:168
 msgid "No balances found."
 msgstr ""
 
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:131
 #: components/CarbonTonnesRetiredCard/index.tsx:29
 msgid "Not Connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
 msgstr ""
 
 #: components/views/Offset/index.tsx:27
@@ -108,843 +704,441 @@ msgstr ""
 msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:32
 msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
 msgstr ""
 
 #: components/DisclaimerModal/index.tsx:53
 msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:29
-msgid "Risk Disclaimer"
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:72
-msgid "Switch to Polygon"
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:68
-msgid "This app only works on Polygon Mainnet."
-msgstr ""
-
-#: components/DisclaimerModal/index.tsx:75
-msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:63
-msgid "Wrong Network"
-msgstr ""
-
-#: components/CarbonBalancesCard/index.tsx:171
-msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
-msgstr ""
-
 #. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr ""
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr ""
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr ""
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr ""
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr ""
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr ""
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr ""
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr ""
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr ""
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr ""
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr ""
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr ""
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr ""
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr ""
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr ""
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr ""
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr ""
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr ""
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr ""
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr ""
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr ""
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr ""
-
-#. Long sentence
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:924
 msgid "bond.unredeemed.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr ""
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:746
-#: components/views/Bond/index.tsx:890
-msgid "bond.you_will_get"
-msgstr ""
-
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr ""
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr ""
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr ""
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr ""
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr ""
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr ""
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr ""
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr ""
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr ""
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr ""
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr ""
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:239
-msgid "choose_bond.percent_discount"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr ""
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr ""
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr ""
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr ""
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr ""
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: lib/constants.ts:40
 msgid "connect_modal.error_processing"
 msgstr ""
 
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
+#: components/DisclaimerModal/index.tsx:29
+msgid "Risk Disclaimer"
 msgstr ""
 
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
 msgstr ""
 
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
 msgstr ""
 
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
 msgstr ""
 
-#. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
 msgstr ""
 
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr ""
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr ""
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr ""
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr ""
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr ""
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr ""
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr ""
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr ""
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr ""
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr ""
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr ""
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr ""
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr ""
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr ""
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr ""
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
-msgstr ""
-
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:170
-msgid "pklima.approve_pklima"
-msgstr ""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr ""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr ""
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
-msgstr ""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr ""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr ""
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr ""
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr ""
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr ""
-
-#: components/views/errors/Custom404.tsx:16
-msgid "shared.404"
-msgstr ""
-
-#: components/BalancesCard/index.tsx:47
-msgid "shared.balances"
-msgstr ""
-
-#: components/ChangeLanguageButton/index.tsx:56
-msgid "shared.change_language"
-msgstr ""
-
-#: components/views/Bond/index.tsx:432
-#: components/views/PKlima/index.tsx:165
-#: components/views/Wrap/index.tsx:220
-msgid "shared.confirming"
-msgstr ""
-
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr ""
-
-#: components/views/Stake/index.tsx:259
-#: components/views/Stake/index.tsx:268
-msgid "shared.enter_amount"
-msgstr ""
-
-#: components/views/Bond/index.tsx:475
-#: components/views/Bond/index.tsx:494
-#: components/views/Stake/index.tsx:276
-#: components/views/Wrap/index.tsx:247
-msgid "shared.error"
-msgstr ""
-
-#: components/views/Bond/index.tsx:397
-#: components/views/Buy/index.tsx:65
-#: components/views/Home/index.tsx:154
-#: components/views/PKlima/index.tsx:149
-#: components/views/Stake/index.tsx:229
-#: components/views/Wrap/index.tsx:199
-msgid "shared.login_connect"
-msgstr ""
-
-#: components/views/Bond/index.tsx:605
-#: components/views/PKlima/index.tsx:239
-#: components/views/Stake/index.tsx:372
-#: components/views/Wrap/index.tsx:346
-msgid "shared.max"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:405
 msgid "shared.sold_out"
 msgstr ""
 
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
 msgstr ""
 
 #. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr ""
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
 msgstr ""
 
 #. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
 msgstr ""
 
-#. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
 msgstr ""
 
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr ""
-
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr ""
-
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr ""
-
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr ""
-
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr ""
-
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr ""
-
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr ""
-
-#: components/RebaseCard/index.tsx:73
-msgid "stake.percent_payout"
-msgstr ""
-
-#: components/RebaseCard/index.tsx:44
-msgid "stake.rebase"
-msgstr ""
-
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:335
 msgid "stake.stake"
 msgstr ""
 
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:258
 #: components/views/Stake/index.tsx:306
 #: components/views/Stake/index.tsx:471
 msgid "stake.stake_klima"
 msgstr ""
 
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:72
+msgid "Switch to Polygon"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:68
+msgid "This app only works on Polygon Mainnet."
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr ""
+
+#: components/DisclaimerModal/index.tsx:75
+msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:347
 msgid "stake.unstake"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:267
 #: components/views/Stake/index.tsx:473
 msgid "stake.unstake_klima"
 msgstr ""
 
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr ""
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr ""
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr ""
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr ""
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr ""
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr ""
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr ""
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:324
 msgid "wrap.unwrap"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:313
 msgid "wrap.wrap"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:279
 msgid "wrap.wrap_sklima"
 msgstr ""
 
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
 msgstr ""
 
 #. Long sentence
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:282
 msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
 msgstr ""
 
+#: components/InvalidNetworkModal/index.tsx:63
+msgid "Wrong Network"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:55
 msgid "wrap.wsklima_to_unwrap"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr ""
+
+#: components/CarbonBalancesCard/index.tsx:171
+msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:746
+#: components/views/Bond/index.tsx:890
+msgid "bond.you_will_get"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
 msgstr ""
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
 msgstr ""

--- a/app/locale/en/messages.po
+++ b/app/locale/en/messages.po
@@ -13,9 +13,149 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:239
+msgid "choose_bond.percent_discount"
+msgstr "% Discount"
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr "<0>app.klimadao.finance</0> is the only official domain."
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr "⚠️ Verify the URL and bookmark this page!"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr "⚠️ Warning: this bond price is inflated because the current discount rate is negative."
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr "❌ Error: something went wrong..."
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr "1. Approve"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:170
+msgid "pklima.approve_pklima"
+msgstr "1. Approve pKLIMA"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr "1. Open Metamask and switch to Ethereum Mainnet"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr "2. Approve BCT"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr "2. Go to Settings/Networks/Polygon and click 'delete'"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr "2. Submit"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr "3. Return to app.klimadao.finance and click 'switch to mainnet'."
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:16
+msgid "shared.404"
+msgstr "404 - Page Not Found"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr "5 Day Rewards"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr "A percent of total token supply. Your index-adjusted claim may not exceed this value."
+
 #: components/DisclaimerModal/index.tsx:84
 msgid "Acknowledge and Accept"
 msgstr "Acknowledge and Accept"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr "AKR"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr "Amount of bonded KLIMA you will get, at the provided input quantity"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr "Amount of KLIMA that has already vested and can be redeemed"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Used to calculate wsKLIMA value."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Useful for accounting purposes."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr "Amount to bond"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr "Amount to redeem"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr "Amount to stake"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr "Amount to unstake"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr "Amount you will get, at the provided input quantity"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
+msgstr "Annualized KLIMA Rewards, including compounding, should the current reward rate remain unchanged for 12 months (reward rate may be subject to change)."
 
 #: components/TransactionModal/Approve.tsx:93
 #: components/views/Bond/index.tsx:454
@@ -24,9 +164,90 @@ msgstr "Acknowledge and Accept"
 msgid "Approve"
 msgstr "Approve"
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr "Approx. next rebase"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr "Approximate rewards, including compounding, should you remain staked for 5 days."
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr "Automatically stake for sKLIMA"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr "BACK"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr "Balance"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr "Balance"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr "Balance available for bonding"
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:47
+msgid "shared.balances"
+msgstr "Balances"
+
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
 msgstr "Balances"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr "Bond"
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr "Bond {0}"
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr "Bond {0}"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr "Bond Carbon"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr "Bond Carbon"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr "Bond discount"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
+msgstr "Bond price"
 
 #: components/views/Redeem/index.tsx:25
 msgid "Buy & Redeem Carbon"
@@ -36,27 +257,303 @@ msgstr "Buy & Redeem Carbon"
 msgid "Buy Carbon"
 msgstr "Buy Carbon"
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr "Buy KLIMA"
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr "Buy KLIMA"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr "C3 Nature Based Offset"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr "C3 Universal Basic Offset"
+
 #: components/views/Bond/index.tsx:697
 msgid "Capacity"
 msgstr "Capacity"
 
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
-msgstr "Enter Quantity"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr "CAPACITY EXCEEDED"
+
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:56
+msgid "shared.change_language"
+msgstr "Change language"
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr "Check your network settings"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr "Choose a bond"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr "Close"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr "Common app-related questions and useful links. For comprehensive reading on KlimaDAO, see our <0>official documentation</0>."
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr "Confirm amount"
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr "CONFIRMATION"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:432
+#: components/views/PKlima/index.tsx:165
+#: components/views/Wrap/index.tsx:220
+msgid "shared.confirming"
+msgstr "Confirming"
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr "connect a wallet"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr "Connect with your browser web3 provider"
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr "Connecting..."
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr "Connection Error"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr "Contract address"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr "Contract address"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr "Cross-chain staking is now available through <0>LI.FI and Etherspot</0>, with support for multiple chains and tokens."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr "Current trading price of KLIMA on the market"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr "Current trading price of KLIMA, without bond discount"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr "Date of full vesting"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr "Date when the entire bond value can be redeemed"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr "Debt ratio"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr "Discounted price. Total amount to bond 1 full KLIMA (fractional bonds are also allowed)"
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr "Don't Remind Me"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr "Easy one-click wallet by Torus"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr "Email or Social"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:259
+#: components/views/Stake/index.tsx:268
+msgid "shared.enter_amount"
+msgstr "Enter Amount"
 
 #: components/views/Stake/index.tsx:242
 #: components/views/Wrap/index.tsx:212
 msgid "Enter quantity"
 msgstr "Enter quantity"
 
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr "Enter Quantity"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr "Equivalent sKLIMA claimed, assuming you staked all of your redeemed KLIMA until today."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:475
+#: components/views/Bond/index.tsx:494
+#: components/views/Stake/index.tsx:276
+#: components/views/Wrap/index.tsx:247
+msgid "shared.error"
+msgstr "ERROR"
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr "Est. payout (sKLIMA)"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr "EXERCISE"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr "Exercise 1 pKLIMA and 1 BCT to receive 1 KLIMA."
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr "FAILURE!"
+
 #: components/views/Offset/index.tsx:45
 msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
 msgstr "For users who want to offset paying with a pool token, please use <0>this site</0>."
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr "Got it"
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr "How to get started"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr "If the app says 'loading...' this is likely a problem with your network configuration in Metamask. To fix this:"
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr "If you are a beginner, we recommend following our step-by-step tutorial: <0>How to Buy KLIMA</0>."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr "If you bond 1 KLIMA, you will receive this amount in USDC."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr "If you bond now, your vesting term ends at this date. Klima is slowly unlocked for redemption over the duration of this term."
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr "Index"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr "Index"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr "Index adjusted"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr "Info"
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
+msgstr "Info & FAQ"
 
 #: components/views/Stake/index.tsx:247
 #: components/views/Wrap/index.tsx:225
 msgid "Insufficient balance"
 msgstr "Insufficient balance"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr "JUST FOR YOU"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr "KLIMA/BCT Sushiswap Liquidity"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr "KLIMA/MCO2 Quickswap Liquidity"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr "KLIMA/USDC Sushiswap Liquidity"
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr "KlimaDAO's digital carbon liquidity pools are common resources available for driving environmental impact."
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
+msgstr "KlimaDAO's retirement aggregator is an open-source tool that enables the retirement of digital carbon credits."
 
 #: components/DisclaimerModal/index.tsx:47
 msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
@@ -81,26 +578,119 @@ msgstr "Loading balances..."
 msgid "Loading..."
 msgstr "Loading..."
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr "Loading..."
+
 #: components/views/Home/index.tsx:178
 msgid "Login"
 msgstr "Login"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:397
+#: components/views/Buy/index.tsx:65
+#: components/views/Home/index.tsx:154
+#: components/views/PKlima/index.tsx:149
+#: components/views/Stake/index.tsx:229
+#: components/views/Wrap/index.tsx:199
+msgid "shared.login_connect"
+msgstr "Login / Connect"
 
 #: components/DisclaimerModal/index.tsx:39
 msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 msgstr "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
-msgstr "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr "Make sure to stake your redeemed pKLIMA, and stay staked, until global GHG emissions have plateaued."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr "Market price"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:605
+#: components/views/PKlima/index.tsx:239
+#: components/views/Stake/index.tsx:372
+#: components/views/Wrap/index.tsx:346
+msgid "shared.max"
+msgstr "Max"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr "MAX EXCEEDED"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr "Maximum"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr "Maximum amount you can acquire by bonding"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr "Metamask should prompt you to add Polygon, with the correct RPC configuration."
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr "MOSS Carbon Credit Token"
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr "New to KLIMA?"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
+msgstr "Next"
 
 #: components/CarbonBalancesCard/index.tsx:168
 msgid "No balances found."
 msgstr "No balances found."
 
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+
 #: components/CarbonBalancesCard/index.tsx:131
 #: components/CarbonTonnesRetiredCard/index.tsx:29
 msgid "Not Connected"
 msgstr "Not Connected"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr "NOT CONNECTED"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr "Not Redeemable"
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr "Official Contract Addresses"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
+msgstr "Offset"
 
 #: components/views/Offset/index.tsx:27
 msgid "Offset"
@@ -114,843 +704,441 @@ msgstr "On April 12, 2022 we migrated from \"dapp\" to \"app\". Please update yo
 msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 msgstr "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 
-#: components/DisclaimerModal/index.tsx:32
-msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
-msgstr "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr "Otherwise, if you already have a wallet with MATIC on Polygon, the best way to get KLIMA is to swap on <0>Sushi.com</0>. If you prefer to pay with a credit card instead, you can use <1>Transak</1> to buy KLIMA directly."
 
-#: components/DisclaimerModal/index.tsx:53
-msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
-msgstr "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
-
-#: components/DisclaimerModal/index.tsx:29
-msgid "Risk Disclaimer"
-msgstr "Risk Disclaimer"
-
-#: components/InvalidNetworkModal/index.tsx:72
-msgid "Switch to Polygon"
-msgstr "Switch to Polygon"
-
-#: components/InvalidNetworkModal/index.tsx:68
-msgid "This app only works on Polygon Mainnet."
-msgstr "This app only works on Polygon Mainnet."
-
-#: components/DisclaimerModal/index.tsx:75
-msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
-msgstr "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
-
-#: components/InvalidNetworkModal/index.tsx:63
-msgid "Wrong Network"
-msgstr "Wrong Network"
-
-#: components/CarbonBalancesCard/index.tsx:171
-msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
-msgstr "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr "SOLD OUT. All demand has been filled for this bond. Thank you, Klimates!"
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr "Balance"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr "Balance available for bonding"
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr "Bond"
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr "Bond price"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr "Discounted price. Total amount to bond 1 full KLIMA (fractional bonds are also allowed)"
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr "Current trading price of KLIMA on the market"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr "Bond {0}"
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr "CAPACITY EXCEEDED"
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr "Date of full vesting"
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr "Date when the entire bond value can be redeemed"
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr "Debt ratio"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr "Protocol's current ratio of supply to outstanding bonds"
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr "Bond discount"
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr "Percentage discount (or premium if negative) relative to the market value of KLIMA."
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr "Amount to bond"
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr "Amount to redeem"
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr "Premium"
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr "Premium relative to the market value of KLIMA."
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr "Market price"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr "Current trading price of KLIMA, without bond discount"
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr "MAX EXCEEDED"
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr "Maximum"
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr "Maximum amount you can acquire by bonding"
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr "Not Redeemable"
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:660
 msgid "bond.payout_per_klima"
 msgstr "Payout per KLIMA"
 
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr "If you bond 1 KLIMA, you will receive this amount in USDC."
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr "PENDING"
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr "Percent payout"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr "Percentage discount (or premium if negative) relative to the market value of KLIMA."
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr "pKLIMA"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr "pKLIMA to exercise"
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr "Please click 'confirm' in your wallet to continue."
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr "Please Log In Or Connect A Wallet"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr "Please submit the transaction."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr "Premium"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr "Premium relative to the market value of KLIMA."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr "Protocol's current ratio of supply to outstanding bonds"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr "Provide KLIMA, receive USDC"
+
+#: components/DisclaimerModal/index.tsx:32
+msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+msgstr "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr "Quantity to approve"
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr "Rebase"
+
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:468
 #: components/views/Bond/index.tsx:580
 msgid "bond.redeem"
 msgstr "Redeem"
 
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr "Redeemable"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr "Amount of KLIMA that has already vested and can be redeemed"
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr "Automatically stake for sKLIMA"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr "⚠️ Warning: this bond price is inflated because the current discount rate is negative."
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr "Bond {0}"
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:1081
 msgid "bond.transaction_modal.redeem.title"
 msgstr "Redeem Klima"
 
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr "Unredeemed"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:924
-msgid "bond.unredeemed.tooltip"
-msgstr "Remaining unredeemed value (vested and un-vested)"
-
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr "Vesting term end"
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr "If you bond now, your vesting term ends at this date. Klima is slowly unlocked for redemption over the duration of this term."
-
-#: components/views/Bond/index.tsx:746
-#: components/views/Bond/index.tsx:890
-msgid "bond.you_will_get"
-msgstr "You will get"
-
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr "Amount you will get, at the provided input quantity"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr "Amount of bonded KLIMA you will get, at the provided input quantity"
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr "Buy KLIMA"
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr "This feature is available only to users who are logged in. You can log in or create an account via the button below."
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr "If you are a beginner, we recommend following our step-by-step tutorial: <0>How to Buy KLIMA</0>."
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr "Otherwise, if you already have a wallet with MATIC on Polygon, the best way to get KLIMA is to swap on <0>Sushi.com</0>. If you prefer to pay with a credit card instead, you can use <1>Transak</1> to buy KLIMA directly."
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr "Please Log In Or Connect A Wallet"
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr "This is the amount of USDC in the contract available for bonds."
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr "Don't Remind Me"
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr "Got it"
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr "<0>app.klimadao.finance</0> is the only official domain."
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr "⚠️ Verify the URL and bookmark this page!"
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr "Toucan Base Carbon Tonne"
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr "Bond Carbon"
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr "The best way to buy KLIMA. Commit carbon to our treasury, and receive KLIMA at a discount. All bonds (except inverse bonds) have a mandatory 5 day vesting period."
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr "Choose a bond"
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr "Provide KLIMA, receive USDC"
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr "KLIMA/BCT Sushiswap Liquidity"
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr "KLIMA/USDC Sushiswap Liquidity"
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr "MOSS Carbon Credit Token"
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr "KLIMA/MCO2 Quickswap Liquidity"
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr "C3 Nature Based Offset"
-
-#: components/views/ChooseBond/index.tsx:239
-msgid "choose_bond.percent_discount"
-msgstr "% Discount"
-
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr "SOLD OUT"
-
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr "Treasury Balance"
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr "C3 Universal Basic Offset"
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr "social or email"
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr "connect a wallet"
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr "Connecting..."
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr "We had some trouble connecting. Please try again."
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr "User refused connection."
-
-#: lib/constants.ts:40
-msgid "connect_modal.error_processing"
-msgstr "Request already processing. Please open your wallet and complete the request."
-
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
-msgstr "Connection Error"
-
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
-msgstr "Sorry, looks like we sent you the wrong way. <0/>Please select a destination from the menu."
-
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
-msgstr "How to get started"
-
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
-msgstr "New to KLIMA?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
-msgstr "1. Open Metamask and switch to Ethereum Mainnet"
-
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr "2. Go to Settings/Networks/Polygon and click 'delete'"
-
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr "3. Return to app.klimadao.finance and click 'switch to mainnet'."
-
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr "If the app says 'loading...' this is likely a problem with your network configuration in Metamask. To fix this:"
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr "Metamask should prompt you to add Polygon, with the correct RPC configuration."
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr "Why won't the app load for me?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr "Common app-related questions and useful links. For comprehensive reading on KlimaDAO, see our <0>official documentation</0>."
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr "Info & FAQ"
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr "Official Contract Addresses"
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr "The network could not be reached. This is most likely caused by an old Polygon RPC configuration in your wallet. See <0>this guide</0> for a fix. Otherwise, reach out to us on <1>Discord</1> if problems persist."
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr "Check your network settings"
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr "Bond Carbon"
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr "Buy KLIMA"
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr "Info"
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr "JUST FOR YOU"
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr "NOT CONNECTED"
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr "Offset"
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr "Stake KLIMA"
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr "Your Wallet Address"
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr "Wrap sKLIMA"
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr "SUCCESS!"
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr "FAILURE!"
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr "PENDING"
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr "CONFIRMATION"
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr "BACK"
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
-msgstr "KlimaDAO's retirement aggregator is an open-source tool that enables the retirement of digital carbon credits."
-
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr "Visit our <0> documentation </0> to build it into your application, or visit <1> Carbonmark </1> to use a live implementation."
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr "Total retirements"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr "Tonnes of carbon"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr "View Retirements"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr "You've Retired"
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr "2. Approve BCT"
-
-#: components/views/PKlima/index.tsx:170
-msgid "pklima.approve_pklima"
-msgstr "1. Approve pKLIMA"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr "Make sure to stake your redeemed pKLIMA, and stay staked, until global GHG emissions have plateaued."
-
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr "EXERCISE"
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr "Exercise 1 pKLIMA and 1 BCT to receive 1 KLIMA."
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr "Index adjusted"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr "Equivalent sKLIMA claimed, assuming you staked all of your redeemed KLIMA until today."
-
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr "pKLIMA to exercise"
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr "You've claimed more KLIMA than your supply-share limit. This is likely due to a fix implemented on November 24th, 2021 to the pKLIMA redemption contract."
-
+#. js-lingui-explicit-id
 #: components/views/PKlima/index.tsx:209
 msgid "pklima.redeem_pklima"
 msgstr "Redeem pKLIMA"
 
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr "Redeemable"
+
+#. js-lingui-explicit-id
 #: components/views/PKlima/index.tsx:268
 msgid "pklima.redeemed"
 msgstr "Redeemed"
 
-#. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr "Total KLIMA you have redeemed so far."
-
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr "Supply limit"
+#: components/DisclaimerModal/index.tsx:53
+msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
+msgstr "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
 
 #. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr "A percent of total token supply. Your index-adjusted claim may not exceed this value."
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:924
+msgid "bond.unredeemed.tooltip"
+msgstr "Remaining unredeemed value (vested and un-vested)"
 
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr "The updated contract now assumes pKLIMA holders have staked and earned rewards on previously claimed tokens. Prior to the November fix, these staking rewards were not counted against your supply share limit, which meant your share of the total KLIMA supply could surpass the limit defined in your terms."
+#. js-lingui-explicit-id
+#: lib/constants.ts:40
+msgid "connect_modal.error_processing"
+msgstr "Request already processing. Please open your wallet and complete the request."
 
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr "KlimaDAO's digital carbon liquidity pools are common resources available for driving environmental impact."
+#: components/DisclaimerModal/index.tsx:29
+msgid "Risk Disclaimer"
+msgstr "Risk Disclaimer"
 
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr "Visit our <0>documentation </0> to find the LP contract addresses, or visit <1> Carbonmark </1> to acquire carbon via a simple user interface."
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr "Scan with Coinbase to connect"
 
-#: components/views/errors/Custom404.tsx:16
-msgid "shared.404"
-msgstr "404 - Page Not Found"
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr "Scan with WalletConnect to connect"
 
-#: components/BalancesCard/index.tsx:47
-msgid "shared.balances"
-msgstr "Balances"
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
+msgstr "sKLIMA to wrap"
 
-#: components/ChangeLanguageButton/index.tsx:56
-msgid "shared.change_language"
-msgstr "Change language"
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
+msgstr "social or email"
 
-#: components/views/Bond/index.tsx:432
-#: components/views/PKlima/index.tsx:165
-#: components/views/Wrap/index.tsx:220
-msgid "shared.confirming"
-msgstr "Confirming"
-
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr "Loading..."
-
-#: components/views/Stake/index.tsx:259
-#: components/views/Stake/index.tsx:268
-msgid "shared.enter_amount"
-msgstr "Enter Amount"
-
-#: components/views/Bond/index.tsx:475
-#: components/views/Bond/index.tsx:494
-#: components/views/Stake/index.tsx:276
-#: components/views/Wrap/index.tsx:247
-msgid "shared.error"
-msgstr "ERROR"
-
-#: components/views/Bond/index.tsx:397
-#: components/views/Buy/index.tsx:65
-#: components/views/Home/index.tsx:154
-#: components/views/PKlima/index.tsx:149
-#: components/views/Stake/index.tsx:229
-#: components/views/Wrap/index.tsx:199
-msgid "shared.login_connect"
-msgstr "Login / Connect"
-
-#: components/views/Bond/index.tsx:605
-#: components/views/PKlima/index.tsx:239
-#: components/views/Stake/index.tsx:372
-#: components/views/Wrap/index.tsx:346
-msgid "shared.max"
-msgstr "Max"
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:405
 msgid "shared.sold_out"
 msgstr "Sold Out"
 
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
-msgstr "5 Day Rewards"
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
+msgstr "SOLD OUT"
 
 #. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr "Approximate rewards, including compounding, should you remain staked for 5 days."
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
-msgstr "AKR"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
+msgstr "SOLD OUT. All demand has been filled for this bond. Thank you, Klimates!"
 
 #. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
-msgstr "Annualized KLIMA Rewards, including compounding, should the current reward rate remain unchanged for 12 months (reward rate may be subject to change)."
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr "Some find this useful for accounting purposes, but the rewards are exactly the same. Wrap and unwrap values are calculated based on the current index."
 
-#. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
-msgstr "Stake your KLIMA tokens to receive sKLIMA. After every rebase, your sKLIMA balance will increase by the given percentage."
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
+msgstr "Sorry, looks like we sent you the wrong way. <0/>Please select a destination from the menu."
 
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr "Est. payout (sKLIMA)"
-
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr "Index"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Useful for accounting purposes."
-
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr "Amount to stake"
-
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr "Amount to unstake"
-
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr "Cross-chain staking is now available through <0>LI.FI and Etherspot</0>, with support for multiple chains and tokens."
-
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr "Approx. next rebase"
-
-#: components/RebaseCard/index.tsx:73
-msgid "stake.percent_payout"
-msgstr "Percent payout"
-
-#: components/RebaseCard/index.tsx:44
-msgid "stake.rebase"
-msgstr "Rebase"
-
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr "The protocol automatically mints and distributes rewards. Your payout is a percentage of your sKLIMA balance"
-
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:335
 msgid "stake.stake"
 msgstr "Stake"
 
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
-msgstr "Stake, hold, and earn compounding sKLIMA."
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
+msgstr "Stake KLIMA"
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:258
 #: components/views/Stake/index.tsx:306
 #: components/views/Stake/index.tsx:471
 msgid "stake.stake_klima"
 msgstr "Stake KLIMA"
 
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr "Stake your KLIMA tokens to receive sKLIMA. After every rebase, your sKLIMA balance will increase by the given percentage."
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr "Stake, hold, and earn compounding sKLIMA."
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr "Submit"
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr "SUCCESS!"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
+msgstr "Supply limit"
+
+#: components/InvalidNetworkModal/index.tsx:72
+msgid "Switch to Polygon"
+msgstr "Switch to Polygon"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr "The best way to buy KLIMA. Commit carbon to our treasury, and receive KLIMA at a discount. All bonds (except inverse bonds) have a mandatory 5 day vesting period."
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr "The network could not be reached. This is most likely caused by an old Polygon RPC configuration in your wallet. See <0>this guide</0> for a fix. Otherwise, reach out to us on <1>Discord</1> if problems persist."
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr "The protocol automatically mints and distributes rewards. Your payout is a percentage of your sKLIMA balance"
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr "The updated contract now assumes pKLIMA holders have staked and earned rewards on previously claimed tokens. Prior to the November fix, these staking rewards were not counted against your supply share limit, which meant your share of the total KLIMA supply could surpass the limit defined in your terms."
+
+#: components/InvalidNetworkModal/index.tsx:68
+msgid "This app only works on Polygon Mainnet."
+msgstr "This app only works on Polygon Mainnet."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr "This feature is available only to users who are logged in. You can log in or create an account via the button below."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr "This is the amount of USDC in the contract available for bonds."
+
+#: components/DisclaimerModal/index.tsx:75
+msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
+msgstr "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr "Tonnes of carbon"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr "Total KLIMA you have redeemed so far."
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr "Total retirements"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr "Toucan Base Carbon Tonne"
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr "Transaction complete."
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr "Transaction initiated. Waiting for network confirmation."
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr "Treasury Balance"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr "Unredeemed"
+
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:347
 msgid "stake.unstake"
 msgstr "Unstake"
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:267
 #: components/views/Stake/index.tsx:473
 msgid "stake.unstake_klima"
 msgstr "Unstake KLIMA"
 
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr "Transaction complete."
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr "❌ Error: something went wrong..."
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr "Transaction initiated. Waiting for network confirmation."
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr "Please click 'confirm' in your wallet to continue."
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr "You chose to reject the transaction"
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr "pKLIMA"
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr "You must first give permission to our smart contract to transfer tokens on your behalf."
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr "Contract address"
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr "Quantity to approve"
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr "Close"
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr "Next"
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr "Confirm amount"
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr "Submit"
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr "Please submit the transaction."
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr "Contract address"
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Approve"
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Submit"
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr "Connect with your browser web3 provider"
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr "Easy one-click wallet by Torus"
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr "Email or Social"
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr "Scan with WalletConnect to connect"
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr "Scan with Coinbase to connect"
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr "Balance"
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr "Wrap sKLIMA to receive index-adjusted wrapped-staked-KLIMA"
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr "Index"
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr "Amount of KLIMA you would have today if you staked 1 KLIMA on launch day. Used to calculate wsKLIMA value."
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr "sKLIMA to wrap"
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:324
 msgid "wrap.unwrap"
 msgstr "Unwrap"
 
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr "unwrapped"
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr "User refused connection."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr "Vesting term end"
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr "View Retirements"
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr "Visit our <0> documentation </0> to build it into your application, or visit <1> Carbonmark </1> to use a live implementation."
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr "Visit our <0>documentation </0> to find the LP contract addresses, or visit <1> Carbonmark </1> to acquire carbon via a simple user interface."
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr "We had some trouble connecting. Please try again."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr "Why won't the app load for me?"
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:313
 msgid "wrap.wrap"
 msgstr "Wrap"
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr "Wrap sKLIMA"
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:279
 msgid "wrap.wrap_sklima"
 msgstr "Wrap sKLIMA"
 
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
-msgstr "Some find this useful for accounting purposes, but the rewards are exactly the same. Wrap and unwrap values are calculated based on the current index."
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
+msgstr "Wrap sKLIMA to receive index-adjusted wrapped-staked-KLIMA"
 
 #. Long sentence
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:282
 msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
 msgstr "Wrap sKLIMA to receive wsKLIMA. Unlike sKLIMA, your wsKLIMA balance will not increase over time."
 
+#: components/InvalidNetworkModal/index.tsx:63
+msgid "Wrong Network"
+msgstr "Wrong Network"
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:55
 msgid "wrap.wsklima_to_unwrap"
 msgstr "wsKLIMA to unwrap"
 
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr "You chose to reject the transaction"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr "You must first give permission to our smart contract to transfer tokens on your behalf."
+
+#: components/CarbonBalancesCard/index.tsx:171
+msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
+msgstr "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:746
+#: components/views/Bond/index.tsx:890
+msgid "bond.you_will_get"
+msgstr "You will get"
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
 msgstr "You Will Get"
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
-msgstr "unwrapped"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr "You've claimed more KLIMA than your supply-share limit. This is likely due to a fix implemented on November 24th, 2021 to the pKLIMA redemption contract."
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr "You've Retired"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
+msgstr "Your Wallet Address"

--- a/app/locale/es/messages.po
+++ b/app/locale/es/messages.po
@@ -6,10 +6,156 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: es\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:239
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:170
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:16
+msgid "shared.404"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:84
 msgid "Acknowledge and Accept"
 msgstr "Reconocer y aceptar"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
+msgstr ""
 
 #: components/TransactionModal/Approve.tsx:93
 #: components/views/Bond/index.tsx:454
@@ -18,9 +164,90 @@ msgstr "Reconocer y aceptar"
 msgid "Approve"
 msgstr "Aprobar"
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:47
+msgid "shared.balances"
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
 msgstr "Saldos"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
+msgstr ""
 
 #: components/views/Redeem/index.tsx:25
 msgid "Buy & Redeem Carbon"
@@ -30,27 +257,303 @@ msgstr "Comprar y canjear carbono"
 msgid "Buy Carbon"
 msgstr "Comprar Carbono"
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr ""
+
 #: components/views/Bond/index.tsx:697
 msgid "Capacity"
 msgstr "Capacidad"
 
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
-msgstr "Introduce la cantidad"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:56
+msgid "shared.change_language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:432
+#: components/views/PKlima/index.tsx:165
+#: components/views/Wrap/index.tsx:220
+msgid "shared.confirming"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:259
+#: components/views/Stake/index.tsx:268
+msgid "shared.enter_amount"
+msgstr ""
 
 #: components/views/Stake/index.tsx:242
 #: components/views/Wrap/index.tsx:212
 msgid "Enter quantity"
 msgstr "Introduce la cantidad"
 
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr "Introduce la cantidad"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:475
+#: components/views/Bond/index.tsx:494
+#: components/views/Stake/index.tsx:276
+#: components/views/Wrap/index.tsx:247
+msgid "shared.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
 #: components/views/Offset/index.tsx:45
 msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
 msgstr "Para los usuarios que quieran compensar el pago con un pool token, utilice <0>este sitio</0> ."
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
+msgstr ""
 
 #: components/views/Stake/index.tsx:247
 #: components/views/Wrap/index.tsx:225
 msgid "Insufficient balance"
 msgstr "Saldo insuficiente"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:47
 msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
@@ -75,26 +578,119 @@ msgstr "Cargando saldos..."
 msgid "Loading..."
 msgstr "Cargando..."
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr ""
+
 #: components/views/Home/index.tsx:178
 msgid "Login"
 msgstr "Iniciar sesión"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:397
+#: components/views/Buy/index.tsx:65
+#: components/views/Home/index.tsx:154
+#: components/views/PKlima/index.tsx:149
+#: components/views/Stake/index.tsx:229
+#: components/views/Wrap/index.tsx:199
+msgid "shared.login_connect"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:39
 msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 msgstr "Pérdida de la inversión: El valor de $KLIMA y otras criptomonedas puede aumentar o disminuir rápidamente en cualquier momento. Como resultado, usted podría experimentar pérdidas significativas y rápidas, incluyendo la pérdida de todo el dinero invertido."
 
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
-msgstr "Sin garantía: No hay garantía de que la plataforma KlimaDAO o el token $KLIMA logren sus objetivos o de que se conserve algún valor en el Protocolo."
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:605
+#: components/views/PKlima/index.tsx:239
+#: components/views/Stake/index.tsx:372
+#: components/views/Wrap/index.tsx:346
+msgid "shared.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:168
 msgid "No balances found."
 msgstr "No se encontraron saldos."
 
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr "Sin garantía: No hay garantía de que la plataforma KlimaDAO o el token $KLIMA logren sus objetivos o de que se conserve algún valor en el Protocolo."
+
 #: components/CarbonBalancesCard/index.tsx:131
 #: components/CarbonTonnesRetiredCard/index.tsx:29
 msgid "Not Connected"
 msgstr "No conectado"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
+msgstr ""
 
 #: components/views/Offset/index.tsx:27
 msgid "Offset"
@@ -108,843 +704,441 @@ msgstr "El 12 de abril de 2022 migramos de \"dapp\" a \"app\". Por favor, actual
 msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 msgstr "Riesgos operativos: La plataforma KlimaDAO se basa en diversas tecnologías relacionadas con la red Polygon y otros activos digitales. Estas tecnologías están sujetas a cambios, y dichos cambios podrían afectar negativamente a su inversión."
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:32
 msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
 msgstr "La compra de criptomonedas, incluyendo el token $KLIMA, implica un alto grado de riesgo y debe considerarse extremadamente especulativa. Estos son algunos puntos importantes a tener en cuenta:"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:53
 msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
 msgstr "Acciones y cambios regulatorios:El entorno normativo de las criptomonedas está evolucionando y los cambios en la regulación podrían afectar negativamente a su inversión."
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:924
+msgid "bond.unredeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:40
+msgid "connect_modal.error_processing"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:29
 msgid "Risk Disclaimer"
 msgstr "Exención de responsabilidad"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:405
+msgid "shared.sold_out"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:335
+msgid "stake.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:258
+#: components/views/Stake/index.tsx:306
+#: components/views/Stake/index.tsx:471
+msgid "stake.stake_klima"
+msgstr ""
+
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
+msgstr ""
 
 #: components/InvalidNetworkModal/index.tsx:72
 msgid "Switch to Polygon"
 msgstr "Cambiar a Polygon"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:68
 msgid "This app only works on Polygon Mainnet."
 msgstr "Esta aplicación sólo funciona en Polygon Mainnet."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:75
 msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
 msgstr "Esta advertencia de riesgo resumida no revela todos los riesgos asociados a la inversión en $KLIMA.Usted debe llevar a cabo su propia diligencia debida y consultar con un asesor financiero antes de tomar cualquier decisión de inversión."
 
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:347
+msgid "stake.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:267
+#: components/views/Stake/index.tsx:473
+msgid "stake.unstake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:324
+msgid "wrap.unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:313
+msgid "wrap.wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:279
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:282
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:63
 msgid "Wrong Network"
 msgstr "Red incorrecta"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:55
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:171
 msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
 msgstr "Tienes que cargar tu monedero con USDC, KLIMA o un token del pool de carbono. Próximamente se admitirán tarjetas de crédito."
 
-#. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr "AGOTADO. Se ha cubierto toda la demanda para este bono. ¡Gracias, Klimates!"
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr "Saldo"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr "Saldo disponible para vincular"
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr "Vincular bono"
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr "Precio del bono"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr "Precio con descuento. Cantidad total de la fianza de 1 KLIMA completo (también se permiten las fianzas fraccionadas)"
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr "Precio de cotización actual de KLIMA en el mercado"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr "Bono {0}"
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr "CAPACIDAD EXCEDIDA"
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr "Fecha de consolidación completa"
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr "Fecha en la que se puede reembolsar la totalidad del valor del bono"
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr "Ratio de deuda"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr "Relación actual entre la oferta y los bonos en circulación del Protocolo"
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr "Descuento de bono"
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr "Porcentaje de descuento (o de prima si es negativo) en relación con el valor de mercado de KLIMA."
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr "Cantidad a vincular"
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr "Importe a redimir"
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr "Prima"
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr "Premium relative to the market value of KLIMA."
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr "Precio de mercado"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr "Precio actual de KLIMA, sin descuento de bonos"
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr "MÁXIMO EXCEDIDO"
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr "Máxima"
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr "Monto máximo que puede adquirir por vinculación"
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr "No redimible"
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr "Pago por KLIMA"
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr "Si vincula 1 KLIMA, recibirá esta cantidad en USDC."
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr "Redimir"
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr "Redimible"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr "Importe de KLIMA que ya se ha consolidado y que puede redimirse"
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr "Hacer staking automáticamente para sKLIMA"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr "⚠️ Atención: el precio de este bono está inflado porque la tasa de descuento actual es negativa."
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr "Bono {0}"
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr "Canjear Klima"
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr "No redimido"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:924
-msgid "bond.unredeemed.tooltip"
-msgstr "Valor restante no reembolsado (adquirido y sin adquirir)"
-
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr "Fin del plazo de adquisición"
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr "Si hace bonding ahora, su plazo de adquisición finaliza en esta fecha. Klima se va desbloqueando poco a poco para su reembolso a lo largo de este plazo."
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:746
 #: components/views/Bond/index.tsx:890
 msgid "bond.you_will_get"
-msgstr "Conseguirás"
+msgstr ""
 
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr "Monto que obtendrá, con la cantidad introducida."
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr "Cantidad de KLIMA en bonos que obtendrá, en la cantidad de entrada proporcionada"
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr "Comprar KLIMA"
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr "Esta función sólo está disponible para usuarios que hayan iniciado sesión. Puede iniciar sesión o crear una cuenta a través del siguiente botón."
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr "Si eres principiante, te recomendamos seguir nuestro tutorial paso a paso: <0>Cómo comprar KLIMA</0>."
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr "De lo contrario, si ya tienes una cartera con MATIC en Polygon, la mejor forma de conseguir KLIMA es intercambiar en <0>Sushi.com</0>. Si prefieres pagar con tarjeta de crédito, puedes usar <1>Transak</1> para comprar KLIMA directamente."
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr "Inicie sesión o conecte una billetera"
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr "Esta es la cantidad de USDC en el contrato disponible para bonos."
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr "No me lo recuerdes"
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr "Entiendo"
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr "<0>app.klimadao.finance</0> es el único dominio oficial."
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr "⚠️ ¡Verifica la URL y marca esta página!"
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr "Toucan Base Carbon Tonne"
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr "Vincular bono de carbono"
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr "La mejor manera de comprar KLIMA. Deposite carbono en nuestra tesorería y reciba KLIMA con descuento. Todos los bonos (excepto los bonos inversos) tienen un periodo de concesión obligatorio de 5 días."
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr "Elige un bono"
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr "Proporcione KLIMA, reciba USDC"
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr "Liquidez BCT/USDC Sushiswap"
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr "Liquidez BCT/USDC Sushiswap"
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr "Token de crédito de carbono MOSS"
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr "Liquidez BCT/USDC Sushiswap"
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr "Compensación basada en la naturaleza C3"
-
-#: components/views/ChooseBond/index.tsx:239
-msgid "choose_bond.percent_discount"
-msgstr "% Descuento"
-
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr "AGOTADO"
-
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr "Saldo de la Tesorería"
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr "Compensación universal basica C3"
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr "redes sociales o correo electrónico"
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr "conectar un monedero"
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr "Conectando..."
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr "Hemos tenido problemas para realizar la conexión. Por favor, inténtelo de nuevo."
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr "El usuario rechazó la conexión."
-
-#: lib/constants.ts:40
-msgid "connect_modal.error_processing"
-msgstr "Solicitud ya en trámite. Por favor, abra su monedero y complete la solicitud."
-
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
-msgstr "Error de conexión"
-
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
-msgstr "Lo sentimos, parece que te enviamos por el camino equivocado. <0/>Seleccione un destino del menú."
-
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
-msgstr "Cómo empezar"
-
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
-msgstr "¿Nuevo en KLIMA?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
-msgstr "1. Abra Metamask y cambie a Ethereum Mainnet"
-
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr "2. Vaya a Configuración/Redes/Polygon y haga clic en \"eliminar\"."
-
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr "3. Vuelve a app.klimadao.finance y haz clic en \"cambiar a la red principal\"."
-
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr "Si la aplicación dice \"cargando...\" es probable que haya un problema con la configuración de la red en Metamask. Para solucionarlo:"
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr "Metamask debería pedirle que añada Polygon, con la configuración RPC correcta."
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr "¿Por qué no se me carga la aplicación?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr "Preguntas comunes relacionadas con la aplicación y enlaces útiles. Para una lectura completa de KlimaDAO, consulte nuestra <0>documentación oficial</0>."
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr "Información y preguntas frecuentes"
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr "Direcciones oficiales del contrato"
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr "No se ha podido acceder a la red. Esto es probablemente causado por una configuración antigua de Polygon RPC en su cartera. Consulta <0>esta guía</0> para solucionarlo. De lo contrario, póngase en contacto con nosotros en <1>Discord</1> si los problemas persisten."
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr "Compruebe la configuración de su red"
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr "Vincular bono de carbono"
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr "Comprar KLIMA"
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr "Información"
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr "SOLO PARA TI"
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr "NO CONECTADO"
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr "Compensación"
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr "Stake KLIMA"
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr "La dirección de su monedero"
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr "Empaquetar sKLIMA"
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr "¡ÉXITO!"
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr "¡FALLO!"
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr "PENDIENTE"
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr "CONFIRMACIÓN"
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr "VOLVER"
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
-msgstr "El agregador de retiro de KlimaDAO es una herramienta de código abierto que permite el retiro de créditos de carbono digitales."
-
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr "Visite nuestra <0> documentación </0> para construirlo en su aplicación, o visite <1> Carbonmark </1> para utilizar una implementación en vivo."
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr "Total de retiros"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr "toneladas de carbono"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr "Ver los retiros"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr "Has retirado"
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr "2. Aprobar BCT"
-
-#: components/views/PKlima/index.tsx:170
-msgid "pklima.approve_pklima"
-msgstr "1. Aprobar pKLIMA"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr "Asegúrate de hacer staking con tu pKLIMA redimido, y de mantenerlo ahi hasta que las emisiones globales de gases de efecto invernadero se hayan estabilizado."
-
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr "EJERCER"
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr "Ejerce 1 pKLIMA y 1 BCT para recibir 1 KLIMA."
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr "Índice ajustado"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr "Equivalente sKLIMA reclamado, asumiendo que usted puso en staking todo su KLIMA redimido hasta hoy."
-
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr "pKLIMA a ejercer"
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr "Has reclamado más KLIMA que tu límite de suministro. Esto se debe probablemente a un arreglo implementado el 24 de noviembre de 2021 en el contrato de canje de pKLIMA."
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr "Redimir pKLIMA"
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
-msgstr "Redimido"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr "Total de KLIMA que has redimido hasta ahora."
-
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr "Límite de suministro"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr "Un porcentaje del suministro total de tokens. Su demanda ajustada al índice no puede superar este valor."
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr "El contrato actualizado asume ahora que los titulares de pKLIMA han hecho staking y ganado recompensas sobre tokens previamente reclamados. Antes de la corrección de noviembre, estas recompensas de staking no se contaban para el límite de la cuota de suministro, lo que significaba que su cuota del suministro total de KLIMA podía superar el límite definido en sus condiciones."
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr "Los fondos digitales de liquidez de carbono de KlimaDAO son recursos comunes disponibles para impulsar el impacto medioambiental."
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr "Visite nuestra <0>documentación </0> para encontrar las direcciones de los contratos LP, o visite <1> Carbonmark </1> para adquirir carbono a través de una sencilla interfaz de usuario."
-
-#: components/views/errors/Custom404.tsx:16
-msgid "shared.404"
-msgstr "404 Pagina no encontrada"
-
-#: components/BalancesCard/index.tsx:47
-msgid "shared.balances"
-msgstr "Saldos"
-
-#: components/ChangeLanguageButton/index.tsx:56
-msgid "shared.change_language"
-msgstr "Cambiar idioma"
-
-#: components/views/Bond/index.tsx:432
-#: components/views/PKlima/index.tsx:165
-#: components/views/Wrap/index.tsx:220
-msgid "shared.confirming"
-msgstr "Confirmando"
-
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr "Cargando..."
-
-#: components/views/Stake/index.tsx:259
-#: components/views/Stake/index.tsx:268
-msgid "shared.enter_amount"
-msgstr "Ingrese la cantidad"
-
-#: components/views/Bond/index.tsx:475
-#: components/views/Bond/index.tsx:494
-#: components/views/Stake/index.tsx:276
-#: components/views/Wrap/index.tsx:247
-msgid "shared.error"
-msgstr "ERROR"
-
-#: components/views/Bond/index.tsx:397
-#: components/views/Buy/index.tsx:65
-#: components/views/Home/index.tsx:154
-#: components/views/PKlima/index.tsx:149
-#: components/views/Stake/index.tsx:229
-#: components/views/Wrap/index.tsx:199
-msgid "shared.login_connect"
-msgstr "Iniciar sesión / Conectar"
-
-#: components/views/Bond/index.tsx:605
-#: components/views/PKlima/index.tsx:239
-#: components/views/Stake/index.tsx:372
-#: components/views/Wrap/index.tsx:346
-msgid "shared.max"
-msgstr "Max"
-
-#: components/views/Bond/index.tsx:405
-msgid "shared.sold_out"
-msgstr "Agotado"
-
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
-msgstr "Recompensas en 5 días"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr "Recompensas aproximadas, incluyendo el compounding, en caso de hacer staking durante 5 días."
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
-msgstr "AKR"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
-msgstr "Recompensas KLIMA anualizadas, incluida la capitalización, en caso de que la tasa de recompensa actual se mantenga sin cambios durante 12 meses (la tasa de recompensa puede estar sujeta a cambios)."
-
-#. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
-msgstr "Haga staking con sus tokens KLIMA para recibir sKLIMA. Después de cada rebase, su saldo de sKLIMA aumentará en el porcentaje indicado."
-
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr "Pago estimado (sKLIMA)"
-
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr "Índice"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr "Cantidad de KLIMA que tendrías hoy si hubieras hecho staking con 1 KLIMA el día del lanzamiento. Útil para fines contables."
-
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr "Cantidad para hacer staking"
-
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr "Cantidad para retirar"
-
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr "El staking entre cadenas ya está disponible a través de <0>LI.FI y Etherspot</0>, con soporte para múltiples cadenas y tokens."
-
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr "Siguiente rebase aprox."
-
-#: components/RebaseCard/index.tsx:73
-msgid "stake.percent_payout"
-msgstr "Porcentaje de pago"
-
-#: components/RebaseCard/index.tsx:44
-msgid "stake.rebase"
-msgstr "Rebase"
-
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr "El protocolo mintea y distribuye automáticamente las recompensas. Su pago es un porcentaje de su saldo sKLIMA"
-
-#: components/views/Stake/index.tsx:335
-msgid "stake.stake"
-msgstr "Stake"
-
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
-msgstr "Haz staking, holdea y gana sKLIMA."
-
-#: components/views/Stake/index.tsx:258
-#: components/views/Stake/index.tsx:306
-#: components/views/Stake/index.tsx:471
-msgid "stake.stake_klima"
-msgstr "Stake KLIMA"
-
-#: components/views/Stake/index.tsx:347
-msgid "stake.unstake"
-msgstr "Retirar"
-
-#: components/views/Stake/index.tsx:267
-#: components/views/Stake/index.tsx:473
-msgid "stake.unstake_klima"
-msgstr "Retirar KLIMA"
-
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr "Transacción completa."
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr "❌ Error: algo ha salido mal..."
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr "Transacción iniciada. Esperando confirmación de la red."
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr "Por favor, haga clic en \"confirmar\" en su cartera para continuar."
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr "Usted eligió rechazar la transacción"
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr "pKLIMA"
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr "Primero debes dar permiso a nuestro contrato inteligente para que transfiera tokens en tu nombre."
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr "Dirección del contrato"
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr "Cantidad a aprobar"
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr "Cerrar"
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr "Siguiente"
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr "Confirmar cantidad"
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr "Enviar"
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr "Por favor, envíe la transacción."
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr "Dirección del contrato"
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Aprobar"
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Enviar"
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr "Conéctate con el proveedor de tu navegador web3"
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr "Monedero fácil con un solo clic de Torus"
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr "Correo electrónico o redes sociales"
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr "Escanea con WalletConnect para conectarte"
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr "Escanea con Coinbase para conectarte"
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr "Saldo"
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr "Empaqueta tus sKLIMA para recibir el KLIMA ajustado al índice"
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr "Índice"
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr "Cantidad de KLIMA que tendrías hoy si hubieras hecho staking con 1 KLIMA el día del lanzamiento. Se utiliza para calcular el valor de wsKLIMA."
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr "sKLIMA para empaquetar"
-
-#: components/views/Wrap/index.tsx:324
-msgid "wrap.unwrap"
-msgstr "Desempaquetar"
-
-#: components/views/Wrap/index.tsx:313
-msgid "wrap.wrap"
-msgstr "Empaquetar"
-
-#: components/views/Wrap/index.tsx:279
-msgid "wrap.wrap_sklima"
-msgstr "Empaquetar sKLIMA"
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
-msgstr "A algunos les resulta útil para la contabilidad, pero las recompensas son exactamente las mismas. Los valores de empaquetado y desempaquetado se calculan en función del índice actual."
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:282
-msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
-msgstr "Empaqueta tus sKLIMA para recibir wsKLIMA. A diferencia de sKLIMA, su saldo de wsKLIMA no aumentará con el tiempo."
-
-#: components/views/Wrap/index.tsx:55
-msgid "wrap.wsklima_to_unwrap"
-msgstr "wsKLIMA para desempaquetar"
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
-msgstr "Conseguirás"
+msgstr ""
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
-msgstr "Desempaquetado"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
+msgstr ""

--- a/app/locale/fr/messages.po
+++ b/app/locale/fr/messages.po
@@ -6,10 +6,156 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:239
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:170
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:16
+msgid "shared.404"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:84
 msgid "Acknowledge and Accept"
 msgstr "Accuser réception et Accepter"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
+msgstr ""
 
 #: components/TransactionModal/Approve.tsx:93
 #: components/views/Bond/index.tsx:454
@@ -18,9 +164,90 @@ msgstr "Accuser réception et Accepter"
 msgid "Approve"
 msgstr "Approuver"
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:47
+msgid "shared.balances"
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
 msgstr "Soldes"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
+msgstr ""
 
 #: components/views/Redeem/index.tsx:25
 msgid "Buy & Redeem Carbon"
@@ -30,27 +257,303 @@ msgstr "Acheter et Réclamer du carbone"
 msgid "Buy Carbon"
 msgstr "Acheter du Carbone"
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr ""
+
 #: components/views/Bond/index.tsx:697
 msgid "Capacity"
 msgstr "Capacité"
 
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
-msgstr "Entrez la Quantité"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:56
+msgid "shared.change_language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:432
+#: components/views/PKlima/index.tsx:165
+#: components/views/Wrap/index.tsx:220
+msgid "shared.confirming"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:259
+#: components/views/Stake/index.tsx:268
+msgid "shared.enter_amount"
+msgstr ""
 
 #: components/views/Stake/index.tsx:242
 #: components/views/Wrap/index.tsx:212
 msgid "Enter quantity"
 msgstr "Entrez la quantité"
 
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr "Entrez la Quantité"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:475
+#: components/views/Bond/index.tsx:494
+#: components/views/Stake/index.tsx:276
+#: components/views/Wrap/index.tsx:247
+msgid "shared.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
 #: components/views/Offset/index.tsx:45
 msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
 msgstr "Pour les utilisateurs qui souhaitent compenser le paiement par un jeton de pool, veuillez utiliser <0>ce site</0>."
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
+msgstr ""
 
 #: components/views/Stake/index.tsx:247
 #: components/views/Wrap/index.tsx:225
 msgid "Insufficient balance"
 msgstr "Solde insuffisant"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:47
 msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
@@ -75,26 +578,119 @@ msgstr "Chargement des soldes des comptes..."
 msgid "Loading..."
 msgstr "Chargement..."
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr ""
+
 #: components/views/Home/index.tsx:178
 msgid "Login"
 msgstr "Se connecter"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:397
+#: components/views/Buy/index.tsx:65
+#: components/views/Home/index.tsx:154
+#: components/views/PKlima/index.tsx:149
+#: components/views/Stake/index.tsx:229
+#: components/views/Wrap/index.tsx:199
+msgid "shared.login_connect"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:39
 msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 msgstr "Perte d'Investissement : La valeur de $KLIMA et d'autres cryptomonnaies peut augmenter ou diminuer rapidement à tout moment. Par conséquent, vous pourriez subir des pertes importantes et rapides, y compris la perte de l'intégralité du capital investi."
 
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
-msgstr "Aucune Garantie : Il n'y a aucune garantie que la plateforme KlimaDAO ou le jeton $KLIMA atteindra ses objectifs ou qu'une quelconque valeur sera préservée dans le protocole."
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:605
+#: components/views/PKlima/index.tsx:239
+#: components/views/Stake/index.tsx:372
+#: components/views/Wrap/index.tsx:346
+msgid "shared.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:168
 msgid "No balances found."
 msgstr "Aucun solde trouvé."
 
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr "Aucune Garantie : Il n'y a aucune garantie que la plateforme KlimaDAO ou le jeton $KLIMA atteindra ses objectifs ou qu'une quelconque valeur sera préservée dans le protocole."
+
 #: components/CarbonBalancesCard/index.tsx:131
 #: components/CarbonTonnesRetiredCard/index.tsx:29
 msgid "Not Connected"
 msgstr "Non connecté"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
+msgstr ""
 
 #: components/views/Offset/index.tsx:27
 msgid "Offset"
@@ -108,843 +704,441 @@ msgstr "Le 12 avril 2022, nous avons migré de \"dapp\" à \"app\". Veuillez met
 msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 msgstr "Risques Opérationnels : La plateforme KlimaDAO repose sur diverses technologies liées au réseau Polygon et à d'autres actifs numériques. Ces technologies sont sujettes à des changements qui pourraient avoir un impact négatif sur votre investissement."
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:32
 msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
 msgstr "L'achat de crypto-monnaies, y compris le jeton $KLIMA, implique un degré élevé de risque et doit être considéré comme extrêmement spéculatif. Voici quelques points importants à prendre en compte :"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:53
 msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
 msgstr "Actions et Évolutions Réglementaires : L'environnement réglementaire des crypto-monnaies évolue et les changements de réglementation pourraient avoir un impact négatif sur votre investissement."
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:924
+msgid "bond.unredeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:40
+msgid "connect_modal.error_processing"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:29
 msgid "Risk Disclaimer"
 msgstr "Clause de non-responsabilité concernant les risques"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:405
+msgid "shared.sold_out"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:335
+msgid "stake.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:258
+#: components/views/Stake/index.tsx:306
+#: components/views/Stake/index.tsx:471
+msgid "stake.stake_klima"
+msgstr ""
+
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
+msgstr ""
 
 #: components/InvalidNetworkModal/index.tsx:72
 msgid "Switch to Polygon"
 msgstr "Passer sur le réseau Polygon"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:68
 msgid "This app only works on Polygon Mainnet."
 msgstr "Cette application fonctionne uniquement sur le réseau Polygon principal."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:75
 msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
 msgstr "Cette liste de risques ne couvre pas tous les risques liés à l'investissement dans $KLIMA. Vous devez procéder à vos propres vérifications et consulter un conseiller financier agréé avant de prendre toute décision d'investissement."
 
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:347
+msgid "stake.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:267
+#: components/views/Stake/index.tsx:473
+msgid "stake.unstake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:324
+msgid "wrap.unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:313
+msgid "wrap.wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:279
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:282
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:63
 msgid "Wrong Network"
 msgstr "Mauvais réseau"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:55
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:171
 msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
 msgstr "Vous devez charger votre portefeuille avec des jetons USDC, KLIMA ou d'un pool de carbone. La prise en charge des cartes de crédit sera bientôt possible."
 
-#. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr "ÉPUISÉ. Toute la demande a été remplie pour cet obligation. Merci à tous, les Klimates !"
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr "Solde"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr "Solde disponible pour acheter des obligations"
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr "Obligation"
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr "Prix de l'obligation"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr "Prix soldé. Montant total pour contracter 1 KLIMA complet (les contrats fractionnaires sont également autorisées)"
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr "Cours actuel du KLIMA sur le marché"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr "Obligation {0}"
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr "CAPACITÉ DÉPASSÉE"
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr "Date d'acquisition complète"
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr "Date à laquelle la valeur totale de l'obligation pourra être réclamée"
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr "Ratio d'endettement"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr "Ratio actuel de l'offre par rapport aux obligations en circulation du protocole"
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr "Escompte obligataire"
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr "Pourcentage de réduction (ou premium si négatif) par rapport à la valeur sur le marché du KLIMA."
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr "Montant à investir"
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr "Montant à réclamer"
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr "Premium"
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr "Premium comparé à la valeur sur le marché du KLIMA."
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr "Prix du marché"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr "Cours actuel de KLIMA, sans décote obligataire"
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr "MAX DÉPASSÉ"
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr "Maximum"
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr "Montant maximum que vous pouvez acquérir avec des obligations"
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr "Ne pouvant être réclamé"
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr "Paiement par KLIMA"
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr "Si vous prêtez 1 KLIMA, vous recevrez ce montant en USDC."
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr "Réclamer"
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr "Réclamable"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr "Montant de KLIMA déjà disponible et pouvant être réclamés"
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr "Mettre en jeu automatiquement contre des sKLIMA"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr "⚠️ Attention : le prix de l'obligation est augmenté car la remise actuelle est négative."
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr "Obligation {0}"
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr "Réclamer Klima"
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr "Non réclamé"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:924
-msgid "bond.unredeemed.tooltip"
-msgstr "Valeur non réclamée restante (disponible et non disponible)"
-
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr "Fin de la période de maturation"
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr "Si vous contractez une obligation maintenant, votre période d'acquisition se terminera à cette date. La réclamation de Klima est lentement déverrouillé sur cette durée."
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:746
 #: components/views/Bond/index.tsx:890
 msgid "bond.you_will_get"
-msgstr "Vous obtiendrez"
+msgstr ""
 
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr "Montant d'obligations que vous obtiendrez, d'après la quantité fournie."
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr "Montant d'obligations KLIMA liée que vous obtiendrez, d'après la quantité soumise en entrée."
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr "Acheter KLIMA"
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr "Cette fonction n'est disponible que pour les utilisateurs qui sont connectés. Vous pouvez vous connecter ou créer un compte en cliquant sur le bouton ci-dessous."
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr "Si vous êtes un débutant, nous vous recommandons de suivre notre tutoriel étape par étape : <0>Comment acheter des KLIMA</0>."
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr "Autrement, si vous avez déjà un portefeuille avec des MATIC sur Polygon, la meilleure façon d'obtenir KLIMA est de faire un échange sur <0>Sushi.com</0>. Si vous préférez plutôt payer avec une carte de crédit, vous pouvez utiliser <1>Transak</1> pour acheter KLIMA directement."
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr "Veuillez Vous Identifier ou Connecter Un Portefeuille"
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr "Il s'agit du montant d'USDC disponible dans le contrat pour les obligations."
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr "Ne pas me le rappeler"
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr "J'ai compris"
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr "<0>app.klimadao.finance</0> est le seul domaine officiel."
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr "⚠️ Vérifiez l'URL et mettez cette page dans vos favoris !"
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr "Tonne de Carbone de base Toucan"
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr "Obligation carbone"
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr "La meilleure façon d'acheter des KLIMA. Déposez des équivalents carbone dans notre trésorerie et recevez des KLIMA à prix réduit. Toutes les obligations (sauf celles à taux variable inversé) ont une période de maturation obligatoire de 5 jours."
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr "Choisissez une obligation"
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr "Fournissez des KLIMA, recevez des USDC"
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr "Liquidité Sushiswap KLIMA/BCT"
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr "Liquidité Sushiswap KLIMA/USDC"
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr "Jeton de crédit carbone MOSS"
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr "Liquidité Quickswap KLIMA/MCO2"
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr "Compensation C3 basée sur la nature"
-
-#: components/views/ChooseBond/index.tsx:239
-msgid "choose_bond.percent_discount"
-msgstr "% Remise"
-
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr "ÉPUISÉ"
-
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr "Solde de la trésorerie"
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr "Compensation C3 standard"
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr "réseau social ou email"
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr "connecter un portefeuille"
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr "Connexion en cours..."
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr "Nous avons eu des problèmes de connexion. Veuillez réessayer."
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr "L'utilisateur a refusé la connexion."
-
-#: lib/constants.ts:40
-msgid "connect_modal.error_processing"
-msgstr "Demande en cours de traitement. Veuillez ouvrir votre portefeuille et compléter la demande."
-
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
-msgstr "Erreur de connexion"
-
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
-msgstr "Désolé, il semble que nous vous ayons envoyé au mauvais endroit. <0/>Sélectionnez un élément dans le menu s'il vous plaît."
-
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
-msgstr "Comment commencer"
-
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
-msgstr "Nouveau sur KLIMA ?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
-msgstr "1. Ouvrez Metamask et choisissez le réseau Ethereum Mainnet"
-
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr "2. Allez dans Paramètres/Réseaux/Polygon et cliquez sur 'supprimer'"
-
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr "3. Retournez sur app.klimadao.finance et choisissez le réseau principal"
-
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr "Si l'application indique \"chargement...\", il s'agit probablement d'un problème lié à la configuration de votre réseau dans Metamask. Pour résoudre ce problème :"
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr "Metamask devrait vous inviter à ajouter le réseau Polygon, avec la configuration RPC qui convient."
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr "Pourquoi l'application ne charge-t-elle pas ?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr "Questions courantes concernant l'application et liens utiles. Pour des informations plus complètes sur KlimaDAO, veuillez consulter notre <0>documentation officielle</0> ."
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr "Informations et FAQ"
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr "Adresses officielles des contrats"
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr "Le réseau n'a pas pu être atteint. Ceci est très probablement causé par une ancienne configuration du RPC de Polygon dans votre portefeuille. Voir <0>ce guide</0> pour la corriger. Sinon, contactez-nous sur <1>Discord</1> si les problèmes persistent."
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr "Vérifiez vos paramètres réseau"
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr "Obligation carbone"
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr "Acheter KLIMA"
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr "Informations"
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr "JUSTE POUR VOUS"
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr "NON CONNECTÉ"
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr "Compenser"
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr "Mettre en jeu des KLIMA"
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr "L'adresse de votre portefeuille"
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr "Encapsuler sKLIMA"
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr "SUCCÈS!"
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr "ÉCHEC!"
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr "EN ATTENTE"
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr "CONFIRMATION"
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr "RETOUR"
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
-msgstr "L'agrégateur de retrait de KlimaDAO est un outil à code source libre qui permet le retrait des crédits de carbone numériques."
-
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr "Consultez notre <0> documentation </0> pour l'intégrer dans votre application, ou visitez <1> Carbonmark </1> pour utiliser une implémentation en direct."
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr "Retraits totaux"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr "Tonnes de carbone"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr "Voir les Retraits du marché"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr "Vous avez retiré du marché"
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr "2. Approuvez BCT"
-
-#: components/views/PKlima/index.tsx:170
-msgid "pklima.approve_pklima"
-msgstr "1. Approuver pKLIMA"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr "Assurez-vous de mettre en jeu le pKLIMA réclamé et de conserver votre mise jusqu'à ce que les émissions mondiales de GHG aient atteint un plateau."
-
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr "EXERCER"
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr "Exercez 1 pKLIMA et 1 BCT pour recevoir 1 KLIMA."
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr "Indice ajusté"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr "Équivalent sKLIMA réclamé, en supposant que vous avez mis en jeu tous vos KLIMA jusqu'à aujourd'hui."
-
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr "pKLIMA que vous pouvez exercer"
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr "Vous avez réclamé plus de KLIMA que votre limite de partage d'approvisionnement ne le permet. Cela est probablement dû au correctif mis en œuvre le 24 novembre 2021 au contrat de réclamation de pKLIMA."
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr "Réclamer pKlima"
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
-msgstr "Réclamé"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr "Montant total de KLIMA que vous avez échangé jusqu'à présent."
-
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr "Quantité maximale"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr "Un pourcentage de l'offre totale de jetons. Votre créance ajustée par l’indice ne peut pas dépasser cette valeur."
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr "Le nouveau contrat présuppose que les détenteurs de pKLIMA ont mis en jeu et gagné des récompenses provenant d'actifs réclamés au préalable. Avant le correctif de novembre, le rendement des dépôts n'étaient pas pris en compte dans votre limite d'approvisionnement. De fait votre approvisionnement total en KLIMA pouvait dépasser la limite définie dans vos conditions."
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr "Les pools de liquidités numériques de carbone de KlimaDAO sont des ressources communes disponibles pour faire progresser l'impact sur l'environnement."
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr "Visitez notre <0>documentation </0> pour trouver les adresses des contrats LP, ou visitez <1> Carbonmark </1> pour acquérir du carbone via une interface utilisateur simple."
-
-#: components/views/errors/Custom404.tsx:16
-msgid "shared.404"
-msgstr "404 Page non trouvée"
-
-#: components/BalancesCard/index.tsx:47
-msgid "shared.balances"
-msgstr "Soldes"
-
-#: components/ChangeLanguageButton/index.tsx:56
-msgid "shared.change_language"
-msgstr "Changer de langue"
-
-#: components/views/Bond/index.tsx:432
-#: components/views/PKlima/index.tsx:165
-#: components/views/Wrap/index.tsx:220
-msgid "shared.confirming"
-msgstr "Confirmation en cours"
-
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr "Chargement..."
-
-#: components/views/Stake/index.tsx:259
-#: components/views/Stake/index.tsx:268
-msgid "shared.enter_amount"
-msgstr "Entrez le montant"
-
-#: components/views/Bond/index.tsx:475
-#: components/views/Bond/index.tsx:494
-#: components/views/Stake/index.tsx:276
-#: components/views/Wrap/index.tsx:247
-msgid "shared.error"
-msgstr "ERREUR"
-
-#: components/views/Bond/index.tsx:397
-#: components/views/Buy/index.tsx:65
-#: components/views/Home/index.tsx:154
-#: components/views/PKlima/index.tsx:149
-#: components/views/Stake/index.tsx:229
-#: components/views/Wrap/index.tsx:199
-msgid "shared.login_connect"
-msgstr "S'identifier / Se connecter"
-
-#: components/views/Bond/index.tsx:605
-#: components/views/PKlima/index.tsx:239
-#: components/views/Stake/index.tsx:372
-#: components/views/Wrap/index.tsx:346
-msgid "shared.max"
-msgstr "Max"
-
-#: components/views/Bond/index.tsx:405
-msgid "shared.sold_out"
-msgstr "Épuisé"
-
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
-msgstr "Récompenses sur 5 jours"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr "Récompenses approximatives, comprenant les intérêts composés, si vous laissez votre mise pendant 5 jours."
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
-msgstr "AKR"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
-msgstr "Rendement en KLIMA annualisé, y compris les intérêts composés, si le rendement actuel reste inchangé pendant 12 mois (le rendement peut être variable)."
-
-#. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
-msgstr "Mettez en jeu vos jetons KLIMA pour recevoir des sKLIMA. Après chaque rebasement, votre solde sKLIMA augmentera du pourcentage indiqué."
-
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr "Est. paiement (sKLIMA)"
-
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr "Indice"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr "Montant de KLIMA que vous auriez aujourd'hui si vous aviez mis en jeu 1 KLIMA le jour du lancement. Utile à des fins comptables."
-
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr "Montant à mettre en jeu"
-
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr "Montant de la mise à enlever"
-
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr "La mise en jeu inter-chaînes est désormais disponible via <0>LI.FI et Etherspot</0>, avec un support pour plusieurs chaînes et jetons."
-
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr "Environ. Prochain rebasage"
-
-#: components/RebaseCard/index.tsx:73
-msgid "stake.percent_payout"
-msgstr "de rendement"
-
-#: components/RebaseCard/index.tsx:44
-msgid "stake.rebase"
-msgstr "Rebasage"
-
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr "Le protocole génère et distribue automatiquement les intérêts. Vous êtes rémunéré un pourcentage de votre solde en sKLIMA"
-
-#: components/views/Stake/index.tsx:335
-msgid "stake.stake"
-msgstr "Mettre en jeu"
-
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
-msgstr "Mettez en jeu, accumulez et gagnez des sKLIMA via les intérêts composés."
-
-#: components/views/Stake/index.tsx:258
-#: components/views/Stake/index.tsx:306
-#: components/views/Stake/index.tsx:471
-msgid "stake.stake_klima"
-msgstr "Mettre en jeu des KLIMA"
-
-#: components/views/Stake/index.tsx:347
-msgid "stake.unstake"
-msgstr "Enlever sa mise"
-
-#: components/views/Stake/index.tsx:267
-#: components/views/Stake/index.tsx:473
-msgid "stake.unstake_klima"
-msgstr "Enlever sa mise de KLIMA"
-
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr "Transaction terminée."
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr "❌ Erreur : quelque chose s'est mal passé..."
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr "Transaction initiée. En attente de confirmation du réseau."
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr "Veuillez cliquer sur « confirmer » dans votre portefeuille pour continuer."
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr "Vous avez rejeté la transaction"
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr "pKLIMA"
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr "Vous devez d'abord donner la permission à notre contrat intelligent de transférer des jetons en votre nom."
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr "Adresse du contrat"
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr "Quantité à approuver"
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr "Fermer"
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr "Suivant"
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr "Confirmer le montant"
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr "Envoyer"
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr "Veuillez confirmer la transaction."
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr "Adresse du contrat"
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Approuver"
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Envoyez"
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr "Connectez-vous avec le portefeuille web3 de votre navigateur"
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr "Portefeuille rapide en 1 clic avec Torus"
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr "Email ou Réseau Social"
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr "Scannez avec l'application WalletConnect pour vous connecter"
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr "Scannez avec Coinbase pour vous connecter"
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr "Solde"
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr "Encapsulez sKLIMA pour recevoir un KLIMA ajusté à l'indice, encapsulé et mis en jeu"
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr "Indice"
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr "Montant de KLIMA que vous posséderiez aujourd'hui si vous aviez mis en jeu 1 KLIMA le jour du lancement. Utilisé pour calculer la valeur wsKLIMA."
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr "sKLIMA à encapsuler"
-
-#: components/views/Wrap/index.tsx:324
-msgid "wrap.unwrap"
-msgstr "Dés-encapsuler"
-
-#: components/views/Wrap/index.tsx:313
-msgid "wrap.wrap"
-msgstr "Encapsuler"
-
-#: components/views/Wrap/index.tsx:279
-msgid "wrap.wrap_sklima"
-msgstr "Encapsuler sKLIMA"
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
-msgstr "Peut être utile à des fins comptables, néanmoins, les récompenses sont exactement les mêmes. Les valeurs d'encapsulation et de dés-encapsulation sont calculées en fonction de l'indice actuel."
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:282
-msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
-msgstr "Encapsulez sKLIMA pour recevoir wsKLIMA. Contrairement à sKLIMA, votre solde wsKLIMA n'augmentera pas avec le temps."
-
-#: components/views/Wrap/index.tsx:55
-msgid "wrap.wsklima_to_unwrap"
-msgstr "wsKLIMA à dés-encapsuler"
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
-msgstr "Vous obtiendrez"
+msgstr ""
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
-msgstr "Désencapsulé"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
+msgstr ""

--- a/app/locale/hi/messages.po
+++ b/app/locale/hi/messages.po
@@ -6,10 +6,156 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: hi\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:239
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:170
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:16
+msgid "shared.404"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:84
 msgid "Acknowledge and Accept"
 msgstr "स्वीकार करें और स्वीकार करें"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
+msgstr ""
 
 #: components/TransactionModal/Approve.tsx:93
 #: components/views/Bond/index.tsx:454
@@ -18,9 +164,90 @@ msgstr "स्वीकार करें और स्वीकार कर�
 msgid "Approve"
 msgstr "मंज़ूरी दें"
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:47
+msgid "shared.balances"
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
 msgstr "बैलेंस"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
+msgstr ""
 
 #: components/views/Redeem/index.tsx:25
 msgid "Buy & Redeem Carbon"
@@ -30,27 +257,303 @@ msgstr "कार्बन खरीदें और रिडीम करे�
 msgid "Buy Carbon"
 msgstr "कार्बन खरीदें"
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr ""
+
 #: components/views/Bond/index.tsx:697
 msgid "Capacity"
 msgstr "क्षमता"
 
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
-msgstr "मात्रा दर्ज करें"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:56
+msgid "shared.change_language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:432
+#: components/views/PKlima/index.tsx:165
+#: components/views/Wrap/index.tsx:220
+msgid "shared.confirming"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:259
+#: components/views/Stake/index.tsx:268
+msgid "shared.enter_amount"
+msgstr ""
 
 #: components/views/Stake/index.tsx:242
 #: components/views/Wrap/index.tsx:212
 msgid "Enter quantity"
 msgstr "मात्रा दर्ज करें"
 
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr "मात्रा दर्ज करें"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:475
+#: components/views/Bond/index.tsx:494
+#: components/views/Stake/index.tsx:276
+#: components/views/Wrap/index.tsx:247
+msgid "shared.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
 #: components/views/Offset/index.tsx:45
 msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
 msgstr ""
 
 #: components/views/Stake/index.tsx:247
 #: components/views/Wrap/index.tsx:225
 msgid "Insufficient balance"
 msgstr "अपर्याप्त शेषराशि"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:47
 msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
@@ -75,26 +578,119 @@ msgstr "लोड हो रहा है..."
 msgid "Loading..."
 msgstr "लोड हो रहा है..."
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr ""
+
 #: components/views/Home/index.tsx:178
 msgid "Login"
 msgstr "लॉग इन करें"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:397
+#: components/views/Buy/index.tsx:65
+#: components/views/Home/index.tsx:154
+#: components/views/PKlima/index.tsx:149
+#: components/views/Stake/index.tsx:229
+#: components/views/Wrap/index.tsx:199
+msgid "shared.login_connect"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:39
 msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 msgstr "निवेश का नुकसान: $KLIMA और अन्य क्रिप्टोकरेंसी का मूल्य किसी भी समय तेजी से बढ़ या घट सकता है। परिणामस्वरूप, आपको महत्वपूर्ण और तीव्र हानि का अनुभव हो सकता है, जिसमें निवेश किए गए सभी धन की हानि भी शामिल है।"
 
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
-msgstr "कोई गारंटी नहीं: इस बात की कोई गारंटी नहीं है कि KlimaDAO प्लेटफ़ॉर्म या $KLIMA टोकन अपने उद्देश्यों को प्राप्त करेगा या प्रोटोकॉल में कोई मूल्य बरकरार रखा जाएगा।"
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:605
+#: components/views/PKlima/index.tsx:239
+#: components/views/Stake/index.tsx:372
+#: components/views/Wrap/index.tsx:346
+msgid "shared.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:168
 msgid "No balances found."
 msgstr "कोई बैलेंस नहीं मिला."
 
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr "कोई गारंटी नहीं: इस बात की कोई गारंटी नहीं है कि KlimaDAO प्लेटफ़ॉर्म या $KLIMA टोकन अपने उद्देश्यों को प्राप्त करेगा या प्रोटोकॉल में कोई मूल्य बरकरार रखा जाएगा।"
+
 #: components/CarbonBalancesCard/index.tsx:131
 #: components/CarbonTonnesRetiredCard/index.tsx:29
 msgid "Not Connected"
 msgstr "कनेक्ट नहीं हैं"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
+msgstr ""
 
 #: components/views/Offset/index.tsx:27
 msgid "Offset"
@@ -108,843 +704,441 @@ msgstr "12 अप्रैल, 2022 को हम \"dapp\" (डैप) से \"
 msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 msgstr "परिचालन जोखिम: KlimaDAO प्लेटफ़ॉर्म पॉलीगॉन नेटवर्क और अन्य डिजिटल परिसंपत्तियों से संबंधित विभिन्न तकनीकों पर निर्भर करता है। ये प्रौद्योगिकियाँ परिवर्तन के अधीन हैं, और ऐसे परिवर्तन आपके निवेश पर प्रतिकूल प्रभाव डाल सकते हैं।"
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:32
 msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
 msgstr "$KLIMA टोकन सहित क्रिप्टोकरेंसी खरीदने में उच्च स्तर का जोखिम शामिल है और इसे अत्यधिक सट्टा माना जाना चाहिए। यहां विचार करने योग्य कुछ महत्वपूर्ण बिंदु दिए गए हैं:"
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:53
 msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
 msgstr "नियामक कार्रवाइयां और परिवर्तन: क्रिप्टोकरेंसी के लिए नियामक वातावरण विकसित हो रहा है और विनियमन में बदलाव आपके निवेश पर प्रतिकूल प्रभाव डाल सकता है।"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:924
+msgid "bond.unredeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:40
+msgid "connect_modal.error_processing"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:29
 msgid "Risk Disclaimer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:405
+msgid "shared.sold_out"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:335
+msgid "stake.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:258
+#: components/views/Stake/index.tsx:306
+#: components/views/Stake/index.tsx:471
+msgid "stake.stake_klima"
+msgstr ""
+
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
 msgstr ""
 
 #: components/InvalidNetworkModal/index.tsx:72
 msgid "Switch to Polygon"
 msgstr "Polygon (पॉलिगॉन) पर स्विच करें"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:68
 msgid "This app only works on Polygon Mainnet."
 msgstr "यह ऐप केवल Polygon Mainnet (पॉलीगॉन मेननेट) पर ही काम करता है।"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:75
 msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
 msgstr "यह सारांश जोखिम चेतावनी $KLIMA में निवेश से जुड़े सभी जोखिमों का खुलासा नहीं करती है। आपको कोई भी निवेश निर्णय लेने से पहले अपना उचित परिश्रम करना चाहिए और वित्तीय सलाहकार से परामर्श लेना चाहिए।"
 
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:347
+msgid "stake.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:267
+#: components/views/Stake/index.tsx:473
+msgid "stake.unstake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:324
+msgid "wrap.unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:313
+msgid "wrap.wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:279
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:282
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:63
 msgid "Wrong Network"
 msgstr "ग़लत नेटवर्क"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:55
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:171
 msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
 msgstr "आपको अपने वॉलेट को USDC, KLIMA या कार्बन पूल टोकन से लोड करना होगा। क्रेडिट कार्ड समर्थन जल्द ही आ रहा है।"
 
-#. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr "बिक चुका है। इस बॉन्ड की संपूर्ण माँग पूरी कर दी गई है। धन्यवाद, क्लीमेट्स!"
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr "बैलेंस"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr "बॉन्डिंग के लिए उपलब्ध बैलेंस"
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr "बॉन्ड"
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr "बॉन्ड क़ीमत"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr "रियायती मूल्य। बॉन्ड की कुल राशि 1 पूर्ण KLIMA (आंशिक बॉन्ड्स की अनुमति भी है)"
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr "बाज़ार में KLIMA का वर्तमान ट्रेडिंग मूल्य"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr "बॉन्ड {0}"
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr "क्षमता से अधिक"
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr "पूर्ण निहित होने की तिथि"
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr "दिनांक जब संपूर्ण बॉन्ड मूल्य को भुनाया जा सकता है"
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr "ऋण अनुपात"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr " प्रोटोकॉल का बकाया बॉन्ड्स के प्रति वर्तमान आपूर्त्ति अनुपात"
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr "बॉन्ड छूट"
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr "KLIMA के बाज़ार मूल्य के सापेक्ष प्रतिशत छूट (या नकारात्मक होने पर प्रीमियम)।"
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr "बंधित राशि"
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr "रिडीम राशि"
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr "प्रीमियम"
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr "KLIMA के बाज़ार मूल्य के सापेक्ष प्रीमियम।"
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr "बाज़ार क़ीमत"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr "KLIMA का वर्तमान ट्रेडिंग मूल्य, बिना बॉन्ड छूट के"
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr "अधिकतम सीमा पार हो गयी"
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr "ज़्यादा से ज़्यादा"
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr "अधिकतम राशि जो बॉन्डिंग द्वारा आप प्राप्त कर सकते हैं"
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr "प्रतिदेय नहीं"
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr "भुगतान प्रति KLIMA"
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr "यदि आप 1 KLIMA को बॉन्ड करते हैं, तो आपको यह राशि USDC (यूएसडीसी) में प्राप्त होगी।"
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr "भुनाना"
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr "प्रतिदेय"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr "KLIMA की राशि जो पहले से ही निहित है और जिसे भुनाया जा सकता है"
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr "sKLIMA के लिए स्वचालित रूप से स्टेकिंग"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr "⚠️️ चेतावनी: इस बॉन्ड की क़ीमत बढ़ गयी है क्योंकि वर्तमान छूट दर नकारात्मक है।"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr "बॉन्ड {0}"
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr "Klima रिडीम करें"
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr "अनरिडीम्ड"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:924
-msgid "bond.unredeemed.tooltip"
-msgstr "शेष अविमोचित राशि (निहित और अनिहित)"
-
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr "निधान अवधि की समाप्ति "
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr "यदि आप अभी बॉन्ड करते हैं, तो आपकी निहित अवधि इस तिथि पर समाप्त हो जाती है। इस अवधि के दौरान Klima ऋणमोचन के लिए धीरे-धीरे अनलॉक हो जाता है।"
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:746
 #: components/views/Bond/index.tsx:890
 msgid "bond.you_will_get"
-msgstr "आपको मिलेगा"
-
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr "प्रदान की गई इनपुट मात्रा पर आपको यह राशि मिलेगी"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr "प्रदान की गई इनपुट मात्रा पर आपको बंधित KLIMA की राशि मिलेगी"
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr "KLIMA ख़रीदें"
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr "यह सुविधा केवल उन उपयोगकर्ताओं के लिए उपलब्ध है जो लॉग इन हैं। आप नीचे दिए गए बटन के माध्यम से लॉग इन कर सकते हैं या खाता बना सकते हैं।"
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr "यदि आप एक नौसिखिया हैं, तो हम अनुशंसा करते हैं कि आप हमारे चरण-दर-चरण ट्यूटोरियल का अनुसरण करें: <0>How to Buy KLIMA</0>."
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr "अन्यथा, यदि आपके पास पहले से ही पॉलीगॉन पर MATIC वाला वॉलेट है, तो KLIMA प्राप्त करने का सबसे अच्छा तरीका <0>Sushi.com</0> पर स्वैप करना है। यदि आप इसके बजाय क्रेडिट कार्ड से भुगतान करना पसंद करते हैं, तो आप <1>Transak</1> का उपयोग कर सकते हैं KLIMA को सीधे खरीदने के लिए।"
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr "कृपया लॉग इन करें या वॉलेट कनेक्ट करें"
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr "यह बॉन्ड के लिए उपलब्ध अनुबंध में USDC (यूएसडीसी) की राशि है।"
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr "मुझे याद न दिलाएँ"
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr "समझ गए"
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr "<0>app.klimadao.finance</0> एकमात्र आधिकारिक डोमेन है। "
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr "️ ⚠️ URL (यूआरएल) सत्यापित करें और इस पृष्ठ को बुकमार्क कर लें!"
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr "Toucan (टूकन) Base Carbon Tonne (बेस कार्बन टन)"
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr "कार्बन बांधें"
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr "KLIMA ख़रीदने का सबसे बढ़िया तरीक़ा। हमारी ट्रेज़री में कार्बन जमा करें, और छूट के साथ KLIMA प्राप्त करें। सभी बॉन्ड्स (इनवर्स बॉन्ड्स के अलावा) में 5 दिनों की अनिवार्य निहित अवधि होती है।"
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr "एक बॉन्ड चुनें"
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr "KLIMA प्रदान करें, USDC (यूएसडीसी) प्राप्त करें"
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr "KLIMA/BCT (बीसीटी) Sushiswap (सुशीस्वैप) लिक्विडिटी"
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr "KLIMA/USDC (यूएसडीसी) Sushiswap (सुशीस्वैप) लिक्विडिटी"
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr "MOSS (मॉस) कार्बन क्रेडिट टोकन"
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr "KLIMA/MCO2 (एमसीओ2) Quickswap (क्विकस्वैप) लिक्विडिटी"
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr "C3 प्रकृति आधारित ऑफ़सेट"
-
-#: components/views/ChooseBond/index.tsx:239
-msgid "choose_bond.percent_discount"
-msgstr "% छूट"
-
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr "बिक चुका है"
-
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr "ट्रेज़री बैलेंस"
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr "C3 यूनिवर्सल बेसिक ऑफ़सेट"
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr "ईमेल या सोशल"
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr "वॉलेट कनेक्ट करें"
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr "कनेक्ट हो रहा है..."
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr "कुछ गड़बड़ हो गयी। कृपया पुन: प्रयास करें।"
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr "उपयोगकर्ता ने कनेक्शन अस्वीकार कर दिया।"
-
-#: lib/constants.ts:40
-msgid "connect_modal.error_processing"
-msgstr "अनुरोध पहले से ही प्रोसेस हो रही है। कृपया अपना वॉलेट ओपन करें और अनुरोध पूरा करें।"
-
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
-msgstr "संपर्क त्रुटि"
-
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
-msgstr "क्षमा करें, ऐसा लगता है कि हमने आपको गलत तरीके से भेजा है। <0/>कृपया मेनू से एक गंतव्य चुनें।"
-
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
-msgstr "शुरुआत कैसे करें"
-
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
-msgstr "KLIMA में नए हैं?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
-msgstr "1. Metamask (मेटामास्क) खोलें और Ethereum Mainnet पर स्विच करें"
-
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr "2. Settings/Network/Polygon पर जाएँ और 'delete' पर क्लिक करें"
-
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr "3. app.klimadao.finance पर लौटें और 'switch to mainnet' पर क्लिक करें।"
-
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr "यदि ऐप में 'loading...' दिखाए तो संभवतः Metamask (मेटामास्क) में आपकी नेटवर्क कॉन्फ़िगरेशन में कोई समस्या है। इसे ठीक करने के लिए:"
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr "Metamask (मेटामास्क) आपको सही RPC (आरपीसी) कॉन्फ़िगरेशन के साथ Polygon (पॉलिगॉन) जोड़ने के लिए प्रेरित करेगा।"
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr "मेरा ऐप लोड क्यों नहीं होता?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr "ऐप से संबंधित सामान्य प्रश्न और उपयोगी लिंक। KlimaDAO पर विस्तारपूर्वक पढ़ने के लिए, हमारा <0>official documentation</0> देखें।"
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr "जानकारी और FAQ (अक्सर पूछे जाने वाले प्रश्न)"
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr "आधिकारिक अनुबंध पते"
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr "नेटवर्क पहुँच से बाहर है। बहुत संभव है कि ऐसा आपकी वॉलेट की किसी पुरानी Polygon RPC (पॉलिगॉन आरपीसी) कॉन्फ़िगरेशन के कारण हो। इसे सही करने के लिए <0>this guide</0> पढ़ें। अन्यथा, समस्याएँ बनीं रहने पर <1>Discord</1> पर हमसे संपर्क करें।"
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr "अपनी नेटवर्क सेटिंग बदलें"
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr "कार्बन बांधें"
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr "KLIMA ख़रीदें"
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr "जानकारी"
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr "सिर्फ आपके लिए"
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr "कनेक्ट नहीं हैं"
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr "ऑफ़सेट"
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr "KLIMA दाँव पर लगाएँ"
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr "आपका वॉलेट पता"
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr "sKLIMA रैप करें"
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr "सफलता!"
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr "असफलता!"
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr "लंबित"
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr "पुष्टिकरण"
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr "पीछे"
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
 msgstr ""
 
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr "कुल रिटायरमेंट्स"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr "टन कार्बन"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr "रिटयरमेंट देखें"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr "अपने रिटायर किया"
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr "2. BCT(बीसीटी) को मंज़ूरी दें"
-
-#: components/views/PKlima/index.tsx:170
-msgid "pklima.approve_pklima"
-msgstr "1. pKLIMA को मंज़ूरी दें"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr "अपने भुनाए गए pKLIMA को दाँव पर लगाना सुनिश्चित करें, और जब तक वैश्विक GHG (जीएचजी) उत्सर्जन स्थिर न हो जाए, तब तक दाँव पर लगाए रहें।"
-
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr "अभ्यास"
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr "1 KLIMA प्राप्त करने के लिए 1 pKLIMA और 1 BCT को प्रयोग करें।"
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr "समायोजित इंडेक्स"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr "बराबर मूल्य का sKLIMA क्लेम किया गया, यह मानते हुए कि आपने आज तक अपने द्वारा भुनाया गया संपूर्ण KLIMA दाँव पर लगा दिया।"
-
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr "प्रयुक्त pKLIMA"
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr "आपने अपनी आपूर्त्ति-शेयर सीमा से अधिक KLIMA क्लेम किया है। ऐसा शायद 24 नवंबर, 2021 को pKLIMA मोचन अनुबंध के लिए लागू किए गए सुधार के कारण हुआ है।"
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr "pKLIMA रिडीम करें"
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
-msgstr "रिडीम किया गया"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr "कुल KLIMA जिसे आपने अब तक रिडीम किया है।"
-
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr "आपूर्त्ति सीमा"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr "कुल टोकन आपूर्त्ति का एक प्रतिशत। आपका अनुक्रमणिका-समायोजित दावा इस मान से अधिक नहीं हो सकता है।"
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr "अपडेटेड अनुबंध अब मानता है कि pKLIMA धारकों ने पहले दावा किए गए टोकनों पर दाँव लगाया और पुरस्कार अर्जित किया। नवंबर फिक्स से पहले, इन दाँव पुरस्कारों को आपकी आपूर्त्ति शेयर सीमा के मुक़ाबले नहीं गिना जाता था, जिसका अर्थ था कि कुल KLIMA आपूर्त्ति का आपका हिस्सा आपकी शर्तों में परिभाषित सीमा को पार कर सकता है।"
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr ""
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr ""
-
-#: components/views/errors/Custom404.tsx:16
-msgid "shared.404"
-msgstr "404 - पृष्ठ नहीं मिला"
-
-#: components/BalancesCard/index.tsx:47
-msgid "shared.balances"
-msgstr "बैलेंस"
-
-#: components/ChangeLanguageButton/index.tsx:56
-msgid "shared.change_language"
-msgstr "भाषा बदलें"
-
-#: components/views/Bond/index.tsx:432
-#: components/views/PKlima/index.tsx:165
-#: components/views/Wrap/index.tsx:220
-msgid "shared.confirming"
-msgstr "पुष्टि"
-
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr "लोड हो रहा है..."
-
-#: components/views/Stake/index.tsx:259
-#: components/views/Stake/index.tsx:268
-msgid "shared.enter_amount"
-msgstr "राशि डालें"
-
-#: components/views/Bond/index.tsx:475
-#: components/views/Bond/index.tsx:494
-#: components/views/Stake/index.tsx:276
-#: components/views/Wrap/index.tsx:247
-msgid "shared.error"
-msgstr "ग़लती"
-
-#: components/views/Bond/index.tsx:397
-#: components/views/Buy/index.tsx:65
-#: components/views/Home/index.tsx:154
-#: components/views/PKlima/index.tsx:149
-#: components/views/Stake/index.tsx:229
-#: components/views/Wrap/index.tsx:199
-msgid "shared.login_connect"
-msgstr "साइन इन / कनेक्ट करें"
-
-#: components/views/Bond/index.tsx:605
-#: components/views/PKlima/index.tsx:239
-#: components/views/Stake/index.tsx:372
-#: components/views/Wrap/index.tsx:346
-msgid "shared.max"
-msgstr "अधिकतम"
-
-#: components/views/Bond/index.tsx:405
-msgid "shared.sold_out"
-msgstr "बिक चुका है"
-
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
-msgstr "5 दिवसीय पुरस्कार"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr "कंपाउंडिंग सहित अनुमानित पुरस्कार, यदि आप 5 दिनों तक दाँव पर लगाते हैं।"
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
-msgstr "AKR"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
-msgstr "कंपाउंडिंग सहित वार्षिक KLIMA पुरस्कार, यदि वर्तमान इनाम दर 12 महीनों के लिए अपरिवर्तित रहे (इनाम दर परिवर्तन के अधीन हो सकती है)।"
-
-#. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
-msgstr "sKLIMA प्राप्त करने के लिए अपने KLIMA टोकन को दाँव पर लगाएँ। हर रिबेस के बाद, आपका sKLIMA बैलेंस दिए गए प्रतिशत के हिसाब से बढ़ जाएगा।"
-
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr "अनुमानित भुगतान (sKLIMA)"
-
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr "इंडेक्स"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr "यदि आप लॉन्च के दिन 1 KLIMA दाँव पर लगाते तो आज आपके पास KLIMA की यह राशि होती। लेखांकन के लिए उपयोगी।"
-
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr "स्टेक राशि"
-
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr "अनस्टेक राशि"
-
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr "क्रॉस-चेन ऑफ़सेटिंग, कई श्रृंखलाओं और टोकन के समर्थन के साथ, अब <0>LI.FI and Etherspot</0> के माध्यम से उपलब्ध है।"
-
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr "लगभग। अगला रिबेस"
-
-#: components/RebaseCard/index.tsx:73
-msgid "stake.percent_payout"
-msgstr "प्रतिशत भुगतान"
-
-#: components/RebaseCard/index.tsx:44
-msgid "stake.rebase"
-msgstr "रिबेस करना"
-
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr "प्रोटोकॉल स्वचालित रूप से पुरस्कार बनाता और वितरित करता है। आपका भुगतान आपके sKLIMA बैलेंस का कुछेक प्रतिशत है"
-
-#: components/views/Stake/index.tsx:335
-msgid "stake.stake"
-msgstr "दाँव लगाना"
-
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
-msgstr "दाँव पर लगाएँ, होल्ड करें, और कंपाउंडिंग sKLIMA अर्जित करें"
-
-#: components/views/Stake/index.tsx:258
-#: components/views/Stake/index.tsx:306
-#: components/views/Stake/index.tsx:471
-msgid "stake.stake_klima"
-msgstr "KLIMA दाँव पर लगाएँ"
-
-#: components/views/Stake/index.tsx:347
-msgid "stake.unstake"
-msgstr "अनस्टेक करना"
-
-#: components/views/Stake/index.tsx:267
-#: components/views/Stake/index.tsx:473
-msgid "stake.unstake_klima"
-msgstr "KLIMA अनस्टेक करें"
-
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr "लेन-देन पूर्ण हुआ।"
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr "❌ एरर: कुछ गड़बड़ हो गयी..."
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr "लेन-देन शुरू किया। नेटवर्क पुष्टि की प्रतीक्षा कर रहा है।"
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr "जारी रखने के लिए कृपया अपने वॉलेट में 'confirm' (कन्फ़र्म) पर क्लिक करें।"
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr "आपने लेन-देन को अस्वीकार करना चयनित किया"
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr "pKLIMA"
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr "आपको अपनी ओर से टोकन ट्रांस्फ़र करने के लिए पहले हमारे स्मार्ट कॉन्ट्रैक्ट को अनुमति देनी होगी।"
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr "अनुबंध का पता"
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr "मंज़ूरी मात्रा"
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr "बंद करें"
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr "इसके बाद"
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr "राशि की पुष्टि करें"
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr "सबमिट करें"
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr "कृपया लेनदेन पूर्ण करें।"
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr "अनुबंध का पता"
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr "मंज़ूरी"
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr "सबमिट करें"
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr "अपने ब्राउज़र web3 प्रदाता से जुड़ें"
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr "Torus (टोरस) द्वारा आसान एक-क्लिक वॉलेट"
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr "ईमेल या सोशल"
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr "जुड़ने के लिए WalletConnect (वॉलेटकनेक्ट) के साथ स्कैन करें"
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr "जुड़ने के लिए Coinbase (कॉइनबेस) के साथ स्कैन करें"
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr "बैलेंस"
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr "इंडेक्स-समायोजित रैप्ड-स्टैक्ड-KLIMA प्राप्त करने के लिए sKLIMA रैप करें"
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr "इंडेक्स"
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr "यदि आप लॉन्च के दिन 1 KLIMA दाँव पर लगाते तो आज आपके पास KLIMA की यह राशि होती। wsKLIMA मूल्य की गणना करने के लिए उपयोग किया जाता है।"
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr "रैप किया जाने वाला sKLIMA"
-
-#: components/views/Wrap/index.tsx:324
-msgid "wrap.unwrap"
-msgstr "अनरैप करना"
-
-#: components/views/Wrap/index.tsx:313
-msgid "wrap.wrap"
-msgstr "रैप करना"
-
-#: components/views/Wrap/index.tsx:279
-msgid "wrap.wrap_sklima"
-msgstr "sKLIMA  रैप करें"
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
-msgstr "कुछ इसे लेखांकन उद्देश्यों के लिए उपयोगी पाते हैं, लेकिन पुरस्कार बिल्कुल समान हैं। रैप और अनरैप मानों की गणना वर्तमान इंडेक्स के आधार पर की जाती है।"
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:282
-msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
-msgstr "WsKLIMA प्राप्त करने के लिए sKLIMA रैप करें। sKLIMA के विपरीत, आपका wsKLIMA बैलेंस समय के साथ नहीं बढ़ेगा।"
-
-#: components/views/Wrap/index.tsx:55
-msgid "wrap.wsklima_to_unwrap"
-msgstr "अनरैप किया जाने वाला wsKLIMA"
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
-msgstr "आपको मिलेगा"
+msgstr ""
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
-msgstr "अनरैप किया गया"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
+msgstr ""

--- a/app/locale/ko/messages.po
+++ b/app/locale/ko/messages.po
@@ -6,9 +6,155 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ko\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:239
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:170
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:16
+msgid "shared.404"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:84
 msgid "Acknowledge and Accept"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
 msgstr ""
 
 #: components/TransactionModal/Approve.tsx:93
@@ -18,8 +164,89 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:47
+msgid "shared.balances"
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
 msgstr ""
 
 #: components/views/Redeem/index.tsx:25
@@ -30,12 +257,164 @@ msgstr ""
 msgid "Buy Carbon"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr ""
+
 #: components/views/Bond/index.tsx:697
 msgid "Capacity"
 msgstr ""
 
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:56
+msgid "shared.change_language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:432
+#: components/views/PKlima/index.tsx:165
+#: components/views/Wrap/index.tsx:220
+msgid "shared.confirming"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:259
+#: components/views/Stake/index.tsx:268
+msgid "shared.enter_amount"
 msgstr ""
 
 #: components/views/Stake/index.tsx:242
@@ -43,13 +422,137 @@ msgstr ""
 msgid "Enter quantity"
 msgstr ""
 
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:475
+#: components/views/Bond/index.tsx:494
+#: components/views/Stake/index.tsx:276
+#: components/views/Wrap/index.tsx:247
+msgid "shared.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
 #: components/views/Offset/index.tsx:45
 msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
 msgstr ""
 
 #: components/views/Stake/index.tsx:247
 #: components/views/Wrap/index.tsx:225
 msgid "Insufficient balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
 msgstr ""
 
 #: components/DisclaimerModal/index.tsx:47
@@ -75,25 +578,118 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr ""
+
 #: components/views/Home/index.tsx:178
 msgid "Login"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:397
+#: components/views/Buy/index.tsx:65
+#: components/views/Home/index.tsx:154
+#: components/views/PKlima/index.tsx:149
+#: components/views/Stake/index.tsx:229
+#: components/views/Wrap/index.tsx:199
+msgid "shared.login_connect"
 msgstr ""
 
 #: components/DisclaimerModal/index.tsx:39
 msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:605
+#: components/views/PKlima/index.tsx:239
+#: components/views/Stake/index.tsx:372
+#: components/views/Wrap/index.tsx:346
+msgid "shared.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
 msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:168
 msgid "No balances found."
 msgstr ""
 
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:131
 #: components/CarbonTonnesRetiredCard/index.tsx:29
 msgid "Not Connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
 msgstr ""
 
 #: components/views/Offset/index.tsx:27
@@ -108,843 +704,441 @@ msgstr ""
 msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:32
 msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
 msgstr ""
 
 #: components/DisclaimerModal/index.tsx:53
 msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:29
-msgid "Risk Disclaimer"
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:72
-msgid "Switch to Polygon"
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:68
-msgid "This app only works on Polygon Mainnet."
-msgstr ""
-
-#: components/DisclaimerModal/index.tsx:75
-msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
-msgstr ""
-
-#: components/InvalidNetworkModal/index.tsx:63
-msgid "Wrong Network"
-msgstr ""
-
-#: components/CarbonBalancesCard/index.tsx:171
-msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
-msgstr ""
-
 #. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr ""
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr ""
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr ""
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr ""
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr ""
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr ""
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr ""
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr ""
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr ""
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr ""
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr ""
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr ""
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr ""
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr ""
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr ""
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr ""
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr ""
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr ""
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr ""
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr ""
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr ""
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr ""
-
-#. Long sentence
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:924
 msgid "bond.unredeemed.tooltip"
 msgstr ""
 
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr ""
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr ""
-
-#: components/views/Bond/index.tsx:746
-#: components/views/Bond/index.tsx:890
-msgid "bond.you_will_get"
-msgstr ""
-
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr ""
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr ""
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr ""
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr ""
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr ""
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr ""
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr ""
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr ""
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr ""
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr ""
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr ""
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr ""
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:239
-msgid "choose_bond.percent_discount"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr ""
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr ""
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr ""
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr ""
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr ""
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr ""
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: lib/constants.ts:40
 msgid "connect_modal.error_processing"
 msgstr ""
 
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
+#: components/DisclaimerModal/index.tsx:29
+msgid "Risk Disclaimer"
 msgstr ""
 
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
 msgstr ""
 
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
 msgstr ""
 
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
 msgstr ""
 
-#. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
 msgstr ""
 
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr ""
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr ""
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr ""
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr ""
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr ""
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr ""
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr ""
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr ""
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr ""
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr ""
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr ""
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr ""
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr ""
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr ""
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr ""
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr ""
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr ""
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
-msgstr ""
-
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:170
-msgid "pklima.approve_pklima"
-msgstr ""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr ""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr ""
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
-msgstr ""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr ""
-
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr ""
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr ""
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr ""
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr ""
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr ""
-
-#: components/views/errors/Custom404.tsx:16
-msgid "shared.404"
-msgstr ""
-
-#: components/BalancesCard/index.tsx:47
-msgid "shared.balances"
-msgstr ""
-
-#: components/ChangeLanguageButton/index.tsx:56
-msgid "shared.change_language"
-msgstr ""
-
-#: components/views/Bond/index.tsx:432
-#: components/views/PKlima/index.tsx:165
-#: components/views/Wrap/index.tsx:220
-msgid "shared.confirming"
-msgstr ""
-
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr ""
-
-#: components/views/Stake/index.tsx:259
-#: components/views/Stake/index.tsx:268
-msgid "shared.enter_amount"
-msgstr ""
-
-#: components/views/Bond/index.tsx:475
-#: components/views/Bond/index.tsx:494
-#: components/views/Stake/index.tsx:276
-#: components/views/Wrap/index.tsx:247
-msgid "shared.error"
-msgstr ""
-
-#: components/views/Bond/index.tsx:397
-#: components/views/Buy/index.tsx:65
-#: components/views/Home/index.tsx:154
-#: components/views/PKlima/index.tsx:149
-#: components/views/Stake/index.tsx:229
-#: components/views/Wrap/index.tsx:199
-msgid "shared.login_connect"
-msgstr ""
-
-#: components/views/Bond/index.tsx:605
-#: components/views/PKlima/index.tsx:239
-#: components/views/Stake/index.tsx:372
-#: components/views/Wrap/index.tsx:346
-msgid "shared.max"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:405
 msgid "shared.sold_out"
 msgstr ""
 
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
 msgstr ""
 
 #. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr ""
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
 msgstr ""
 
 #. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
 msgstr ""
 
-#. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
 msgstr ""
 
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr ""
-
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr ""
-
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr ""
-
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr ""
-
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr ""
-
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr ""
-
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr ""
-
-#: components/RebaseCard/index.tsx:73
-msgid "stake.percent_payout"
-msgstr ""
-
-#: components/RebaseCard/index.tsx:44
-msgid "stake.rebase"
-msgstr ""
-
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:335
 msgid "stake.stake"
 msgstr ""
 
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:258
 #: components/views/Stake/index.tsx:306
 #: components/views/Stake/index.tsx:471
 msgid "stake.stake_klima"
 msgstr ""
 
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:72
+msgid "Switch to Polygon"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
+#: components/InvalidNetworkModal/index.tsx:68
+msgid "This app only works on Polygon Mainnet."
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr ""
+
+#: components/DisclaimerModal/index.tsx:75
+msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:347
 msgid "stake.unstake"
 msgstr ""
 
+#. js-lingui-explicit-id
 #: components/views/Stake/index.tsx:267
 #: components/views/Stake/index.tsx:473
 msgid "stake.unstake_klima"
 msgstr ""
 
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr ""
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr ""
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr ""
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr ""
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr ""
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr ""
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr ""
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr ""
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr ""
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr ""
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr ""
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr ""
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:324
 msgid "wrap.unwrap"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:313
 msgid "wrap.wrap"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:279
 msgid "wrap.wrap_sklima"
 msgstr ""
 
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
 msgstr ""
 
 #. Long sentence
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:282
 msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
 msgstr ""
 
+#: components/InvalidNetworkModal/index.tsx:63
+msgid "Wrong Network"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:55
 msgid "wrap.wsklima_to_unwrap"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr ""
+
+#: components/CarbonBalancesCard/index.tsx:171
+msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:746
+#: components/views/Bond/index.tsx:890
+msgid "bond.you_will_get"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
 msgstr ""
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
 msgstr ""

--- a/app/locale/ru/messages.po
+++ b/app/locale/ru/messages.po
@@ -6,9 +6,155 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ru\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:239
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:170
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:16
+msgid "shared.404"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:84
 msgid "Acknowledge and Accept"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
 msgstr ""
 
 #: components/TransactionModal/Approve.tsx:93
@@ -18,9 +164,90 @@ msgstr ""
 msgid "Approve"
 msgstr "Одобрить"
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:47
+msgid "shared.balances"
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
 msgstr "Балансы"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
+msgstr ""
 
 #: components/views/Redeem/index.tsx:25
 msgid "Buy & Redeem Carbon"
@@ -30,12 +257,164 @@ msgstr "Купить и вывести углерод"
 msgid "Buy Carbon"
 msgstr "Купить углерод"
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr ""
+
 #: components/views/Bond/index.tsx:697
 msgid "Capacity"
 msgstr "Вместимость"
 
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:56
+msgid "shared.change_language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:432
+#: components/views/PKlima/index.tsx:165
+#: components/views/Wrap/index.tsx:220
+msgid "shared.confirming"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:259
+#: components/views/Stake/index.tsx:268
+msgid "shared.enter_amount"
 msgstr ""
 
 #: components/views/Stake/index.tsx:242
@@ -43,13 +422,137 @@ msgstr ""
 msgid "Enter quantity"
 msgstr "Введите количество"
 
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:475
+#: components/views/Bond/index.tsx:494
+#: components/views/Stake/index.tsx:276
+#: components/views/Wrap/index.tsx:247
+msgid "shared.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
 #: components/views/Offset/index.tsx:45
 msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
 msgstr ""
 
 #: components/views/Stake/index.tsx:247
 #: components/views/Wrap/index.tsx:225
 msgid "Insufficient balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
 msgstr ""
 
 #: components/DisclaimerModal/index.tsx:47
@@ -75,26 +578,119 @@ msgstr "Загрузка остатков..."
 msgid "Loading..."
 msgstr "Загрузка..."
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr ""
+
 #: components/views/Home/index.tsx:178
 msgid "Login"
 msgstr "Авторизоваться"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:397
+#: components/views/Buy/index.tsx:65
+#: components/views/Home/index.tsx:154
+#: components/views/PKlima/index.tsx:149
+#: components/views/Stake/index.tsx:229
+#: components/views/Wrap/index.tsx:199
+msgid "shared.login_connect"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:39
 msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 msgstr ""
 
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:605
+#: components/views/PKlima/index.tsx:239
+#: components/views/Stake/index.tsx:372
+#: components/views/Wrap/index.tsx:346
+msgid "shared.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
 msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:168
 msgid "No balances found."
 msgstr "Балансы не найдены."
 
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:131
 #: components/CarbonTonnesRetiredCard/index.tsx:29
 msgid "Not Connected"
 msgstr "Не подключен"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
+msgstr ""
 
 #: components/views/Offset/index.tsx:27
 msgid "Offset"
@@ -108,853 +704,441 @@ msgstr "12 апреля 2022 года мы перешли с «dapp» на «app
 msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:32
 msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
 msgstr ""
 
 #: components/DisclaimerModal/index.tsx:53
 msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
 msgstr ""
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:924
+msgid "bond.unredeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:40
+msgid "connect_modal.error_processing"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:29
 msgid "Risk Disclaimer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:405
+msgid "shared.sold_out"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:335
+msgid "stake.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:258
+#: components/views/Stake/index.tsx:306
+#: components/views/Stake/index.tsx:471
+msgid "stake.stake_klima"
+msgstr ""
+
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
 msgstr ""
 
 #: components/InvalidNetworkModal/index.tsx:72
 msgid "Switch to Polygon"
 msgstr "Переключиться на Polygon"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:68
 msgid "This app only works on Polygon Mainnet."
 msgstr "Это приложение работает только в Polygon Mainnet."
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:75
 msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:347
+msgid "stake.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:267
+#: components/views/Stake/index.tsx:473
+msgid "stake.unstake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:324
+msgid "wrap.unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:313
+msgid "wrap.wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:279
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:282
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
 msgstr ""
 
 #: components/InvalidNetworkModal/index.tsx:63
 msgid "Wrong Network"
 msgstr "Неверная сеть"
 
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:55
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:171
 msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
 msgstr "Вам необходимо пополнить свой кошелек с помощью USDC, KLIMA или токеном углеродного пула. Поддержка кредитных карт появится в ближайшее время."
 
-#. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr "РАСПРОДАНО. Весь спрос на эту облигацию был удовлетворен. Спасибо, Klimates!"
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr "Баланс"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr "Баланс доступен для бондинга"
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr "Бонд"
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr "Цена Бонда"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr "Цена со скидкой. Общая сумма для бонда 1 полная KLIMA (допускаются также разбивка бонда)"
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr "Текущая рыночная цена KLIMA на рынке"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr "Бонд{0}"
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr "Вместимость превышена"
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr "Дата полного вестинга"
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr "Дата, когда может быть погашена вся стоимость бонда"
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr "соотношение долга"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr "Текущее отношение предложения к размещенным бондам по протоколу"
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr "Дисконт бонда"
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr "Процентная скидка (или надбавка, если она отрицательная) по отношению к рыночной стоимости KLIMA."
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr "равносильно бонду"
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr "Сумма к погашению"
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr "Премиум"
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr "Премия по отношению к рыночной стоимости KLIMA."
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr "Рыночная цена"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr "Текущая торговая цена KLIMA, без учета дисконта по бондам"
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr "ПРЕВЫШЕН МАКС."
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr "Максимум"
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr "Максимальная сумма, которую вы можете приобрести с помощью бондирования"
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr "Не подлежащие погашению"
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr "Выплата за KLIMA"
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr "Если вы связываете 1 KLIMA, вы получите эту сумму в USDC."
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr "Погасить"
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr "Погашаемый"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr "Сумма KLIMA, права на которую уже распределены и могут быть погашены"
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr "Автоматический стейкинг для sKLIMA"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr "⚠️ Внимание: цена этой облигации завышена, поскольку текущая ставка дисконтирования отрицательна."
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr "Бонд{0}"
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr ""
-"Выкупить Klima\n"
-""
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr "Непогашенный"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:924
-msgid "bond.unredeemed.tooltip"
-msgstr "Оставшаяся невыкупленная стоимость ((наделенная и не наделенная правами)"
-
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr "Дата полного вестинга"
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr "Если вы разместите бонд сейчас, срок наделения правами закончится в эту дату. Klima постепенно разблокируется для погашения в течение этого срока."
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:746
 #: components/views/Bond/index.tsx:890
 msgid "bond.you_will_get"
-msgstr "Вы получете"
-
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr "Сумма, которую вы получите при заданном количестве ввода"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr "Количество бондированого KLIMA, которое вы получите, при указанном количестве входных данных"
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr "Купить KLIMA"
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr "Эта функция доступна только для пользователей, которые вошли в систему. Вы можете войти или создать учетную запись с помощью кнопки ниже."
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr "Если вы новичок, мы рекомендуем следовать нашему пошаговому руководству: <0>Как купить KLIMA.</0> ."
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr "В противном случае, если у вас уже есть кошелек с MATIC на Polygon, лучшим способом получить KLIMA будет обмен на <0>Sushi.com</0>. Если вы предпочитаете платить кредитной картой, вы можете использовать <1>Transak</1>, чтобы купить KLIMA напрямую."
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr "Пожалуйста, войдите или подключите кошелек"
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr "Это сумма USDC в контракте, доступная для бондирования."
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr "Больше не напоминать"
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr "Понятно"
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr "<0>app.klimadao.finance</0> является единственным официальным доменом."
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr "⚠️ Проверьте URL и добавьте эту страницу в закладки!"
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr "Toucan Базовая тонна углерода"
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr "Бонд Карбон"
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr "Лучший способ купить KLIMA. Вложите углерод в нашу казну и получите KLIMA со скидкой. Все облигации (кроме обратных облигаций) имеют обязательный 5-дневный период наделения правами."
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr "Выберите бонд"
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr "Предоставьте KLIMA, получите USDC"
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr "KLIMA/BCT Sushiswap ликвидность"
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr "KLIMA/BCT Sushiswap ликвидность"
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr "MOSS Carbon Credit Token"
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr "KLIMA/MCO2 Quickswap ликвидность"
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr "СЗ Природный офсет"
-
-#: components/views/ChooseBond/index.tsx:239
-msgid "choose_bond.percent_discount"
-msgstr ""
-"% Дисконт\n"
-""
-
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr "РАСПРОДАННЫЙ"
-
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr "Баланс казначейства"
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr "C3 Универсальный базовый офсет"
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr "Электронная почта или социальные сети"
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr "подключите кошелек"
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr "Подключение..."
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr "У нас возникли проблемы с подключением. Пожалуйста, попробуйте еще раз."
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr "Пользователь отказался от подключения."
-
-#: lib/constants.ts:40
-msgid "connect_modal.error_processing"
-msgstr "Запрос уже обрабатывается. Пожалуйста, откройте свой кошелек и завершите запрос."
-
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
-msgstr "Ошибка подключения"
-
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
-msgstr "Извините, похоже, мы отправили вас не туда. <0/>Пожалуйста, выберите пункт назначения в меню."
-
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
-msgstr "С чего начать"
-
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
-msgstr "Впервые на KLIMA?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
-msgstr "1. Откройте Metamask и переключитесь на сеть Ethereum Mainnet."
-
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr ""
-"2. Перейдите в Настройки/Сети/Polygon и нажмите «Удалить».\n"
-""
-
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr "3. Вернитесь на app.klimadao.finance и нажмите «переключиться на основную сеть»."
-
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr "Если приложение показывает сообщение \"загрузка...\", это, скорее всего, проблема с конфигурацией сети в Metamask. Чтобы исправить это:"
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr "Metamask должен предложить вам добавить Polygon с правильной конфигурацией RPC."
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr "Почему у меня не загружается приложение?"
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr "Общие вопросы, связанные с приложением, и полезные ссылки. Подробную информацию о KlimaDAO см. в нашей <0>официальной документации.</0> ."
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr "Информация и часто задаваемые вопросы"
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr "Официальные адреса контрактов"
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr "Не удалось связаться с сетью. Скорее всего, это вызвано старой конфигурацией Polygon RPC в вашем кошельке. См. <0>это руководство</0> для исправления. В противном случае свяжитесь с нами в <1>Discord.</1> если проблемы сохраняются."
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr "Проверьте настройки сети"
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr "Бонд Карбон"
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr "Купить KLIMA"
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr "Информация"
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr "ТОЛЬКО ДЛЯ ВАС"
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr "НЕ ПОДКЛЮЧЕН"
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr "Офсет"
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr "Стейкинг KLIMA"
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr "Адрес вашего кошелька"
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr "обернуть sKLIMA"
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr "УСПЕШНО"
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr "НЕУДАЧНО"
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr "В ОЖИДАНИИ"
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr "ПОДТВЕРЖДЕНИЕ"
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr "НАЗАД"
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
 msgstr ""
 
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr ""
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr "Итого выведено "
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr "Тонны углерода"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr "Посмотреть употребление"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr "Вы выбили"
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr "Одобрить BCT"
-
-#: components/views/PKlima/index.tsx:170
-msgid "pklima.approve_pklima"
-msgstr "1. Одобрить pKLIMA"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr "Обязательно застейкайте вашу выкупленную pKLIMA и оставайтесь в стейке до тех пор, пока глобальные выбросы парниковых газов не стабилизируются."
-
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr "Осуществление "
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr "Объедините 1 pKLIMA и 1 BCT для получения 1 KLIMA."
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr "Показатель скорректирован"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr "Требуемый эквивалент sKLIMA , при условии, что вы застейкали все свои полученные KLIMA до сегодняшнего дня."
-
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr "pKLIMA к обьеденинеию"
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr "Вы потребовали больше KLIMA, чем ваш лимит поставок. Вероятно, это связано с исправлением, внесенным 24 ноября 2021 года в контракт выкупа pKLIMA."
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr "Погасить pKLIMA"
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
-msgstr "Погашенно"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr "Общее количество KLIMA, которые вы использовали на данный момент."
-
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr "Предел предложения"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr "Процент от общего количества токенов. Ваша заявка с поправкой на индекс не может превышать это значение."
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr "Обновленный контракт теперь предполагает, что держатели pKLIMA застейкали и заработали награды за ранее полученные токены. До ноябрьского исправления эти награды за стейкинг не учитывались в лимите доли поставок, что означало, что ваша доля в общем объеме поставок KLIMA могла превысить лимит, определенный в ваших условиях."
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr ""
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr ""
-
-#: components/views/errors/Custom404.tsx:16
-msgid "shared.404"
-msgstr "404 Страница не найдена"
-
-#: components/BalancesCard/index.tsx:47
-msgid "shared.balances"
-msgstr "Балансы"
-
-#: components/ChangeLanguageButton/index.tsx:56
-msgid "shared.change_language"
-msgstr "измененить язык"
-
-#: components/views/Bond/index.tsx:432
-#: components/views/PKlima/index.tsx:165
-#: components/views/Wrap/index.tsx:220
-msgid "shared.confirming"
-msgstr "Подтверждение"
-
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr "Загрузка..."
-
-#: components/views/Stake/index.tsx:259
-#: components/views/Stake/index.tsx:268
-msgid "shared.enter_amount"
-msgstr "Введите сумму"
-
-#: components/views/Bond/index.tsx:475
-#: components/views/Bond/index.tsx:494
-#: components/views/Stake/index.tsx:276
-#: components/views/Wrap/index.tsx:247
-msgid "shared.error"
-msgstr "ОШИБКА"
-
-#: components/views/Bond/index.tsx:397
-#: components/views/Buy/index.tsx:65
-#: components/views/Home/index.tsx:154
-#: components/views/PKlima/index.tsx:149
-#: components/views/Stake/index.tsx:229
-#: components/views/Wrap/index.tsx:199
-msgid "shared.login_connect"
-msgstr "Войти / Подключиться"
-
-#: components/views/Bond/index.tsx:605
-#: components/views/PKlima/index.tsx:239
-#: components/views/Stake/index.tsx:372
-#: components/views/Wrap/index.tsx:346
-msgid "shared.max"
-msgstr "Максимум"
-
-#: components/views/Bond/index.tsx:405
-msgid "shared.sold_out"
-msgstr "РАСПРОДАННЫЙ"
-
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
-msgstr "5-дневные награды"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr "Приблизительные вознаграждения, включая начисление сложных процентов, если вы будете оставаться в ставках в течение 5 дней."
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
-msgstr "АКР"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
-msgstr "Годовые вознаграждения KLIMA, включая начисление сложных процентов, если текущая ставка вознаграждения останется неизменной в течение 12 месяцев (ставка вознаграждения может быть изменена)."
-
-#. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
-msgstr "Стейкайте ваши KLIMA, чтобы получить sKLIMA. После каждого пополнения ваш баланс sKLIMA будет увеличиваться на указанный процент."
-
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr "приблизительная выплата (sKLIMA)"
-
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr "Показатель"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr "Сумма KLIMA, которую вы имели бы сегодня, если бы сделали ставку в 1 KLIMA в день запуска. Полезно для бухгалтерских целей."
-
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr "Сумма стейкинга"
-
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr "Сумма анстейкинга"
-
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr "Межсетевой стейкинг теперь доступен через <0>LI.FI и Etherspot.</0> , с поддержкой нескольких цепочек и токенов."
-
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr "приблизительный следующий пересмотр"
-
-#: components/RebaseCard/index.tsx:73
-msgid "stake.percent_payout"
-msgstr "Процент выплат"
-
-#: components/RebaseCard/index.tsx:44
-msgid "stake.rebase"
-msgstr "следующий пересмотр"
-
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr "Протокол автоматически майнит и распределяет вознаграждения. Ваша выплата - это процент от вашего баланса sKLIMA"
-
-#: components/views/Stake/index.tsx:335
-msgid "stake.stake"
-msgstr "Стейкинг"
-
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
-msgstr "Стейкайте, сохраняйте и зарабатывайте на sKLIMA."
-
-#: components/views/Stake/index.tsx:258
-#: components/views/Stake/index.tsx:306
-#: components/views/Stake/index.tsx:471
-msgid "stake.stake_klima"
-msgstr "Стейкинг KLIMA"
-
-#: components/views/Stake/index.tsx:347
-msgid "stake.unstake"
-msgstr "Unstake"
-
-#: components/views/Stake/index.tsx:267
-#: components/views/Stake/index.tsx:473
-msgid "stake.unstake_klima"
-msgstr "Unstake KLIMA"
-
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr "Транзакция завершена."
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr "❌ Ошибка: что-то пошло не так..."
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr "Транзакция инициирована. Ожидание подтверждения сети."
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr "Пожалуйста, нажмите \"подтвердить\" в вашем кошельке, чтобы продолжить."
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr "Вы решили отклонить транзакцию"
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr "pKLIMA"
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr "Сначала вы должны дать разрешение нашему смарт-контракту на перевод токенов от вашего имени."
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr "Адрес контракта"
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr ""
-"Количество для утверждения\n"
-""
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr "Закрыть"
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr "Следующий"
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr "Подтвердить сумму"
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr "Отправить"
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr "Пожалуйста, отправьте транзакцию."
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr "Адрес контракта"
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Одобрить"
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr ""
-"2. Отправить\n"
-""
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr "Подключение к провайдеру web3 вашего браузера"
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr "Простой кошелек в один клик от Torus"
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr "Электронная почта или социальные сети"
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr "Сканируйте с помощью WalletConnect для подключения"
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr "Сканируйте с помощью Coinbase, чтобы подключиться"
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr "Баланс"
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr "Оберните sKLIMA для получения скорректированного индекса обернутого стейкинга KLIMA"
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr "Показатель"
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr "Количество KLIMA, которое вы имели бы сегодня, если бы сделали ставку в 1 KLIMA в день запуска. Используется для расчета значения wsKLIMA."
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr "sKLIMA  к обертыванию"
-
-#: components/views/Wrap/index.tsx:324
-msgid "wrap.unwrap"
-msgstr "Развернуть"
-
-#: components/views/Wrap/index.tsx:313
-msgid "wrap.wrap"
-msgstr "обернуть"
-
-#: components/views/Wrap/index.tsx:279
-msgid "wrap.wrap_sklima"
-msgstr "обернуть sKLIMA"
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
-msgstr "Некоторые считают это полезным для бухгалтерских целей, но вознаграждения точно такие же. Стоимость обертывания и развертывания рассчитывается на основе текущего индекса."
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:282
-msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
-msgstr "Оберните sKLIMA, чтобы получить wsKLIMA. В отличие от sKLIMA, ваш баланс wsKLIMA не будет увеличиваться со временем."
-
-#: components/views/Wrap/index.tsx:55
-msgid "wrap.wsklima_to_unwrap"
-msgstr "wsKLIMA к развертыванию"
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
-msgstr "Вы получете"
+msgstr ""
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
-msgstr "развернутый"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
+msgstr ""

--- a/app/locale/zh-CN/messages.po
+++ b/app/locale/zh-CN/messages.po
@@ -6,10 +6,156 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:239
+msgid "choose_bond.percent_discount"
+msgstr ""
+
+#. <0>app.klimadao.finance</0> is the only official domain.
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:31
+msgid "checkurlbanner.is_the_only_official_domain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:26
+msgid "checkurlbanner.verify_url_and_bookmark_this_page"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1012
+msgid "bond.this_bond_price_is_inflated"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:28
+msgid "status.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:50
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:170
+msgid "pklima.approve_pklima"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:147
+msgid "info.app_not_loading.1_open_metamask"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:179
+msgid "pklima.approve_bct"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:154
+msgid "info.app_not_loading.2_go_to_settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/index.tsx:60
+msgid "transaction_modal.view.submit.title"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:161
+msgid "info.app_not_loading.3_return_to_app"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:16
+msgid "shared.404"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:385
+msgid "stake.5_day_rewards"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:255
+msgid "pklima.supply_limit.tooltip"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:84
 msgid "Acknowledge and Accept"
 msgstr "确认并接受"
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:401
+msgid "stake.akr"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:894
+msgid "bond.you_will_get.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:953
+msgid "bond.redeemable.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:364
+msgid "wrap.index.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:418
+msgid "stake.index.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:484
+msgid "bond.inputplaceholder.amount_to_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:489
+msgid "bond.inputplaceholder.amount_to_redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:55
+msgid "stake.inputplaceholder.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:59
+msgid "stake.inputplaceholder.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:750
+msgid "bond.you_will_get.description_inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:404
+msgid "stake.akr.tooltip"
+msgstr ""
 
 #: components/TransactionModal/Approve.tsx:93
 #: components/views/Bond/index.tsx:454
@@ -18,9 +164,90 @@ msgstr "确认并接受"
 msgid "Approve"
 msgstr "批准"
 
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:61
+msgid "stake.next_rebase"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:388
+msgid "stake.5_day_rewards.tooltip"
+msgstr ""
+
+#. should autostake?
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1053
+msgid "bond.should_autostake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:534
+msgid "nav.back"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:620
+msgid "bond.balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:374
+msgid "wrap.balance"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:624
+msgid "bond.balance.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:47
+msgid "shared.balances"
+msgstr ""
+
 #: components/CarbonBalancesCard/index.tsx:126
 msgid "Balances"
 msgstr "余额"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:462
+#: components/views/Bond/index.tsx:570
+msgid "bond.bond"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:549
+msgid "bond.bond_token"
+msgstr ""
+
+#. Bond {0}
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1074
+msgid "bond.transaction_modal.bond.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:178
+msgid "menu.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:209
+msgid "choose_bond.bond_carbon"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:848
+msgid "bond.discount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:777
+msgid "bond.bond_price"
+msgstr ""
 
 #: components/views/Redeem/index.tsx:25
 msgid "Buy & Redeem Carbon"
@@ -30,27 +257,303 @@ msgstr "购买和赎回碳"
 msgid "Buy Carbon"
 msgstr "购买碳"
 
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:162
+msgid "menu.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:31
+msgid "buy.buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:91
+msgid "choose_bond.nbo.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:87
+msgid "choose_bond.ubo.description"
+msgstr ""
+
 #: components/views/Bond/index.tsx:697
 msgid "Capacity"
 msgstr "容量"
 
-#: components/views/Bond/index.tsx:417
-msgid "Enter Quantity"
-msgstr "输入数量"
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:448
+msgid "bond.capacity_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ChangeLanguageButton/index.tsx:56
+msgid "shared.change_language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:21
+msgid "invalid_rpc.modal.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:236
+msgid "choose_bond.choose_bond"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:98
+msgid "transaction_modal.close"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:122
+msgid "info.common_app_related_questions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:65
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:28
+msgid "modal.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:432
+#: components/views/PKlima/index.tsx:165
+#: components/views/Wrap/index.tsx:220
+msgid "shared.confirming"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:173
+msgid "connectModal.wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:13
+msgid "web3modal.injected.des"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:179
+msgid "connect_modal.connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:183
+msgid "connect_modal.error_title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:55
+msgid "transaction_modal.approve.approve_quantity.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:54
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:315
+msgid "stake.lifi"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:646
+msgid "bond.bond_price.tooltip.inverse"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:797
+msgid "bond.market_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:983
+msgid "bond.date_of_full_vesting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:988
+msgid "bond.date_of_full_vesting.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:813
+msgid "bond.debt_ratio"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:781
+msgid "bond.bond_price.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:47
+msgid "checkurlbanner.dont_remind_me"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:21
+msgid "web3modal.torus.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:17
+msgid "web3modal.torus.name"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:259
+#: components/views/Stake/index.tsx:268
+msgid "shared.enter_amount"
+msgstr ""
 
 #: components/views/Stake/index.tsx:242
 #: components/views/Wrap/index.tsx:212
 msgid "Enter quantity"
 msgstr "输入数量"
 
+#: components/views/Bond/index.tsx:417
+msgid "Enter Quantity"
+msgstr "输入数量"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:283
+msgid "pklima.index_adjusted.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:475
+#: components/views/Bond/index.tsx:494
+#: components/views/Stake/index.tsx:276
+#: components/views/Wrap/index.tsx:247
+msgid "shared.error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:82
+msgid "stake.estimated_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:184
+msgid "pklima.exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:212
+msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:27
+msgid "modal.error"
+msgstr ""
+
 #: components/views/Offset/index.tsx:45
 msgid "For users who want to offset paying with a pool token, please use <0>this site</0>."
 msgstr "对于想要使用矿池代币抵消付款的用户，请使用<0>此网站</0>。"
+
+#. js-lingui-explicit-id
+#: components/CheckURLBanner/index.tsx:50
+msgid "checkurlbanner.got_it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:16
+msgid "imagecard.how_to_get_started"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:139
+msgid "info.app_not_loading.if_app_says_loading"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:34
+msgid "buy.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:664
+msgid "bond.payout_per_klima.description_inverse"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:837
+msgid "bond.vesting_term_end.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:415
+msgid "stake.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:361
+msgid "wrap.index"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:280
+msgid "pklima.index_adjusted"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:210
+msgid "menu.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:119
+msgid "info.info_and_faq"
+msgstr ""
 
 #: components/views/Stake/index.tsx:247
 #: components/views/Wrap/index.tsx:225
 msgid "Insufficient balance"
 msgstr "余额不足"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:215
+msgid "menu.just_for_you"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:107
+msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:111
+msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:103
+msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:28
+msgid "redeem.cta_1"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:30
+msgid "offset.cta_1"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:47
 msgid "Lack of Liquidity: There may be no active market for $KLIMA, which may result in losses if you need to sell your tokens quickly."
@@ -75,26 +578,119 @@ msgstr "正在加载余额..."
 msgid "Loading..."
 msgstr "正在加载..."
 
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:237
+msgid "shared.connect_wallet"
+msgstr ""
+
 #: components/views/Home/index.tsx:178
 msgid "Login"
 msgstr "登录"
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:397
+#: components/views/Buy/index.tsx:65
+#: components/views/Home/index.tsx:154
+#: components/views/PKlima/index.tsx:149
+#: components/views/Stake/index.tsx:229
+#: components/views/Wrap/index.tsx:199
+msgid "shared.login_connect"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:39
 msgid "Loss of Investment: The value of $KLIMA and other cryptocurrencies can rapidly increase or decrease at any time. As a result, you could experience significant and rapid losses, including the loss of all money invested."
 msgstr "投资损失：$KLIMA 和其他加密货币的价值可能随时快速增加或减少。因此，您可能会遭受重大且快速的损失，包括损失所有投资资金。"
 
-#: components/DisclaimerModal/index.tsx:68
-msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
-msgstr "无担保：不能保证KlimaDAO平台或$KLIMA代币会实现其目标，也不能保证协议中会保留任何价值。"
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:196
+msgid "pklima.balances_card.make_sure_to_stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:642
+#: components/views/Bond/index.tsx:793
+msgid "bond.market_price"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:605
+#: components/views/PKlima/index.tsx:239
+#: components/views/Stake/index.tsx:372
+#: components/views/Wrap/index.tsx:346
+msgid "shared.max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:438
+msgid "bond.max_exceeded"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:715
+#: components/views/Bond/index.tsx:867
+msgid "bond.maximum"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:719
+#: components/views/Bond/index.tsx:871
+msgid "bond.maximum.tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:168
+msgid "info.app_not_loading.metamask_should_prompt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:95
+msgid "choose_bond.mco2.moss_carbon_credit_token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ImageCard/index.tsx:13
+msgid "imagecard.new_to_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:101
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:168
 msgid "No balances found."
 msgstr "未找到余额。"
 
+#: components/DisclaimerModal/index.tsx:68
+msgid "No Guarantee: There is no guarantee that the KlimaDAO platform or the $KLIMA token will achieve its objectives or that any value will be retained in the Protocol."
+msgstr "无担保：不能保证KlimaDAO平台或$KLIMA代币会实现其目标，也不能保证协议中会保留任何价值。"
+
 #: components/CarbonBalancesCard/index.tsx:131
 #: components/CarbonTonnesRetiredCard/index.tsx:29
 msgid "Not Connected"
 msgstr "未连接"
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:68
+msgid "menu.not_connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:423
+msgid "bond.not_redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:182
+msgid "info.official_contract_addresses"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:194
+msgid "menu.offset"
+msgstr ""
 
 #: components/views/Offset/index.tsx:27
 msgid "Offset"
@@ -108,843 +704,441 @@ msgstr "2022年4月12日起，“dapp”迁移至“app”。请更新您的书�
 msgid "Operational Risks: The KlimaDAO platform relies on various technologies related to the Polygon network and other digital assets. These technologies are subject to change, and such changes could adversely affect your investment."
 msgstr "操作风险：KlimaDAO 平台依赖于与 Polygon 网络和其他数字资产相关的各种技术。这些技术可能会发生变化，并且此类变化可能会对您的投资产生不利影响。"
 
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:40
+msgid "buy.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:660
+msgid "bond.payout_per_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:29
+msgid "modal.pending"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:73
+msgid "stake.percent_payout"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:852
+msgid "bond.discount.description_tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:222
+msgid "token.pKLIMA"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:228
+msgid "pklima.klima_to_exercise"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:35
+msgid "status.user_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:54
+msgid "buy.please_log_in"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:47
+msgid "transaction_modal.submit.confirm_transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:679
+msgid "bond.inverse.premium"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:683
+msgid "bond.inverse.premium.description"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:817
+msgid "bond.debt_ratio.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:115
+msgid "choose_bond.inverse_usdc"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:32
 msgid "Purchasing cryptocurrencies, including the $KLIMA token, involves a high degree of risk and should be considered extremely speculative. Here are some important points to consider:"
 msgstr "购买加密货币，包括$KLIMA代币，涉及高度风险，应被视为极具投机性。以下是一些重要考虑要点："
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:66
+msgid "transaction_modal.approve_quantity.quantity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:44
+msgid "stake.rebase"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:468
+#: components/views/Bond/index.tsx:580
+msgid "bond.redeem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1081
+msgid "bond.transaction_modal.redeem.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:209
+msgid "pklima.redeem_pklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:950
+msgid "bond.redeemable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:268
+msgid "pklima.redeemed"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:53
 msgid "Regulatory Actions and Changes: The regulatory environment for cryptocurrencies is evolving and changes in regulation could adversely affect your investment."
 msgstr "监管行动和变化：加密货币的监管环境在不断发展，监管政策的变化可能对您的投资产生不利影响。"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:924
+msgid "bond.unredeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:40
+msgid "connect_modal.error_processing"
+msgstr ""
+
 #: components/DisclaimerModal/index.tsx:29
 msgid "Risk Disclaimer"
 msgstr "风险免责声明"
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:9
+msgid "web3modal.walletlink.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/getWeb3ModalStrings.ts:5
+msgid "web3modal.walletconnect.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:51
+msgid "wrap.sklima_to_wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Home/index.tsx:169
+msgid "connectModal.torus"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:405
+msgid "shared.sold_out"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:265
+msgid "choose_bond.sold_out"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:1023
+msgid "bond.all_demand_has_been_filled"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:291
+msgid "wrap.wrap_sklima.some_find_this_useful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/errors/Custom404.tsx:19
+msgid "error.404.page.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:335
+msgid "stake.stake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:170
+msgid "menu.stake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:258
+#: components/views/Stake/index.tsx:306
+#: components/views/Stake/index.tsx:471
+msgid "stake.stake_klima"
+msgstr ""
+
+#. Long sentence
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:78
+#: components/views/Stake/index.tsx:294
+msgid "stake.balancescard.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:309
+msgid "stake.stake_hold_earn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Submit.tsx:90
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NotificationModal/index.tsx:26
+msgid "modal.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:252
+msgid "pklima.supply_limit"
+msgstr ""
 
 #: components/InvalidNetworkModal/index.tsx:72
 msgid "Switch to Polygon"
 msgstr "切换到 Polygon"
 
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:212
+msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/InvalidRPCModal/index.tsx:28
+msgid "invalid_rpc.modal.text"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/RebaseCard/index.tsx:48
+msgid "stake.rebase.info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:22
+msgid "pklima.update"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:68
 msgid "This app only works on Polygon Mainnet."
 msgstr "此应用程序仅适用于 Polygon 主网。"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Buy/index.tsx:59
+msgid "buy.connect_to_buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:700
+msgid "capacity.description_inverse"
+msgstr ""
 
 #: components/DisclaimerModal/index.tsx:75
 msgid "This summary risk warning does not disclose all the risks associated with investing in $KLIMA. You should conduct your own due diligence and consult with a financial advisor before making any investment decisions."
 msgstr "本风险警告摘要并未披露与投资 $KLIMA 相关的所有风险。在做出任何投资决定之前，您应该自行进行尽职调查并咨询财务顾问。"
 
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:39
+msgid "offset.tonnes_of_carbon_retired"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/PKlima/index.tsx:271
+msgid "pklima.redeemed.tooltip"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:49
+msgid "offset.number_of_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:99
+msgid "choose_bond.bct.toucan_base_carbon_tonne"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:33
+msgid "status.done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:40
+msgid "status.network_confirmation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/ChooseBond/index.tsx:226
+msgid "choose_bond.treasury_balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:921
+msgid "bond.unredeemed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:347
+msgid "stake.unstake"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Stake/index.tsx:267
+#: components/views/Stake/index.tsx:473
+msgid "stake.unstake_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:324
+msgid "wrap.unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/BalancesCard/index.tsx:33
+msgid "wsklima.unwrapped.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:36
+msgid "connect_modal.error_message_refused"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Bond/index.tsx:833
+msgid "bond.vesting_term_end"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:61
+msgid "offset.view_retirements"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Offset/index.tsx:36
+msgid "offset.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Redeem/index.tsx:34
+msgid "redeem.cta_2"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: lib/constants.ts:32
+msgid "connect_modal.error_message_default"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Info/index.tsx:134
+msgid "info.app_not_loading.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:313
+msgid "wrap.wrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:186
+msgid "menu.wrap_klima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:279
+msgid "wrap.wrap_sklima"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:269
+msgid "wrap.balances_tooltip"
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:282
+msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
+msgstr ""
+
 #: components/InvalidNetworkModal/index.tsx:63
 msgid "Wrong Network"
 msgstr "网络错误"
+
+#. js-lingui-explicit-id
+#: components/views/Wrap/index.tsx:55
+msgid "wrap.wsklima_to_unwrap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: actions/utils.ts:22
+msgid "status.user_rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/TransactionModal/Approve.tsx:47
+msgid "transaction_modal.approve.allow_amount"
+msgstr ""
 
 #: components/CarbonBalancesCard/index.tsx:171
 msgid "You need to load your wallet with USDC, KLIMA or a carbon pool token. Credit card support is coming soon."
 msgstr "您的钱包需加载 USDC、KLIMA 或碳池代币。信用卡支付功能即将推出。"
 
-#. Long sentence
-#: components/views/Bond/index.tsx:1023
-msgid "bond.all_demand_has_been_filled"
-msgstr "售罄。该债券的所有需求均已满足。感谢各位Klimates！"
-
-#: components/views/Bond/index.tsx:620
-msgid "bond.balance"
-msgstr "余额"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:624
-msgid "bond.balance.tooltip"
-msgstr "可用于债券化的余额"
-
-#: components/views/Bond/index.tsx:462
-#: components/views/Bond/index.tsx:570
-msgid "bond.bond"
-msgstr "债券"
-
-#: components/views/Bond/index.tsx:777
-msgid "bond.bond_price"
-msgstr "债券价格"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:781
-msgid "bond.bond_price.tooltip"
-msgstr "折后价。1 KLIMA的总债券量（也允许部分零星债券）"
-
-#: components/views/Bond/index.tsx:646
-msgid "bond.bond_price.tooltip.inverse"
-msgstr "KLIMA 在市场上的当前交易价格"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:549
-msgid "bond.bond_token"
-msgstr "债券{0}"
-
-#: components/views/Bond/index.tsx:448
-msgid "bond.capacity_exceeded"
-msgstr "超出容量"
-
-#: components/views/Bond/index.tsx:983
-msgid "bond.date_of_full_vesting"
-msgstr "完全归属的日期"
-
-#: components/views/Bond/index.tsx:988
-msgid "bond.date_of_full_vesting.tooltip"
-msgstr "可赎回全部债券值的日期"
-
-#: components/views/Bond/index.tsx:813
-msgid "bond.debt_ratio"
-msgstr "资产负债率"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:817
-msgid "bond.debt_ratio.tooltip"
-msgstr "协议的当前供应与未偿债券的比率"
-
-#: components/views/Bond/index.tsx:848
-msgid "bond.discount"
-msgstr "债券折扣"
-
-#: components/views/Bond/index.tsx:852
-msgid "bond.discount.description_tooltip"
-msgstr "对于 KLIMA 市场价值的百分比折扣（如果为负数则溢价）。"
-
-#: components/views/Bond/index.tsx:484
-msgid "bond.inputplaceholder.amount_to_bond"
-msgstr "债券量"
-
-#: components/views/Bond/index.tsx:489
-msgid "bond.inputplaceholder.amount_to_redeem"
-msgstr "赎回量"
-
-#: components/views/Bond/index.tsx:679
-msgid "bond.inverse.premium"
-msgstr "溢价"
-
-#: components/views/Bond/index.tsx:683
-msgid "bond.inverse.premium.description"
-msgstr "对于 KLIMA 市场价值的溢价。"
-
-#: components/views/Bond/index.tsx:642
-#: components/views/Bond/index.tsx:793
-msgid "bond.market_price"
-msgstr "市场价"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:797
-msgid "bond.market_price.tooltip"
-msgstr "KLIMA当前交易价格，不含债券折扣"
-
-#: components/views/Bond/index.tsx:438
-msgid "bond.max_exceeded"
-msgstr "最大上限值"
-
-#: components/views/Bond/index.tsx:715
-#: components/views/Bond/index.tsx:867
-msgid "bond.maximum"
-msgstr "最大额度"
-
-#: components/views/Bond/index.tsx:719
-#: components/views/Bond/index.tsx:871
-msgid "bond.maximum.tooltip"
-msgstr "您可以通过债券化绑定获得的最大数量"
-
-#: components/views/Bond/index.tsx:423
-msgid "bond.not_redeemable"
-msgstr "不可赎回"
-
-#: components/views/Bond/index.tsx:660
-msgid "bond.payout_per_klima"
-msgstr "每 KLIMA 的支出"
-
-#: components/views/Bond/index.tsx:664
-msgid "bond.payout_per_klima.description_inverse"
-msgstr "如果您抵押 1 个 KLIMA，您将收到等金额的 USDC。"
-
-#: components/views/Bond/index.tsx:468
-#: components/views/Bond/index.tsx:580
-msgid "bond.redeem"
-msgstr "赎回"
-
-#: components/views/Bond/index.tsx:950
-msgid "bond.redeemable"
-msgstr "可赎回"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:953
-msgid "bond.redeemable.tooltip"
-msgstr "已归属且可赎回的 KLIMA 数量"
-
-#. should autostake?
-#: components/views/Bond/index.tsx:1053
-msgid "bond.should_autostake"
-msgstr "自动质押以获得 sKLIMA"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:1012
-msgid "bond.this_bond_price_is_inflated"
-msgstr "⚠️ 警告：由于当前的贴现率为负，此债券价格虚高。"
-
-#. Bond {0}
-#: components/views/Bond/index.tsx:1074
-msgid "bond.transaction_modal.bond.title"
-msgstr "债券{0}"
-
-#: components/views/Bond/index.tsx:1081
-msgid "bond.transaction_modal.redeem.title"
-msgstr "赎回 Klima"
-
-#: components/views/Bond/index.tsx:921
-msgid "bond.unredeemed"
-msgstr "未赎回"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:924
-msgid "bond.unredeemed.tooltip"
-msgstr "剩余未赎回价值（已归属和未归属）"
-
-#: components/views/Bond/index.tsx:833
-msgid "bond.vesting_term_end"
-msgstr "归属期限结束"
-
-#: components/views/Bond/index.tsx:837
-msgid "bond.vesting_term_end.tooltip"
-msgstr "如果您现在绑定，您的归属期限将即日终止。在这个期限内，Klima会慢慢解锁以进行赎回。"
-
+#. js-lingui-explicit-id
 #: components/views/Bond/index.tsx:746
 #: components/views/Bond/index.tsx:890
 msgid "bond.you_will_get"
-msgstr "你将获得"
+msgstr ""
 
-#: components/views/Bond/index.tsx:750
-msgid "bond.you_will_get.description_inverse"
-msgstr "在提供输入数量的情况下，您将获得的金额"
-
-#. Long sentence
-#: components/views/Bond/index.tsx:894
-msgid "bond.you_will_get.tooltip"
-msgstr "在提供输入量的情况下，您将获得的债券化KLIMA数量"
-
-#: components/views/Buy/index.tsx:31
-msgid "buy.buy_klima"
-msgstr "购买 KLIMA"
-
-#. Long sentence
-#: components/views/Buy/index.tsx:59
-msgid "buy.connect_to_buy"
-msgstr "此功能仅对已登录的用户可用。您可以通过下面的按键登录或创建帐户。"
-
-#: components/views/Buy/index.tsx:34
-msgid "buy.cta_1"
-msgstr "如果您是初学者，我们建议您遵循我们的分步教程：<0>如何购买 KLIMA</0> ."
-
-#: components/views/Buy/index.tsx:40
-msgid "buy.cta_2"
-msgstr "另外，如果您已经在 Polygon 上拥有一个带有 MATIC 的钱包，获得 KLIMA 的最佳方式是在 <0>Sushi.com </0>上交换. 如果您更喜欢用信用卡支付，您可以使用 <1>Transak</1>直接购买 KLIMA。"
-
-#: components/views/Buy/index.tsx:54
-msgid "buy.please_log_in"
-msgstr "请登录或连接钱包"
-
-#: components/views/Bond/index.tsx:700
-msgid "capacity.description_inverse"
-msgstr "这是可用于债券合约中的 USDC 数量。"
-
-#: components/CheckURLBanner/index.tsx:47
-msgid "checkurlbanner.dont_remind_me"
-msgstr "不再提醒"
-
-#: components/CheckURLBanner/index.tsx:50
-msgid "checkurlbanner.got_it"
-msgstr "收到"
-
-#. <0>app.klimadao.finance</0> is the only official domain.
-#: components/CheckURLBanner/index.tsx:31
-msgid "checkurlbanner.is_the_only_official_domain"
-msgstr "<0>app.klimadao.finance</0>是唯一官方域名。"
-
-#: components/CheckURLBanner/index.tsx:26
-msgid "checkurlbanner.verify_url_and_bookmark_this_page"
-msgstr "⚠️ 验证 URL 并将此页面添加为书签！"
-
-#: components/views/ChooseBond/index.tsx:99
-msgid "choose_bond.bct.toucan_base_carbon_tonne"
-msgstr "Toucan基地碳吨"
-
-#: components/views/ChooseBond/index.tsx:209
-msgid "choose_bond.bond_carbon"
-msgstr "碳债券"
-
-#. Long sentence
-#: components/views/ChooseBond/index.tsx:212
-msgid "choose_bond.bond_carbon.the_best_way_to_buy_klima"
-msgstr "购买 KLIMA 的最佳方式。将碳汇入我们的国库，并以折扣价获得 KLIMA。所有债券（反向债券除外）都有 5 天的强制性归属期。"
-
-#: components/views/ChooseBond/index.tsx:236
-msgid "choose_bond.choose_bond"
-msgstr "选择一款债券"
-
-#: components/views/ChooseBond/index.tsx:115
-msgid "choose_bond.inverse_usdc"
-msgstr "提供KLIMA，收到USDC"
-
-#: components/views/ChooseBond/index.tsx:107
-msgid "choose_bond.klima_bct_lp.klima_bct_sushiswap_liquidity"
-msgstr "KLIMA/BCT Sushiswap 流动性"
-
-#: components/views/ChooseBond/index.tsx:103
-msgid "choose_bond.klima_usdc_lp.klima_usdc_sushiswap_liquidity"
-msgstr "KLIMA/USDC Sushiswap 流动性"
-
-#: components/views/ChooseBond/index.tsx:95
-msgid "choose_bond.mco2.moss_carbon_credit_token"
-msgstr "MOSS碳信用代币"
-
-#: components/views/ChooseBond/index.tsx:111
-msgid "choose_bond.mco2_lp.klima_mco2_quickswap_liquidity"
-msgstr "KLIMA/MCO2 Quickswap 流动性"
-
-#: components/views/ChooseBond/index.tsx:91
-msgid "choose_bond.nbo.description"
-msgstr "C3 基于自然抵消"
-
-#: components/views/ChooseBond/index.tsx:239
-msgid "choose_bond.percent_discount"
-msgstr "％ 折扣"
-
-#: components/views/ChooseBond/index.tsx:265
-msgid "choose_bond.sold_out"
-msgstr "售罄"
-
-#: components/views/ChooseBond/index.tsx:226
-msgid "choose_bond.treasury_balance"
-msgstr "国库余额"
-
-#: components/views/ChooseBond/index.tsx:87
-msgid "choose_bond.ubo.description"
-msgstr "C3 基本通用抵消"
-
-#: components/views/Home/index.tsx:169
-msgid "connectModal.torus"
-msgstr "社交或电子邮件"
-
-#: components/views/Home/index.tsx:173
-msgid "connectModal.wallet"
-msgstr "连接钱包"
-
-#: components/views/Home/index.tsx:179
-msgid "connect_modal.connecting"
-msgstr "正在连接..."
-
-#: lib/constants.ts:32
-msgid "connect_modal.error_message_default"
-msgstr "我们在连接时遇到了一些问题，请重试。"
-
-#: lib/constants.ts:36
-msgid "connect_modal.error_message_refused"
-msgstr "用户拒绝连接。"
-
-#: lib/constants.ts:40
-msgid "connect_modal.error_processing"
-msgstr "请求已在处理中。请打开您的钱包并完成请求。"
-
-#: components/views/Home/index.tsx:183
-msgid "connect_modal.error_title"
-msgstr "连接错误"
-
-#: components/views/errors/Custom404.tsx:19
-msgid "error.404.page.text"
-msgstr "抱歉，好像我们发送了错误路径。 <0/>请从菜单中选择发送目的地。"
-
-#: components/ImageCard/index.tsx:16
-msgid "imagecard.how_to_get_started"
-msgstr "如何开始"
-
-#: components/ImageCard/index.tsx:13
-msgid "imagecard.new_to_klima"
-msgstr "刚接触 KLIMA？"
-
-#. Long sentence
-#: components/views/Info/index.tsx:147
-msgid "info.app_not_loading.1_open_metamask"
-msgstr "1. 打开 Metamask 并切换到以太坊主网"
-
-#. Long sentence
-#: components/views/Info/index.tsx:154
-msgid "info.app_not_loading.2_go_to_settings"
-msgstr "2. 到 设置 / 网络 / Polygon 并点击“删除”"
-
-#. Long sentence
-#: components/views/Info/index.tsx:161
-msgid "info.app_not_loading.3_return_to_app"
-msgstr "3. 返回 app.klimadao.finance 并点击“切换到主网”."
-
-#. Long sentence
-#: components/views/Info/index.tsx:139
-msgid "info.app_not_loading.if_app_says_loading"
-msgstr "如果应用程序显示 “正在加载...”，这可能是您的 Metamask 网络配置存在问题。要解决这个问题："
-
-#. Long sentence
-#: components/views/Info/index.tsx:168
-msgid "info.app_not_loading.metamask_should_prompt"
-msgstr "Metamask 会提示您使用正确的 RPC 配置来添加 Polygon。"
-
-#. Long sentence
-#: components/views/Info/index.tsx:134
-msgid "info.app_not_loading.title"
-msgstr "我为什么无法加载应用程序？"
-
-#. Long sentence
-#: components/views/Info/index.tsx:122
-msgid "info.common_app_related_questions"
-msgstr "与应用程序相关的常见问题和一些有用的链接。如需全面了解KlimaDAO，请参阅我们的<0>官方文档</0>."
-
-#: components/views/Info/index.tsx:119
-msgid "info.info_and_faq"
-msgstr "信息和常见问题解答"
-
-#: components/views/Info/index.tsx:182
-msgid "info.official_contract_addresses"
-msgstr "官方合同地址"
-
-#: components/InvalidRPCModal/index.tsx:28
-msgid "invalid_rpc.modal.text"
-msgstr "无法访问网络。这很可能是由您钱包中的旧 Polygon RPC 设置引起的。请参阅<0>本指南</0>修复; 如果尝试修复后问题仍然存在，请通过 <1>Discord </1> 联系我们。"
-
-#: components/InvalidRPCModal/index.tsx:21
-msgid "invalid_rpc.modal.title"
-msgstr "检查您的网络设置"
-
-#: components/NavMenu/index.tsx:178
-msgid "menu.bond_carbon"
-msgstr "碳债券"
-
-#: components/NavMenu/index.tsx:162
-msgid "menu.buy_klima"
-msgstr "购买 KLIMA"
-
-#: components/NavMenu/index.tsx:210
-msgid "menu.info"
-msgstr "信息"
-
-#: components/NavMenu/index.tsx:215
-msgid "menu.just_for_you"
-msgstr "只为您服务"
-
-#: components/NavMenu/index.tsx:68
-msgid "menu.not_connected"
-msgstr "未连接"
-
-#: components/NavMenu/index.tsx:194
-msgid "menu.offset"
-msgstr "抵消"
-
-#: components/NavMenu/index.tsx:170
-msgid "menu.stake_klima"
-msgstr "质押 KLIMA"
-
-#: components/NavMenu/index.tsx:50
-msgid "menu.wallet_address"
-msgstr "您的钱包地址"
-
-#: components/NavMenu/index.tsx:186
-msgid "menu.wrap_klima"
-msgstr "打包 sKLIMA"
-
-#: components/NotificationModal/index.tsx:26
-msgid "modal.done"
-msgstr "成功！"
-
-#: components/NotificationModal/index.tsx:27
-msgid "modal.error"
-msgstr "失败！"
-
-#: components/NotificationModal/index.tsx:29
-msgid "modal.pending"
-msgstr "等待中"
-
-#: components/NotificationModal/index.tsx:28
-msgid "modal.user_confirmation"
-msgstr "确认"
-
-#: components/views/Bond/index.tsx:534
-msgid "nav.back"
-msgstr "返回"
-
-#: components/views/Offset/index.tsx:30
-msgid "offset.cta_1"
-msgstr "KlimaDAO 的碳停用聚合器是一个开源工具，可以实现数字碳信用额的停用。"
-
-#: components/views/Offset/index.tsx:36
-msgid "offset.cta_2"
-msgstr "访问我们的<0>documentation</0>将其构建到您的应用程序中，或访问 <1> Carbonmark</1>使用实时处理。"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:49
-msgid "offset.number_of_retirements"
-msgstr "总碳停用"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:39
-msgid "offset.tonnes_of_carbon_retired"
-msgstr "...吨碳"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:61
-msgid "offset.view_retirements"
-msgstr "查看停用情况"
-
-#: components/CarbonTonnesRetiredCard/index.tsx:23
-msgid "offset.you_have_retired"
-msgstr "您已停用了..."
-
-#: components/views/PKlima/index.tsx:179
-msgid "pklima.approve_bct"
-msgstr "2.批准 BCT"
-
-#: components/views/PKlima/index.tsx:170
-msgid "pklima.approve_pklima"
-msgstr "1. 批准 pKLIMA"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:196
-msgid "pklima.balances_card.make_sure_to_stake"
-msgstr "确保用已赎回的 pKLIMA 来做质押，并持续质押，直至全球温室气体排放量趋于稳定。"
-
-#: components/views/PKlima/index.tsx:184
-msgid "pklima.exercise"
-msgstr "使用"
-
-#: components/views/PKlima/index.tsx:212
-msgid "pklima.exercise_1_pklima_and_1_bct_to_receive_1_klima"
-msgstr "每使用 1个 pKLIMA 和 1个 BCT，即可获取 1个 KLIMA。"
-
-#: components/views/PKlima/index.tsx:280
-msgid "pklima.index_adjusted"
-msgstr "指数调整"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:283
-msgid "pklima.index_adjusted.tooltip"
-msgstr "等价的 sKLIMA 称，假设你把所有赎回的KLIMA质押到今天。"
-
-#: components/views/PKlima/index.tsx:228
-msgid "pklima.klima_to_exercise"
-msgstr "用 pKLIMA 来..."
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:15
-msgid "pklima.overclaim"
-msgstr "您申请的 KLIMA 已经超过了您的供应份额限制。该情况可能是由2021年11月24日对  pKLIMA 赎回合约的修复造成的。"
-
-#: components/views/PKlima/index.tsx:209
-msgid "pklima.redeem_pklima"
-msgstr "赎回 pKLIMA"
-
-#: components/views/PKlima/index.tsx:268
-msgid "pklima.redeemed"
-msgstr "已赎回"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:271
-msgid "pklima.redeemed.tooltip"
-msgstr "到目前为止，您已赎回的 KLIMA 总数。"
-
-#: components/views/PKlima/index.tsx:252
-msgid "pklima.supply_limit"
-msgstr "供应限制"
-
-#. Long sentence
-#: components/views/PKlima/index.tsx:255
-msgid "pklima.supply_limit.tooltip"
-msgstr "代币总供应量的百分比。指数调整后的索赔不得超过此值。"
-
-#: components/views/PKlima/ClaimExceededModal/index.tsx:22
-msgid "pklima.update"
-msgstr "更新后的合约，假设现在 pKLIMA 的持有者已经质押了之前获得的代币，并挣得奖励。在11月合约修复之前，这些质押奖励不计入供应份额限制，就是说您在 KLIMA 总供应量中持有的份额，可能会超过条款定义中限定的份额。"
-
-#: components/views/Redeem/index.tsx:28
-msgid "redeem.cta_1"
-msgstr "KlimaDAO 的数字碳流动性池是可作为推动环境影响的公共资源。"
-
-#: components/views/Redeem/index.tsx:34
-msgid "redeem.cta_2"
-msgstr "访问我们的<0>documentation</0>查找LP合约地址，或访问<1>Carbonmark</1>，通过简单的用户界面获取碳。"
-
-#: components/views/errors/Custom404.tsx:16
-msgid "shared.404"
-msgstr "404 - 页面不存在"
-
-#: components/BalancesCard/index.tsx:47
-msgid "shared.balances"
-msgstr "余额"
-
-#: components/ChangeLanguageButton/index.tsx:56
-msgid "shared.change_language"
-msgstr "变更语言"
-
-#: components/views/Bond/index.tsx:432
-#: components/views/PKlima/index.tsx:165
-#: components/views/Wrap/index.tsx:220
-msgid "shared.confirming"
-msgstr "确认中"
-
-#: components/views/Stake/index.tsx:237
-msgid "shared.connect_wallet"
-msgstr "正在加载..."
-
-#: components/views/Stake/index.tsx:259
-#: components/views/Stake/index.tsx:268
-msgid "shared.enter_amount"
-msgstr "输入金额"
-
-#: components/views/Bond/index.tsx:475
-#: components/views/Bond/index.tsx:494
-#: components/views/Stake/index.tsx:276
-#: components/views/Wrap/index.tsx:247
-msgid "shared.error"
-msgstr "错误"
-
-#: components/views/Bond/index.tsx:397
-#: components/views/Buy/index.tsx:65
-#: components/views/Home/index.tsx:154
-#: components/views/PKlima/index.tsx:149
-#: components/views/Stake/index.tsx:229
-#: components/views/Wrap/index.tsx:199
-msgid "shared.login_connect"
-msgstr "登录/连接"
-
-#: components/views/Bond/index.tsx:605
-#: components/views/PKlima/index.tsx:239
-#: components/views/Stake/index.tsx:372
-#: components/views/Wrap/index.tsx:346
-msgid "shared.max"
-msgstr "最大额度"
-
-#: components/views/Bond/index.tsx:405
-msgid "shared.sold_out"
-msgstr "售罄"
-
-#: components/views/Stake/index.tsx:385
-msgid "stake.5_day_rewards"
-msgstr "5天奖励"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:388
-msgid "stake.5_day_rewards.tooltip"
-msgstr "如果连续质押5天，约可获得...奖励，包括复利。"
-
-#: components/views/Stake/index.tsx:401
-msgid "stake.akr"
-msgstr "KLIMA年化奖励率"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:404
-msgid "stake.akr.tooltip"
-msgstr "如果当前奖励利率在12个月内保持不变（奖励利率可能会发生变化), KLIMA 年化奖利率...，包括复利。"
-
-#. Long sentence
-#. Long sentence
-#: components/views/Buy/index.tsx:78
-#: components/views/Stake/index.tsx:294
-msgid "stake.balancescard.tooltip"
-msgstr "质押代币 KLIMA 即获得 sKLIMA。每次变基后，sKLIMA余额将按给定的百分比增加。"
-
-#: components/RebaseCard/index.tsx:82
-msgid "stake.estimated_payout"
-msgstr "预计支出 (sKLIMA)"
-
-#: components/views/Stake/index.tsx:415
-msgid "stake.index"
-msgstr "指数"
-
-#. Long sentence
-#: components/views/Stake/index.tsx:418
-msgid "stake.index.tooltip"
-msgstr "如果在发行当日质押1个KLIMA，至今您将拥有的 KLIMA 数量。对做账有利。"
-
-#: components/views/Stake/index.tsx:55
-msgid "stake.inputplaceholder.stake"
-msgstr "质押量"
-
-#: components/views/Stake/index.tsx:59
-msgid "stake.inputplaceholder.unstake"
-msgstr "取消质押量"
-
-#: components/views/Stake/index.tsx:315
-msgid "stake.lifi"
-msgstr "现在可以通过 <0>LI.FI 和 Etherspot </0> 进行跨链质押，支持多个链和通证。"
-
-#: components/RebaseCard/index.tsx:61
-msgid "stake.next_rebase"
-msgstr "至下次变基约还有..."
-
-#: components/RebaseCard/index.tsx:73
-msgid "stake.percent_payout"
-msgstr "支付百分比"
-
-#: components/RebaseCard/index.tsx:44
-msgid "stake.rebase"
-msgstr "变基"
-
-#: components/RebaseCard/index.tsx:48
-msgid "stake.rebase.info"
-msgstr "该协议自动铸造和分配奖励。所得是您的 sKLIMA 余额的百分比"
-
-#: components/views/Stake/index.tsx:335
-msgid "stake.stake"
-msgstr "质押"
-
-#: components/views/Stake/index.tsx:309
-msgid "stake.stake_hold_earn"
-msgstr "质押、持有并赚取 sKLIMA 复利 。"
-
-#: components/views/Stake/index.tsx:258
-#: components/views/Stake/index.tsx:306
-#: components/views/Stake/index.tsx:471
-msgid "stake.stake_klima"
-msgstr "质押 KLIMA"
-
-#: components/views/Stake/index.tsx:347
-msgid "stake.unstake"
-msgstr "取消质押"
-
-#: components/views/Stake/index.tsx:267
-#: components/views/Stake/index.tsx:473
-msgid "stake.unstake_klima"
-msgstr "取消质押KLIMA"
-
-#: actions/utils.ts:33
-msgid "status.done"
-msgstr "交易完成。"
-
-#: actions/utils.ts:28
-msgid "status.error"
-msgstr "❌ 错误：出了点问题..."
-
-#: actions/utils.ts:40
-msgid "status.network_confirmation"
-msgstr "交易已启动。等待网络确认。"
-
-#: actions/utils.ts:35
-msgid "status.user_confirmation"
-msgstr "请点击您钱包中的 \"确认\" 以继续。"
-
-#: actions/utils.ts:22
-msgid "status.user_rejected"
-msgstr "您已选择拒绝交易"
-
-#: components/NavMenu/index.tsx:222
-msgid "token.pKLIMA"
-msgstr "pKLIMA"
-
-#: components/TransactionModal/Approve.tsx:47
-msgid "transaction_modal.approve.allow_amount"
-msgstr "您必须先授权我们的智能合约，我们才可以代表您转移代币。"
-
-#: components/TransactionModal/Approve.tsx:55
-msgid "transaction_modal.approve.approve_quantity.contract_address"
-msgstr "合约地址"
-
-#: components/TransactionModal/Approve.tsx:66
-msgid "transaction_modal.approve_quantity.quantity"
-msgstr "批准数量"
-
-#: components/TransactionModal/Submit.tsx:98
-msgid "transaction_modal.close"
-msgstr "关闭"
-
-#: components/TransactionModal/Approve.tsx:101
-msgid "transaction_modal.next"
-msgstr "下一步"
-
-#: components/TransactionModal/Submit.tsx:65
-msgid "transaction_modal.submit.amount"
-msgstr "确认金额"
-
-#: components/TransactionModal/Submit.tsx:90
-msgid "transaction_modal.submit.button"
-msgstr "提交"
-
-#: components/TransactionModal/Submit.tsx:47
-msgid "transaction_modal.submit.confirm_transaction"
-msgstr "请提交交易。"
-
-#: components/TransactionModal/Submit.tsx:54
-msgid "transaction_modal.submit.contract_address"
-msgstr "合约地址"
-
-#: components/TransactionModal/index.tsx:50
-msgid "transaction_modal.view.approve.title"
-msgstr "1. 批准"
-
-#: components/TransactionModal/index.tsx:60
-msgid "transaction_modal.view.submit.title"
-msgstr "2. 提交"
-
-#: lib/getWeb3ModalStrings.ts:13
-msgid "web3modal.injected.des"
-msgstr "与您的浏览器 web3 供应商连接"
-
-#: lib/getWeb3ModalStrings.ts:21
-msgid "web3modal.torus.desc"
-msgstr "简单的一键式 Torus 钱包"
-
-#: lib/getWeb3ModalStrings.ts:17
-msgid "web3modal.torus.name"
-msgstr "电子邮件或社交媒体"
-
-#: lib/getWeb3ModalStrings.ts:5
-msgid "web3modal.walletconnect.desc"
-msgstr "使用 WalletConnect 扫描进行连接"
-
-#: lib/getWeb3ModalStrings.ts:9
-msgid "web3modal.walletlink.desc"
-msgstr "使用 Coinbase 扫描进行连接"
-
-#: components/views/Wrap/index.tsx:374
-msgid "wrap.balance"
-msgstr "余额"
-
-#: components/views/Wrap/index.tsx:269
-msgid "wrap.balances_tooltip"
-msgstr "打包 sKLIMA 以获得指数调整的已打包质押的 KLIMA"
-
-#: components/views/Wrap/index.tsx:361
-msgid "wrap.index"
-msgstr "指数"
-
-#: components/views/Wrap/index.tsx:364
-msgid "wrap.index.tooltip"
-msgstr "如果在发行当日质押1个KLIMA，至今您将拥有的 KLIMA 数量。用于计算 wsKLIMA 价值。"
-
-#: components/views/Wrap/index.tsx:51
-msgid "wrap.sklima_to_wrap"
-msgstr "待打包的 sKLIMA"
-
-#: components/views/Wrap/index.tsx:324
-msgid "wrap.unwrap"
-msgstr "分拆"
-
-#: components/views/Wrap/index.tsx:313
-msgid "wrap.wrap"
-msgstr "打包"
-
-#: components/views/Wrap/index.tsx:279
-msgid "wrap.wrap_sklima"
-msgstr "打包 sKLIMA"
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:291
-msgid "wrap.wrap_sklima.some_find_this_useful"
-msgstr "部分人认为这对做账有帮助，但其实收益则完全相同。 打包数值和分拆数值是根据当前指标计算得出的。"
-
-#. Long sentence
-#: components/views/Wrap/index.tsx:282
-msgid "wrap.wrap_sklima.wrap_sklima_to_receive_sklima"
-msgstr "打包 sKLIMA 即获得 wsKLIMA。与 sKLIMA 不同，wsKLIMA 余额不会随着时间的推移而增加。"
-
-#: components/views/Wrap/index.tsx:55
-msgid "wrap.wsklima_to_unwrap"
-msgstr "待拆分的 wsKLIMA"
-
+#. js-lingui-explicit-id
 #: components/views/Wrap/index.tsx:377
 msgid "wrap.you_will_get"
-msgstr "你将获得"
+msgstr ""
 
-#: components/BalancesCard/index.tsx:33
-msgid "wsklima.unwrapped.label"
-msgstr "已拆分"
+#. js-lingui-explicit-id
+#: components/views/PKlima/ClaimExceededModal/index.tsx:15
+msgid "pklima.overclaim"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CarbonTonnesRetiredCard/index.tsx:23
+msgid "offset.you_have_retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/NavMenu/index.tsx:50
+msgid "menu.wallet_address"
+msgstr ""

--- a/carbon/locale/de/messages.po
+++ b/carbon/locale/de/messages.po
@@ -6,6 +6,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
+msgid "{0} retired"
+msgstr ""
+
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr ""
+
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr ""
+
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
@@ -41,10 +95,6 @@ msgstr ""
 msgid "All Tokens"
 msgstr "Alle Tokens"
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
 msgid "Amount bridged"
 msgstr ""
@@ -54,12 +104,24 @@ msgstr ""
 msgid "Amount retired"
 msgstr ""
 
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
 msgid "Avg tonnes per transaction"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr ""
+
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
 #: lib/charts/options.ts:92
 msgid "BCT"
@@ -71,14 +133,6 @@ msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:126
 msgid "BCT retired VCUs"
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr ""
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
@@ -122,13 +176,13 @@ msgstr ""
 msgid "C3"
 msgstr ""
 
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:86
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
 msgid "C3 bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:87
@@ -245,12 +299,12 @@ msgstr ""
 msgid "Digital carbon retirements snapshot"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr ""
-
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
 msgid "Digital carbon supply - {chainLabel}"
+msgstr ""
+
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
@@ -261,12 +315,12 @@ msgstr ""
 msgid "Digital carbon supply snapshot"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
 msgid "Distribution of methodologies"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
 msgstr ""
 
 #: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
@@ -291,20 +345,20 @@ msgstr ""
 msgid "Ethereum supply"
 msgstr ""
 
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:14
 msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: app/[locale]/supply/page.tsx:18
 msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr ""
+
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: components/Skeleton/index.tsx:4
@@ -319,8 +373,8 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: lib/charts/options.ts:32
 msgid "Issued"
 msgstr ""
@@ -382,14 +436,14 @@ msgstr ""
 msgid "Moss"
 msgstr ""
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:145
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
 msgid "Moss bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:146
@@ -402,8 +456,16 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr ""
+
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
 #: lib/charts/options.ts:78
 msgid "NBO"
@@ -417,8 +479,8 @@ msgstr ""
 msgid "NBO retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
 #: lib/charts/options.ts:96
 msgid "NCT"
@@ -432,21 +494,13 @@ msgstr ""
 msgid "NCT retired VCUs"
 msgstr ""
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr ""
-
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr ""
-
 #: components/charts/helpers/NoDataWrapper/index.tsx:14
 msgid "No data availble"
 msgstr ""
 
+#: components/cards/tokenDetails/helpers.ts:79
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
 msgid "Not pooled"
 msgstr ""
 
@@ -456,6 +510,10 @@ msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
 msgid "Number of transactions"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
@@ -470,8 +528,8 @@ msgstr ""
 msgid "Off vs On-chain carbon"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
@@ -486,8 +544,12 @@ msgstr ""
 msgid "Off-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
-msgid "On-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
@@ -498,12 +560,16 @@ msgstr ""
 msgid "On-chain"
 msgstr ""
 
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr ""
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
 msgid "On-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
+msgid "On-Chain Verra credits retired over time"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
@@ -524,12 +590,12 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:64
 msgid "Percentage of tokenized VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
@@ -596,25 +662,25 @@ msgstr ""
 msgid "Retired outside of KlimaDAO"
 msgstr ""
 
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr ""
+
 #: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
 #: components/charts/DailyCarbonRetirementsChart/index.tsx:13
 msgid "Retired via KlimaDAO"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
 msgid "Retirement Details"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:11
 msgid "Retirement trends"
+msgstr ""
+
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
@@ -634,10 +700,6 @@ msgstr ""
 msgid "Selective cost"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
 msgid "State of {0} digital carbon"
 msgstr ""
@@ -646,18 +708,22 @@ msgstr ""
 msgid "State of {bridgeLabel} digital carbon"
 msgstr ""
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
 msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr ""
+
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
@@ -777,16 +843,12 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr ""
-
 #: app/[locale]/token-details/page.tsx:15
 msgid "Token details"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
 msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
@@ -795,16 +857,20 @@ msgstr ""
 msgid "Tokenized credits by bridge"
 msgstr ""
 
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
 msgid "Tonnes"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
 msgid "Total issued VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:70
@@ -846,13 +912,13 @@ msgstr ""
 msgid "Toucan"
 msgstr ""
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:116
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
 msgid "Toucan bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:117
@@ -860,8 +926,8 @@ msgstr ""
 msgid "Toucan retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
@@ -933,64 +999,4 @@ msgstr ""
 #: app/[locale]/overview/digital-carbon/page.tsx:42
 #: app/[locale]/overview/page.tsx:37
 msgid "What is digital carbon?"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
-msgid "{0} retired"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr ""
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
 msgstr ""

--- a/carbon/locale/en-pseudo/messages.po
+++ b/carbon/locale/en-pseudo/messages.po
@@ -6,6 +6,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
+msgid "{0} retired"
+msgstr ""
+
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr ""
+
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr ""
+
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
@@ -41,10 +95,6 @@ msgstr ""
 msgid "All Tokens"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
 msgid "Amount bridged"
 msgstr ""
@@ -54,12 +104,24 @@ msgstr ""
 msgid "Amount retired"
 msgstr ""
 
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
 msgid "Avg tonnes per transaction"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr ""
+
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
 #: lib/charts/options.ts:92
 msgid "BCT"
@@ -71,14 +133,6 @@ msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:126
 msgid "BCT retired VCUs"
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr ""
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
@@ -122,13 +176,13 @@ msgstr ""
 msgid "C3"
 msgstr ""
 
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:86
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
 msgid "C3 bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:87
@@ -245,12 +299,12 @@ msgstr ""
 msgid "Digital carbon retirements snapshot"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr ""
-
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
 msgid "Digital carbon supply - {chainLabel}"
+msgstr ""
+
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
@@ -261,12 +315,12 @@ msgstr ""
 msgid "Digital carbon supply snapshot"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
 msgid "Distribution of methodologies"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
 msgstr ""
 
 #: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
@@ -291,20 +345,20 @@ msgstr ""
 msgid "Ethereum supply"
 msgstr ""
 
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:14
 msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: app/[locale]/supply/page.tsx:18
 msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr ""
+
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: components/Skeleton/index.tsx:4
@@ -319,8 +373,8 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: lib/charts/options.ts:32
 msgid "Issued"
 msgstr ""
@@ -382,14 +436,14 @@ msgstr ""
 msgid "Moss"
 msgstr ""
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:145
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
 msgid "Moss bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:146
@@ -402,8 +456,16 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr ""
+
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
 #: lib/charts/options.ts:78
 msgid "NBO"
@@ -417,8 +479,8 @@ msgstr ""
 msgid "NBO retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
 #: lib/charts/options.ts:96
 msgid "NCT"
@@ -432,21 +494,13 @@ msgstr ""
 msgid "NCT retired VCUs"
 msgstr ""
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr ""
-
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr ""
-
 #: components/charts/helpers/NoDataWrapper/index.tsx:14
 msgid "No data availble"
 msgstr ""
 
+#: components/cards/tokenDetails/helpers.ts:79
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
 msgid "Not pooled"
 msgstr ""
 
@@ -456,6 +510,10 @@ msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
 msgid "Number of transactions"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
@@ -470,8 +528,8 @@ msgstr ""
 msgid "Off vs On-chain carbon"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
@@ -486,8 +544,12 @@ msgstr ""
 msgid "Off-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
-msgid "On-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
@@ -498,12 +560,16 @@ msgstr ""
 msgid "On-chain"
 msgstr ""
 
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr ""
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
 msgid "On-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
+msgid "On-Chain Verra credits retired over time"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
@@ -524,12 +590,12 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:64
 msgid "Percentage of tokenized VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
@@ -596,25 +662,25 @@ msgstr ""
 msgid "Retired outside of KlimaDAO"
 msgstr ""
 
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr ""
+
 #: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
 #: components/charts/DailyCarbonRetirementsChart/index.tsx:13
 msgid "Retired via KlimaDAO"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
 msgid "Retirement Details"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:11
 msgid "Retirement trends"
+msgstr ""
+
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
@@ -634,10 +700,6 @@ msgstr ""
 msgid "Selective cost"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
 msgid "State of {0} digital carbon"
 msgstr ""
@@ -646,18 +708,22 @@ msgstr ""
 msgid "State of {bridgeLabel} digital carbon"
 msgstr ""
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
 msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr ""
+
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
@@ -777,16 +843,12 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr ""
-
 #: app/[locale]/token-details/page.tsx:15
 msgid "Token details"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
 msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
@@ -795,16 +857,20 @@ msgstr ""
 msgid "Tokenized credits by bridge"
 msgstr ""
 
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
 msgid "Tonnes"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
 msgid "Total issued VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:70
@@ -846,13 +912,13 @@ msgstr ""
 msgid "Toucan"
 msgstr ""
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:116
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
 msgid "Toucan bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:117
@@ -860,8 +926,8 @@ msgstr ""
 msgid "Toucan retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
@@ -933,64 +999,4 @@ msgstr ""
 #: app/[locale]/overview/digital-carbon/page.tsx:42
 #: app/[locale]/overview/page.tsx:37
 msgid "What is digital carbon?"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
-msgid "{0} retired"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr ""
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
 msgstr ""

--- a/carbon/locale/en/messages.po
+++ b/carbon/locale/en/messages.po
@@ -13,6 +13,54 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr "{0} Bridged"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr "{0} outstanding"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
+msgid "{0} retired"
+msgstr "{0} retired"
+
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr "{0} Tonnes"
+
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr "{bridgeLabel} distribution of methodologies"
+
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr "{bridgeLabel} distribution of projects"
+
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr "{bridgeLabel} Distribution of vintage start dates"
+
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr "{bridgeLabel} volume over time"
+
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr "{formattedCurrentSupply} tonnes available"
+
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr "{poolLabel} volume deposited over time"
+
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr "{poolLabel} volume redeemed over time"
+
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr "{poolLabel} volume retired over time"
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
 msgid "A breakdown of carbon credits issued by carbon registry Verra which have been bridged and tokenized on a public blockchain."
@@ -47,10 +95,6 @@ msgstr "A collection of data for quick reference including total supply, supply 
 msgid "All Tokens"
 msgstr "All Tokens"
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr "Amount Retired"
-
 #: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
 msgid "Amount bridged"
 msgstr "Amount bridged"
@@ -60,12 +104,24 @@ msgstr "Amount bridged"
 msgid "Amount retired"
 msgstr "Amount retired"
 
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr "Amount Retired"
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
 msgid "Avg tonnes per transaction"
 msgstr "Avg tonnes per transaction"
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr "Banner image"
+
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr "Base Carbon Tonne (BCT)"
+
 #: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
 #: lib/charts/options.ts:92
 msgid "BCT"
@@ -78,14 +134,6 @@ msgstr "BCT pooled VCUs"
 #: components/charts/DistributionOfProjectsChart/index.tsx:126
 msgid "BCT retired VCUs"
 msgstr "BCT retired VCUs"
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr "Banner image"
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
-msgstr "Base Carbon Tonne (BCT)"
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
 msgid "Beneficiary"
@@ -128,14 +176,14 @@ msgstr "By token"
 msgid "C3"
 msgstr "C3"
 
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr "C3 Carbon Credit (C3T)"
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:86
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
 msgid "C3 bridged VCUs"
 msgstr "C3 bridged VCUs"
+
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
+msgstr "C3 Carbon Credit (C3T)"
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:87
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
@@ -251,13 +299,13 @@ msgstr "Digital carbon retirements - {chainLabel}"
 msgid "Digital carbon retirements snapshot"
 msgstr "Digital carbon retirements snapshot"
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr "Digital carbon supply - quick facts"
-
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
 msgid "Digital carbon supply - {chainLabel}"
 msgstr "Digital carbon supply - {chainLabel}"
+
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
+msgstr "Digital carbon supply - quick facts"
 
 #: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
 msgid "Digital carbon supply by Blockchain"
@@ -267,13 +315,13 @@ msgstr "Digital carbon supply by Blockchain"
 msgid "Digital carbon supply snapshot"
 msgstr "Digital carbon supply snapshot"
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr "Distribution of Projects"
-
 #: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
 msgid "Distribution of methodologies"
 msgstr "Distribution of methodologies"
+
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
+msgstr "Distribution of Projects"
 
 #: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
 msgid "Distribution of vintage start dates"
@@ -297,14 +345,6 @@ msgstr "Ethereum retirements"
 msgid "Ethereum supply"
 msgstr "Ethereum supply"
 
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr "Explore Marketplace"
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-
 #: app/[locale]/retirement-trends/page.tsx:14
 msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
@@ -312,6 +352,14 @@ msgstr "Explore digital carbon retirement trends by public blockhchain, digtial 
 #: app/[locale]/supply/page.tsx:18
 msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
 msgstr "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr "Explore Marketplace"
+
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
+msgstr "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
 
 #: components/Skeleton/index.tsx:4
 msgid "Fetching data…"
@@ -325,8 +373,8 @@ msgstr "Historical prices (USD)"
 msgid "Insights"
 msgstr "Insights"
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: lib/charts/options.ts:32
 msgid "Issued"
 msgstr "Issued"
@@ -396,15 +444,15 @@ msgstr "Missing"
 msgid "Moss"
 msgstr "Moss"
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr "Moss Carbon Credit (MCO2)"
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:145
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
 msgid "Moss bridged VCUs"
 msgstr "Moss bridged VCUs"
+
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
+msgstr "Moss Carbon Credit (MCO2)"
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:146
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:51
@@ -416,8 +464,16 @@ msgstr "Moss retired VCUs"
 msgid "N/A"
 msgstr "N/A"
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr "Nature Based Offset (NBO)"
+
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr "Nature Carbon Tonne (NCT)"
+
 #: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
 #: lib/charts/options.ts:78
 msgid "NBO"
@@ -431,8 +487,8 @@ msgstr "NBO pooled VCUs"
 msgid "NBO retired VCUs"
 msgstr "NBO retired VCUs"
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
 #: lib/charts/options.ts:96
 msgid "NCT"
@@ -446,21 +502,13 @@ msgstr "NCT pooled VCUs"
 msgid "NCT retired VCUs"
 msgstr "NCT retired VCUs"
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr "Nature Based Offset (NBO)"
-
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr "Nature Carbon Tonne (NCT)"
-
 #: components/charts/helpers/NoDataWrapper/index.tsx:14
 msgid "No data availble"
 msgstr "No data availble"
 
+#: components/cards/tokenDetails/helpers.ts:79
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
 msgid "Not pooled"
 msgstr "Not pooled"
 
@@ -471,6 +519,10 @@ msgstr "Number of retirements"
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
 msgid "Number of transactions"
 msgstr "Number of transactions"
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
+msgstr "of retired credits"
 
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
 msgid "Of total retired credits"
@@ -484,9 +536,9 @@ msgstr "Off vs On-Chain"
 msgid "Off vs On-chain carbon"
 msgstr "Off vs On-chain carbon"
 
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
-msgstr "Off-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
+msgstr "off-chain"
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:52
@@ -500,9 +552,13 @@ msgstr "Off-chain"
 msgid "Off-chain Verra credits retired over time"
 msgstr "Off-chain Verra credits retired over time"
 
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
-msgid "On-Chain Verra credits retired over time"
-msgstr "On-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
+msgstr "Off-Chain Verra credits retired over time"
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
+msgstr "on-chain"
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:58
@@ -512,13 +568,17 @@ msgstr "On-Chain Verra credits retired over time"
 msgid "On-chain"
 msgstr "On-chain"
 
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr "On-chain retirements"
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
 msgid "On-chain Verra credits retired over time"
 msgstr "On-chain Verra credits retired over time"
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
-msgstr "On-chain retirements"
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
+msgid "On-Chain Verra credits retired over time"
+msgstr "On-Chain Verra credits retired over time"
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
 msgid "On/Off chain"
@@ -538,13 +598,13 @@ msgstr "Outstanding"
 msgid "Overview"
 msgstr "Overview"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr "Percentage of VCUs retired offchain"
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:64
 msgid "Percentage of tokenized VCUs"
 msgstr "Percentage of tokenized VCUs"
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
+msgstr "Percentage of VCUs retired offchain"
 
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
 msgid "Percentage retired onchain"
@@ -610,26 +670,26 @@ msgstr "Retired"
 msgid "Retired outside of KlimaDAO"
 msgstr "Retired outside of KlimaDAO"
 
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr "Retired via klimaDAO"
+
 #: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
 #: components/charts/DailyCarbonRetirementsChart/index.tsx:13
 msgid "Retired via KlimaDAO"
 msgstr "Retired via KlimaDAO"
 
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
-msgstr "Retired via klimaDAO"
-
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
 msgid "Retirement Details"
 msgstr "Retirement Details"
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr "Retirement Trends"
-
 #: app/[locale]/retirement-trends/page.tsx:11
 msgid "Retirement trends"
 msgstr "Retirement trends"
+
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
+msgstr "Retirement Trends"
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:37
@@ -648,10 +708,6 @@ msgstr "Retirements by token"
 msgid "Selective cost"
 msgstr "Selective cost"
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr "State of the Digital Carbon Market"
-
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
 msgid "State of {0} digital carbon"
 msgstr "State of {0} digital carbon"
@@ -660,19 +716,23 @@ msgstr "State of {0} digital carbon"
 msgid "State of {bridgeLabel} digital carbon"
 msgstr "State of {bridgeLabel} digital carbon"
 
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
+msgstr "State of the Digital Carbon Market"
+
 #: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
 #: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
 msgid "Supply"
 msgstr "Supply"
-
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
-msgstr "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
 msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
 msgstr "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+msgstr "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
 msgid "The percentage of all carbon credit retirements that are retired via infrastructure built by KlimaDAO over a given time period."
@@ -796,17 +856,13 @@ msgstr "This cost includes the asset spot price + the {0}% fee to selectively re
 msgid "Token"
 msgstr "Token"
 
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr "Token Details"
-
 #: app/[locale]/token-details/page.tsx:15
 msgid "Token details"
 msgstr "Token details"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
-msgstr "Tokenized VCUs"
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
+msgstr "Token Details"
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:9
@@ -814,17 +870,21 @@ msgstr "Tokenized VCUs"
 msgid "Tokenized credits by bridge"
 msgstr "Tokenized credits by bridge"
 
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr "Tokenized VCUs"
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
 msgid "Tonnes"
 msgstr "Tonnes"
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr "Total Issued VCUs"
-
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
 msgid "Total issued VCUs"
 msgstr "Total issued VCUs"
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
+msgstr "Total Issued VCUs"
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:70
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:76
@@ -865,22 +925,22 @@ msgstr "Total tonnes retired"
 msgid "Toucan"
 msgstr "Toucan"
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr "Toucan Carbon Credit (TCO2)"
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:116
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
 msgid "Toucan bridged VCUs"
 msgstr "Toucan bridged VCUs"
+
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
+msgstr "Toucan Carbon Credit (TCO2)"
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:117
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:42
 msgid "Toucan retired VCUs"
 msgstr "Toucan retired VCUs"
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
@@ -953,63 +1013,3 @@ msgstr "Volume retired over time"
 #: app/[locale]/overview/page.tsx:37
 msgid "What is digital carbon?"
 msgstr "What is digital carbon?"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr "of retired credits"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr "off-chain"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr "on-chain"
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr "{0} Bridged"
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr "{0} Tonnes"
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr "{0} outstanding"
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
-msgid "{0} retired"
-msgstr "{0} retired"
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr "{bridgeLabel} Distribution of vintage start dates"
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr "{bridgeLabel} distribution of methodologies"
-
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr "{bridgeLabel} distribution of projects"
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr "{bridgeLabel} volume over time"
-
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr "{formattedCurrentSupply} tonnes available"
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr "{poolLabel} volume deposited over time"
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr "{poolLabel} volume redeemed over time"
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
-msgstr "{poolLabel} volume retired over time"

--- a/carbon/locale/es/messages.po
+++ b/carbon/locale/es/messages.po
@@ -6,6 +6,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: es\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
+msgid "{0} retired"
+msgstr ""
+
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr ""
+
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr ""
+
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
@@ -41,10 +95,6 @@ msgstr ""
 msgid "All Tokens"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
 msgid "Amount bridged"
 msgstr ""
@@ -54,12 +104,24 @@ msgstr ""
 msgid "Amount retired"
 msgstr ""
 
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
 msgid "Avg tonnes per transaction"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr ""
+
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
 #: lib/charts/options.ts:92
 msgid "BCT"
@@ -71,14 +133,6 @@ msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:126
 msgid "BCT retired VCUs"
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr ""
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
@@ -122,13 +176,13 @@ msgstr ""
 msgid "C3"
 msgstr ""
 
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:86
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
 msgid "C3 bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:87
@@ -245,12 +299,12 @@ msgstr ""
 msgid "Digital carbon retirements snapshot"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr ""
-
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
 msgid "Digital carbon supply - {chainLabel}"
+msgstr ""
+
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
@@ -261,12 +315,12 @@ msgstr ""
 msgid "Digital carbon supply snapshot"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
 msgid "Distribution of methodologies"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
 msgstr ""
 
 #: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
@@ -291,20 +345,20 @@ msgstr ""
 msgid "Ethereum supply"
 msgstr ""
 
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:14
 msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: app/[locale]/supply/page.tsx:18
 msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr ""
+
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: components/Skeleton/index.tsx:4
@@ -319,8 +373,8 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: lib/charts/options.ts:32
 msgid "Issued"
 msgstr ""
@@ -382,14 +436,14 @@ msgstr ""
 msgid "Moss"
 msgstr ""
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:145
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
 msgid "Moss bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:146
@@ -402,8 +456,16 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr ""
+
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
 #: lib/charts/options.ts:78
 msgid "NBO"
@@ -417,8 +479,8 @@ msgstr ""
 msgid "NBO retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
 #: lib/charts/options.ts:96
 msgid "NCT"
@@ -432,21 +494,13 @@ msgstr ""
 msgid "NCT retired VCUs"
 msgstr ""
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr ""
-
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr ""
-
 #: components/charts/helpers/NoDataWrapper/index.tsx:14
 msgid "No data availble"
 msgstr ""
 
+#: components/cards/tokenDetails/helpers.ts:79
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
 msgid "Not pooled"
 msgstr ""
 
@@ -456,6 +510,10 @@ msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
 msgid "Number of transactions"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
@@ -470,8 +528,8 @@ msgstr ""
 msgid "Off vs On-chain carbon"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
@@ -486,8 +544,12 @@ msgstr ""
 msgid "Off-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
-msgid "On-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
@@ -498,12 +560,16 @@ msgstr ""
 msgid "On-chain"
 msgstr ""
 
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr ""
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
 msgid "On-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
+msgid "On-Chain Verra credits retired over time"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
@@ -524,12 +590,12 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:64
 msgid "Percentage of tokenized VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
@@ -596,25 +662,25 @@ msgstr ""
 msgid "Retired outside of KlimaDAO"
 msgstr ""
 
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr ""
+
 #: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
 #: components/charts/DailyCarbonRetirementsChart/index.tsx:13
 msgid "Retired via KlimaDAO"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
 msgid "Retirement Details"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:11
 msgid "Retirement trends"
+msgstr ""
+
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
@@ -634,10 +700,6 @@ msgstr ""
 msgid "Selective cost"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
 msgid "State of {0} digital carbon"
 msgstr ""
@@ -646,18 +708,22 @@ msgstr ""
 msgid "State of {bridgeLabel} digital carbon"
 msgstr ""
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
 msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr ""
+
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
@@ -777,16 +843,12 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr ""
-
 #: app/[locale]/token-details/page.tsx:15
 msgid "Token details"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
 msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
@@ -795,16 +857,20 @@ msgstr ""
 msgid "Tokenized credits by bridge"
 msgstr ""
 
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
 msgid "Tonnes"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
 msgid "Total issued VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:70
@@ -846,13 +912,13 @@ msgstr ""
 msgid "Toucan"
 msgstr ""
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:116
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
 msgid "Toucan bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:117
@@ -860,8 +926,8 @@ msgstr ""
 msgid "Toucan retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
@@ -933,64 +999,4 @@ msgstr ""
 #: app/[locale]/overview/digital-carbon/page.tsx:42
 #: app/[locale]/overview/page.tsx:37
 msgid "What is digital carbon?"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
-msgid "{0} retired"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr ""
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
 msgstr ""

--- a/carbon/locale/fr/messages.po
+++ b/carbon/locale/fr/messages.po
@@ -6,6 +6,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
+msgid "{0} retired"
+msgstr ""
+
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr ""
+
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr ""
+
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
@@ -41,10 +95,6 @@ msgstr ""
 msgid "All Tokens"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
 msgid "Amount bridged"
 msgstr ""
@@ -54,12 +104,24 @@ msgstr ""
 msgid "Amount retired"
 msgstr ""
 
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
 msgid "Avg tonnes per transaction"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr ""
+
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
 #: lib/charts/options.ts:92
 msgid "BCT"
@@ -71,14 +133,6 @@ msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:126
 msgid "BCT retired VCUs"
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr ""
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
@@ -122,13 +176,13 @@ msgstr ""
 msgid "C3"
 msgstr ""
 
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:86
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
 msgid "C3 bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:87
@@ -245,12 +299,12 @@ msgstr ""
 msgid "Digital carbon retirements snapshot"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr ""
-
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
 msgid "Digital carbon supply - {chainLabel}"
+msgstr ""
+
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
@@ -261,12 +315,12 @@ msgstr ""
 msgid "Digital carbon supply snapshot"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
 msgid "Distribution of methodologies"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
 msgstr ""
 
 #: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
@@ -291,20 +345,20 @@ msgstr ""
 msgid "Ethereum supply"
 msgstr ""
 
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:14
 msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: app/[locale]/supply/page.tsx:18
 msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr ""
+
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: components/Skeleton/index.tsx:4
@@ -319,8 +373,8 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: lib/charts/options.ts:32
 msgid "Issued"
 msgstr ""
@@ -382,14 +436,14 @@ msgstr ""
 msgid "Moss"
 msgstr ""
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:145
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
 msgid "Moss bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:146
@@ -402,8 +456,16 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr ""
+
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
 #: lib/charts/options.ts:78
 msgid "NBO"
@@ -417,8 +479,8 @@ msgstr ""
 msgid "NBO retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
 #: lib/charts/options.ts:96
 msgid "NCT"
@@ -432,21 +494,13 @@ msgstr ""
 msgid "NCT retired VCUs"
 msgstr ""
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr ""
-
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr ""
-
 #: components/charts/helpers/NoDataWrapper/index.tsx:14
 msgid "No data availble"
 msgstr ""
 
+#: components/cards/tokenDetails/helpers.ts:79
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
 msgid "Not pooled"
 msgstr ""
 
@@ -456,6 +510,10 @@ msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
 msgid "Number of transactions"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
@@ -470,8 +528,8 @@ msgstr ""
 msgid "Off vs On-chain carbon"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
@@ -486,8 +544,12 @@ msgstr ""
 msgid "Off-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
-msgid "On-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
@@ -498,12 +560,16 @@ msgstr ""
 msgid "On-chain"
 msgstr ""
 
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr ""
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
 msgid "On-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
+msgid "On-Chain Verra credits retired over time"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
@@ -524,12 +590,12 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:64
 msgid "Percentage of tokenized VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
@@ -596,25 +662,25 @@ msgstr ""
 msgid "Retired outside of KlimaDAO"
 msgstr ""
 
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr ""
+
 #: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
 #: components/charts/DailyCarbonRetirementsChart/index.tsx:13
 msgid "Retired via KlimaDAO"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
 msgid "Retirement Details"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:11
 msgid "Retirement trends"
+msgstr ""
+
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
@@ -634,10 +700,6 @@ msgstr ""
 msgid "Selective cost"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
 msgid "State of {0} digital carbon"
 msgstr ""
@@ -646,18 +708,22 @@ msgstr ""
 msgid "State of {bridgeLabel} digital carbon"
 msgstr ""
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
 msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr ""
+
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
@@ -777,16 +843,12 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr ""
-
 #: app/[locale]/token-details/page.tsx:15
 msgid "Token details"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
 msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
@@ -795,16 +857,20 @@ msgstr ""
 msgid "Tokenized credits by bridge"
 msgstr ""
 
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
 msgid "Tonnes"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
 msgid "Total issued VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:70
@@ -846,13 +912,13 @@ msgstr ""
 msgid "Toucan"
 msgstr ""
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:116
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
 msgid "Toucan bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:117
@@ -860,8 +926,8 @@ msgstr ""
 msgid "Toucan retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
@@ -933,64 +999,4 @@ msgstr ""
 #: app/[locale]/overview/digital-carbon/page.tsx:42
 #: app/[locale]/overview/page.tsx:37
 msgid "What is digital carbon?"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
-msgid "{0} retired"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr ""
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
 msgstr ""

--- a/carbon/locale/hi/messages.po
+++ b/carbon/locale/hi/messages.po
@@ -6,6 +6,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: hi\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
+msgid "{0} retired"
+msgstr ""
+
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr "{0} टन"
+
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr "{bridgeLabel} पद्धतियों का वितरण"
+
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr "{bridgeLabel} परियोजनाओं का वितरण"
+
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr "{bridgeLabel} पुरानी आरंभ तिथियों का वितरण"
+
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr ""
+
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr "{formattedCurrentSupply} टन उपलब्ध है"
+
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
@@ -41,10 +95,6 @@ msgstr ""
 msgid "All Tokens"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
 msgid "Amount bridged"
 msgstr ""
@@ -54,12 +104,24 @@ msgstr ""
 msgid "Amount retired"
 msgstr ""
 
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
 msgid "Avg tonnes per transaction"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr ""
+
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
 #: lib/charts/options.ts:92
 msgid "BCT"
@@ -71,14 +133,6 @@ msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:126
 msgid "BCT retired VCUs"
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr ""
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
@@ -122,13 +176,13 @@ msgstr ""
 msgid "C3"
 msgstr ""
 
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:86
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
 msgid "C3 bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:87
@@ -245,12 +299,12 @@ msgstr ""
 msgid "Digital carbon retirements snapshot"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr ""
-
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
 msgid "Digital carbon supply - {chainLabel}"
+msgstr ""
+
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
@@ -261,12 +315,12 @@ msgstr ""
 msgid "Digital carbon supply snapshot"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
 msgid "Distribution of methodologies"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
 msgstr ""
 
 #: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
@@ -291,20 +345,20 @@ msgstr ""
 msgid "Ethereum supply"
 msgstr ""
 
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:14
 msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: app/[locale]/supply/page.tsx:18
 msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr ""
+
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: components/Skeleton/index.tsx:4
@@ -319,8 +373,8 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: lib/charts/options.ts:32
 msgid "Issued"
 msgstr ""
@@ -382,14 +436,14 @@ msgstr ""
 msgid "Moss"
 msgstr ""
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:145
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
 msgid "Moss bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:146
@@ -402,8 +456,16 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr ""
+
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
 #: lib/charts/options.ts:78
 msgid "NBO"
@@ -417,8 +479,8 @@ msgstr ""
 msgid "NBO retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
 #: lib/charts/options.ts:96
 msgid "NCT"
@@ -432,21 +494,13 @@ msgstr ""
 msgid "NCT retired VCUs"
 msgstr ""
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr ""
-
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr ""
-
 #: components/charts/helpers/NoDataWrapper/index.tsx:14
 msgid "No data availble"
 msgstr ""
 
+#: components/cards/tokenDetails/helpers.ts:79
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
 msgid "Not pooled"
 msgstr ""
 
@@ -457,6 +511,10 @@ msgstr ""
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
 msgid "Number of transactions"
 msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
+msgstr "सेवानिवृत्त क्रेडिट का"
 
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
 msgid "Of total retired credits"
@@ -470,9 +528,9 @@ msgstr ""
 msgid "Off vs On-chain carbon"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
-msgstr ""
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
+msgstr "ऑफ-चेन"
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:52
@@ -486,9 +544,13 @@ msgstr ""
 msgid "Off-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
-msgid "On-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
 msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
+msgstr "ऑन-चेन"
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:58
@@ -498,12 +560,16 @@ msgstr ""
 msgid "On-chain"
 msgstr ""
 
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr ""
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
 msgid "On-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
+msgid "On-Chain Verra credits retired over time"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
@@ -524,12 +590,12 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:64
 msgid "Percentage of tokenized VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
@@ -596,25 +662,25 @@ msgstr ""
 msgid "Retired outside of KlimaDAO"
 msgstr ""
 
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr ""
+
 #: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
 #: components/charts/DailyCarbonRetirementsChart/index.tsx:13
 msgid "Retired via KlimaDAO"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
 msgid "Retirement Details"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:11
 msgid "Retirement trends"
+msgstr ""
+
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
@@ -634,10 +700,6 @@ msgstr ""
 msgid "Selective cost"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
 msgid "State of {0} digital carbon"
 msgstr ""
@@ -646,18 +708,22 @@ msgstr ""
 msgid "State of {bridgeLabel} digital carbon"
 msgstr ""
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
 msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr ""
+
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
@@ -777,16 +843,12 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr ""
-
 #: app/[locale]/token-details/page.tsx:15
 msgid "Token details"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
 msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
@@ -795,16 +857,20 @@ msgstr ""
 msgid "Tokenized credits by bridge"
 msgstr ""
 
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
 msgid "Tonnes"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
 msgid "Total issued VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:70
@@ -846,13 +912,13 @@ msgstr ""
 msgid "Toucan"
 msgstr ""
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:116
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
 msgid "Toucan bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:117
@@ -860,8 +926,8 @@ msgstr ""
 msgid "Toucan retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
@@ -934,63 +1000,3 @@ msgstr "वॉल्यूम समय के साथ समाप्त ह�
 #: app/[locale]/overview/page.tsx:37
 msgid "What is digital carbon?"
 msgstr "डिजिटल कार्बन क्या है?"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr "सेवानिवृत्त क्रेडिट का"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr "ऑफ-चेन"
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr "ऑन-चेन"
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr "{0} टन"
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
-msgid "{0} retired"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr "{bridgeLabel} पुरानी आरंभ तिथियों का वितरण"
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr "{bridgeLabel} पद्धतियों का वितरण"
-
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr "{bridgeLabel} परियोजनाओं का वितरण"
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr "{formattedCurrentSupply} टन उपलब्ध है"
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
-msgstr ""

--- a/carbon/locale/ko/messages.po
+++ b/carbon/locale/ko/messages.po
@@ -6,6 +6,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ko\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
+msgid "{0} retired"
+msgstr ""
+
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr ""
+
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr ""
+
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
@@ -41,10 +95,6 @@ msgstr ""
 msgid "All Tokens"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
 msgid "Amount bridged"
 msgstr ""
@@ -54,12 +104,24 @@ msgstr ""
 msgid "Amount retired"
 msgstr ""
 
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
 msgid "Avg tonnes per transaction"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr ""
+
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
 #: lib/charts/options.ts:92
 msgid "BCT"
@@ -71,14 +133,6 @@ msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:126
 msgid "BCT retired VCUs"
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr ""
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
@@ -122,13 +176,13 @@ msgstr ""
 msgid "C3"
 msgstr ""
 
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:86
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
 msgid "C3 bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:87
@@ -245,12 +299,12 @@ msgstr ""
 msgid "Digital carbon retirements snapshot"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr ""
-
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
 msgid "Digital carbon supply - {chainLabel}"
+msgstr ""
+
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
@@ -261,12 +315,12 @@ msgstr ""
 msgid "Digital carbon supply snapshot"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
 msgid "Distribution of methodologies"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
 msgstr ""
 
 #: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
@@ -291,20 +345,20 @@ msgstr ""
 msgid "Ethereum supply"
 msgstr ""
 
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:14
 msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: app/[locale]/supply/page.tsx:18
 msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr ""
+
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: components/Skeleton/index.tsx:4
@@ -319,8 +373,8 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: lib/charts/options.ts:32
 msgid "Issued"
 msgstr ""
@@ -382,14 +436,14 @@ msgstr ""
 msgid "Moss"
 msgstr ""
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:145
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
 msgid "Moss bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:146
@@ -402,8 +456,16 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr ""
+
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
 #: lib/charts/options.ts:78
 msgid "NBO"
@@ -417,8 +479,8 @@ msgstr ""
 msgid "NBO retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
 #: lib/charts/options.ts:96
 msgid "NCT"
@@ -432,21 +494,13 @@ msgstr ""
 msgid "NCT retired VCUs"
 msgstr ""
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr ""
-
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr ""
-
 #: components/charts/helpers/NoDataWrapper/index.tsx:14
 msgid "No data availble"
 msgstr ""
 
+#: components/cards/tokenDetails/helpers.ts:79
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
 msgid "Not pooled"
 msgstr ""
 
@@ -456,6 +510,10 @@ msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
 msgid "Number of transactions"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
@@ -470,8 +528,8 @@ msgstr ""
 msgid "Off vs On-chain carbon"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
@@ -486,8 +544,12 @@ msgstr ""
 msgid "Off-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
-msgid "On-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
@@ -498,12 +560,16 @@ msgstr ""
 msgid "On-chain"
 msgstr ""
 
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr ""
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
 msgid "On-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
+msgid "On-Chain Verra credits retired over time"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
@@ -524,12 +590,12 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:64
 msgid "Percentage of tokenized VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
@@ -596,25 +662,25 @@ msgstr ""
 msgid "Retired outside of KlimaDAO"
 msgstr ""
 
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr ""
+
 #: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
 #: components/charts/DailyCarbonRetirementsChart/index.tsx:13
 msgid "Retired via KlimaDAO"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
 msgid "Retirement Details"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:11
 msgid "Retirement trends"
+msgstr ""
+
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
@@ -634,10 +700,6 @@ msgstr ""
 msgid "Selective cost"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
 msgid "State of {0} digital carbon"
 msgstr ""
@@ -646,18 +708,22 @@ msgstr ""
 msgid "State of {bridgeLabel} digital carbon"
 msgstr ""
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
 msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr ""
+
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
@@ -777,16 +843,12 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr ""
-
 #: app/[locale]/token-details/page.tsx:15
 msgid "Token details"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
 msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
@@ -795,16 +857,20 @@ msgstr ""
 msgid "Tokenized credits by bridge"
 msgstr ""
 
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
 msgid "Tonnes"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
 msgid "Total issued VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:70
@@ -846,13 +912,13 @@ msgstr ""
 msgid "Toucan"
 msgstr ""
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:116
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
 msgid "Toucan bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:117
@@ -860,8 +926,8 @@ msgstr ""
 msgid "Toucan retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
@@ -933,64 +999,4 @@ msgstr ""
 #: app/[locale]/overview/digital-carbon/page.tsx:42
 #: app/[locale]/overview/page.tsx:37
 msgid "What is digital carbon?"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
-msgid "{0} retired"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr ""
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
 msgstr ""

--- a/carbon/locale/ru/messages.po
+++ b/carbon/locale/ru/messages.po
@@ -6,6 +6,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ru\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
+msgid "{0} retired"
+msgstr ""
+
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr ""
+
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr ""
+
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
@@ -41,10 +95,6 @@ msgstr ""
 msgid "All Tokens"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
 msgid "Amount bridged"
 msgstr ""
@@ -54,12 +104,24 @@ msgstr ""
 msgid "Amount retired"
 msgstr ""
 
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
 msgid "Avg tonnes per transaction"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr ""
+
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
 #: lib/charts/options.ts:92
 msgid "BCT"
@@ -71,14 +133,6 @@ msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:126
 msgid "BCT retired VCUs"
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr ""
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
@@ -122,13 +176,13 @@ msgstr ""
 msgid "C3"
 msgstr ""
 
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:86
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
 msgid "C3 bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:87
@@ -245,12 +299,12 @@ msgstr ""
 msgid "Digital carbon retirements snapshot"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr ""
-
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
 msgid "Digital carbon supply - {chainLabel}"
+msgstr ""
+
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
@@ -261,12 +315,12 @@ msgstr ""
 msgid "Digital carbon supply snapshot"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
 msgid "Distribution of methodologies"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
 msgstr ""
 
 #: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
@@ -291,20 +345,20 @@ msgstr ""
 msgid "Ethereum supply"
 msgstr ""
 
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:14
 msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: app/[locale]/supply/page.tsx:18
 msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr ""
+
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: components/Skeleton/index.tsx:4
@@ -319,8 +373,8 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: lib/charts/options.ts:32
 msgid "Issued"
 msgstr ""
@@ -382,14 +436,14 @@ msgstr ""
 msgid "Moss"
 msgstr ""
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:145
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
 msgid "Moss bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:146
@@ -402,8 +456,16 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr ""
+
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
 #: lib/charts/options.ts:78
 msgid "NBO"
@@ -417,8 +479,8 @@ msgstr ""
 msgid "NBO retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
 #: lib/charts/options.ts:96
 msgid "NCT"
@@ -432,21 +494,13 @@ msgstr ""
 msgid "NCT retired VCUs"
 msgstr ""
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr ""
-
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr ""
-
 #: components/charts/helpers/NoDataWrapper/index.tsx:14
 msgid "No data availble"
 msgstr ""
 
+#: components/cards/tokenDetails/helpers.ts:79
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
 msgid "Not pooled"
 msgstr ""
 
@@ -456,6 +510,10 @@ msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
 msgid "Number of transactions"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
@@ -470,8 +528,8 @@ msgstr ""
 msgid "Off vs On-chain carbon"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
@@ -486,8 +544,12 @@ msgstr ""
 msgid "Off-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
-msgid "On-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
@@ -498,12 +560,16 @@ msgstr ""
 msgid "On-chain"
 msgstr ""
 
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr ""
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
 msgid "On-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
+msgid "On-Chain Verra credits retired over time"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
@@ -524,12 +590,12 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:64
 msgid "Percentage of tokenized VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
@@ -596,25 +662,25 @@ msgstr ""
 msgid "Retired outside of KlimaDAO"
 msgstr ""
 
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr ""
+
 #: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
 #: components/charts/DailyCarbonRetirementsChart/index.tsx:13
 msgid "Retired via KlimaDAO"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
 msgid "Retirement Details"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:11
 msgid "Retirement trends"
+msgstr ""
+
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
@@ -634,10 +700,6 @@ msgstr ""
 msgid "Selective cost"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
 msgid "State of {0} digital carbon"
 msgstr ""
@@ -646,18 +708,22 @@ msgstr ""
 msgid "State of {bridgeLabel} digital carbon"
 msgstr ""
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
 msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr ""
+
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
@@ -777,16 +843,12 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr ""
-
 #: app/[locale]/token-details/page.tsx:15
 msgid "Token details"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
 msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
@@ -795,16 +857,20 @@ msgstr ""
 msgid "Tokenized credits by bridge"
 msgstr ""
 
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
 msgid "Tonnes"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
 msgid "Total issued VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:70
@@ -846,13 +912,13 @@ msgstr ""
 msgid "Toucan"
 msgstr ""
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:116
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
 msgid "Toucan bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:117
@@ -860,8 +926,8 @@ msgstr ""
 msgid "Toucan retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
@@ -933,64 +999,4 @@ msgstr ""
 #: app/[locale]/overview/digital-carbon/page.tsx:42
 #: app/[locale]/overview/page.tsx:37
 msgid "What is digital carbon?"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
-msgid "{0} retired"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr ""
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
 msgstr ""

--- a/carbon/locale/zh-CN/messages.po
+++ b/carbon/locale/zh-CN/messages.po
@@ -6,6 +6,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
+msgid "{0} Bridged"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
+msgid "{0} outstanding"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
+msgid "{0} retired"
+msgstr ""
+
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
+msgid "{0} Tonnes"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of methodologies"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
+msgid "{bridgeLabel} distribution of projects"
+msgstr ""
+
+#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
+msgid "{bridgeLabel} Distribution of vintage start dates"
+msgstr ""
+
+#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
+msgid "{bridgeLabel} volume over time"
+msgstr ""
+
+#: components/cards/overview/TokensPriceCard/index.tsx:76
+msgid "{formattedCurrentSupply} tonnes available"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume deposited over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume redeemed over time"
+msgstr ""
+
+#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
+msgid "{poolLabel} volume retired over time"
+msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:12
 #: app/[locale]/overview/verra-credits-tokenized-by-bridge/page.tsx:12
@@ -41,10 +95,6 @@ msgstr ""
 msgid "All Tokens"
 msgstr ""
 
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
-msgid "Amount Retired"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/TokenOriginsListConfiguration.tsx:48
 msgid "Amount bridged"
 msgstr ""
@@ -54,12 +104,24 @@ msgstr ""
 msgid "Amount retired"
 msgstr ""
 
+#: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:36
+msgid "Amount Retired"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:51
 msgid "Avg tonnes per transaction"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
+#: app/[locale]/overview/digital-carbon/page.tsx:36
+msgid "Banner image"
+msgstr ""
+
+#: lib/tokens.tsx:15
+msgid "Base Carbon Tonne (BCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:57
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:59
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:60
 #: lib/charts/options.ts:92
 msgid "BCT"
@@ -71,14 +133,6 @@ msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:126
 msgid "BCT retired VCUs"
-msgstr ""
-
-#: app/[locale]/overview/digital-carbon/page.tsx:36
-msgid "Banner image"
-msgstr ""
-
-#: lib/tokens.tsx:15
-msgid "Base Carbon Tonne (BCT)"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:48
@@ -122,13 +176,13 @@ msgstr ""
 msgid "C3"
 msgstr ""
 
-#: lib/protocols.tsx:10
-msgid "C3 Carbon Credit (C3T)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:86
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:58
 msgid "C3 bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:10
+msgid "C3 Carbon Credit (C3T)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:87
@@ -245,12 +299,12 @@ msgstr ""
 msgid "Digital carbon retirements snapshot"
 msgstr ""
 
-#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
-msgid "Digital carbon supply - quick facts"
-msgstr ""
-
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:13
 msgid "Digital carbon supply - {chainLabel}"
+msgstr ""
+
+#: app/[locale]/supply/digital-carbon-supply-quick-facts/page.tsx:9
+msgid "Digital carbon supply - quick facts"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply-by-blockchain/page.tsx:9
@@ -261,12 +315,12 @@ msgstr ""
 msgid "Digital carbon supply snapshot"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
-msgid "Distribution of Projects"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenDistributionOfMethodologiesCard/index.tsx:28
 msgid "Distribution of methodologies"
+msgstr ""
+
+#: components/cards/tokenDetails/TokenDistributionOfProjectsCard/index.tsx:27
+msgid "Distribution of Projects"
 msgstr ""
 
 #: components/cards/tokenDetails/TokenDistributionOfVintageCard/index.tsx:28
@@ -291,20 +345,20 @@ msgstr ""
 msgid "Ethereum supply"
 msgstr ""
 
-#: components/ExploreMarketplaceButton/index.tsx:14
-msgid "Explore Marketplace"
-msgstr ""
-
-#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
-msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:14
 msgid "Explore digital carbon retirement trends by public blockhchain, digtial carbon token, and retirement beneficiary using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: app/[locale]/supply/page.tsx:18
 msgid "Explore digital carbon supply on Polygon, Ethereum, Celo and more using the Klima Data Carbon Dashboard."
+msgstr ""
+
+#: components/ExploreMarketplaceButton/index.tsx:14
+msgid "Explore Marketplace"
+msgstr ""
+
+#: app/[locale]/off-chain-vs-on-chain/page.tsx:18
+msgid "Explore Off and On-chain digital carbon trends using the Klima Data Carbon Dashboard."
 msgstr ""
 
 #: components/Skeleton/index.tsx:4
@@ -319,8 +373,8 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:55
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedVsTokenizedCreditsChart.tsx:39
 #: lib/charts/options.ts:32
 msgid "Issued"
 msgstr ""
@@ -382,14 +436,14 @@ msgstr ""
 msgid "Moss"
 msgstr ""
 
-#: lib/protocols.tsx:12
-#: lib/tokens.tsx:17
-msgid "Moss Carbon Credit (MCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:145
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:50
 msgid "Moss bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:12
+#: lib/tokens.tsx:17
+msgid "Moss Carbon Credit (MCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:146
@@ -402,8 +456,16 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
+#: lib/tokens.tsx:19
+msgid "Nature Based Offset (NBO)"
+msgstr ""
+
+#: lib/tokens.tsx:16
+msgid "Nature Carbon Tonne (NCT)"
+msgstr ""
+
 #: components/cards/tokenDetails/helpers.ts:46
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:114
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:52
 #: lib/charts/options.ts:78
 msgid "NBO"
@@ -417,8 +479,8 @@ msgstr ""
 msgid "NBO retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/cards/tokenDetails/helpers.ts:68
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:65
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:68
 #: lib/charts/options.ts:96
 msgid "NCT"
@@ -432,21 +494,13 @@ msgstr ""
 msgid "NCT retired VCUs"
 msgstr ""
 
-#: lib/tokens.tsx:19
-msgid "Nature Based Offset (NBO)"
-msgstr ""
-
-#: lib/tokens.tsx:16
-msgid "Nature Carbon Tonne (NCT)"
-msgstr ""
-
 #: components/charts/helpers/NoDataWrapper/index.tsx:14
 msgid "No data availble"
 msgstr ""
 
+#: components/cards/tokenDetails/helpers.ts:79
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:71
 #: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:120
-#: components/cards/tokenDetails/helpers.ts:79
 msgid "Not pooled"
 msgstr ""
 
@@ -456,6 +510,10 @@ msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByPoolSummaryConfiguration.tsx:44
 msgid "Number of transactions"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
+msgid "of retired credits"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:92
@@ -470,8 +528,8 @@ msgstr ""
 msgid "Off vs On-chain carbon"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
-msgid "Off-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
+msgid "off-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:27
@@ -486,8 +544,12 @@ msgstr ""
 msgid "Off-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
-msgid "On-Chain Verra credits retired over time"
+#: components/cards/offVsOnChain/DailyVerraCreditsCard/index.tsx:54
+msgid "Off-Chain Verra credits retired over time"
+msgstr ""
+
+#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
+msgid "on-chain"
 msgstr ""
 
 #: components/cards/retirementTrends/RetirementsByChainChartCard/index.tsx:28
@@ -498,12 +560,16 @@ msgstr ""
 msgid "On-chain"
 msgstr ""
 
+#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
+msgid "On-chain retirements"
+msgstr ""
+
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-retired-on-chain-over-time/page.tsx:9
 msgid "On-chain Verra credits retired over time"
 msgstr ""
 
-#: components/cards/overview/DailyCarbonRetirementsCard/index.tsx:22
-msgid "On-chain retirements"
+#: components/cards/offVsOnChain/DailyCarbonSupplyByProtocolCard/index.tsx:88
+msgid "On-Chain Verra credits retired over time"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByChainListConfiguration.tsx:25
@@ -524,12 +590,12 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:76
-msgid "Percentage of VCUs retired offchain"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:64
 msgid "Percentage of tokenized VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:76
+msgid "Percentage of VCUs retired offchain"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:85
@@ -596,25 +662,25 @@ msgstr ""
 msgid "Retired outside of KlimaDAO"
 msgstr ""
 
+#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
+msgid "Retired via klimaDAO"
+msgstr ""
+
 #: components/cards/supply/CarbonSupplyQuickFactsCard/index.tsx:114
 #: components/charts/DailyCarbonRetirementsChart/index.tsx:13
 msgid "Retired via KlimaDAO"
-msgstr ""
-
-#: components/cards/retirementTrends/RetirementsByChainOverviewCard/index.tsx:72
-msgid "Retired via klimaDAO"
 msgstr ""
 
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsByBeneficiaryListConfiguration.tsx:53
 msgid "Retirement Details"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:37
-msgid "Retirement Trends"
-msgstr ""
-
 #: app/[locale]/retirement-trends/page.tsx:11
 msgid "Retirement trends"
+msgstr ""
+
+#: components/Layout/NavItems/index.tsx:37
+msgid "Retirement Trends"
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:9
@@ -634,10 +700,6 @@ msgstr ""
 msgid "Selective cost"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:15
-msgid "State of the Digital Carbon Market"
-msgstr ""
-
 #: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:29
 msgid "State of {0} digital carbon"
 msgstr ""
@@ -646,18 +708,22 @@ msgstr ""
 msgid "State of {bridgeLabel} digital carbon"
 msgstr ""
 
-#: app/[locale]/supply/page.tsx:15
-#: components/Layout/NavItems/index.tsx:31
-#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
-msgid "Supply"
+#: app/[locale]/overview/page.tsx:15
+msgid "State of the Digital Carbon Market"
 msgstr ""
 
-#: app/[locale]/overview/page.tsx:18
-msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
+#: app/[locale]/supply/page.tsx:15
+#: components/cards/overview/DailyCarbonSupplyOverviewCard/index.tsx:24
+#: components/Layout/NavItems/index.tsx:31
+msgid "Supply"
 msgstr ""
 
 #: app/[locale]/supply/digital-carbon-supply/[chain]/page.tsx:18
 msgid "The current supply of digital carbon on the {chainLabel} blockchain broken down by digital carbon pool."
+msgstr ""
+
+#: app/[locale]/overview/page.tsx:18
+msgid "The Klima Data Carbon Dashboard provides a complete overview of digital carbon pricing, volumes, and retirement trends for the Digital Carbon Market. It is made available to anyone by KlimaDAO as a public good, creating transparency for the DCM."
 msgstr ""
 
 #: app/[locale]/retirement-trends/retirement-trends-by-chain/page.tsx:12
@@ -777,16 +843,12 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: components/Layout/NavItems/index.tsx:43
-msgid "Token Details"
-msgstr ""
-
 #: app/[locale]/token-details/page.tsx:15
 msgid "Token details"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:62
-msgid "Tokenized VCUs"
+#: components/Layout/NavItems/index.tsx:43
+msgid "Token Details"
 msgstr ""
 
 #: app/[locale]/off-chain-vs-on-chain/verra-credits-tokenized-by-bridge/page.tsx:9
@@ -795,16 +857,20 @@ msgstr ""
 msgid "Tokenized credits by bridge"
 msgstr ""
 
+#: components/charts/DistributionOfProjectsChart/index.tsx:62
+msgid "Tokenized VCUs"
+msgstr ""
+
 #: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:92
 msgid "Tonnes"
 msgstr ""
 
-#: components/charts/DistributionOfProjectsChart/index.tsx:61
-msgid "Total Issued VCUs"
-msgstr ""
-
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:75
 msgid "Total issued VCUs"
+msgstr ""
+
+#: components/charts/DistributionOfProjectsChart/index.tsx:61
+msgid "Total Issued VCUs"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:70
@@ -846,13 +912,13 @@ msgstr ""
 msgid "Toucan"
 msgstr ""
 
-#: lib/protocols.tsx:11
-msgid "Toucan Carbon Credit (TCO2)"
-msgstr ""
-
 #: components/charts/DistributionOfProjectsChart/index.tsx:116
 #: components/charts/helpers/DataTable/configurations/VerraCreditsOriginsListConfiguration.tsx:41
 msgid "Toucan bridged VCUs"
+msgstr ""
+
+#: lib/protocols.tsx:11
+msgid "Toucan Carbon Credit (TCO2)"
 msgstr ""
 
 #: components/charts/DistributionOfProjectsChart/index.tsx:117
@@ -860,8 +926,8 @@ msgstr ""
 msgid "Toucan retired VCUs"
 msgstr ""
 
-#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/cards/tokenDetails/helpers.ts:38
+#: components/cards/tokenDetails/TokenPoolBreakdownCard/index.tsx:108
 #: components/charts/helpers/CarbonSupplyOverTimeChart/index.ts:44
 #: lib/charts/options.ts:74
 msgid "UBO"
@@ -933,64 +999,4 @@ msgstr ""
 #: app/[locale]/overview/digital-carbon/page.tsx:42
 #: app/[locale]/overview/page.tsx:37
 msgid "What is digital carbon?"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:111
-msgid "of retired credits"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:20
-msgid "off-chain"
-msgstr ""
-
-#: components/cards/offVsOnChain/VerraCreditsBreakdownCard/issuedvsRetiredCreditsChart.tsx:39
-msgid "on-chain"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:105
-msgid "{0} Bridged"
-msgstr ""
-
-#: components/charts/helpers/DataTable/configurations/KlimaRetirementsListConfigurationBase.tsx:111
-msgid "{0} Tonnes"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:100
-msgid "{0} outstanding"
-msgstr ""
-
-#: components/cards/tokenDetails/TokenStateOfDigitalCarbonCard/index.tsx:94
-msgid "{0} retired"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-vintage-date/[bridge]/page.tsx:11
-msgid "{bridgeLabel} Distribution of vintage start dates"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-methodologies/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of methodologies"
-msgstr ""
-
-#: app/[locale]/token-details/token-by-projects/[bridge]/page.tsx:10
-msgid "{bridgeLabel} distribution of projects"
-msgstr ""
-
-#: app/[locale]/token-details/token-volume-over-time/[bridge]/page.tsx:10
-msgid "{bridgeLabel} volume over time"
-msgstr ""
-
-#: components/cards/overview/TokensPriceCard/index.tsx:76
-msgid "{formattedCurrentSupply} tonnes available"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-deposited-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume deposited over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-redeemed-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume redeemed over time"
-msgstr ""
-
-#: app/[locale]/token-details/pool-volume-retired-over-time/[bridge]/page.tsx:10
-msgid "{poolLabel} volume retired over time"
 msgstr ""

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx
@@ -97,9 +97,9 @@ export const ProvenanceTimeline = (props: ProvenanceComponentProps) => {
                   boxShadow: "unset",
                 }}
               >
-                <span className={styles.timelineIcon}>
+                <div className={styles.timelineIcon}>
                   {recordInfo(record)?.icon}
-                </span>
+                </div>
               </TimelineDot>
               {record.transactionType == "TRANSFER" && <TimelineConnector />}
             </TimelineSeparator>

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx
@@ -45,9 +45,9 @@ export const ProvenanceTimeline = (props: ProvenanceComponentProps) => {
     (record) => record.transactionType == "TRANSFER"
   ).length;
   const dividerText = showTransfers ? (
-    <Trans>Hide {numberOfTransfers} transfers</Trans>
+    <Trans>Hide {numberOfTransfers} transactions</Trans>
   ) : (
-    <Trans>View {numberOfTransfers} transfers</Trans>
+    <Trans>View {numberOfTransfers} transactions</Trans>
   );
   const dividerIcon = showTransfers ? (
     <KeyboardArrowUp fontSize="large" />
@@ -97,7 +97,9 @@ export const ProvenanceTimeline = (props: ProvenanceComponentProps) => {
                   boxShadow: "unset",
                 }}
               >
-                {recordInfo(record)?.icon}
+                <span className={styles.timelineIcon}>
+                  {recordInfo(record)?.icon}
+                </span>
               </TimelineDot>
               {record.transactionType == "TRANSFER" && <TimelineConnector />}
             </TimelineSeparator>
@@ -176,6 +178,7 @@ export const ProvenanceTimeline = (props: ProvenanceComponentProps) => {
                         <Text t="responsiveBody2">
                           <A
                             href={`${verra.appSearch}?programType=ISSUANCE&exactResId=${projectId}`}
+                            className={styles.verraLink}
                           >
                             <Trans>View issuance on Verra</Trans>
                           </A>

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/styles.ts
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/styles.ts
@@ -82,6 +82,8 @@ export const verraLinkAndTooltip = css`
   align-items: center;
   svg {
     color: var(--font-03);
+    width: 2rem;
+    height: 2rem;
   }
 `;
 
@@ -97,4 +99,15 @@ export const divider = css`
   align-items: center;
   font-size: 1.4rem;
   cursor: pointer;
+`;
+
+export const timelineIcon = css`
+  svg {
+    width: 2rem;
+    height: 2rem;
+  }
+`;
+
+export const verraLink = css`
+  text-decoration: underline;
 `;

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/styles.ts
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/styles.ts
@@ -102,6 +102,8 @@ export const divider = css`
 `;
 
 export const timelineIcon = css`
+  display: grid;
+  place-content: center;
   svg {
     width: 2rem;
     height: 2rem;

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx
@@ -1,9 +1,12 @@
-import { Trans } from "@lingui/macro";
-import ChangeCircleOutlined from "@mui/icons-material/ChangeCircleOutlined";
+import { Trans, t } from "@lingui/macro";
 import DeviceHub from "@mui/icons-material/DeviceHub";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import NorthEastIcon from "@mui/icons-material/NorthEast";
 import Park from "@mui/icons-material/Park";
+import { TextInfoTooltip } from "components/TextInfoTooltip";
 import { ReactNode } from "react";
 import { ProvenanceRecordType } from "./RetirementProvenance.types";
+import * as styles from "./styles";
 
 export const PROVENANCE_RECORDS_INFO: Record<
   ProvenanceRecordType,
@@ -21,9 +24,19 @@ export const PROVENANCE_RECORDS_INFO: Record<
     iconBackgroundColor: "#E0FFE8",
   },
   TRANSFER: {
-    label: <Trans>Transfer</Trans>,
+    label: (
+      <div className={styles.labelWithInfo}>
+        <Trans>Send</Trans>
+        <TextInfoTooltip
+          align="start"
+          tooltip={t`Asset moved from one account to another, either via sale or inter-account transfer.`}
+        >
+          <InfoOutlinedIcon />
+        </TextInfoTooltip>
+      </div>
+    ),
     icon: (
-      <ChangeCircleOutlined
+      <NorthEastIcon
         sx={{
           color: "#0019FF",
         }}

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx
@@ -32,7 +32,7 @@ export const PROVENANCE_RECORDS_INFO: Record<
     iconBackgroundColor: "#EBEDFF",
   },
   ORIGINATION: {
-    label: <Trans>Bridge</Trans>,
+    label: <Trans>Transfer</Trans>,
     icon: (
       <DeviceHub
         sx={{

--- a/carbonmark/components/pages/Retirements/RetirementProvenance/styles.ts
+++ b/carbonmark/components/pages/Retirements/RetirementProvenance/styles.ts
@@ -51,3 +51,17 @@ export const social = css`
   padding-bottom: 2rem;
   align-items: center;
 `;
+
+export const labelWithInfo = css`
+  font-family: var(--font-family-secondary);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  svg {
+    color: var(--font-03);
+    width: 2rem;
+    height: 2rem;
+  }
+`;

--- a/carbonmark/locale/de/messages.po
+++ b/carbonmark/locale/de/messages.po
@@ -6,10 +6,85 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/CreateListing/Transaction/Approve.tsx:51
+#: components/CreateListing/Transaction/index.tsx:62
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
+msgid "{0}"
+msgstr "{0}"
+
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr "{0} | Profil | Carbonmark"
+
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
+msgid "{0} maximum for credit cards"
+msgstr "Maximal {0} für Kreditkarten"
+
+#: components/pages/Purchases/index.tsx:29
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr "{amount} Tonnen wurden für Projekt {0} gekauft"
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr "{DEFAULT_EXPIRATION_DAYS} Tage ({expirationDatestring})"
+
+#: components/Quantity/index.tsx:28
+msgid "{formattedAmount} tonnes"
+msgstr "{formattedAmount} Tonnen"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
+#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
+msgid "{formattedAmount} Tonnes"
+msgstr "{formattedAmount} Tonnen"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:46
+msgid "retirement.provenance.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
+msgid "{tokenSymbol}"
+msgstr "{tokenSymbol}"
+
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "@Username (note: this can not be changed!)"
+msgstr "@Benutzername (Achtung: dies kann nicht mehr verändert werden!)"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
+msgid "<0>* </0> Required Field"
+msgstr "<0>*</0> Pflichtfeld"
+
+#: lib/statusMessage.ts:23
+msgid "❌ Error: something went wrong..."
+msgstr "❌ Fehler: etwas ist schiefgelaufen..."
 
 #: components/pages/Home/index.tsx:358
 msgid "0% listing fee"
 msgstr "0 % Angebotsgebühr"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:47
+#: components/Transaction/index.tsx:45
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:57
+#: components/Transaction/index.tsx:55
+msgid "transaction_modal.view.submit.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:193
 msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
@@ -32,14 +107,6 @@ msgstr "500 - Serverfehler"
 msgid "500 - Server error occurred"
 msgstr "500 - Serverfehler aufgetreten"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
-msgid "<0>* </0> Required Field"
-msgstr "<0>*</0> Pflichtfeld"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "@Username (note: this can not be changed!)"
-msgstr "@Benutzername (Achtung: dies kann nicht mehr verändert werden!)"
-
 #: components/pages/Project/PayWithBank/index.tsx:153
 msgid "A valid email address is required"
 msgstr "Eine gültige E-Mail-Adresse wird benötigt"
@@ -54,6 +121,11 @@ msgstr "A-Z"
 msgid "About"
 msgstr "Über Klima"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr ""
+
 #: components/Stats/StatsListings.tsx:49
 msgid "Active listings:"
 msgstr "Aktive Einträge:"
@@ -62,6 +134,11 @@ msgstr "Aktive Einträge:"
 msgid "Activity"
 msgstr "Aktivität"
 
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr ""
+
 #: lib/getCategoryInfo.ts:53
 msgid "Agriculture"
 msgstr "Landwirtschaft"
@@ -69,6 +146,11 @@ msgstr "Landwirtschaft"
 #: components/pages/Home/index.tsx:362
 msgid "All assets sourced from major registries"
 msgstr "Alle Assets stammen von großen Zertifizierern"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:41
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
@@ -111,6 +193,10 @@ msgstr "Genehmigen"
 msgid "Asset"
 msgstr "Asset"
 
+#: components/AssetDetails/index.tsx:53
+msgid "Asset details"
+msgstr "Asset-Details"
+
 #: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:24
 msgid "Asset Details"
 msgstr "Asset-Details"
@@ -119,9 +205,13 @@ msgstr "Asset-Details"
 msgid "Asset ID"
 msgstr "Asset-ID"
 
-#: components/AssetDetails/index.tsx:53
-msgid "Asset details"
-msgstr "Asset-Details"
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:32
+msgid "Asset moved from one account to another, either via sale or inter-account transfer."
+msgstr ""
+
+#: components/Activities/Activity.tsx:34
+msgid "at"
+msgstr "bei"
 
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:131
 msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
@@ -133,11 +223,6 @@ msgid ""
 "exceeding {0}. Please adjust the\n"
 "quantity and try again later."
 msgstr "Aktuell kann Carbonmark keine Kreditkartenzahlungen annehmen, die {0} überschreiten. Bitte passen Sie die Menge an und versuchen Sie es noch einmal."
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
-msgstr "Verfügbare Tonnen:"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:116
 msgid "Available balance exceeded"
@@ -163,6 +248,11 @@ msgstr "Zum Kauf verfügbar"
 msgid "Available to retire"
 msgstr "Für CO2-Ausgleich verfügbar"
 
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr "Verfügbare Tonnen:"
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:219
 msgid "Available:"
 msgstr "Verfügbar:"
@@ -176,14 +266,20 @@ msgstr "Verfügbar: {0}"
 msgid "Available: {unlistedBalance}"
 msgstr "Verfügbar: {unlistedBalance}"
 
-#: components/BetaBadge/index.tsx:18
-msgid "BETA"
-msgstr "BETA"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
+msgid "retire.back_button"
+msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:44
 #: components/pages/Project/Retire/index.tsx:35
 msgid "Back to Project"
 msgstr "Zurück zum Projekt"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:49
+msgid "project.single.button.back_to_project_details"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:397
 msgid "Balance"
@@ -199,6 +295,16 @@ msgstr "Guthaben überschritten"
 msgid "Balance: {0}"
 msgstr "Guthaben: {0}"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
+msgid "offset_disclaimer"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:450
 msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
 msgstr "Achten Sie darauf, keine persönlichen Daten (wie E-Mail-Adressen) im Ausgleichsnamen oder der -nachricht anzugeben. Die hier eingegebenen Informationen werden auf einer öffentlichen Blockchain für immer einsehbar sein und können nicht bearbeitet werden."
@@ -207,12 +313,17 @@ msgstr "Achten Sie darauf, keine persönlichen Daten (wie E-Mail-Adressen) im Au
 msgid "Beneficiary Address"
 msgstr "Empfängeradresse"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
-msgid "Beneficiary Name"
-msgstr "Name des Begünstigten"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
+msgid "retirement.single.beneficiary_address.title"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:263
 msgid "Beneficiary name"
+msgstr "Name des Begünstigten"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
+msgid "Beneficiary Name"
 msgstr "Name des Begünstigten"
 
 #: components/pages/Project/PayWithBank/index.tsx:232
@@ -225,11 +336,20 @@ msgstr "Wallet-Adresse des Begünstigten"
 msgid "Beneficiary wallet address (optional)"
 msgstr "Wallet-Adresse des Begünstigten (optional)"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:34
 #: components/pages/Project/BuyOptions/SellerListing.tsx:67
 #: components/pages/Project/index.tsx:137
 msgid "Best Price"
 msgstr "Niedrigster Preis"
+
+#: components/BetaBadge/index.tsx:18
+msgid "BETA"
+msgstr "BETA"
 
 #: lib/getCategoryInfo.ts:65
 msgid "Blue Carbon"
@@ -239,9 +359,9 @@ msgstr "Blue Carbon"
 msgid "Book a demo"
 msgstr "Demo anfordern"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:35
-msgid "Bridge"
-msgstr "Bridge"
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
+msgstr "gekauft von"
 
 #: components/pages/Home/index.tsx:157
 #: components/pages/Home/index.tsx:188
@@ -256,6 +376,11 @@ msgstr "Projekte ansehen"
 #: components/pages/Project/BuyOptions/SellerListing.tsx:98
 msgid "Buy"
 msgstr "Kaufen"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:70
+msgid "seller.listing.buy"
+msgstr ""
 
 #: components/pages/Home/index.tsx:168
 msgid "Buy or retire carbon"
@@ -273,6 +398,25 @@ msgstr "Sollen wir Sie später noch einmal an dieses neue Feature erinnern?"
 msgid "Cancel"
 msgstr "Abbrechen"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr ""
+
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr "Sie können die von Ihnen gekauften CO2-Assets jederzeit aus Ihrem <0>Portfolio</0> heraus auf Carbonmark anbieten."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:30
 msgid "Carbon Pool"
 msgstr "CO2-Pool"
@@ -280,6 +424,10 @@ msgstr "CO2-Pool"
 #: components/Layout/NavDropdown/index.tsx:117
 msgid "Carbon Portfolio"
 msgstr "CO2-Portfolio"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
+msgid "Carbon provenance"
+msgstr "CO2-Zertifikatshistorie"
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:60
 msgid "Carbon Provenance"
@@ -289,17 +437,35 @@ msgstr "CO2-Zertifikatshistorie"
 msgid "Carbon Retirements"
 msgstr "CO2-Ausgleiche"
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-msgstr "Sie können die von Ihnen gekauften CO2-Assets jederzeit aus Ihrem <0>Portfolio</0> heraus auf Carbonmark anbieten."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:60
+msgid "retirement.totals.page_headline"
+msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
-msgid "Carbon provenance"
-msgstr "CO2-Zertifikatshistorie"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
+msgstr ""
 
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
-msgstr "Carbonmark-Übersicht"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:42
+msgid "retirement.provenance.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:51
+#: components/pages/Home/index.tsx:52
+msgid "Carbonmark | The Universal Carbon Marketplace"
+msgstr "Carbonmark | Der Universelle CO2-Marktplatz"
 
 #: components/pages/Home/index.tsx:174
 msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
@@ -315,14 +481,18 @@ msgstr "Carbonmark-Gebühr"
 msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 msgstr "Durch Carbonmark können Sie jetzt auch via Banküberweisung CO2 ausgleichen. Füllen Sie dazu das Formular aus und wir werden Sie innerhalb von zwei Werktagen kontaktieren, um letzte Details zu klären und Ihnen eine Rechnung zuzustellen."
 
-#: components/pages/Home/index.tsx:51
-#: components/pages/Home/index.tsx:52
-msgid "Carbonmark | The Universal Carbon Marketplace"
-msgstr "Carbonmark | Der Universelle CO2-Marktplatz"
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
+msgstr "Carbonmark-Übersicht"
 
 #: components/pages/Home/index.tsx:488
 msgid "Carbonmark's role"
 msgstr "Carbonmarks Bedeutung"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
+msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:130
 msgid "Category"
@@ -333,6 +503,11 @@ msgstr "Kategorie"
 msgid "Change language"
 msgstr "Sprache wechseln"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:236
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
 #: components/pages/Home/index.tsx:206
 msgid "Choose a project and quantity"
 msgstr "Projekt und Menge auswählen"
@@ -341,8 +516,13 @@ msgstr "Projekt und Menge auswählen"
 msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 msgstr "Kaufen, verkaufen, CO2-Fußabdruck ausgleichen: Über 20 Millionen verifizierte digitale CO2-Credits aus Hunderten Projekten stehen Ihnen zur Verfügung."
 
-#: components/ProjectFilterModal/index.tsx:162
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
 #: components/pages/Projects/ProjectSearch/index.tsx:55
+#: components/ProjectFilterModal/index.tsx:162
 msgid "Clear Filters"
 msgstr "Filter löschen"
 
@@ -353,6 +533,11 @@ msgstr "Klicken Sie auf \"Profil erstellen\", um diese Seite anzupassen und losz
 #: components/CreateListing/Transaction/Submit.tsx:98
 msgid "Close"
 msgstr "Schließen"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
+msgstr ""
 
 #: components/Footer/index.tsx:32
 msgid "Code of Ethics"
@@ -379,6 +564,16 @@ msgstr "Preise aller Verkäufer und Handelspools vergleichen"
 msgid "Compiling Results ..."
 msgstr "Ergebnisse werden berechnet..."
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr ""
+
 #: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:83
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
 #: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
@@ -386,9 +581,18 @@ msgstr "Ergebnisse werden berechnet..."
 msgid "Confirm Purchase"
 msgstr "Kauf bestätigen"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
+msgid "offset.retire_carbon"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:75
 msgid "Confirm Retirement"
 msgstr "CO2-Ausgleich bestätigen"
+
+#: components/Layout/index.tsx:52
+msgid "connect a wallet"
+msgstr "Wallet verbinden"
 
 #: components/pages/Portfolio/ConnectedWallet/index.tsx:33
 msgid "Connected Wallet"
@@ -414,6 +618,16 @@ msgstr "Kontakt"
 msgid "Continue"
 msgstr "Weiter"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
 #: components/CopyAddressButton/index.tsx:37
 msgid "Copy"
 msgstr "Kopieren"
@@ -431,15 +645,10 @@ msgstr "Eintrag konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 msgid "Country"
 msgstr "Land"
 
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr "Neuen Eintrag erstellen"
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Create Profile"
-msgstr "Profil erstellen"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
+msgid "retirement.single.country_region.title"
+msgstr ""
 
 #: components/CreateListing/index.tsx:165
 msgid "Create a listing"
@@ -457,6 +666,21 @@ msgstr "Verkäuferprofil erstellen"
 msgid "Create and edit listings, and track your activity with your Carbonmark profile."
 msgstr "Erstellen und bearbeiten Sie Einträge und protokollieren Sie Ihre Aktivität mit Ihrem Carbonmark-Profil"
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:136
+msgid "profile.addListing_modal.submit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr "Neuen Eintrag erstellen"
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Create Profile"
+msgstr "Profil erstellen"
+
 #: components/pages/Home/index.tsx:313
 msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
 msgstr "Erstellen Sie Ihr eigenes CO2-Schaufenster. Verkaufen Sie direkt an Organisationen oder Einzelpersonen."
@@ -465,25 +689,29 @@ msgstr "Erstellen Sie Ihr eigenes CO2-Schaufenster. Verkaufen Sie direkt an Orga
 msgid "Create your own retirement"
 msgstr "Ihren eigenen CO2-Ausgleich erstellen"
 
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr "Eintrag erstellt"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:87
 msgid "Created:"
 msgstr "Erstellt:"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
-msgid "Credit ID"
-msgstr "Zertifikats-ID"
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
-msgstr "Minimumpreis für Kreditkartenzahlungen ist ${formattedFiatMinimum}"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:77
 msgid "Credit card minimum purchase is {0}"
 msgstr "Mindestpreis für Kreditkartenzahlungen ist {0}"
 
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr "Minimumpreis für Kreditkartenzahlungen ist ${formattedFiatMinimum}"
+
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:247
 msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
 msgstr "Kreditkartenzahlungen verursachen eine zusätzliche Bearbeitungsgebühr. <0>Mehr erfahren.</0>"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
+msgid "Credit ID"
+msgstr "Zertifikats-ID"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:435
 msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
@@ -493,10 +721,6 @@ msgstr "Derzeit akzeptiert Carbonmark nur Zahlungen via USDC (Polygon-Netzwerk) 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
 msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
 msgstr "Derzeit akzeptiert Carbonmark nur Zahlungen via USDC (Polygon-Netzwerk). <0>Klicken Sie hier, um mehr über USDC zu erfahren.</0>"
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
-msgstr "DATUM"
 
 #: components/pages/Project/index.tsx:234
 msgid "Data for this project and vintage"
@@ -511,9 +735,27 @@ msgstr "Informationen über diesen Verkäufer"
 msgid "Date"
 msgstr "Datum"
 
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr "DATUM"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
+msgid "offset.default_retirement_address"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:296
 msgid "Defaults to the connected wallet address"
 msgstr "Standardmäßig die aktuell verbundene Walletadresse"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
+msgid "profile.listing.edit.delete_listing"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
+msgstr "Eintrag gelöscht"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:307
 msgid "Describe the purpose of this retirement"
@@ -523,6 +765,11 @@ msgstr "Beschreibe den Zweck dieses Ausgleichs"
 msgid "Description"
 msgstr "Beschreibung"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
+msgid "retirement.single.project_description.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:51
 msgid "Digital Carbon"
 msgstr "Digitales CO2"
@@ -530,6 +777,11 @@ msgstr "Digitales CO2"
 #: components/pages/Home/index.tsx:264
 msgid "Digitize your carbon by using a supported bridge"
 msgstr "Digitalisieren Sie Ihr CO2 mithilfe eines unterstützten Anbieters"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
 msgid "Display name"
@@ -555,18 +807,29 @@ msgstr "Wird heruntergeladen ..."
 msgid "Drive climate action and earn rewards with a carbon-backed digital currency."
 msgstr "Fördere Klimaschutzmaßnahmen und erhalte Belohnungen durch eine CO2-gedeckte, digitale Währung."
 
+#: components/pages/Project/Purchase/Listing/Price.tsx:18
+#: components/pages/Project/Purchase/Pool/Price.tsx:17
+#: components/pages/Project/Retire/Pool/Price.tsx:17
+msgid "each"
+msgstr "pro Tonne"
+
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:195
 msgid "Edit"
 msgstr "Bearbeiten"
+
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
+msgid "Edit listing"
+msgstr "Angebot bearbeiten"
 
 #: components/pages/Users/SellerConnected/index.tsx:113
 #: components/pages/Users/SellerConnected/index.tsx:138
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
-msgid "Edit listing"
-msgstr "Angebot bearbeiten"
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:143
 #: components/pages/Project/PayWithBank/index.tsx:307
@@ -626,6 +889,19 @@ msgstr "Der Vorname sollte keine Zahlen oder Sonderzeichen enthalten"
 msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
 msgstr "Geben Sie Carbonmark zuerst das Recht, dieses Asset in Ihrem Auftrag zu übertragen."
 
+#: components/Activities/Activity.tsx:112
+msgid "for"
+msgstr "für"
+
+#: components/pages/Retire/index.tsx:52
+msgid "for beneficiary"
+msgstr "für Empfänger"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:66
+msgid "retirement.totals.page_subline"
+msgstr ""
+
 #: components/pages/Home/index.tsx:340
 msgid "For carbon traders"
 msgstr "Für CO2-Händler"
@@ -642,20 +918,26 @@ msgstr "Forstwirtschaft"
 msgid "Form complete"
 msgstr "Formular ausgefüllt"
 
-#: components/pages/Home/index.tsx:76
-msgid "Get Started"
-msgstr "Jetzt starten"
-
 #: components/pages/Home/index.tsx:390
 msgid "Get paid immediately: transactions are resolved in seconds"
 msgstr "Transaktionsabwicklung in Sekunden: werden Sie sofort bezahlt"
 
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
-msgstr "Zurück"
+#: components/pages/Home/index.tsx:76
+msgid "Get Started"
+msgstr "Jetzt starten"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:83
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
 msgid "Go back"
+msgstr "Zurück"
+
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
 msgstr "Zurück"
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:145
@@ -681,8 +963,8 @@ msgid "Here’s a list of readily available, discounted carbon tokens to retire 
 msgstr "Dies ist eine Liste aus reichhaltig verfügbaren, vergünstigten CO2-Tokens, die Sie schnell und einfach ausgleichen können."
 
 #: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:48
-msgid "Hide {numberOfTransfers} transfers"
-msgstr "{numberOfTransfers} Überweisungen ausblenden"
+msgid "Hide {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:80
 msgid "How many tonnes do you want to list for sale?"
@@ -696,6 +978,11 @@ msgstr "Wie viele Tonnen CO2 möchten Sie kaufen?"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:249
 msgid "How many tonnes of carbon do you want to retire?"
 msgstr "Wie viele Tonnen CO2 möchten Sie ausgleichen?"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
+msgid "offset.amount_in_tonnes"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:215
 msgid "How many tonnes of carbon would you like to retire?"
@@ -720,6 +1007,11 @@ msgstr "ICR-Zertifikate können nur in ganzen Tonnen ausgeglichen werden"
 #: components/pages/Purchases/index.tsx:93
 msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
 msgstr "Falls Sie einige CO2-Credits aus diesem Kauf nutzen möchten, um Ihren CO2-Fußabdruck auszugleichen, klicken Sie bitte auf den \"Ausgleichen\"-Button in Ihrem <0>Portfolio</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
+msgid "retirement.single.transaction_record.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:116
 msgid "Indicates required field"
@@ -775,14 +1067,14 @@ msgstr "Der Nachname sollte keine Zahlen oder Sonderzeichen enthalten"
 msgid "Latest First"
 msgstr "Neueste Einträge zuerst"
 
+#: components/pages/Home/index.tsx:417
+msgid "Learn more"
+msgstr "Mehr erfahren"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:92
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:103
 msgid "Learn More"
 msgstr "Erfahren Sie mehr"
-
-#: components/pages/Home/index.tsx:417
-msgid "Learn more"
-msgstr "Mehr erfahren"
 
 #: components/pages/Home/index.tsx:491
 msgid "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
@@ -815,11 +1107,11 @@ msgid "Loading your assets"
 msgstr "Assets werden geladen"
 
 #: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:295
 #: components/pages/Retire/Activity/Overview.tsx:73
 #: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
 msgid "Loading..."
 msgstr "Lade..."
 
@@ -859,6 +1151,11 @@ msgstr "Abmelden"
 msgid "Marketplace"
 msgstr "Marktplatz"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr ""
+
 #: components/pages/Projects/index.tsx:73
 #: components/pages/Projects/index.tsx:74
 msgid "Marketplace | Carbonmark"
@@ -868,21 +1165,36 @@ msgstr "Marktplatz | Carbonmark"
 msgid "Maximize your climate impact."
 msgstr "Maximieren Sie Ihre positive Klimawirkung."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.moss_offset.description"
+msgstr ""
+
 #: components/pages/Project/index.tsx:144
 msgid "Methodology"
 msgstr "Methodik"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.methodology.title"
+msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:54
 msgid "Moss"
 msgstr "Moss"
 
-#: components/FeatureBanner/index.tsx:33
-msgid "NEW FEATURE:"
-msgstr "NEUES FEATURE:"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
+msgid "retirement.single.moss_offset.name"
+msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:171
 msgid "Navigation Menu"
 msgstr "Navigationsmenü"
+
+#: components/FeatureBanner/index.tsx:33
+msgid "NEW FEATURE:"
+msgstr "NEUES FEATURE:"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
 msgid "New Quantity"
@@ -896,18 +1208,28 @@ msgstr "Neuer Stückpreis (USDC)"
 msgid "Next"
 msgstr "Weiter"
 
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
-msgstr "Keine Aktivitäten zum Anzeigen."
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:197
 #: components/pages/Users/SellerUnconnected/index.tsx:83
 msgid "No active listings."
 msgstr "Keine aktiven Einträge."
 
+#. js-lingui-explicit-id
+#: components/Activities/index.tsx:29
+msgid "user.activities.empty_state"
+msgstr ""
+
 #: components/pages/Retire/Activity/Quotes.tsx:38
 msgid "No activity to show"
 msgstr "Keine Aktivitäten zum Anzeigen"
+
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
+msgstr "Keine Aktivitäten zum Anzeigen."
 
 #: components/pages/Home/index.tsx:400
 msgid "No barriers to entry for verified carbon projects"
@@ -916,6 +1238,11 @@ msgstr "Keine Barrieren für verifizierte CO2-Projekte"
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:40
 msgid "No beneficiary address available"
 msgstr "Keine Empfängeradresse verfügbar"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
+msgid "retirement.single.beneficiary.placeholder"
+msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:62
 msgid "No data to show"
@@ -950,24 +1277,39 @@ msgstr "Keine Aufzeichnungen gefunden"
 msgid "No retirement message provided."
 msgstr "Keine Nachricht an den CO2-Ausgleich angehängt."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
 msgid "No transaction id available"
 msgstr "Keine Transaktions-ID verfügbar"
-
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
-msgstr "Nicht verbunden"
 
 #: components/pages/Project/PayWithBank/index.tsx:240
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:288
 msgid "Not a valid polygon address"
 msgstr "Keine gültige Polygonadresse"
 
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr "Nicht verbunden"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
+msgid "retirement.single.official_certificate.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:72
 msgid "Oldest First"
 msgstr "Älteste Einträge zuerst"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:185
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:188
 msgid "On the Verra page, search for the specific serial number."
 msgstr "Suchen Sie nach einer spezifischen Seriennummer auf der Verra-Seite."
 
@@ -991,22 +1333,18 @@ msgstr "Es dauert was länger als erwartet. Ihre CO2-Kompensation sollte demnäc
 msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 msgstr "Über 20 Millionen verifizierte digitale CO2-Credits aus Hunderten von Projekten mit über 4 Milliarden US-Dollar Transaktionsvolumen"
 
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr "PROJEKT"
-
 #: components/pages/Projects/Banners/BankTransfer.tsx:74
 msgid "Pay via Bank Transfer / Wire"
 msgstr "Bezahlen per Banküberweisung"
+
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
+msgstr "Bezahlen Sie per Banküberweisung"
 
 #: components/pages/Project/PayWithBank/index.tsx:89
 #: components/pages/Project/PayWithBank/index.tsx:90
 msgid "Pay with Bank Transfer | Carbonmark"
 msgstr "Bezahlen Sie per Banküberweisung | Carbonmark"
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
-msgstr "Bezahlen Sie per Banküberweisung"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:94
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:112
@@ -1014,22 +1352,18 @@ msgstr "Bezahlen Sie per Banküberweisung"
 msgid "Pay with:"
 msgstr "Bezahlen mit:"
 
-#: components/pages/Purchases/index.tsx:62
-msgid "Payment Successful"
-msgstr "Bezahlung erfolgreich"
-
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:243
 msgid "Payment processing fee"
 msgstr "Zahlungsabwicklungsgebühr"
+
+#: components/pages/Purchases/index.tsx:62
+msgid "Payment Successful"
+msgstr "Bezahlung erfolgreich"
 
 #: components/pages/Project/PayWithBank/index.tsx:161
 #: components/pages/Project/PayWithBank/index.tsx:313
 msgid "Phone number"
 msgstr "Telefonnummer"
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
-msgstr "Bitte melden Sie sich an"
 
 #: lib/statusMessage.ts:27
 msgid "Please click 'confirm' in your wallet to continue."
@@ -1039,11 +1373,25 @@ msgstr "Klicken Sie bitte auf \"Bestätigen\" in Ihrer Wallet, um fortzufahren."
 msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr "Bitte füllen Sie das Formular auf der nächsten Seite aus. Wir werden Ihnen innerhalb von zwei Tagen eine Rechnung zukommen lassen."
 
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr "Bitte melden Sie sich an"
+
 #: components/pages/Portfolio/index.tsx:66
 #: components/pages/Users/SellerConnected/index.tsx:75
 #: components/pages/Users/SellerConnected/index.tsx:101
 msgid "Please refresh the page. There was an error updating your data: {e}."
 msgstr "Bitte aktualisieren Sie die Seite. Beim Aktualisieren Ihrer Daten ist ein Fehler aufgetreten: {e}."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:243
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:76
 #: components/pages/Portfolio/index.tsx:77
@@ -1062,10 +1410,6 @@ msgstr "Pressemeldungen"
 msgid "Price Highest"
 msgstr "Höchster Preis"
 
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr "Niedrigster Preis"
-
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:180
@@ -1075,6 +1419,10 @@ msgstr "Preis beinhaltet Netzwerkgebühren. <0>Mehr erfahren.</0>"
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:160
 msgid "Price is required"
 msgstr "Preis ist erforderlich"
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
+msgstr "Niedrigster Preis"
 
 #: components/CreateListing/Transaction/Submit.tsx:62
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
@@ -1110,19 +1458,48 @@ msgstr "CO2-Ausgleich wird bearbeitet..."
 msgid "Profile"
 msgstr "Profil"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:192
 msgid "Profile picture"
 msgstr "Profilbild"
+
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr "PROJEKT"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
+msgid "retirement.single.project_name.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:253
 #: components/pages/Project/PayWithBank/index.tsx:357
 msgid "Project names of interest"
 msgstr "Ähnliche Projektnamen"
 
-#: components/pages/Purchases/index.tsx:36
-#: components/pages/Purchases/index.tsx:37
-msgid "Purchase Receipt | Carbonmark"
-msgstr "Kaufbeleg | Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
+msgid "retirement.single.project.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr ""
+
+#: components/pages/Project/Purchase/index.tsx:32
+#: components/pages/Project/Purchase/index.tsx:33
+msgid "Purchase {0} | Carbonmark"
+msgstr "{0} kaufen | Carbonmark"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:53
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
@@ -1133,6 +1510,11 @@ msgstr "Einkaufsmenge (Tonnen):"
 msgid "Purchase more Carbon"
 msgstr "Mehr CO2-Tokens kaufen"
 
+#: components/pages/Purchases/index.tsx:36
+#: components/pages/Purchases/index.tsx:37
+msgid "Purchase Receipt | Carbonmark"
+msgstr "Kaufbeleg | Carbonmark"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:79
 msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer."
 msgstr "Kaufen Sie CO2-Tonnen von jedem Projekt bei Carbonmark und bezahlen Sie via Überweisung."
@@ -1140,11 +1522,6 @@ msgstr "Kaufen Sie CO2-Tonnen von jedem Projekt bei Carbonmark und bezahlen Sie 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
 msgid "Purchase successful"
 msgstr "Kauf erfolgreich"
-
-#: components/pages/Project/Purchase/index.tsx:32
-#: components/pages/Project/Purchase/index.tsx:33
-msgid "Purchase {0} | Carbonmark"
-msgstr "{0} kaufen | Carbonmark"
 
 #: components/pages/Retire/Activity/Table.tsx:47
 msgid "QTY"
@@ -1160,6 +1537,11 @@ msgstr "Menge"
 msgid "Quantity Available:"
 msgstr "Verfügbare Menge:"
 
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:240
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:108
 msgid "Quantity is required"
@@ -1173,21 +1555,18 @@ msgstr "Angebotene Menge: {listedQuantity}, nicht angebotene Menge {unlistedQuan
 msgid "Quantity purchased:"
 msgstr "Gekaufte Menge:"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr ""
+
 #: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr "Jetzt kompensieren"
 
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr "CO2 KOMPENSIEREN"
-
 #: components/pages/Project/index.tsx:198
 msgid "Read Less"
 msgstr "Weniger anzeigen"
-
-#: components/pages/Project/index.tsx:198
-msgid "Read More"
-msgstr "Weiterlesen"
 
 #: components/pages/Home/index.tsx:445
 #: components/pages/Home/index.tsx:472
@@ -1195,6 +1574,10 @@ msgstr "Weiterlesen"
 #: components/pages/Resources/BlogPostCard/index.tsx:38
 #: components/pages/Resources/FeaturedArticles/Article.tsx:45
 msgid "Read more"
+msgstr "Weiterlesen"
+
+#: components/pages/Project/index.tsx:198
+msgid "Read More"
 msgstr "Weiterlesen"
 
 #: components/pages/Home/index.tsx:351
@@ -1213,14 +1596,14 @@ msgstr "Verbleibendes Angebot:"
 msgid "Renewable Energy"
 msgstr "Erneuerbare Energie"
 
+#: lib/constants.ts:82
+msgid "Request already processing. Please open your wallet and complete the request."
+msgstr "Anfrage ist bereits in Bearbeitung. Bitte öffnen Sie Ihre Wallet und schließen Sie die Anfrage ab."
+
 #: components/pages/Home/index.tsx:301
 #: components/pages/Home/index.tsx:325
 msgid "Request Demo"
 msgstr "Demo anfordern"
-
-#: lib/constants.ts:82
-msgid "Request already processing. Please open your wallet and complete the request."
-msgstr "Anfrage ist bereits in Bearbeitung. Bitte öffnen Sie Ihre Wallet und schließen Sie die Anfrage ab."
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:210
 msgid "Required Field"
@@ -1230,6 +1613,11 @@ msgstr "Pflichtfeld"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:311
 msgid "Required when proceeding with Credit Card"
 msgstr "Erforderlich, wenn Sie mit Kreditkarte fortfahren"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
+msgstr ""
 
 #: components/Footer/index.tsx:38
 #: components/pages/Home/index.tsx:508
@@ -1257,15 +1645,36 @@ msgstr "Ergebnisse"
 msgid "Retire"
 msgstr "Kompensieren"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/index.tsx:88
+#: components/pages/Portfolio/Retire/index.tsx:89
+#: components/pages/Retire/index.tsx:38
+#: components/pages/Retire/index.tsx:39
+msgid "Retire | Carbonmark"
+msgstr "Ausgleichen | Carbonmark"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:388
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
 msgid "Retire Carbon"
 msgstr "CO2-Fußabdruck ausgleichen"
 
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr "CO2 KOMPENSIEREN"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:233
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "Gleichen Sie Ihren eigenen CO2-Fußabdruck aus oder handeln Sie im Auftrag anderer Personen oder Organisationen"
+
+#: components/pages/Project/Retire/index.tsx:23
+#: components/pages/Project/Retire/index.tsx:24
+msgid "Retire from {fullProjectid} | Carbonmark"
+msgstr "Mit {fullProjectid} ausgleichen | Carbonmark"
 
 #: components/pages/Retire/index.tsx:72
 msgid "Retire from a featured project"
@@ -1275,23 +1684,18 @@ msgstr "Durch ein vorgestelltes Projekt ausgleichen"
 msgid "Retire from your portfolio"
 msgstr "Aus Ihrem Portfolio ausgleichen"
 
-#: components/pages/Project/Retire/index.tsx:23
-#: components/pages/Project/Retire/index.tsx:24
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr "Mit {fullProjectid} ausgleichen | Carbonmark"
-
 #: components/pages/Home/index.tsx:232
 msgid "Retire instantly, or purchase and hold digital carbon"
 msgstr "Gleichen Sie Ihren CO2-Fußabdruck in Echtzeit aus oder kaufen und verwahren Sie digitales CO2"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
-msgstr "Mehr CO2 ausgleichen"
 
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
 msgid "Retire more carbon"
+msgstr "Mehr CO2 ausgleichen"
+
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
 msgstr "Mehr CO2 ausgleichen"
 
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:56
@@ -1307,14 +1711,16 @@ msgstr "Jetzt ausgleichen oder CO2 kaufen und später ausgleichen: Sobald CO2-As
 msgid "Retire your carbon via bank transfer."
 msgstr "Gleich Sie CO2 via Banküberweisung aus."
 
-#: components/pages/Portfolio/Retire/index.tsx:88
-#: components/pages/Portfolio/Retire/index.tsx:89
-#: components/pages/Retire/index.tsx:38
-#: components/pages/Retire/index.tsx:39
-msgid "Retire | Carbonmark"
-msgstr "Ausgleichen | Carbonmark"
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
+msgstr "ausgeglichen"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:13
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:90
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:16
 msgid "Retirement"
 msgstr "CO2-Ausgleich"
 
@@ -1322,33 +1728,53 @@ msgstr "CO2-Ausgleich"
 msgid "Retirement Activity"
 msgstr "Ausgleichsaktivität"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
-msgid "Retirement Message"
-msgstr "Ausgleichsnachricht"
-
-#: components/pages/Retire/Activity/Overview.tsx:60
-#: components/pages/Retire/Activity/Overview.tsx:70
-msgid "Retirement Overview"
-msgstr "Ausgleichsübersicht"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr "Ausgleich erfolgreich!"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
+msgid "offset.retirement_message"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:264
 #: components/pages/Project/PayWithBank/index.tsx:363
 msgid "Retirement message"
 msgstr "Möchtest du eine Nachricht anhängen?"
 
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
+msgid "Retirement Message"
+msgstr "Ausgleichsnachricht"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr ""
+
+#: components/pages/Retire/Activity/Overview.tsx:60
+#: components/pages/Retire/Activity/Overview.tsx:70
+msgid "Retirement Overview"
+msgstr "Ausgleichsübersicht"
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:74
 msgid "Retirement successful"
 msgstr "CO2-Ausgleich erfolgreich"
 
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr "Ausgleich erfolgreich!"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:106
+msgid "retirement.totals.retirements"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:384
 msgid "Retiring Token"
 msgstr "Für Ausgleich genutztes Token"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
+msgid "profile.edit_modal.submit"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:201
 msgid "Say a few words about yourself. This will be visible in your seller profile."
@@ -1385,6 +1811,11 @@ msgstr "Auswählen"
 msgid "Select a language"
 msgstr "Sprache wählen"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr ""
+
 #: components/pages/Portfolio/AssetProject/index.tsx:100
 #: components/pages/Portfolio/AssetProject/index.tsx:108
 msgid "Sell"
@@ -1402,13 +1833,27 @@ msgstr "Ihre digitalen CO2-Tokens direkt an Käufer verkaufen"
 msgid "Seller Listing"
 msgstr "Verkäufereintrag"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:159
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:29
+msgid "Send"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:161
 msgid "Serial Number"
 msgstr "Seriennummer"
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:76
 msgid "Share this page"
 msgstr "Diese Seite teilen"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
+msgid "retirement.single.share_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:289
+msgid "resources.mobile_modal.button.show_results"
+msgstr ""
 
 #: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
 #: components/pages/Project/Purchase/Pool/SubmitButton.tsx:31
@@ -1423,6 +1868,19 @@ msgstr "Einzelpreis ist erforderlich"
 #: components/CreateListing/Form/index.tsx:130
 msgid "Single unit price"
 msgstr "Stückpreis"
+
+#: components/Layout/index.tsx:51
+msgid "social or email"
+msgstr "Social oder E-Mail"
+
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr "Verkauft an"
+
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
+msgid "something went wrong loading the allowance"
+msgstr "Beim Laden des Guthabens ist etwas schiefgelaufen"
 
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
 msgid "Something went wrong loading the allowance"
@@ -1448,13 +1906,28 @@ msgstr "Sorry! Etwas ist schiefgelaufen."
 msgid "Sorry, this handle already exists"
 msgstr "Leider existiert dieser Name bereits"
 
-#: components/pages/Resources/ResourcesList/index.tsx:265
-msgid "Sort By"
-msgstr "Sortieren nach"
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:222
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:230
+msgid "resources.page.list.no_search_results.title"
+msgstr ""
 
 #: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "Sort by"
 msgstr "Sortieren nach"
+
+#: components/pages/Resources/ResourcesList/index.tsx:265
+msgid "Sort By"
+msgstr "Sortieren nach"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:197
+msgid "shared.resources.sort_by.header"
+msgstr ""
 
 #: components/Stats/index.tsx:23
 msgid "Stats"
@@ -1480,6 +1953,21 @@ msgstr "Schritt 3"
 msgid "Submit"
 msgstr "Absenden"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr ""
+
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:88
 msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
 msgstr "Erfolgreich! Ihr neuer Eintrag wird in einigen Momenten auf Ihrer <0>Profilseite</0> auftauchen."
@@ -1492,13 +1980,25 @@ msgstr "Einverstanden"
 msgid "Switch to Polygon"
 msgstr "Zu Polygon wechseln"
 
-#: components/BetaBadge/index.tsx:16
-msgid "TESTNET"
-msgstr "TESTNET"
+#: components/pages/Retire/Activity/Overview.tsx:77
+#: components/pages/Retire/Activity/Quotes.tsx:76
+#: components/pages/Retire/Activity/Table.tsx:65
+msgid "t"
+msgstr "t"
 
 #: components/Footer/index.tsx:29
 msgid "Terms of Use"
 msgstr "Nutzungsbedingungen"
+
+#: components/BetaBadge/index.tsx:16
+msgid "TESTNET"
+msgstr "TESTNET"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
 msgid "Thank you for supporting the planet!"
@@ -1508,21 +2008,32 @@ msgstr "Vielen Dank, dass Sie den Planeten unterstützen!"
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr "Danke für die Unterstützung unseres Planeten! Die Kaufdetails finden Sie unten."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:292
 msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr "Vielen Dank, dass Sie den Planeten unterstützen! Wir werden uns demnächst mit Ihnen in Verbindung setzen, um einige Details zu bestätigen und Ihnen eine Rechnung zukommen zu lassen."
-
-#: components/pages/Home/index.tsx:65
-msgid "The Universal Carbon Marketplace"
-msgstr "Der Universelle CO2-Marktplatz"
 
 #: components/CreateListing/Transaction/Approve.tsx:44
 msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 msgstr "Die Assets werden erst aus Ihrer Wallet transferiert, wenn der Verkauf abgeschlossen ist. Sie können diese Bewilligung jederzeit widerrufen."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:34
 msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
 msgstr "Im ersten Schritt bewilligen Sie den Transfer des CO2-Assets aus Ihrer Wallet zu Carbonmark. Im nächsten Schritt genehmigen Sie den eigentlichen Transfer und schließen den Ausgleich ab."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
 msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
@@ -1531,6 +2042,12 @@ msgstr "Im ersten Schritt bewilligen Sie den Transfer des Zahlungstokens aus Ihr
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
 msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
 msgstr "Die unten angegebenen Informationen werden öffentlich einsehbar sein, um Ihren CO2-Ausgleich zu verifizieren. Diese Transaktion ist endgültig; die enthaltenen Informationen können nicht verändert werden, sobald die Transaktion abgeschlossen ist."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
+msgstr ""
 
 #: components/pages/Home/index.tsx:53
 #: components/pages/Home/index.tsx:68
@@ -1570,13 +2087,27 @@ msgstr "Der Mindestpreis pro Tonne beträgt {0}"
 msgid "The minimum quantity to sell is 1 tonne"
 msgstr "Die Mindestverkaufsmenge beträgt 1 Tonne"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:53
 msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 msgstr "Der vorherige Schritt hat nur den Transfer des CO2-Assets aus Ihrer Wallet zu Carbonmark genehmigt. Ihr CO2-Ausgleich ist damit noch nicht abgeschlossen."
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
 msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
 msgstr "Der vorherige Schritt hat den Transfer des Assets aus Ihrer Wallet zu Carbonmark genehmigt."
+
+#: components/pages/Home/index.tsx:65
+msgid "The Universal Carbon Marketplace"
+msgstr "Der Universelle CO2-Marktplatz"
 
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:208
 msgid "There was an error during the checkout process. Please try again."
@@ -1599,6 +2130,11 @@ msgstr "Beim Laden der Gesamtkosten ist ein Fehler aufgetreten."
 msgid "This app only works on Polygon Mainnet."
 msgstr "Die App funktioniert nur im Polygon-Mainnet."
 
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:24
+msgid "user.login.description"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
 msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
 msgstr "Dies ist Ihr Portfolio. Hier finden Sie alle CO2-Assets in Ihrem Besitz, die von Carbonmark unterstützt werden. Sie können die hier angezeigten CO2-Assets verkaufen oder für einen CO2-Ausgleich nutzen, sobald Sie ein Profil erstellt haben."
@@ -1619,13 +2155,27 @@ msgstr "Das Angebot existiert nicht mehr."
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr "Dieses Produkt befindet sich noch in der Betaphase und Audits sind noch nicht abgeschlossen."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
+msgid "retirement.single.immutable_public_records.title"
+msgstr ""
+
 #: components/pages/Users/ProfileHeader/index.tsx:46
 msgid "This user has not yet created a carbonmark profile."
 msgstr "Dieser Nutzer hat noch kein Carbonmark-Profil erstellt."
 
+#: components/Activities/Activity.tsx:119
+msgid "to"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr "Um Ihre Kreditkartentransaktion abzuschließen, werden Sie zu Stripe, unserem Zahlungsabwicklungspartner, weitergeleitet."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:60
 msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
@@ -1639,22 +2189,22 @@ msgstr "Um zu beginnen, sollten Sie Ihr <0>Profil</0> vollständig ausfüllen un
 msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr "Um via Banküberweisung zu bezahlen, benötigen wir einige Informationen über Sie."
 
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr "\"Projekt auswählen\" selektieren"
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr "\"Sortiere nach\" anzeigen"
-
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
 msgid "Toggle payment method"
 msgstr "Zahlungsmethode ändern"
 
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr "\"Projekt auswählen\" selektieren"
+
 #: components/pages/Projects/ProjectSort/index.tsx:29
 msgid "Toggle sort menu"
 msgstr "Sortiermenü einschalten"
+
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
+msgstr "\"Sortiere nach\" anzeigen"
 
 #: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:209
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
@@ -1664,6 +2214,10 @@ msgstr "Token, den Sie erhalten"
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
 msgid "Tokens received:"
 msgstr "Erhaltene Tokens:"
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
+msgid "tonnes"
+msgstr "Tonnen"
 
 #: components/AssetDetails/index.tsx:63
 #: components/pages/Project/PayWithBank/index.tsx:125
@@ -1684,22 +2238,6 @@ msgstr "Angebotene Tonnen:"
 msgid "Tonnes sold:"
 msgstr "Verkaufte Tonnen:"
 
-#: components/CreateListing/Form/index.tsx:85
-msgid "Total Amount to Sell is required"
-msgstr "Der zu verkaufende Gesamtbetrag ist erforderlich"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
-msgid "Total Cost is required"
-msgstr "Gesamtkosten sind erforderlich"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr "Gesamtpreis"
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr "Gesamter CO2-Ausgleich"
-
 #: components/CreateListing/Transaction/Approve.tsx:61
 msgid "Total allowance"
 msgstr "Insgesamt bewilligt"
@@ -1708,9 +2246,18 @@ msgstr "Insgesamt bewilligt"
 msgid "Total amount of tonnes to retire is required"
 msgstr "Gesamttonnenanzahl ist erforderlich"
 
+#: components/CreateListing/Form/index.tsx:85
+msgid "Total Amount to Sell is required"
+msgstr "Der zu verkaufende Gesamtbetrag ist erforderlich"
+
 #: components/pages/Retire/Activity/Overview.tsx:72
 msgid "Total carbon tonnes retired"
 msgstr "CO2-Tonnen insgesamt ausgeglichen"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:98
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr ""
 
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
@@ -1718,9 +2265,17 @@ msgstr "CO2-Tonnen insgesamt ausgeglichen"
 msgid "Total cost"
 msgstr "Gesamtkosten"
 
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
+msgid "Total Cost is required"
+msgstr "Gesamtkosten sind erforderlich"
+
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:166
 msgid "Total price"
+msgstr "Gesamtpreis"
+
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
 msgstr "Gesamtpreis"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:103
@@ -1731,6 +2286,15 @@ msgstr "Gesamtmenge, die zum Verkauf angeboten wird"
 msgid "Total retirement transactions"
 msgstr "Gesamte Ausgleichstransaktionen"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:112
+msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
+msgstr "Gesamter CO2-Ausgleich"
+
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
 msgid "Total sale cost"
@@ -1740,25 +2304,32 @@ msgstr "Gesamtverkaufskosten"
 msgid "Transaction complete."
 msgstr "Transaktion abgeschlossen."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
+msgid "retirement.single.transaction_id.title"
+msgstr ""
+
 #: lib/statusMessage.ts:29
 msgid "Transaction initiated. Waiting for network confirmation."
 msgstr "Transaktion eingeleitet. Warte auf Netzwerkbestätigung."
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:24
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:48
 msgid "Transfer"
 msgstr "Überweisen"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:50
+msgid "retirement.provenance.head.metaDescription"
+msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:128
 msgid "Transparent, on-chain offsets powered by Carbonmark."
 msgstr "Transparente On-Chain-Offsets von Carbonmark."
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "USDC per ton"
-msgstr "USDC pro Tonne"
-
-#: components/CreateListing/Form/index.tsx:110
-msgid "USDC per tonne"
-msgstr "USDC pro Tonne"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.type.title"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:115
 msgid "Unit price is required"
@@ -1776,6 +2347,18 @@ msgstr "Beispiellose Transparenz auf dem gesamten Digitalen CO2-Markt."
 msgid "Update listing"
 msgstr "Angebot aktualisieren"
 
+#: components/Activities/Activities.constants.ts:10
+msgid "updated expiration"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr "Aktualisierter Preis"
+
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr "Aktualisierte Menge"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:91
 msgid "Updated:"
 msgstr "Aktualisiert:"
@@ -1783,6 +2366,14 @@ msgstr "Aktualisiert:"
 #: components/pages/Users/SellerConnected/index.tsx:191
 msgid "Updating your data..."
 msgstr "Ihre Daten werden aktualisiert..."
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "USDC per ton"
+msgstr "USDC pro Tonne"
+
+#: components/CreateListing/Form/index.tsx:110
+msgid "USDC per tonne"
+msgstr "USDC pro Tonne"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:61
 msgid "User Guides"
@@ -1797,6 +2388,21 @@ msgstr "Benutzerprofil | Carbonmark"
 msgid "User refused connection."
 msgstr "Benutzer verweigert Verbindung."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:41
 msgid "Verify all information is correct and click 'approve' to continue."
@@ -1806,17 +2412,9 @@ msgstr "Verifizieren Sie die Korrektheit der Daten und klicken Sie auf \"Genehmi
 msgid "View"
 msgstr "Ansehen"
 
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
-msgid "View Carbonmark Profile"
-msgstr "Carbonmark-Profil anzeigen"
-
-#: components/pages/Project/index.tsx:207
-msgid "View Registry Details <0/>"
-msgstr "Registrierungsdetails anzeigen <0/>"
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
-msgstr "Ergebnisse ansehen"
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
+msgid "View {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:78
 msgid "View a complete overview of the digital carbon that you own in your Portfolio."
@@ -1851,9 +2449,17 @@ msgstr "Betrachten und kaufen Sie dieses CO2-Ausgleichsprojekt auf Carbonmark"
 msgid "View and share certificate"
 msgstr "Zertifikat ansehen und teilen"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:180
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
+msgid "View Carbonmark Profile"
+msgstr "Carbonmark-Profil anzeigen"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:183
 msgid "View issuance on Verra"
 msgstr "Bereitstellung auf der Webseite von Verra ansehen"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
+msgid "View on Polygonscan"
+msgstr "Auf Polygonscan ansehen"
 
 #: components/AssetDetails/index.tsx:69
 msgid "View on PolygonScan"
@@ -1863,9 +2469,13 @@ msgstr "Auf PolygonScan ansehen"
 msgid "View on PolygonScan <0/>"
 msgstr "Auf PolygonScan ansehen <0/>"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
-msgid "View on Polygonscan"
-msgstr "Auf Polygonscan ansehen"
+#: components/pages/Project/index.tsx:207
+msgid "View Registry Details <0/>"
+msgstr "Registrierungsdetails anzeigen <0/>"
+
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
+msgstr "Ergebnisse ansehen"
 
 #: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:99
 msgid "View retirement"
@@ -1879,9 +2489,10 @@ msgstr "Verfolgen Sie den gesamten Transaktionsverlauf - vom Bridging-Event bis 
 msgid "View the project details and other info for this purchase."
 msgstr "Projektdetails und weitere Informationen über diesen Kauf ansehen."
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
-msgid "View {numberOfTransfers} transfers"
-msgstr "{numberOfTransfers} Überweisungen anzeigen"
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:145
+msgid "purchase.button.view_assets"
+msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:141
 msgid "Vintage"
@@ -1894,6 +2505,11 @@ msgstr "Jahrgang neueste"
 #: components/ProjectFilterModal/constants.tsx:15
 msgid "Vintage Oldest"
 msgstr "Jahrgang älteste"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
+msgid "retirement.single.vintage.title"
+msgstr ""
 
 #: components/pages/Purchases/index.tsx:66
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
@@ -1915,12 +2531,22 @@ msgstr "Basierend auf strengen Kriterien - wie Preis, globale Umweltauswirkungen
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr "Was ist Carbonmark? Antworten auf häufig gestellte Fragen über das Interface des Digitalen CO2-Marktes, das Käufer und Verkäufer verifizierter Emissionszertifikate einfach miteinander verbindet."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
+msgid "offset.retirement_credit"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:257
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
 msgid "Who will this retirement be credited to?"
 msgstr "Wem soll dieser CO2-Ausgleich gewidmet werden?"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
+msgstr ""
 
 #: components/shared/InvalidNetworkModal/index.tsx:64
 msgid "Wrong Network"
@@ -1932,9 +2558,19 @@ msgstr "Falsches Netzwerk"
 msgid "You"
 msgstr "Sie"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
 msgid "You are about to purchase a carbon asset."
 msgstr "Sie sind dabei, ein CO2-Asset zu erwerben."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:31
 msgid "You are about to retire a carbon asset."
@@ -1982,13 +2618,10 @@ msgstr "Sie müssen ein Profil erstellen, um Ihre CO2-Assets in Ihrem Carbonmark
 msgid "You successfully acquired carbon!"
 msgstr "Sie haben erfolgreich digitales CO2 gekauft!"
 
-#: components/pages/Users/SellerConnected/index.tsx:221
-msgid "Your Profile"
-msgstr "Ihr Profil"
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
-msgstr "Ihre Walletadresse"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:412
@@ -2005,6 +2638,15 @@ msgstr "Ihr Guthaben:"
 msgid "Your display name"
 msgstr "Ihr Anzeigename"
 
+#: components/pages/Users/SellerConnected/index.tsx:221
+msgid "Your Profile"
+msgstr "Ihr Profil"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
 msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr "Ihr Kauf ist noch nicht abgeschlossen. Stellen Sie die Korrektheit der Informationen sicher und klicken Sie unten auf \"Absenden\", um den Kauf abzuschließen."
@@ -2014,6 +2656,11 @@ msgstr "Ihr Kauf ist noch nicht abgeschlossen. Stellen Sie die Korrektheit der I
 msgid "Your seller data"
 msgstr "Ihre Verkäuferdaten"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/index.tsx:84
 msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
 msgstr "Ihre Transaktion war erfolgreich, aber das Netzwerk benötigt länger als erwartet, um Ihre Daten zu bearbeiten. Die Details Ihres CO2-Ausgleichs sollten in wenigen Sekunden zur Verfügung stehen."
@@ -2022,6 +2669,10 @@ msgstr "Ihre Transaktion war erfolgreich, aber das Netzwerk benötigt länger al
 msgid "Your unique handle"
 msgstr "Ihr einzigartiger Name"
 
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr "Ihre Walletadresse"
+
 #: components/pages/Resources/lib/cmsDataMap.ts:82
 msgid "Z-A"
 msgstr "Z-A"
@@ -2029,540 +2680,3 @@ msgstr "Z-A"
 #: components/pages/Home/index.tsx:437
 msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
 msgstr "Gebührenfreier Handel mit digitalen Emissionszertifikaten: innerhalb von Sekunden, transparent und immer verfügbar. Erfahren Sie, was Carbonmark für Sie als Händler digitaler Emissionszertifikate tun kann."
-
-#: components/Activities/Activity.tsx:34
-msgid "at"
-msgstr "bei"
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr "Die in diesem Blogbeitrag bereitgestellten Informationen zu KlimaDAO („KlimaDAO“), seinen Krypto-Assets, Geschäftsvermögen, Strategie und Betrieb dienen nur allgemeinen Informationszwecken und sind kein formelles Verkaufsangebot oder eine Aufforderung zur Abgabe eines Angebots von Wertpapieren, Optionen, Futures oder andere Derivaten im Zusammenhang mit Wertpapieren in jeglicher Rechtsordnung, und der Inhalt ist nicht durch Wertpapiergesetze vorgeschrieben. Die in diesem Blogbeitrag enthaltenen Informationen sollten nicht als Empfehlung zum Kauf oder Verkauf oder Halten solcher Wertpapiere oder als Angebot zum Verkauf solcher Wertpapiere angesehen werden. Dieser Blog-Beitrag berücksichtigt weder Steuer-, Rechts- oder Anlageberatung noch gibt er eine Stellungnahme zu den spezifischen Anlagezielen oder der finanziellen Situation einer Person ab. KlimaDAO und seine Vertreter, Berater, Direktoren, leitenden Angestellten, Mitarbeiter und Aktionäre geben keine ausdrücklichen oder stillschweigenden Zusicherungen oder Gewährleistungen hinsichtlich der Richtigkeit dieser Informationen ab, und KlimaDAO lehnt ausdrücklich jegliche Haftung ab, die auf solchen Informationen oder Fehlern oder Auslassungen beruhen könnte. KlimaDAO behält sich das Recht vor, die hierin enthaltenen Informationen ganz oder teilweise jederzeit zu ändern oder zu ersetzen, und übernimmt keine Verpflichtung, dem Empfänger die geänderten Informationen zugänglich zu machen oder den Empfänger hiervon in Kenntnis zu setzen. Die in diesem Blog-Beitrag enthaltenen Informationen ersetzen alle in früheren Blog-Beiträge oder Konversationen ähnlichen oder verwandten Informationen. Auf Informationen, Darstellungen oder Aussagen, die hier nicht enthalten sind, darf für keinen Zweck vertraut werden. Weder KlimaDAO noch einer seiner Vertreter haften Ihnen oder einer anderen Person gegenüber aus jeglichen Gründen, die sich aus der Verwendung oder Nichtverwendung der Informationen in diesem Blog-Beitrag durch Sie oder einen Ihrer Vertreter ergibt. Darüber hinaus übernimmt KlimaDAO keine Verpflichtung, die Erwartungen oder Aussagen Dritter in Bezug auf die in diesem Blogbeitrag erörterten Angelegenheiten zu kommentieren."
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr "Haftungsausschluss:"
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr "gekauft von"
-
-#: components/Layout/index.tsx:52
-msgid "connect a wallet"
-msgstr "Wallet verbinden"
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr "Eintrag erstellt"
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr "Eintrag gelöscht"
-
-#: components/pages/Project/Purchase/Listing/Price.tsx:18
-#: components/pages/Project/Purchase/Pool/Price.tsx:17
-#: components/pages/Project/Retire/Pool/Price.tsx:17
-msgid "each"
-msgstr "pro Tonne"
-
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr "Sobald Sie über den Button unten fortfahren, werden Sie gebeten, Ihre Wallet zu verbinden. Das von Ihnen ausgewählte Projekt wird anschließend bereits auf klimadao.finance für Sie ausgewählt sein. Folgen Sie dort den weiteren Anweisungen, um Ihre Transaktion zu beenden."
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr "Von Ihnen auf klimadao.finance gekaufte oder ausgegliche CO2-Credits werden auch in Ihrem Carbonmark-Portfolio abrufbar sein."
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr "Sie werden zu klimadao.finance weitergeleitet, um diese Transaktion abzuschließen."
-
-#: components/Activities/Activity.tsx:112
-msgid "for"
-msgstr "für"
-
-#: components/pages/Retire/index.tsx:52
-msgid "for beneficiary"
-msgstr "für Empfänger"
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr "Marktplatz"
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr "Portfolio"
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr "Profil"
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr "Kompensieren"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
-msgid "offset.amount_in_tonnes"
-msgstr "Wie viele Tonnen CO2 möchten Sie ausgleichen? <0>*</0>"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
-msgid "offset.default_retirement_address"
-msgstr "Standardmäßig die aktuell verbundene Walletadresse"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
-msgid "offset.retire_carbon"
-msgstr "CO2-Ausgleich bestätigen"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
-msgid "offset.retirement_credit"
-msgstr "Wem soll dieser CO2-Ausgleich gewidmet werden?"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
-msgid "offset.retirement_message"
-msgstr "Möchtest du eine Nachricht anhängen?"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr "Danke, dass Sie den Planeten unterstützen! Sehen Sie sich Ihre Transaktion auf <0>PolygonScan</0> an."
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr "Vielen Dank, dass Sie den Planeten unterstützen!"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr "Ihre Transaktion wurde erfolgreich verarbeitet, doch die Indexierung dauert länger als erwartet. Sie wird demnächst in Ihren <0>CO2-Kompensierungen</0> erscheinen."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
-msgid "offset_disclaimer"
-msgstr "Achten Sie darauf, keine persönlichen Daten (wie E-Mail-Adressen) im Ausgleichsnamen oder der -nachricht anzugeben. Die hier eingegebenen Informationen werden auf einer öffentlichen Blockchain für immer einsehbar sein und können nicht bearbeitet werden."
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr "Guthaben"
-
-#: components/CreateListing/Form/index.tsx:136
-msgid "profile.addListing_modal.submit"
-msgstr "Eintrag erstellen"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
-msgid "profile.edit_modal.submit"
-msgstr "Änderungen speichern"
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr "Bearbeiten Sie Ihr Profil, um eine Beschreibung hinzuzufügen."
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
-msgid "profile.listing.edit.delete_listing"
-msgstr "Eintrag löschen"
-
-#: components/pages/Purchases/index.tsx:49
-msgid "project.single.button.back_to_project_details"
-msgstr "Zurück zu den Projektdetails"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr "Sie sind dabei, ein CO2-Asset zu erwerben."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr "Im ersten Schritt bewilligen Sie den Transfer des Zahlungstokens aus Ihrer Wallet zu Carbonmark. Im nächsten Schritt genehmigen Sie den eigentlichen Transfer und schließen den Kauf ab."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr "Sie können die von Ihnen gekauften CO2-Assets jederzeit aus Ihrem <0>Portfolio</0> heraus auf Carbonmark anbieten."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr "Überprüfen Sie, ob alle Informationen korrekt sind, und klicken Sie auf „Approve/Genehmigen“, um fortzufahren."
-
-#: components/pages/Purchases/index.tsx:145
-msgid "purchase.button.view_assets"
-msgstr "Sehen Sie sich Ihre Assets an"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr "Der vorherige Schritt hat den Transfer des Assets aus Ihrer Wallet zu Carbonmark genehmigt."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr "Ihr Kauf ist noch nicht abgeschlossen. Stellen Sie die Korrektheit der Informationen sicher und klicken Sie unten auf \"Absenden\", um den Kauf abzuschließen."
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr "Kategorien"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr "Wähle eine oder mehrere aus"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr "Alles löschen"
-
-#: components/pages/Resources/ResourcesList/index.tsx:289
-msgid "resources.mobile_modal.button.show_results"
-msgstr "Ergebnisse anzeigen"
-
-#: components/pages/Resources/ResourcesList/index.tsx:230
-msgid "resources.page.list.no_search_results.title"
-msgstr "Tut uns leid. Wir konnten keine passenden Ergebnisse finden."
-
-#: components/pages/Resources/ResourcesList/index.tsx:222
-msgid "resources.page.list.on_fetch_error"
-msgstr "Sorry! Etwas ist schief gelaufen."
-
-#: components/pages/Resources/ResourcesList/index.tsx:243
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr "Bitte verwenden Sie eine andere Filterkombination."
-
-#: components/pages/Resources/ResourcesList/index.tsx:236
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr "Überprüfen Sie Ihre Suche auf Tippfehler oder versuchen Sie es mit einem anderen Suchbegriff."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
-msgid "retire.back_button"
-msgstr "zurück"
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr "ausgeglichen"
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr "Mit über 20 Millionen verifizierten Emissionszertifikaten von Hunderten von Projekten bietet Carbonmark die weltweit größte Auswahl digitaler CO2-Credits an. Kaufen und verkaufen Sie provisionsfrei digitales CO2 von jedem beliebigen Projekt und nutzen Sie es für den CO2-Ausgleich. <0>Beginnen Sie jetzt</0>."
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr "Über Carbonmark"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr "{retiree} hat {formattedAmount} Tonnen CO2 ausgeglichen"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr "Carbonmark | Quittung für CO2-Ausgleich"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:50
-msgid "retirement.provenance.head.metaDescription"
-msgstr "Transparente On-Chain-Offsets von Carbonmark."
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:46
-msgid "retirement.provenance.head.metaTitle"
-msgstr "{retiree} hat {formattedAmount} Tonnen CO2 ausgeglichen"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:42
-msgid "retirement.provenance.head.title"
-msgstr "Carbonmark | Verlauf des CO2-Ausgleichs"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
-msgid "retirement.single.beneficiary.placeholder"
-msgstr "Keinen Empfängername angegeben"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.title"
-msgstr "Begünstigter:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
-msgid "retirement.single.beneficiary_address.title"
-msgstr "0x-Adresse des Begünstigten"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr "CO2-Credit-Ausgleich"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
-msgid "retirement.single.country_region.title"
-msgstr "Land/Region:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
-msgid "retirement.single.immutable_public_records.title"
-msgstr "Dies repräsentiert einen permanenten CO2-Ausgleich durch ein digitales CO2-Asset. Der Ausgleichsvorgang und alle damit verbundenen Daten werden unveränderbar und öffentlich zugänglich aufgezeichnet."
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr "Ausgleichsnachricht:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.methodology.title"
-msgstr "Methodik:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
-msgid "retirement.single.moss_offset.description"
-msgstr "MCO2-Zertifikate werden durch Projekte aus dem Amazonas-Regenwald generiert, die zahlreiche positiven externen Nebeneffekt mitbringen - wie die Schaffung regionaler Arbeitsplätze und den Erhalt lokaler Artenvielfalt. Entdecken Sie MCO2 auf <0>https://data.klimadao.finance/de/token-details?tab=moss</0>."
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
-msgid "retirement.single.moss_offset.name"
-msgstr "Moss Earth MCO2"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
-msgid "retirement.single.official_certificate.title"
-msgstr "Offizielles Zertifikat für On-Chain-CO2-Ausgleich bereitgestellt von <0>Carbonmark.com</0>"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
-msgid "retirement.single.project.title"
-msgstr "Projekt:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
-msgid "retirement.single.project_description.title"
-msgstr "Beschreibung"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
-msgid "retirement.single.project_details.title"
-msgstr "Projektinformationen"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
-msgid "retirement.single.project_name.title"
-msgstr "Projektname"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr "Beweis für"
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr "AUSGEGLICHENE MENGE"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
-msgid "retirement.single.share_retirement.title"
-msgstr "Diesen Ausgleich teilen"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr "Kein Ausgleichszeitpunkt angegeben"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
-msgid "retirement.single.transaction_id.title"
-msgstr "Transaktions-ID"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
-msgid "retirement.single.transaction_record.title"
-msgstr "Unveränderlicher Transaktionsdatensatz"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.type.title"
-msgstr "Typ:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr "Verifizierte CO2-Tonnen ausgeglichen"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
-msgid "retirement.single.vintage.title"
-msgstr "Jahrgang:"
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr "Keine CO2-Ausgleiche gefunden"
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr "Alle CO2-Ausgleiche"
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr "Carbonmark - CO2-Ausgleich für {0}"
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr "Carbonmark - CO2-Ausgleich für {0}"
-
-#: components/pages/Retirements/index.tsx:60
-msgid "retirement.totals.page_headline"
-msgstr "CO2-Ausgleich"
-
-#: components/pages/Retirements/index.tsx:66
-msgid "retirement.totals.page_subline"
-msgstr "für Empfänger"
-
-#: components/pages/Retirements/index.tsx:90
-msgid "retirement.totals.retired_assets"
-msgstr "Ausgeglichene Assets"
-
-#: components/pages/Retirements/index.tsx:106
-msgid "retirement.totals.retirements"
-msgstr "CO2-Ausgleiche"
-
-#: components/pages/Retirements/index.tsx:98
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr "CO2-Tonnen insgesamt ausgeglichen"
-
-#: components/pages/Retirements/index.tsx:112
-msgid "retirement.totals.total_retirement_transactions"
-msgstr "Summe der Ausgleichstransaktionen"
-
-#: components/pages/Users/SellerUnconnected/index.tsx:70
-msgid "seller.listing.buy"
-msgstr "Kaufen"
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr "Verfügbare Menge:"
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr "Ressourcen"
-
-#: components/pages/Resources/ResourcesList/index.tsx:197
-msgid "shared.resources.sort_by.header"
-msgstr "Sortieren nach:"
-
-#: components/Layout/index.tsx:51
-msgid "social or email"
-msgstr "Social oder E-Mail"
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr "Verkauft an"
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
-msgid "something went wrong loading the allowance"
-msgstr "Beim Laden des Guthabens ist etwas schiefgelaufen"
-
-#: components/pages/Retire/Activity/Overview.tsx:77
-#: components/pages/Retire/Activity/Quotes.tsx:76
-#: components/pages/Retire/Activity/Table.tsx:65
-msgid "t"
-msgstr "t"
-
-#: components/Activities/Activity.tsx:119
-msgid "to"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
-msgid "tonnes"
-msgstr "Tonnen"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr "Sie sind dabei, ein CO2-Token für einen Ausgleich zu verwenden."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr "Im ersten Schritt bewilligen Sie den Transfer des CO2-Assets aus Ihrer Wallet zu Carbonmark. Im nächsten Schritt genehmigen Sie den eigentlichen Transfer und schließen den Ausgleich ab."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr "Verifizieren Sie die Korrektheit der Daten und klicken Sie auf \"Genehmigen\", um fortzufahren."
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr "Menge bestätigen"
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr "Vertragsadresse"
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr "Preis pro CO2-Tonne bestätigen"
-
-#: components/CreateListing/Transaction/index.tsx:83
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr "Zurück"
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr "Schließen"
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr "Weiter"
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr "Menge absenden"
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr "Absenden"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr "Der vorherige Schritt hat nur den Transfer des CO2-Assets aus Ihrer Wallet zu Carbonmark genehmigt. Ihr CO2-Ausgleich ist damit noch nicht abgeschlossen."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr "Verifizieren Sie die Informationen und klicken Sie unten auf \"Absenden\", um den Ausgleich abzuschließen."
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr "Vertragsadresse"
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr "Preis pro Tonne nennen:"
-
-#: components/CreateListing/Transaction/index.tsx:47
-#: components/Transaction/index.tsx:45
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Genehmigen"
-
-#: components/CreateListing/Transaction/index.tsx:57
-#: components/Transaction/index.tsx:55
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Absenden"
-
-#: components/Activities/Activities.constants.ts:10
-msgid "updated expiration"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr "Aktualisierter Preis"
-
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr "Aktualisierte Menge"
-
-#: components/Activities/index.tsx:29
-msgid "user.activities.empty_state"
-msgstr "Keine Aktivitäten zum Anzeigen"
-
-#: components/LoginCard/index.tsx:24
-msgid "user.login.description"
-msgstr "Diese Funktion steht nur für eingeloggte Nutzer zur Verfügung. Loggen Sie sich bitte ein oder erstellen Sie über den Button einen Account."
-
-#: components/CreateListing/Transaction/Approve.tsx:51
-#: components/CreateListing/Transaction/index.tsx:62
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
-msgid "{0}"
-msgstr "{0}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
-msgid "{0} maximum for credit cards"
-msgstr "Maximal {0} für Kreditkarten"
-
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr "{0} | Profil | Carbonmark"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr "{DEFAULT_EXPIRATION_DAYS} Tage ({expirationDatestring})"
-
-#: components/pages/Purchases/index.tsx:29
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr "{amount} Tonnen wurden für Projekt {0} gekauft"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
-#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
-msgid "{formattedAmount} Tonnes"
-msgstr "{formattedAmount} Tonnen"
-
-#: components/Quantity/index.tsx:28
-msgid "{formattedAmount} tonnes"
-msgstr "{formattedAmount} Tonnen"
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
-msgid "{tokenSymbol}"
-msgstr "{tokenSymbol}"
-
-#: lib/statusMessage.ts:23
-msgid "❌ Error: something went wrong..."
-msgstr "❌ Fehler: etwas ist schiefgelaufen..."

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -6,9 +6,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en-pseudo\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/CreateListing/Transaction/Approve.tsx:51
+#: components/CreateListing/Transaction/index.tsx:62
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
+msgid "{0}"
+msgstr ""
+
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr ""
+
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
+msgid "{0} maximum for credit cards"
+msgstr ""
+
+#: components/pages/Purchases/index.tsx:29
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr ""
+
+#: components/Quantity/index.tsx:28
+msgid "{formattedAmount} tonnes"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
+#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
+msgid "{formattedAmount} Tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:46
+msgid "retirement.provenance.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
+msgid "{tokenSymbol}"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "@Username (note: this can not be changed!)"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
+msgid "<0>* </0> Required Field"
+msgstr ""
+
+#: lib/statusMessage.ts:23
+msgid "❌ Error: something went wrong..."
+msgstr ""
 
 #: components/pages/Home/index.tsx:358
 msgid "0% listing fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:47
+#: components/Transaction/index.tsx:45
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:57
+#: components/Transaction/index.tsx:55
+msgid "transaction_modal.view.submit.title"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:193
@@ -32,14 +107,6 @@ msgstr ""
 msgid "500 - Server error occurred"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
-msgid "<0>* </0> Required Field"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "@Username (note: this can not be changed!)"
-msgstr ""
-
 #: components/pages/Project/PayWithBank/index.tsx:153
 msgid "A valid email address is required"
 msgstr ""
@@ -54,6 +121,11 @@ msgstr ""
 msgid "About"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr ""
+
 #: components/Stats/StatsListings.tsx:49
 msgid "Active listings:"
 msgstr ""
@@ -62,12 +134,22 @@ msgstr ""
 msgid "Activity"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr ""
+
 #: lib/getCategoryInfo.ts:53
 msgid "Agriculture"
 msgstr ""
 
 #: components/pages/Home/index.tsx:362
 msgid "All assets sourced from major registries"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
 msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:41
@@ -111,6 +193,10 @@ msgstr ""
 msgid "Asset"
 msgstr ""
 
+#: components/AssetDetails/index.tsx:53
+msgid "Asset details"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:24
 msgid "Asset Details"
 msgstr ""
@@ -119,8 +205,12 @@ msgstr ""
 msgid "Asset ID"
 msgstr ""
 
-#: components/AssetDetails/index.tsx:53
-msgid "Asset details"
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:32
+msgid "Asset moved from one account to another, either via sale or inter-account transfer."
+msgstr ""
+
+#: components/Activities/Activity.tsx:34
+msgid "at"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:131
@@ -132,11 +222,6 @@ msgid ""
 "At this time, Carbonmark cannot process credit card payments\n"
 "exceeding {0}. Please adjust the\n"
 "quantity and try again later."
-msgstr ""
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:116
@@ -163,6 +248,11 @@ msgstr ""
 msgid "Available to retire"
 msgstr ""
 
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:219
 msgid "Available:"
 msgstr ""
@@ -176,13 +266,19 @@ msgstr ""
 msgid "Available: {unlistedBalance}"
 msgstr ""
 
-#: components/BetaBadge/index.tsx:18
-msgid "BETA"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
+msgid "retire.back_button"
 msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:44
 #: components/pages/Project/Retire/index.tsx:35
 msgid "Back to Project"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:49
+msgid "project.single.button.back_to_project_details"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:397
@@ -199,6 +295,16 @@ msgstr ""
 msgid "Balance: {0}"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
+msgid "offset_disclaimer"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:450
 msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
 msgstr ""
@@ -207,12 +313,17 @@ msgstr ""
 msgid "Beneficiary Address"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
-msgid "Beneficiary Name"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
+msgid "retirement.single.beneficiary_address.title"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:263
 msgid "Beneficiary name"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
+msgid "Beneficiary Name"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:232
@@ -225,10 +336,19 @@ msgstr ""
 msgid "Beneficiary wallet address (optional)"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:34
 #: components/pages/Project/BuyOptions/SellerListing.tsx:67
 #: components/pages/Project/index.tsx:137
 msgid "Best Price"
+msgstr ""
+
+#: components/BetaBadge/index.tsx:18
+msgid "BETA"
 msgstr ""
 
 #: lib/getCategoryInfo.ts:65
@@ -239,8 +359,8 @@ msgstr ""
 msgid "Book a demo"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:35
-msgid "Bridge"
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
 msgstr ""
 
 #: components/pages/Home/index.tsx:157
@@ -255,6 +375,11 @@ msgstr ""
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:45
 #: components/pages/Project/BuyOptions/SellerListing.tsx:98
 msgid "Buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:70
+msgid "seller.listing.buy"
 msgstr ""
 
 #: components/pages/Home/index.tsx:168
@@ -273,12 +398,35 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr ""
+
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:30
 msgid "Carbon Pool"
 msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:117
 msgid "Carbon Portfolio"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
+msgid "Carbon provenance"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:60
@@ -289,16 +437,34 @@ msgstr ""
 msgid "Carbon Retirements"
 msgstr ""
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:60
+msgid "retirement.totals.page_headline"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
-msgid "Carbon provenance"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
 msgstr ""
 
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:42
+msgid "retirement.provenance.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:51
+#: components/pages/Home/index.tsx:52
+msgid "Carbonmark | The Universal Carbon Marketplace"
 msgstr ""
 
 #: components/pages/Home/index.tsx:174
@@ -315,13 +481,17 @@ msgstr ""
 msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 msgstr ""
 
-#: components/pages/Home/index.tsx:51
-#: components/pages/Home/index.tsx:52
-msgid "Carbonmark | The Universal Carbon Marketplace"
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
 msgstr ""
 
 #: components/pages/Home/index.tsx:488
 msgid "Carbonmark's role"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
 msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:130
@@ -333,6 +503,11 @@ msgstr ""
 msgid "Change language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:236
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
 #: components/pages/Home/index.tsx:206
 msgid "Choose a project and quantity"
 msgstr ""
@@ -341,8 +516,13 @@ msgstr ""
 msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 msgstr ""
 
-#: components/ProjectFilterModal/index.tsx:162
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
 #: components/pages/Projects/ProjectSearch/index.tsx:55
+#: components/ProjectFilterModal/index.tsx:162
 msgid "Clear Filters"
 msgstr ""
 
@@ -352,6 +532,11 @@ msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:98
 msgid "Close"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
 msgstr ""
 
 #: components/Footer/index.tsx:32
@@ -379,6 +564,16 @@ msgstr ""
 msgid "Compiling Results ..."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr ""
+
 #: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:83
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
 #: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
@@ -386,8 +581,17 @@ msgstr ""
 msgid "Confirm Purchase"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
+msgid "offset.retire_carbon"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:75
 msgid "Confirm Retirement"
+msgstr ""
+
+#: components/Layout/index.tsx:52
+msgid "connect a wallet"
 msgstr ""
 
 #: components/pages/Portfolio/ConnectedWallet/index.tsx:33
@@ -414,6 +618,16 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
 #: components/CopyAddressButton/index.tsx:37
 msgid "Copy"
 msgstr ""
@@ -431,14 +645,9 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Create Profile"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
+msgid "retirement.single.country_region.title"
 msgstr ""
 
 #: components/CreateListing/index.tsx:165
@@ -457,6 +666,21 @@ msgstr ""
 msgid "Create and edit listings, and track your activity with your Carbonmark profile."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:136
+msgid "profile.addListing_modal.submit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Create Profile"
+msgstr ""
+
 #: components/pages/Home/index.tsx:313
 msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
 msgstr ""
@@ -465,24 +689,28 @@ msgstr ""
 msgid "Create your own retirement"
 msgstr ""
 
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:87
 msgid "Created:"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
-msgid "Credit ID"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:77
 msgid "Credit card minimum purchase is {0}"
 msgstr ""
 
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:247
 msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
+msgid "Credit ID"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:435
@@ -492,10 +720,6 @@ msgstr ""
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:140
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
 msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
-msgstr ""
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
 msgstr ""
 
 #: components/pages/Project/index.tsx:234
@@ -511,8 +735,26 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
+msgid "offset.default_retirement_address"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:296
 msgid "Defaults to the connected wallet address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
+msgid "profile.listing.edit.delete_listing"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:307
@@ -523,12 +765,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
+msgid "retirement.single.project_description.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:51
 msgid "Digital Carbon"
 msgstr ""
 
 #: components/pages/Home/index.tsx:264
 msgid "Digitize your carbon by using a supported bridge"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
@@ -555,8 +807,18 @@ msgstr ""
 msgid "Drive climate action and earn rewards with a carbon-backed digital currency."
 msgstr ""
 
+#: components/pages/Project/Purchase/Listing/Price.tsx:18
+#: components/pages/Project/Purchase/Pool/Price.tsx:17
+#: components/pages/Project/Retire/Pool/Price.tsx:17
+msgid "each"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:195
 msgid "Edit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
+msgid "Edit listing"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:113
@@ -564,8 +826,9 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
-msgid "Edit listing"
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:143
@@ -626,6 +889,19 @@ msgstr ""
 msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
 msgstr ""
 
+#: components/Activities/Activity.tsx:112
+msgid "for"
+msgstr ""
+
+#: components/pages/Retire/index.tsx:52
+msgid "for beneficiary"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:66
+msgid "retirement.totals.page_subline"
+msgstr ""
+
 #: components/pages/Home/index.tsx:340
 msgid "For carbon traders"
 msgstr ""
@@ -642,20 +918,26 @@ msgstr ""
 msgid "Form complete"
 msgstr ""
 
-#: components/pages/Home/index.tsx:76
-msgid "Get Started"
-msgstr ""
-
 #: components/pages/Home/index.tsx:390
 msgid "Get paid immediately: transactions are resolved in seconds"
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
+#: components/pages/Home/index.tsx:76
+msgid "Get Started"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:83
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
 msgid "Go back"
+msgstr ""
+
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:145
@@ -681,7 +963,7 @@ msgid "Here’s a list of readily available, discounted carbon tokens to retire 
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:48
-msgid "Hide {numberOfTransfers} transfers"
+msgid "Hide {numberOfTransfers} transactions"
 msgstr ""
 
 #: components/CreateListing/Form/index.tsx:80
@@ -695,6 +977,11 @@ msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:249
 msgid "How many tonnes of carbon do you want to retire?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
+msgid "offset.amount_in_tonnes"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:215
@@ -719,6 +1006,11 @@ msgstr ""
 
 #: components/pages/Purchases/index.tsx:93
 msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
+msgid "retirement.single.transaction_record.title"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:116
@@ -775,13 +1067,13 @@ msgstr ""
 msgid "Latest First"
 msgstr ""
 
+#: components/pages/Home/index.tsx:417
+msgid "Learn more"
+msgstr ""
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:92
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:103
 msgid "Learn More"
-msgstr ""
-
-#: components/pages/Home/index.tsx:417
-msgid "Learn more"
 msgstr ""
 
 #: components/pages/Home/index.tsx:491
@@ -815,11 +1107,11 @@ msgid "Loading your assets"
 msgstr ""
 
 #: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:295
 #: components/pages/Retire/Activity/Overview.tsx:73
 #: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
 msgid "Loading..."
 msgstr ""
 
@@ -859,6 +1151,11 @@ msgstr ""
 msgid "Marketplace"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr ""
+
 #: components/pages/Projects/index.tsx:73
 #: components/pages/Projects/index.tsx:74
 msgid "Marketplace | Carbonmark"
@@ -868,20 +1165,35 @@ msgstr ""
 msgid "Maximize your climate impact."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.moss_offset.description"
+msgstr ""
+
 #: components/pages/Project/index.tsx:144
 msgid "Methodology"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.methodology.title"
 msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:54
 msgid "Moss"
 msgstr ""
 
-#: components/FeatureBanner/index.tsx:33
-msgid "NEW FEATURE:"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
+msgid "retirement.single.moss_offset.name"
 msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:171
 msgid "Navigation Menu"
+msgstr ""
+
+#: components/FeatureBanner/index.tsx:33
+msgid "NEW FEATURE:"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
@@ -896,8 +1208,9 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:197
@@ -905,8 +1218,17 @@ msgstr ""
 msgid "No active listings."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Activities/index.tsx:29
+msgid "user.activities.empty_state"
+msgstr ""
+
 #: components/pages/Retire/Activity/Quotes.tsx:38
 msgid "No activity to show"
+msgstr ""
+
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
 msgstr ""
 
 #: components/pages/Home/index.tsx:400
@@ -915,6 +1237,11 @@ msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:40
 msgid "No beneficiary address available"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
+msgid "retirement.single.beneficiary.placeholder"
 msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:62
@@ -950,12 +1277,18 @@ msgstr ""
 msgid "No retirement message provided."
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
-msgid "No transaction id available"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
 msgstr ""
 
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
+msgid "No transaction id available"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:240
@@ -963,11 +1296,20 @@ msgstr ""
 msgid "Not a valid polygon address"
 msgstr ""
 
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
+msgid "retirement.single.official_certificate.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:72
 msgid "Oldest First"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:185
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:188
 msgid "On the Verra page, search for the specific serial number."
 msgstr ""
 
@@ -991,21 +1333,17 @@ msgstr ""
 msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 msgstr ""
 
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr ""
-
 #: components/pages/Projects/Banners/BankTransfer.tsx:74
 msgid "Pay via Bank Transfer / Wire"
+msgstr ""
+
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:89
 #: components/pages/Project/PayWithBank/index.tsx:90
 msgid "Pay with Bank Transfer | Carbonmark"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:94
@@ -1014,21 +1352,17 @@ msgstr ""
 msgid "Pay with:"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:62
-msgid "Payment Successful"
-msgstr ""
-
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:243
 msgid "Payment processing fee"
+msgstr ""
+
+#: components/pages/Purchases/index.tsx:62
+msgid "Payment Successful"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:161
 #: components/pages/Project/PayWithBank/index.tsx:313
 msgid "Phone number"
-msgstr ""
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
 msgstr ""
 
 #: lib/statusMessage.ts:27
@@ -1039,10 +1373,24 @@ msgstr ""
 msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr ""
 
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr ""
+
 #: components/pages/Portfolio/index.tsx:66
 #: components/pages/Users/SellerConnected/index.tsx:75
 #: components/pages/Users/SellerConnected/index.tsx:101
 msgid "Please refresh the page. There was an error updating your data: {e}."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:243
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
 msgstr ""
 
 #: components/pages/Portfolio/index.tsx:76
@@ -1062,10 +1410,6 @@ msgstr ""
 msgid "Price Highest"
 msgstr ""
 
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr ""
-
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:180
@@ -1074,6 +1418,10 @@ msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:160
 msgid "Price is required"
+msgstr ""
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
 msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:62
@@ -1110,8 +1458,27 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:192
 msgid "Profile picture"
+msgstr ""
+
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
+msgid "retirement.single.project_name.title"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:253
@@ -1119,9 +1486,19 @@ msgstr ""
 msgid "Project names of interest"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:36
-#: components/pages/Purchases/index.tsx:37
-msgid "Purchase Receipt | Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
+msgid "retirement.single.project.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr ""
+
+#: components/pages/Project/Purchase/index.tsx:32
+#: components/pages/Project/Purchase/index.tsx:33
+msgid "Purchase {0} | Carbonmark"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:53
@@ -1133,17 +1510,17 @@ msgstr ""
 msgid "Purchase more Carbon"
 msgstr ""
 
+#: components/pages/Purchases/index.tsx:36
+#: components/pages/Purchases/index.tsx:37
+msgid "Purchase Receipt | Carbonmark"
+msgstr ""
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:79
 msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer."
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
 msgid "Purchase successful"
-msgstr ""
-
-#: components/pages/Project/Purchase/index.tsx:32
-#: components/pages/Project/Purchase/index.tsx:33
-msgid "Purchase {0} | Carbonmark"
 msgstr ""
 
 #: components/pages/Retire/Activity/Table.tsx:47
@@ -1160,6 +1537,11 @@ msgstr ""
 msgid "Quantity Available:"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:240
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:108
 msgid "Quantity is required"
@@ -1173,20 +1555,17 @@ msgstr ""
 msgid "Quantity purchased:"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr ""
+
 #: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr ""
-
 #: components/pages/Project/index.tsx:198
 msgid "Read Less"
-msgstr ""
-
-#: components/pages/Project/index.tsx:198
-msgid "Read More"
 msgstr ""
 
 #: components/pages/Home/index.tsx:445
@@ -1195,6 +1574,10 @@ msgstr ""
 #: components/pages/Resources/BlogPostCard/index.tsx:38
 #: components/pages/Resources/FeaturedArticles/Article.tsx:45
 msgid "Read more"
+msgstr ""
+
+#: components/pages/Project/index.tsx:198
+msgid "Read More"
 msgstr ""
 
 #: components/pages/Home/index.tsx:351
@@ -1213,13 +1596,13 @@ msgstr ""
 msgid "Renewable Energy"
 msgstr ""
 
+#: lib/constants.ts:82
+msgid "Request already processing. Please open your wallet and complete the request."
+msgstr ""
+
 #: components/pages/Home/index.tsx:301
 #: components/pages/Home/index.tsx:325
 msgid "Request Demo"
-msgstr ""
-
-#: lib/constants.ts:82
-msgid "Request already processing. Please open your wallet and complete the request."
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:210
@@ -1229,6 +1612,11 @@ msgstr ""
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:267
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:311
 msgid "Required when proceeding with Credit Card"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
 msgstr ""
 
 #: components/Footer/index.tsx:38
@@ -1257,14 +1645,35 @@ msgstr ""
 msgid "Retire"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/index.tsx:88
+#: components/pages/Portfolio/Retire/index.tsx:89
+#: components/pages/Retire/index.tsx:38
+#: components/pages/Retire/index.tsx:39
+msgid "Retire | Carbonmark"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:388
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
 msgid "Retire Carbon"
 msgstr ""
 
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:233
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
+msgstr ""
+
+#: components/pages/Project/Retire/index.tsx:23
+#: components/pages/Project/Retire/index.tsx:24
+msgid "Retire from {fullProjectid} | Carbonmark"
 msgstr ""
 
 #: components/pages/Retire/index.tsx:72
@@ -1275,23 +1684,18 @@ msgstr ""
 msgid "Retire from your portfolio"
 msgstr ""
 
-#: components/pages/Project/Retire/index.tsx:23
-#: components/pages/Project/Retire/index.tsx:24
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr ""
-
 #: components/pages/Home/index.tsx:232
 msgid "Retire instantly, or purchase and hold digital carbon"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
 msgstr ""
 
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
 msgid "Retire more carbon"
+msgstr ""
+
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
 msgstr ""
 
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:56
@@ -1307,19 +1711,31 @@ msgstr ""
 msgid "Retire your carbon via bank transfer."
 msgstr ""
 
-#: components/pages/Portfolio/Retire/index.tsx:88
-#: components/pages/Portfolio/Retire/index.tsx:89
-#: components/pages/Retire/index.tsx:38
-#: components/pages/Retire/index.tsx:39
-msgid "Retire | Carbonmark"
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:13
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:90
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:16
 msgid "Retirement"
 msgstr ""
 
 #: components/pages/Retire/Activity/Quotes.tsx:32
 msgid "Retirement Activity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
+msgid "offset.retirement_message"
+msgstr ""
+
+#: components/pages/Project/PayWithBank/index.tsx:264
+#: components/pages/Project/PayWithBank/index.tsx:363
+msgid "Retirement message"
 msgstr ""
 
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
@@ -1328,26 +1744,36 @@ msgstr ""
 msgid "Retirement Message"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr ""
+
 #: components/pages/Retire/Activity/Overview.tsx:60
 #: components/pages/Retire/Activity/Overview.tsx:70
 msgid "Retirement Overview"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:264
-#: components/pages/Project/PayWithBank/index.tsx:363
-msgid "Retirement message"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:74
 msgid "Retirement successful"
 msgstr ""
 
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:106
+msgid "retirement.totals.retirements"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:384
 msgid "Retiring Token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
+msgid "profile.edit_modal.submit"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:201
@@ -1385,6 +1811,11 @@ msgstr ""
 msgid "Select a language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr ""
+
 #: components/pages/Portfolio/AssetProject/index.tsx:100
 #: components/pages/Portfolio/AssetProject/index.tsx:108
 msgid "Sell"
@@ -1402,12 +1833,26 @@ msgstr ""
 msgid "Seller Listing"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:159
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:29
+msgid "Send"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:161
 msgid "Serial Number"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:76
 msgid "Share this page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
+msgid "retirement.single.share_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:289
+msgid "resources.mobile_modal.button.show_results"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
@@ -1422,6 +1867,19 @@ msgstr ""
 
 #: components/CreateListing/Form/index.tsx:130
 msgid "Single unit price"
+msgstr ""
+
+#: components/Layout/index.tsx:51
+msgid "social or email"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr ""
+
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
+msgid "something went wrong loading the allowance"
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
@@ -1448,12 +1906,27 @@ msgstr ""
 msgid "Sorry, this handle already exists"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:265
-msgid "Sort By"
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:222
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:230
+msgid "resources.page.list.no_search_results.title"
 msgstr ""
 
 #: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "Sort by"
+msgstr ""
+
+#: components/pages/Resources/ResourcesList/index.tsx:265
+msgid "Sort By"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:197
+msgid "shared.resources.sort_by.header"
 msgstr ""
 
 #: components/Stats/index.tsx:23
@@ -1480,6 +1953,21 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr ""
+
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:88
 msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
 msgstr ""
@@ -1492,12 +1980,24 @@ msgstr ""
 msgid "Switch to Polygon"
 msgstr ""
 
-#: components/BetaBadge/index.tsx:16
-msgid "TESTNET"
+#: components/pages/Retire/Activity/Overview.tsx:77
+#: components/pages/Retire/Activity/Quotes.tsx:76
+#: components/pages/Retire/Activity/Table.tsx:65
+msgid "t"
 msgstr ""
 
 #: components/Footer/index.tsx:29
 msgid "Terms of Use"
+msgstr ""
+
+#: components/BetaBadge/index.tsx:16
+msgid "TESTNET"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
@@ -1508,20 +2008,31 @@ msgstr ""
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr ""
 
-#: components/pages/Project/PayWithBank/index.tsx:292
-msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
 msgstr ""
 
-#: components/pages/Home/index.tsx:65
-msgid "The Universal Carbon Marketplace"
+#: components/pages/Project/PayWithBank/index.tsx:292
+msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr ""
 
 #: components/CreateListing/Transaction/Approve.tsx:44
 msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:34
 msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
@@ -1530,6 +2041,12 @@ msgstr ""
 
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
 msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
 msgstr ""
 
 #: components/pages/Home/index.tsx:53
@@ -1570,12 +2087,26 @@ msgstr ""
 msgid "The minimum quantity to sell is 1 tonne"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:53
 msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
 msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
+msgstr ""
+
+#: components/pages/Home/index.tsx:65
+msgid "The Universal Carbon Marketplace"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:208
@@ -1599,6 +2130,11 @@ msgstr ""
 msgid "This app only works on Polygon Mainnet."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:24
+msgid "user.login.description"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
 msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
 msgstr ""
@@ -1619,12 +2155,26 @@ msgstr ""
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
+msgid "retirement.single.immutable_public_records.title"
+msgstr ""
+
 #: components/pages/Users/ProfileHeader/index.tsx:46
 msgid "This user has not yet created a carbonmark profile."
 msgstr ""
 
+#: components/Activities/Activity.tsx:119
+msgid "to"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:60
@@ -1639,21 +2189,21 @@ msgstr ""
 msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr ""
 
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr ""
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr ""
-
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
 msgid "Toggle payment method"
 msgstr ""
 
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr ""
+
 #: components/pages/Projects/ProjectSort/index.tsx:29
 msgid "Toggle sort menu"
+msgstr ""
+
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:209
@@ -1663,6 +2213,10 @@ msgstr ""
 
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
 msgid "Tokens received:"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
+msgid "tonnes"
 msgstr ""
 
 #: components/AssetDetails/index.tsx:63
@@ -1684,22 +2238,6 @@ msgstr ""
 msgid "Tonnes sold:"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:85
-msgid "Total Amount to Sell is required"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
-msgid "Total Cost is required"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr ""
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr ""
-
 #: components/CreateListing/Transaction/Approve.tsx:61
 msgid "Total allowance"
 msgstr ""
@@ -1708,8 +2246,17 @@ msgstr ""
 msgid "Total amount of tonnes to retire is required"
 msgstr ""
 
+#: components/CreateListing/Form/index.tsx:85
+msgid "Total Amount to Sell is required"
+msgstr ""
+
 #: components/pages/Retire/Activity/Overview.tsx:72
 msgid "Total carbon tonnes retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:98
+msgid "retirement.totals.total_carbon_tonnes"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
@@ -1718,9 +2265,17 @@ msgstr ""
 msgid "Total cost"
 msgstr ""
 
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
+msgid "Total Cost is required"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:166
 msgid "Total price"
+msgstr ""
+
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:103
@@ -1729,6 +2284,15 @@ msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:83
 msgid "Total retirement transactions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:112
+msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
@@ -1740,24 +2304,31 @@ msgstr ""
 msgid "Transaction complete."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
+msgid "retirement.single.transaction_id.title"
+msgstr ""
+
 #: lib/statusMessage.ts:29
 msgid "Transaction initiated. Waiting for network confirmation."
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:24
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:48
 msgid "Transfer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:50
+msgid "retirement.provenance.head.metaDescription"
 msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:128
 msgid "Transparent, on-chain offsets powered by Carbonmark."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "USDC per ton"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:110
-msgid "USDC per tonne"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.type.title"
 msgstr ""
 
 #: components/CreateListing/Form/index.tsx:115
@@ -1776,12 +2347,32 @@ msgstr ""
 msgid "Update listing"
 msgstr ""
 
+#: components/Activities/Activities.constants.ts:10
+msgid "updated expiration"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:91
 msgid "Updated:"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:191
 msgid "Updating your data..."
+msgstr ""
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "USDC per ton"
+msgstr ""
+
+#: components/CreateListing/Form/index.tsx:110
+msgid "USDC per tonne"
 msgstr ""
 
 #: components/pages/Resources/lib/cmsDataMap.ts:61
@@ -1797,6 +2388,21 @@ msgstr ""
 msgid "User refused connection."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:41
 msgid "Verify all information is correct and click 'approve' to continue."
@@ -1806,16 +2412,8 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
-msgid "View Carbonmark Profile"
-msgstr ""
-
-#: components/pages/Project/index.tsx:207
-msgid "View Registry Details <0/>"
-msgstr ""
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
+msgid "View {numberOfTransfers} transactions"
 msgstr ""
 
 #: components/pages/Portfolio/index.tsx:78
@@ -1851,8 +2449,16 @@ msgstr ""
 msgid "View and share certificate"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:180
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
+msgid "View Carbonmark Profile"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:183
 msgid "View issuance on Verra"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
+msgid "View on Polygonscan"
 msgstr ""
 
 #: components/AssetDetails/index.tsx:69
@@ -1863,8 +2469,12 @@ msgstr ""
 msgid "View on PolygonScan <0/>"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
-msgid "View on Polygonscan"
+#: components/pages/Project/index.tsx:207
+msgid "View Registry Details <0/>"
+msgstr ""
+
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:99
@@ -1879,8 +2489,9 @@ msgstr ""
 msgid "View the project details and other info for this purchase."
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
-msgid "View {numberOfTransfers} transfers"
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:145
+msgid "purchase.button.view_assets"
 msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:141
@@ -1893,6 +2504,11 @@ msgstr ""
 
 #: components/ProjectFilterModal/constants.tsx:15
 msgid "Vintage Oldest"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
+msgid "retirement.single.vintage.title"
 msgstr ""
 
 #: components/pages/Purchases/index.tsx:66
@@ -1915,11 +2531,21 @@ msgstr ""
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
+msgid "offset.retirement_credit"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:257
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
 msgid "Who will this retirement be credited to?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
 msgstr ""
 
 #: components/shared/InvalidNetworkModal/index.tsx:64
@@ -1932,8 +2558,18 @@ msgstr ""
 msgid "You"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
 msgid "You are about to purchase a carbon asset."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:31
@@ -1982,12 +2618,9 @@ msgstr ""
 msgid "You successfully acquired carbon!"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:221
-msgid "Your Profile"
-msgstr ""
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
@@ -2005,6 +2638,15 @@ msgstr ""
 msgid "Your display name"
 msgstr ""
 
+#: components/pages/Users/SellerConnected/index.tsx:221
+msgid "Your Profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
 msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr ""
@@ -2012,6 +2654,11 @@ msgstr ""
 #: components/pages/Portfolio/PortfolioSidebar.tsx:29
 #: components/pages/Users/SellerConnected/index.tsx:215
 msgid "Your seller data"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
 msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:84
@@ -2022,547 +2669,14 @@ msgstr ""
 msgid "Your unique handle"
 msgstr ""
 
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:82
 msgid "Z-A"
 msgstr ""
 
 #: components/pages/Home/index.tsx:437
 msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
-msgstr ""
-
-#: components/Activities/Activity.tsx:34
-msgid "at"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr ""
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr ""
-
-#: components/Layout/index.tsx:52
-msgid "connect a wallet"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/Price.tsx:18
-#: components/pages/Project/Purchase/Pool/Price.tsx:17
-#: components/pages/Project/Retire/Pool/Price.tsx:17
-msgid "each"
-msgstr ""
-
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr ""
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr ""
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr ""
-
-#: components/Activities/Activity.tsx:112
-msgid "for"
-msgstr ""
-
-#: components/pages/Retire/index.tsx:52
-msgid "for beneficiary"
-msgstr ""
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr ""
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr ""
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr ""
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
-msgid "offset.amount_in_tonnes"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
-msgid "offset.default_retirement_address"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
-msgid "offset.retire_carbon"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
-msgid "offset.retirement_credit"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
-msgid "offset.retirement_message"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
-msgid "offset_disclaimer"
-msgstr ""
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:136
-msgid "profile.addListing_modal.submit"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
-msgid "profile.edit_modal.submit"
-msgstr ""
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
-msgid "profile.listing.edit.delete_listing"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:49
-msgid "project.single.button.back_to_project_details"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:145
-msgid "purchase.button.view_assets"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:289
-msgid "resources.mobile_modal.button.show_results"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:230
-msgid "resources.page.list.no_search_results.title"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:222
-msgid "resources.page.list.on_fetch_error"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:243
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:236
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
-msgid "retire.back_button"
-msgstr ""
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr ""
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr ""
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:50
-msgid "retirement.provenance.head.metaDescription"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:46
-msgid "retirement.provenance.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:42
-msgid "retirement.provenance.head.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
-msgid "retirement.single.beneficiary.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
-msgid "retirement.single.beneficiary_address.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
-msgid "retirement.single.country_region.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
-msgid "retirement.single.immutable_public_records.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.methodology.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
-msgid "retirement.single.moss_offset.description"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
-msgid "retirement.single.moss_offset.name"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
-msgid "retirement.single.official_certificate.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
-msgid "retirement.single.project.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
-msgid "retirement.single.project_description.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
-msgid "retirement.single.project_details.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
-msgid "retirement.single.project_name.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
-msgid "retirement.single.share_retirement.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
-msgid "retirement.single.transaction_id.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
-msgid "retirement.single.transaction_record.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.type.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
-msgid "retirement.single.vintage.title"
-msgstr ""
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr ""
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:60
-msgid "retirement.totals.page_headline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:66
-msgid "retirement.totals.page_subline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:90
-msgid "retirement.totals.retired_assets"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:106
-msgid "retirement.totals.retirements"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:98
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:112
-msgid "retirement.totals.total_retirement_transactions"
-msgstr ""
-
-#: components/pages/Users/SellerUnconnected/index.tsx:70
-msgid "seller.listing.buy"
-msgstr ""
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr ""
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:197
-msgid "shared.resources.sort_by.header"
-msgstr ""
-
-#: components/Layout/index.tsx:51
-msgid "social or email"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
-msgid "something went wrong loading the allowance"
-msgstr ""
-
-#: components/pages/Retire/Activity/Overview.tsx:77
-#: components/pages/Retire/Activity/Quotes.tsx:76
-#: components/pages/Retire/Activity/Table.tsx:65
-msgid "t"
-msgstr ""
-
-#: components/Activities/Activity.tsx:119
-msgid "to"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
-msgid "tonnes"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr ""
-
-#: components/CreateListing/Transaction/index.tsx:83
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr ""
-
-#: components/CreateListing/Transaction/index.tsx:47
-#: components/Transaction/index.tsx:45
-msgid "transaction_modal.view.approve.title"
-msgstr ""
-
-#: components/CreateListing/Transaction/index.tsx:57
-#: components/Transaction/index.tsx:55
-msgid "transaction_modal.view.submit.title"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:10
-msgid "updated expiration"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr ""
-
-#: components/Activities/index.tsx:29
-msgid "user.activities.empty_state"
-msgstr ""
-
-#: components/LoginCard/index.tsx:24
-msgid "user.login.description"
-msgstr ""
-
-#: components/CreateListing/Transaction/Approve.tsx:51
-#: components/CreateListing/Transaction/index.tsx:62
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
-msgid "{0}"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
-msgid "{0} maximum for credit cards"
-msgstr ""
-
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:29
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
-#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
-msgid "{formattedAmount} Tonnes"
-msgstr ""
-
-#: components/Quantity/index.tsx:28
-msgid "{formattedAmount} tonnes"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
-msgid "{tokenSymbol}"
-msgstr ""
-
-#: lib/statusMessage.ts:23
-msgid "❌ Error: something went wrong..."
 msgstr ""

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -13,9 +13,78 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: components/CreateListing/Transaction/Approve.tsx:51
+#: components/CreateListing/Transaction/index.tsx:62
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
+msgid "{0}"
+msgstr "{0}"
+
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr "{0} | Profile | Carbonmark"
+
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
+msgid "{0} maximum for credit cards"
+msgstr "{0} maximum for credit cards"
+
+#: components/pages/Purchases/index.tsx:29
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr "{amount} tonnes were purchased for project {0}"
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+
+#: components/Quantity/index.tsx:28
+msgid "{formattedAmount} tonnes"
+msgstr "{formattedAmount} tonnes"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
+#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
+msgid "{formattedAmount} Tonnes"
+msgstr "{formattedAmount} Tonnes"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:46
+msgid "retirement.provenance.head.metaTitle"
+msgstr "{retiree} retired {formattedAmount} Tonnes of carbon"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr "{retiree} retired {formattedAmount} Tonnes of carbon"
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
+msgid "{tokenSymbol}"
+msgstr "{tokenSymbol}"
+
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "@Username (note: this can not be changed!)"
+msgstr "@Username (note: this can not be changed!)"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
+msgid "<0>* </0> Required Field"
+msgstr "<0>* </0> Required Field"
+
+#: lib/statusMessage.ts:23
+msgid "❌ Error: something went wrong..."
+msgstr "❌ Error: something went wrong..."
+
 #: components/pages/Home/index.tsx:358
 msgid "0% listing fee"
 msgstr "0% listing fee"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:47
+#: components/Transaction/index.tsx:45
+msgid "transaction_modal.view.approve.title"
+msgstr "1. Approve"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:57
+#: components/Transaction/index.tsx:55
+msgid "transaction_modal.view.submit.title"
+msgstr "2. Submit"
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:193
 msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
@@ -38,14 +107,6 @@ msgstr "500 - Server Error"
 msgid "500 - Server error occurred"
 msgstr "500 - Server error occurred"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
-msgid "<0>* </0> Required Field"
-msgstr "<0>* </0> Required Field"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "@Username (note: this can not be changed!)"
-msgstr "@Username (note: this can not be changed!)"
-
 #: components/pages/Project/PayWithBank/index.tsx:153
 msgid "A valid email address is required"
 msgstr "A valid email address is required"
@@ -60,6 +121,11 @@ msgstr "A-Z"
 msgid "About"
 msgstr "About"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr "About Carbonmark"
+
 #: components/Stats/StatsListings.tsx:49
 msgid "Active listings:"
 msgstr "Active listings:"
@@ -68,6 +134,11 @@ msgstr "Active listings:"
 msgid "Activity"
 msgstr "Activity"
 
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr "After you click the button below to continue, you will be asked to connect your wallet and the project you selected here will already be selected for you on KlimaDAO.finance. From there, follow the directions on that page to complete your transaction."
+
 #: lib/getCategoryInfo.ts:53
 msgid "Agriculture"
 msgstr "Agriculture"
@@ -75,6 +146,11 @@ msgstr "Agriculture"
 #: components/pages/Home/index.tsx:362
 msgid "All assets sourced from major registries"
 msgstr "All assets sourced from major registries"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr "All Retirements"
 
 #: components/CreateListing/Transaction/Submit.tsx:41
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
@@ -117,6 +193,10 @@ msgstr "Approve"
 msgid "Asset"
 msgstr "Asset"
 
+#: components/AssetDetails/index.tsx:53
+msgid "Asset details"
+msgstr "Asset details"
+
 #: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:24
 msgid "Asset Details"
 msgstr "Asset Details"
@@ -125,9 +205,13 @@ msgstr "Asset Details"
 msgid "Asset ID"
 msgstr "Asset ID"
 
-#: components/AssetDetails/index.tsx:53
-msgid "Asset details"
-msgstr "Asset details"
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:32
+msgid "Asset moved from one account to another, either via sale or inter-account transfer."
+msgstr "Asset moved from one account to another, either via sale or inter-account transfer."
+
+#: components/Activities/Activity.tsx:34
+msgid "at"
+msgstr "at"
 
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:131
 msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
@@ -142,11 +226,6 @@ msgstr ""
 "At this time, Carbonmark cannot process credit card payments\n"
 "exceeding {0}. Please adjust the\n"
 "quantity and try again later."
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
-msgstr "Available Tonnes:"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:116
 msgid "Available balance exceeded"
@@ -172,6 +251,11 @@ msgstr "Available to purchase"
 msgid "Available to retire"
 msgstr "Available to retire"
 
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr "Available Tonnes:"
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:219
 msgid "Available:"
 msgstr "Available:"
@@ -185,14 +269,20 @@ msgstr "Available: {0}"
 msgid "Available: {unlistedBalance}"
 msgstr "Available: {unlistedBalance}"
 
-#: components/BetaBadge/index.tsx:18
-msgid "BETA"
-msgstr "BETA"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
+msgid "retire.back_button"
+msgstr "back"
 
 #: components/pages/Project/Purchase/index.tsx:44
 #: components/pages/Project/Retire/index.tsx:35
 msgid "Back to Project"
 msgstr "Back to Project"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:49
+msgid "project.single.button.back_to_project_details"
+msgstr "Back to Project Details"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:397
 msgid "Balance"
@@ -208,6 +298,16 @@ msgstr "Balance exceeded"
 msgid "Balance: {0}"
 msgstr "Balance: {0}"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr "Balances"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
+msgid "offset_disclaimer"
+msgstr "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:450
 msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
 msgstr "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
@@ -216,13 +316,18 @@ msgstr "Be careful not to include any sensitive personal information (such as an
 msgid "Beneficiary Address"
 msgstr "Beneficiary Address"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
-msgid "Beneficiary Name"
-msgstr "Beneficiary Name"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
+msgid "retirement.single.beneficiary_address.title"
+msgstr "Beneficiary Address:"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:263
 msgid "Beneficiary name"
 msgstr "Beneficiary name"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
+msgid "Beneficiary Name"
+msgstr "Beneficiary Name"
 
 #: components/pages/Project/PayWithBank/index.tsx:232
 #: components/pages/Project/PayWithBank/index.tsx:349
@@ -234,11 +339,20 @@ msgstr "Beneficiary wallet address"
 msgid "Beneficiary wallet address (optional)"
 msgstr "Beneficiary wallet address (optional)"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.title"
+msgstr "Beneficiary:"
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:34
 #: components/pages/Project/BuyOptions/SellerListing.tsx:67
 #: components/pages/Project/index.tsx:137
 msgid "Best Price"
 msgstr "Best Price"
+
+#: components/BetaBadge/index.tsx:18
+msgid "BETA"
+msgstr "BETA"
 
 #: lib/getCategoryInfo.ts:65
 msgid "Blue Carbon"
@@ -248,9 +362,9 @@ msgstr "Blue Carbon"
 msgid "Book a demo"
 msgstr "Book a demo"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:35
-msgid "Bridge"
-msgstr "Bridge"
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
+msgstr "bought from"
 
 #: components/pages/Home/index.tsx:157
 #: components/pages/Home/index.tsx:188
@@ -264,6 +378,11 @@ msgstr "Browse Projects"
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:45
 #: components/pages/Project/BuyOptions/SellerListing.tsx:98
 msgid "Buy"
+msgstr "Buy"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:70
+msgid "seller.listing.buy"
 msgstr "Buy"
 
 #: components/pages/Home/index.tsx:168
@@ -282,6 +401,25 @@ msgstr "Can we remind you about this new feature later?"
 msgid "Cancel"
 msgstr "Cancel"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr "Carbon Credit Retirement"
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr "Carbon credits you purchase or any retirements you make on KlimaDAO.finance will also be accessible in your Carbonmark portfolio."
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:30
 msgid "Carbon Pool"
 msgstr "Carbon Pool"
@@ -289,6 +427,10 @@ msgstr "Carbon Pool"
 #: components/Layout/NavDropdown/index.tsx:117
 msgid "Carbon Portfolio"
 msgstr "Carbon Portfolio"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
+msgid "Carbon provenance"
+msgstr "Carbon provenance"
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:60
 msgid "Carbon Provenance"
@@ -298,17 +440,35 @@ msgstr "Carbon Provenance"
 msgid "Carbon Retirements"
 msgstr "Carbon Retirements"
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-msgstr "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:60
+msgid "retirement.totals.page_headline"
+msgstr "Carbon Retirements"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
-msgid "Carbon provenance"
-msgstr "Carbon provenance"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
+msgstr "Carbonmark - Carbon Retirements for beneficiary {0}"
 
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
-msgstr "Carbonmark Overview"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr "Carbonmark - Carbon Retirements for beneficiary {0}"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:42
+msgid "retirement.provenance.head.title"
+msgstr "Carbonmark | Carbon Retirement provenance"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr "Carbonmark | Carbon Retirement Receipt"
+
+#: components/pages/Home/index.tsx:51
+#: components/pages/Home/index.tsx:52
+msgid "Carbonmark | The Universal Carbon Marketplace"
+msgstr "Carbonmark | The Universal Carbon Marketplace"
 
 #: components/pages/Home/index.tsx:174
 msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
@@ -324,14 +484,18 @@ msgstr "Carbonmark fee"
 msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 msgstr "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 
-#: components/pages/Home/index.tsx:51
-#: components/pages/Home/index.tsx:52
-msgid "Carbonmark | The Universal Carbon Marketplace"
-msgstr "Carbonmark | The Universal Carbon Marketplace"
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
+msgstr "Carbonmark Overview"
 
 #: components/pages/Home/index.tsx:488
 msgid "Carbonmark's role"
 msgstr "Carbonmark's role"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
+msgstr "Categories"
 
 #: components/ProjectFilterModal/index.tsx:130
 msgid "Category"
@@ -342,6 +506,11 @@ msgstr "Category"
 msgid "Change language"
 msgstr "Change language"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:236
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr "Check your search for typos or try a different search term."
+
 #: components/pages/Home/index.tsx:206
 msgid "Choose a project and quantity"
 msgstr "Choose a project and quantity"
@@ -350,8 +519,13 @@ msgstr "Choose a project and quantity"
 msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 msgstr "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 
-#: components/ProjectFilterModal/index.tsx:162
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr "Clear All"
+
 #: components/pages/Projects/ProjectSearch/index.tsx:55
+#: components/ProjectFilterModal/index.tsx:162
 msgid "Clear Filters"
 msgstr "Clear Filters"
 
@@ -361,6 +535,11 @@ msgstr "Click the 'create profile' button to customize this page and get started
 
 #: components/CreateListing/Transaction/Submit.tsx:98
 msgid "Close"
+msgstr "Close"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
 msgstr "Close"
 
 #: components/Footer/index.tsx:32
@@ -388,6 +567,16 @@ msgstr "Compare prices across all sellers and trading pools"
 msgid "Compiling Results ..."
 msgstr "Compiling Results ..."
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr "Confirm amount"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr "Confirm price per tonne"
+
 #: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:83
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
 #: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
@@ -395,9 +584,18 @@ msgstr "Compiling Results ..."
 msgid "Confirm Purchase"
 msgstr "Confirm Purchase"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
+msgid "offset.retire_carbon"
+msgstr "Confirm Retirement"
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:75
 msgid "Confirm Retirement"
 msgstr "Confirm Retirement"
+
+#: components/Layout/index.tsx:52
+msgid "connect a wallet"
+msgstr "connect a wallet"
 
 #: components/pages/Portfolio/ConnectedWallet/index.tsx:33
 msgid "Connected Wallet"
@@ -423,6 +621,16 @@ msgstr "Contact"
 msgid "Continue"
 msgstr "Continue"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr "Contract address"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr "Contract address"
+
 #: components/CopyAddressButton/index.tsx:37
 msgid "Copy"
 msgstr "Copy"
@@ -440,15 +648,10 @@ msgstr "Could not delete listing. Please try again."
 msgid "Country"
 msgstr "Country"
 
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr "Create New Listing"
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Create Profile"
-msgstr "Create Profile"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
+msgid "retirement.single.country_region.title"
+msgstr "Country/Region:"
 
 #: components/CreateListing/index.tsx:165
 msgid "Create a listing"
@@ -466,6 +669,21 @@ msgstr "Create a seller profile"
 msgid "Create and edit listings, and track your activity with your Carbonmark profile."
 msgstr "Create and edit listings, and track your activity with your Carbonmark profile."
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:136
+msgid "profile.addListing_modal.submit"
+msgstr "Create Listing"
+
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr "Create New Listing"
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Create Profile"
+msgstr "Create Profile"
+
 #: components/pages/Home/index.tsx:313
 msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
 msgstr "Create your own carbon storefront. Sell directly to organizations and individuals alike."
@@ -474,25 +692,29 @@ msgstr "Create your own carbon storefront. Sell directly to organizations and in
 msgid "Create your own retirement"
 msgstr "Create your own retirement"
 
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr "created listing"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:87
 msgid "Created:"
 msgstr "Created:"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
-msgid "Credit ID"
-msgstr "Credit ID"
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
-msgstr "Credit card minimum purchase is ${formattedFiatMinimum}"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:77
 msgid "Credit card minimum purchase is {0}"
 msgstr "Credit card minimum purchase is {0}"
 
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr "Credit card minimum purchase is ${formattedFiatMinimum}"
+
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:247
 msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
 msgstr "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
+msgid "Credit ID"
+msgstr "Credit ID"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:435
 msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
@@ -502,10 +724,6 @@ msgstr "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments.
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
 msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
 msgstr "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
-msgstr "DATE"
 
 #: components/pages/Project/index.tsx:234
 msgid "Data for this project and vintage"
@@ -520,9 +738,27 @@ msgstr "Data for this seller"
 msgid "Date"
 msgstr "Date"
 
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr "DATE"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
+msgid "offset.default_retirement_address"
+msgstr "Defaults to the connected wallet address"
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:296
 msgid "Defaults to the connected wallet address"
 msgstr "Defaults to the connected wallet address"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
+msgid "profile.listing.edit.delete_listing"
+msgstr "Delete Listing"
+
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
+msgstr "deleted listing"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:307
 msgid "Describe the purpose of this retirement"
@@ -532,6 +768,11 @@ msgstr "Describe the purpose of this retirement"
 msgid "Description"
 msgstr "Description"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
+msgid "retirement.single.project_description.title"
+msgstr "Description"
+
 #: components/pages/Resources/lib/cmsDataMap.ts:51
 msgid "Digital Carbon"
 msgstr "Digital Carbon"
@@ -539,6 +780,11 @@ msgstr "Digital Carbon"
 #: components/pages/Home/index.tsx:264
 msgid "Digitize your carbon by using a supported bridge"
 msgstr "Digitize your carbon by using a supported bridge"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
+msgstr "Disclaimer:"
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
 msgid "Display name"
@@ -564,18 +810,29 @@ msgstr "Downloading ..."
 msgid "Drive climate action and earn rewards with a carbon-backed digital currency."
 msgstr "Drive climate action and earn rewards with a carbon-backed digital currency."
 
+#: components/pages/Project/Purchase/Listing/Price.tsx:18
+#: components/pages/Project/Purchase/Pool/Price.tsx:17
+#: components/pages/Project/Retire/Pool/Price.tsx:17
+msgid "each"
+msgstr "each"
+
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:195
 msgid "Edit"
 msgstr "Edit"
+
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
+msgid "Edit listing"
+msgstr "Edit listing"
 
 #: components/pages/Users/SellerConnected/index.tsx:113
 #: components/pages/Users/SellerConnected/index.tsx:138
 msgid "Edit Profile"
 msgstr "Edit Profile"
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
-msgid "Edit listing"
-msgstr "Edit listing"
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
+msgstr "Edit your profile to add a description."
 
 #: components/pages/Project/PayWithBank/index.tsx:143
 #: components/pages/Project/PayWithBank/index.tsx:307
@@ -635,6 +892,19 @@ msgstr "First name should not contain numbers or special characters"
 msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
 msgstr "First, approve the Carbonmark system to transfer this asset on your behalf."
 
+#: components/Activities/Activity.tsx:112
+msgid "for"
+msgstr "for"
+
+#: components/pages/Retire/index.tsx:52
+msgid "for beneficiary"
+msgstr "for beneficiary"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:66
+msgid "retirement.totals.page_subline"
+msgstr "for beneficiary"
+
 #: components/pages/Home/index.tsx:340
 msgid "For carbon traders"
 msgstr "For carbon traders"
@@ -651,21 +921,27 @@ msgstr "Forestry"
 msgid "Form complete"
 msgstr "Form complete"
 
-#: components/pages/Home/index.tsx:76
-msgid "Get Started"
-msgstr "Get Started"
-
 #: components/pages/Home/index.tsx:390
 msgid "Get paid immediately: transactions are resolved in seconds"
 msgstr "Get paid immediately: transactions are resolved in seconds"
 
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
-msgstr "Go Back"
+#: components/pages/Home/index.tsx:76
+msgid "Get Started"
+msgstr "Get Started"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:83
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
+msgstr "Go back"
 
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
 msgid "Go back"
 msgstr "Go back"
+
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
+msgstr "Go Back"
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:145
 msgid "Handle is required"
@@ -690,8 +966,8 @@ msgid "Here’s a list of readily available, discounted carbon tokens to retire 
 msgstr "Here’s a list of readily available, discounted carbon tokens to retire quickly and easily."
 
 #: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:48
-msgid "Hide {numberOfTransfers} transfers"
-msgstr "Hide {numberOfTransfers} transfers"
+msgid "Hide {numberOfTransfers} transactions"
+msgstr "Hide {numberOfTransfers} transactions"
 
 #: components/CreateListing/Form/index.tsx:80
 msgid "How many tonnes do you want to list for sale?"
@@ -705,6 +981,11 @@ msgstr "How many tonnes of carbon do you want to buy?"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:249
 msgid "How many tonnes of carbon do you want to retire?"
 msgstr "How many tonnes of carbon do you want to retire?"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
+msgid "offset.amount_in_tonnes"
+msgstr "How many tonnes of carbon would you like to offset? <0>* </0>"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:215
 msgid "How many tonnes of carbon would you like to retire?"
@@ -729,6 +1010,11 @@ msgstr "ICR credits can only be retired in whole tonnes"
 #: components/pages/Purchases/index.tsx:93
 msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
 msgstr "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
+msgid "retirement.single.transaction_record.title"
+msgstr "Immutable transaction record"
 
 #: components/pages/Project/PayWithBank/index.tsx:116
 msgid "Indicates required field"
@@ -784,14 +1070,14 @@ msgstr "Last name should not contain numbers or special characters"
 msgid "Latest First"
 msgstr "Latest First"
 
+#: components/pages/Home/index.tsx:417
+msgid "Learn more"
+msgstr "Learn more"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:92
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:103
 msgid "Learn More"
 msgstr "Learn More"
-
-#: components/pages/Home/index.tsx:417
-msgid "Learn more"
-msgstr "Learn more"
 
 #: components/pages/Home/index.tsx:491
 msgid "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
@@ -824,11 +1110,11 @@ msgid "Loading your assets"
 msgstr "Loading your assets"
 
 #: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:295
 #: components/pages/Retire/Activity/Overview.tsx:73
 #: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
 msgid "Loading..."
 msgstr "Loading..."
 
@@ -868,6 +1154,11 @@ msgstr "Logout"
 msgid "Marketplace"
 msgstr "Marketplace"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr "Marketplace"
+
 #: components/pages/Projects/index.tsx:73
 #: components/pages/Projects/index.tsx:74
 msgid "Marketplace | Carbonmark"
@@ -877,21 +1168,36 @@ msgstr "Marketplace | Carbonmark"
 msgid "Maximize your climate impact."
 msgstr "Maximize your climate impact."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.moss_offset.description"
+msgstr "MC02 credits are generated by projects that preserve the Amazon Forest, with all sorts of positive externalities such as the creation of local jobs and preservation of local biodiversity. Explore MCO2 on <0>data.klimadao.finance</0>."
+
 #: components/pages/Project/index.tsx:144
 msgid "Methodology"
 msgstr "Methodology"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.methodology.title"
+msgstr "Methodology:"
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:54
 msgid "Moss"
 msgstr "Moss"
 
-#: components/FeatureBanner/index.tsx:33
-msgid "NEW FEATURE:"
-msgstr "NEW FEATURE:"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
+msgid "retirement.single.moss_offset.name"
+msgstr "MOSS Earth MC02"
 
 #: components/Layout/NavDropdown/index.tsx:171
 msgid "Navigation Menu"
 msgstr "Navigation Menu"
+
+#: components/FeatureBanner/index.tsx:33
+msgid "NEW FEATURE:"
+msgstr "NEW FEATURE:"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
 msgid "New Quantity"
@@ -905,18 +1211,28 @@ msgstr "New Unit Price (USDC)"
 msgid "Next"
 msgstr "Next"
 
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
-msgstr "No Activity to show."
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
+msgstr "Next"
 
 #: components/pages/Users/SellerConnected/index.tsx:197
 #: components/pages/Users/SellerUnconnected/index.tsx:83
 msgid "No active listings."
 msgstr "No active listings."
 
+#. js-lingui-explicit-id
+#: components/Activities/index.tsx:29
+msgid "user.activities.empty_state"
+msgstr "No activity to show"
+
 #: components/pages/Retire/Activity/Quotes.tsx:38
 msgid "No activity to show"
 msgstr "No activity to show"
+
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
+msgstr "No Activity to show."
 
 #: components/pages/Home/index.tsx:400
 msgid "No barriers to entry for verified carbon projects"
@@ -925,6 +1241,11 @@ msgstr "No barriers to entry for verified carbon projects"
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:40
 msgid "No beneficiary address available"
 msgstr "No beneficiary address available"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
+msgid "retirement.single.beneficiary.placeholder"
+msgstr "No beneficiary name provided"
 
 #: components/pages/Retire/Activity/Overview.tsx:62
 msgid "No data to show"
@@ -959,24 +1280,39 @@ msgstr "No records found"
 msgid "No retirement message provided."
 msgstr "No retirement message provided."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
+msgstr "No retirement timestamp provided"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr "No retirements found"
+
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
 msgid "No transaction id available"
 msgstr "No transaction id available"
-
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
-msgstr "Not Connected"
 
 #: components/pages/Project/PayWithBank/index.tsx:240
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:288
 msgid "Not a valid polygon address"
 msgstr "Not a valid polygon address"
 
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr "Not Connected"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
+msgid "retirement.single.official_certificate.title"
+msgstr "Official Certificate for On-Chain Carbon Retirement Provided by <0>Carbonmark.com</0>"
+
 #: components/pages/Resources/lib/cmsDataMap.ts:72
 msgid "Oldest First"
 msgstr "Oldest First"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:185
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:188
 msgid "On the Verra page, search for the specific serial number."
 msgstr "On the Verra page, search for the specific serial number."
 
@@ -1000,22 +1336,18 @@ msgstr "Our system is taking longer than expected. The retirement should appear 
 msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 msgstr "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr "PROJECT"
-
 #: components/pages/Projects/Banners/BankTransfer.tsx:74
 msgid "Pay via Bank Transfer / Wire"
 msgstr "Pay via Bank Transfer / Wire"
+
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
+msgstr "Pay with bank transfer"
 
 #: components/pages/Project/PayWithBank/index.tsx:89
 #: components/pages/Project/PayWithBank/index.tsx:90
 msgid "Pay with Bank Transfer | Carbonmark"
 msgstr "Pay with Bank Transfer | Carbonmark"
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
-msgstr "Pay with bank transfer"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:94
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:112
@@ -1023,22 +1355,18 @@ msgstr "Pay with bank transfer"
 msgid "Pay with:"
 msgstr "Pay with:"
 
-#: components/pages/Purchases/index.tsx:62
-msgid "Payment Successful"
-msgstr "Payment Successful"
-
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:243
 msgid "Payment processing fee"
 msgstr "Payment processing fee"
+
+#: components/pages/Purchases/index.tsx:62
+msgid "Payment Successful"
+msgstr "Payment Successful"
 
 #: components/pages/Project/PayWithBank/index.tsx:161
 #: components/pages/Project/PayWithBank/index.tsx:313
 msgid "Phone number"
 msgstr "Phone number"
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
-msgstr "Please Log In"
 
 #: lib/statusMessage.ts:27
 msgid "Please click 'confirm' in your wallet to continue."
@@ -1048,11 +1376,25 @@ msgstr "Please click 'confirm' in your wallet to continue."
 msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr "Please Log In"
+
 #: components/pages/Portfolio/index.tsx:66
 #: components/pages/Users/SellerConnected/index.tsx:75
 #: components/pages/Users/SellerConnected/index.tsx:101
 msgid "Please refresh the page. There was an error updating your data: {e}."
 msgstr "Please refresh the page. There was an error updating your data: {e}."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:243
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr "Please use a different filter combination."
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
+msgstr "Portfolio"
 
 #: components/pages/Portfolio/index.tsx:76
 #: components/pages/Portfolio/index.tsx:77
@@ -1071,10 +1413,6 @@ msgstr "Press Releases"
 msgid "Price Highest"
 msgstr "Price Highest"
 
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr "Price Lowest"
-
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:180
@@ -1084,6 +1422,10 @@ msgstr "Price includes network fees. <0>See docs to learn more.</0>"
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:160
 msgid "Price is required"
 msgstr "Price is required"
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
+msgstr "Price Lowest"
 
 #: components/CreateListing/Transaction/Submit.tsx:62
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
@@ -1119,19 +1461,48 @@ msgstr "Processing retirement..."
 msgid "Profile"
 msgstr "Profile"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr "Profile"
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:192
 msgid "Profile picture"
 msgstr "Profile picture"
+
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr "PROJECT"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
+msgid "retirement.single.project_details.title"
+msgstr "Project Details"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
+msgid "retirement.single.project_name.title"
+msgstr "Project Name"
 
 #: components/pages/Project/PayWithBank/index.tsx:253
 #: components/pages/Project/PayWithBank/index.tsx:357
 msgid "Project names of interest"
 msgstr "Project names of interest"
 
-#: components/pages/Purchases/index.tsx:36
-#: components/pages/Purchases/index.tsx:37
-msgid "Purchase Receipt | Carbonmark"
-msgstr "Purchase Receipt | Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
+msgid "retirement.single.project.title"
+msgstr "Project:"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr "Proof of"
+
+#: components/pages/Project/Purchase/index.tsx:32
+#: components/pages/Project/Purchase/index.tsx:33
+msgid "Purchase {0} | Carbonmark"
+msgstr "Purchase {0} | Carbonmark"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:53
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
@@ -1142,6 +1513,11 @@ msgstr "Purchase amount (tonnes):"
 msgid "Purchase more Carbon"
 msgstr "Purchase more Carbon"
 
+#: components/pages/Purchases/index.tsx:36
+#: components/pages/Purchases/index.tsx:37
+msgid "Purchase Receipt | Carbonmark"
+msgstr "Purchase Receipt | Carbonmark"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:79
 msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer."
 msgstr "Purchase retirements from any project on Carbonmark and pay via bank transfer."
@@ -1149,11 +1525,6 @@ msgstr "Purchase retirements from any project on Carbonmark and pay via bank tra
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
 msgid "Purchase successful"
 msgstr "Purchase successful"
-
-#: components/pages/Project/Purchase/index.tsx:32
-#: components/pages/Project/Purchase/index.tsx:33
-msgid "Purchase {0} | Carbonmark"
-msgstr "Purchase {0} | Carbonmark"
 
 #: components/pages/Retire/Activity/Table.tsx:47
 msgid "QTY"
@@ -1169,6 +1540,11 @@ msgstr "Quantity"
 msgid "Quantity Available:"
 msgstr "Quantity Available:"
 
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr "Quantity Available:"
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:240
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:108
 msgid "Quantity is required"
@@ -1182,21 +1558,18 @@ msgstr "Quantity listed: {listedQuantity}, Quantity unlisted: {unlistedQuantity}
 msgid "Quantity purchased:"
 msgstr "Quantity purchased:"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr "QUANTITY RETIRED"
+
 #: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr "Quick Retire"
 
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr "RETIRE CARBON"
-
 #: components/pages/Project/index.tsx:198
 msgid "Read Less"
 msgstr "Read Less"
-
-#: components/pages/Project/index.tsx:198
-msgid "Read More"
-msgstr "Read More"
 
 #: components/pages/Home/index.tsx:445
 #: components/pages/Home/index.tsx:472
@@ -1205,6 +1578,10 @@ msgstr "Read More"
 #: components/pages/Resources/FeaturedArticles/Article.tsx:45
 msgid "Read more"
 msgstr "Read more"
+
+#: components/pages/Project/index.tsx:198
+msgid "Read More"
+msgstr "Read More"
 
 #: components/pages/Home/index.tsx:351
 msgid "Real-time price and transaction data powered by the blockchain"
@@ -1222,14 +1599,14 @@ msgstr "Remaining Supply:"
 msgid "Renewable Energy"
 msgstr "Renewable Energy"
 
+#: lib/constants.ts:82
+msgid "Request already processing. Please open your wallet and complete the request."
+msgstr "Request already processing. Please open your wallet and complete the request."
+
 #: components/pages/Home/index.tsx:301
 #: components/pages/Home/index.tsx:325
 msgid "Request Demo"
 msgstr "Request Demo"
-
-#: lib/constants.ts:82
-msgid "Request already processing. Please open your wallet and complete the request."
-msgstr "Request already processing. Please open your wallet and complete the request."
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:210
 msgid "Required Field"
@@ -1239,6 +1616,11 @@ msgstr "Required Field"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:311
 msgid "Required when proceeding with Credit Card"
 msgstr "Required when proceeding with Credit Card"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
+msgstr "Resource Center"
 
 #: components/Footer/index.tsx:38
 #: components/pages/Home/index.tsx:508
@@ -1266,15 +1648,36 @@ msgstr "Results"
 msgid "Retire"
 msgstr "Retire"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr "Retire"
+
+#: components/pages/Portfolio/Retire/index.tsx:88
+#: components/pages/Portfolio/Retire/index.tsx:89
+#: components/pages/Retire/index.tsx:38
+#: components/pages/Retire/index.tsx:39
+msgid "Retire | Carbonmark"
+msgstr "Retire | Carbonmark"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:388
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
 msgid "Retire Carbon"
 msgstr "Retire Carbon"
 
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr "RETIRE CARBON"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:233
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "Retire carbon credits for yourself, or on behalf of another person or organization."
+
+#: components/pages/Project/Retire/index.tsx:23
+#: components/pages/Project/Retire/index.tsx:24
+msgid "Retire from {fullProjectid} | Carbonmark"
+msgstr "Retire from {fullProjectid} | Carbonmark"
 
 #: components/pages/Retire/index.tsx:72
 msgid "Retire from a featured project"
@@ -1284,24 +1687,19 @@ msgstr "Retire from a featured project"
 msgid "Retire from your portfolio"
 msgstr "Retire from your portfolio"
 
-#: components/pages/Project/Retire/index.tsx:23
-#: components/pages/Project/Retire/index.tsx:24
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr "Retire from {fullProjectid} | Carbonmark"
-
 #: components/pages/Home/index.tsx:232
 msgid "Retire instantly, or purchase and hold digital carbon"
 msgstr "Retire instantly, or purchase and hold digital carbon"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
-msgstr "Retire more Carbon"
 
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
 msgid "Retire more carbon"
 msgstr "Retire more carbon"
+
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
+msgstr "Retire more Carbon"
 
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:56
 #: components/pages/Project/BuyOptions/SellerListing.tsx:106
@@ -1316,14 +1714,16 @@ msgstr "Retire now, or acquire carbon to retire later - you decide what to do wh
 msgid "Retire your carbon via bank transfer."
 msgstr "Retire your carbon via bank transfer."
 
-#: components/pages/Portfolio/Retire/index.tsx:88
-#: components/pages/Portfolio/Retire/index.tsx:89
-#: components/pages/Retire/index.tsx:38
-#: components/pages/Retire/index.tsx:39
-msgid "Retire | Carbonmark"
-msgstr "Retire | Carbonmark"
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
+msgstr "retired"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:13
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:90
+msgid "retirement.totals.retired_assets"
+msgstr "Retired Assets"
+
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:16
 msgid "Retirement"
 msgstr "Retirement"
 
@@ -1331,33 +1731,53 @@ msgstr "Retirement"
 msgid "Retirement Activity"
 msgstr "Retirement Activity"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
-msgid "Retirement Message"
-msgstr "Retirement Message"
-
-#: components/pages/Retire/Activity/Overview.tsx:60
-#: components/pages/Retire/Activity/Overview.tsx:70
-msgid "Retirement Overview"
-msgstr "Retirement Overview"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr "Retirement Successful!"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
+msgid "offset.retirement_message"
+msgstr "Retirement message"
 
 #: components/pages/Project/PayWithBank/index.tsx:264
 #: components/pages/Project/PayWithBank/index.tsx:363
 msgid "Retirement message"
 msgstr "Retirement message"
 
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
+msgid "Retirement Message"
+msgstr "Retirement Message"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr "Retirement Message:"
+
+#: components/pages/Retire/Activity/Overview.tsx:60
+#: components/pages/Retire/Activity/Overview.tsx:70
+msgid "Retirement Overview"
+msgstr "Retirement Overview"
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:74
 msgid "Retirement successful"
 msgstr "Retirement successful"
 
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr "Retirement Successful!"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:106
+msgid "retirement.totals.retirements"
+msgstr "Retirements"
+
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:384
 msgid "Retiring Token"
 msgstr "Retiring Token"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
+msgid "profile.edit_modal.submit"
+msgstr "Save Changes"
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:201
 msgid "Say a few words about yourself. This will be visible in your seller profile."
@@ -1394,6 +1814,11 @@ msgstr "Select"
 msgid "Select a language"
 msgstr "Select a language"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr "Select one or more"
+
 #: components/pages/Portfolio/AssetProject/index.tsx:100
 #: components/pages/Portfolio/AssetProject/index.tsx:108
 msgid "Sell"
@@ -1411,13 +1836,27 @@ msgstr "Sell your digital carbon directly to buyers"
 msgid "Seller Listing"
 msgstr "Seller Listing"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:159
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:29
+msgid "Send"
+msgstr "Send"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:161
 msgid "Serial Number"
 msgstr "Serial Number"
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:76
 msgid "Share this page"
 msgstr "Share this page"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
+msgid "retirement.single.share_retirement.title"
+msgstr "Share this retirement"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:289
+msgid "resources.mobile_modal.button.show_results"
+msgstr "Show Results"
 
 #: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
 #: components/pages/Project/Purchase/Pool/SubmitButton.tsx:31
@@ -1432,6 +1871,19 @@ msgstr "Single Price is required"
 #: components/CreateListing/Form/index.tsx:130
 msgid "Single unit price"
 msgstr "Single unit price"
+
+#: components/Layout/index.tsx:51
+msgid "social or email"
+msgstr "social or email"
+
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr "sold to"
+
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
+msgid "something went wrong loading the allowance"
+msgstr "something went wrong loading the allowance"
 
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
 msgid "Something went wrong loading the allowance"
@@ -1457,13 +1909,28 @@ msgstr "Sorry, something went wrong."
 msgid "Sorry, this handle already exists"
 msgstr "Sorry, this handle already exists"
 
-#: components/pages/Resources/ResourcesList/index.tsx:265
-msgid "Sort By"
-msgstr "Sort By"
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:222
+msgid "resources.page.list.on_fetch_error"
+msgstr "Sorry! Something went wrong."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:230
+msgid "resources.page.list.no_search_results.title"
+msgstr "Sorry. We couldn't find any matching results."
 
 #: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "Sort by"
 msgstr "Sort by"
+
+#: components/pages/Resources/ResourcesList/index.tsx:265
+msgid "Sort By"
+msgstr "Sort By"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:197
+msgid "shared.resources.sort_by.header"
+msgstr "Sort by:"
 
 #: components/Stats/index.tsx:23
 msgid "Stats"
@@ -1489,6 +1956,21 @@ msgstr "Step 3"
 msgid "Submit"
 msgstr "Submit"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr "Submit"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr "Submit amount"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr "Submit price per tonne:"
+
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:88
 msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
 msgstr "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
@@ -1501,13 +1983,25 @@ msgstr "Sure"
 msgid "Switch to Polygon"
 msgstr "Switch to Polygon"
 
-#: components/BetaBadge/index.tsx:16
-msgid "TESTNET"
-msgstr "TESTNET"
+#: components/pages/Retire/Activity/Overview.tsx:77
+#: components/pages/Retire/Activity/Quotes.tsx:76
+#: components/pages/Retire/Activity/Table.tsx:65
+msgid "t"
+msgstr "t"
 
 #: components/Footer/index.tsx:29
 msgid "Terms of Use"
 msgstr "Terms of Use"
+
+#: components/BetaBadge/index.tsx:16
+msgid "TESTNET"
+msgstr "TESTNET"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
+msgstr "Thank you for supporting the planet!"
 
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
 msgid "Thank you for supporting the planet!"
@@ -1517,21 +2011,32 @@ msgstr "Thank you for supporting the planet!"
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr "Thank you for supporting the planet! See purchase details below."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
+msgstr "Thank you for supporting the planet! View transaction on <0> PolygonScan.</0>"
+
 #: components/pages/Project/PayWithBank/index.tsx:292
 msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
-
-#: components/pages/Home/index.tsx:65
-msgid "The Universal Carbon Marketplace"
-msgstr "The Universal Carbon Marketplace"
 
 #: components/CreateListing/Transaction/Approve.tsx:44
 msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 msgstr "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:34
 msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
 msgstr "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
+msgstr "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
 msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
@@ -1540,6 +2045,12 @@ msgstr "The first step is to grant the approval to transfer your payment asset f
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
 msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
 msgstr "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
+msgstr "The information provided in this blog post pertaining to KlimaDAO (“KlimaDAO”), its crypto-assets, business assets, strategy, and operations, is for general informational purposes only and is not a formal offer to sell or a solicitation of an offer to buy any securities, options, futures, or other derivatives related to securities in any jurisdiction and its content is not prescribed by securities laws. Information contained in this blog post should not be relied upon as advice to buy or sell or hold such securities or as an offer to sell such securities. This blog post does not take into account nor does it provide any tax, legal or investment advice or opinion regarding the specific investment objectives or financial situation of any person. KlimaDAO and its agents, advisors, directors, officers, employees and shareholders make no representation or warranties, expressed or implied, as to the accuracy of such information and KlimaDAO expressly disclaims any and all liability that may be based on such information or errors or omissions thereof. KlimaDAO reserves the right to amend or replace the information contained herein, in part or entirely, at any time, and undertakes no obligation to provide the recipient with access to the amended information or to notify the recipient thereof. The information contained in this blog post supersedes any prior blog post or conversation concerning the same, similar or related information. Any information, representations or statements not contained herein shall not be relied upon for any purpose. Neither KlimaDAO nor any of its representatives shall have any liability whatsoever, under contract, tort, trust or otherwise, to you or any person resulting from the use of the information in this blog post by you or any of your representatives or for omissions from the information in this blog post. Additionally, KlimaDAO undertakes no obligation to comment on the expectations of, or statements made by, third parties in respect of the matters discussed in this blog post."
 
 #: components/pages/Home/index.tsx:53
 #: components/pages/Home/index.tsx:68
@@ -1579,13 +2090,27 @@ msgstr "The minimum price per tonne is {0}"
 msgid "The minimum quantity to sell is 1 tonne"
 msgstr "The minimum quantity to sell is 1 tonne"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:53
 msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 msgstr "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
 msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
 msgstr "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
+
+#: components/pages/Home/index.tsx:65
+msgid "The Universal Carbon Marketplace"
+msgstr "The Universal Carbon Marketplace"
 
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:208
 msgid "There was an error during the checkout process. Please try again."
@@ -1608,6 +2133,11 @@ msgstr "There was an error loading the total cost."
 msgid "This app only works on Polygon Mainnet."
 msgstr "This app only works on Polygon Mainnet."
 
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:24
+msgid "user.login.description"
+msgstr "This feature is available only to users who are logged in. You can log in or create an account via the button below."
+
 #: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
 msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
 msgstr "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
@@ -1628,13 +2158,27 @@ msgstr "This offer no longer exists."
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr "This product is still in Beta and audits have not been completed yet."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
+msgid "retirement.single.immutable_public_records.title"
+msgstr "This represents the permanent retirement of a digital carbon asset. This retirement and the associated data are immutable public records."
+
 #: components/pages/Users/ProfileHeader/index.tsx:46
 msgid "This user has not yet created a carbonmark profile."
 msgstr "This user has not yet created a carbonmark profile."
 
+#: components/Activities/Activity.tsx:119
+msgid "to"
+msgstr "to"
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
+msgstr "To finalize your retirement, verify all information is correct and then click 'submit' below."
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:60
 msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
@@ -1648,22 +2192,22 @@ msgstr "To get started, be sure to complete your <0>profile</0> and then head to
 msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr "To pay via bank transfer, we'll need to gather some information from you."
 
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr "Toggle Select Project"
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr "Toggle Sorted by menu"
-
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
 msgid "Toggle payment method"
 msgstr "Toggle payment method"
 
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr "Toggle Select Project"
+
 #: components/pages/Projects/ProjectSort/index.tsx:29
 msgid "Toggle sort menu"
 msgstr "Toggle sort menu"
+
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
+msgstr "Toggle Sorted by menu"
 
 #: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:209
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
@@ -1673,6 +2217,10 @@ msgstr "Token you will receive"
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
 msgid "Tokens received:"
 msgstr "Tokens received:"
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
+msgid "tonnes"
+msgstr "tonnes"
 
 #: components/AssetDetails/index.tsx:63
 #: components/pages/Project/PayWithBank/index.tsx:125
@@ -1693,22 +2241,6 @@ msgstr "Tonnes listed:"
 msgid "Tonnes sold:"
 msgstr "Tonnes sold:"
 
-#: components/CreateListing/Form/index.tsx:85
-msgid "Total Amount to Sell is required"
-msgstr "Total Amount to Sell is required"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
-msgid "Total Cost is required"
-msgstr "Total Cost is required"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr "Total Price"
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr "Total Retirements:"
-
 #: components/CreateListing/Transaction/Approve.tsx:61
 msgid "Total allowance"
 msgstr "Total allowance"
@@ -1717,9 +2249,18 @@ msgstr "Total allowance"
 msgid "Total amount of tonnes to retire is required"
 msgstr "Total amount of tonnes to retire is required"
 
+#: components/CreateListing/Form/index.tsx:85
+msgid "Total Amount to Sell is required"
+msgstr "Total Amount to Sell is required"
+
 #: components/pages/Retire/Activity/Overview.tsx:72
 msgid "Total carbon tonnes retired"
 msgstr "Total carbon tonnes retired"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:98
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr "Total Carbon Tonnes Retired"
 
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
@@ -1727,10 +2268,18 @@ msgstr "Total carbon tonnes retired"
 msgid "Total cost"
 msgstr "Total cost"
 
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
+msgid "Total Cost is required"
+msgstr "Total Cost is required"
+
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:166
 msgid "Total price"
 msgstr "Total price"
+
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
+msgstr "Total Price"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:103
 msgid "Total quantity to list for sale"
@@ -1739,6 +2288,15 @@ msgstr "Total quantity to list for sale"
 #: components/pages/Retire/Activity/Overview.tsx:83
 msgid "Total retirement transactions"
 msgstr "Total retirement transactions"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:112
+msgid "retirement.totals.total_retirement_transactions"
+msgstr "Total Retirement Transactions"
+
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
+msgstr "Total Retirements:"
 
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
@@ -1749,25 +2307,32 @@ msgstr "Total sale cost"
 msgid "Transaction complete."
 msgstr "Transaction complete."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
+msgid "retirement.single.transaction_id.title"
+msgstr "Transaction ID"
+
 #: lib/statusMessage.ts:29
 msgid "Transaction initiated. Waiting for network confirmation."
 msgstr "Transaction initiated. Waiting for network confirmation."
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:24
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:48
 msgid "Transfer"
 msgstr "Transfer"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:50
+msgid "retirement.provenance.head.metaDescription"
+msgstr "Transparent, on-chain offsets powered by Carbonmark."
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:128
 msgid "Transparent, on-chain offsets powered by Carbonmark."
 msgstr "Transparent, on-chain offsets powered by Carbonmark."
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "USDC per ton"
-msgstr "USDC per ton"
-
-#: components/CreateListing/Form/index.tsx:110
-msgid "USDC per tonne"
-msgstr "USDC per tonne"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.type.title"
+msgstr "Type:"
 
 #: components/CreateListing/Form/index.tsx:115
 msgid "Unit price is required"
@@ -1785,6 +2350,18 @@ msgstr "Unprecedented transparency across the digital carbon market."
 msgid "Update listing"
 msgstr "Update listing"
 
+#: components/Activities/Activities.constants.ts:10
+msgid "updated expiration"
+msgstr "updated expiration"
+
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr "updated price"
+
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr "updated quantity"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:91
 msgid "Updated:"
 msgstr "Updated:"
@@ -1792,6 +2369,14 @@ msgstr "Updated:"
 #: components/pages/Users/SellerConnected/index.tsx:191
 msgid "Updating your data..."
 msgstr "Updating your data..."
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "USDC per ton"
+msgstr "USDC per ton"
+
+#: components/CreateListing/Form/index.tsx:110
+msgid "USDC per tonne"
+msgstr "USDC per tonne"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:61
 msgid "User Guides"
@@ -1806,6 +2391,21 @@ msgstr "User Profile | Carbonmark"
 msgid "User refused connection."
 msgstr "User refused connection."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr "Verified tonnes of carbon retired"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr "Verify all information is correct and click 'approve' to continue."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr "Verify all information is correct and click 'approve' to continue."
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:41
 msgid "Verify all information is correct and click 'approve' to continue."
@@ -1815,17 +2415,9 @@ msgstr "Verify all information is correct and click 'approve' to continue."
 msgid "View"
 msgstr "View"
 
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
-msgid "View Carbonmark Profile"
-msgstr "View Carbonmark Profile"
-
-#: components/pages/Project/index.tsx:207
-msgid "View Registry Details <0/>"
-msgstr "View Registry Details <0/>"
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
-msgstr "View Results"
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
+msgid "View {numberOfTransfers} transactions"
+msgstr "View {numberOfTransfers} transactions"
 
 #: components/pages/Portfolio/index.tsx:78
 msgid "View a complete overview of the digital carbon that you own in your Portfolio."
@@ -1860,9 +2452,17 @@ msgstr "View and purchase this carbon offset project on Carbonmark"
 msgid "View and share certificate"
 msgstr "View and share certificate"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:180
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
+msgid "View Carbonmark Profile"
+msgstr "View Carbonmark Profile"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:183
 msgid "View issuance on Verra"
 msgstr "View issuance on Verra"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
+msgid "View on Polygonscan"
+msgstr "View on Polygonscan"
 
 #: components/AssetDetails/index.tsx:69
 msgid "View on PolygonScan"
@@ -1872,9 +2472,13 @@ msgstr "View on PolygonScan"
 msgid "View on PolygonScan <0/>"
 msgstr "View on PolygonScan <0/>"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
-msgid "View on Polygonscan"
-msgstr "View on Polygonscan"
+#: components/pages/Project/index.tsx:207
+msgid "View Registry Details <0/>"
+msgstr "View Registry Details <0/>"
+
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
+msgstr "View Results"
 
 #: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:99
 msgid "View retirement"
@@ -1888,9 +2492,10 @@ msgstr "View the entire transaction history – from bridging event until retire
 msgid "View the project details and other info for this purchase."
 msgstr "View the project details and other info for this purchase."
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
-msgid "View {numberOfTransfers} transfers"
-msgstr "View {numberOfTransfers} transfers"
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:145
+msgid "purchase.button.view_assets"
+msgstr "View Your Assets"
 
 #: components/ProjectFilterModal/index.tsx:141
 msgid "Vintage"
@@ -1903,6 +2508,11 @@ msgstr "Vintage Newest"
 #: components/ProjectFilterModal/constants.tsx:15
 msgid "Vintage Oldest"
 msgstr "Vintage Oldest"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
+msgid "retirement.single.vintage.title"
+msgstr "Vintage:"
 
 #: components/pages/Purchases/index.tsx:66
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
@@ -1924,12 +2534,22 @@ msgstr "We’ve hand-curated some of the best projects based on strict criteria,
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
+msgid "offset.retirement_credit"
+msgstr "Who will this retirement be credited to?"
+
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:257
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
 msgid "Who will this retirement be credited to?"
 msgstr "Who will this retirement be credited to?"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
+msgstr "With over 20 million verified digital carbon credits from hundreds of projects, Carbonmark offers the largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading. <0>Get started today</0>."
 
 #: components/shared/InvalidNetworkModal/index.tsx:64
 msgid "Wrong Network"
@@ -1941,9 +2561,19 @@ msgstr "Wrong Network"
 msgid "You"
 msgstr "You"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr "You are about to purchase a carbon asset."
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
 msgid "You are about to purchase a carbon asset."
 msgstr "You are about to purchase a carbon asset."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
+msgstr "You are about to retire a carbon asset."
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:31
 msgid "You are about to retire a carbon asset."
@@ -1991,13 +2621,10 @@ msgstr "You must have a profile created to view carbon assets you own in your Ca
 msgid "You successfully acquired carbon!"
 msgstr "You successfully acquired carbon!"
 
-#: components/pages/Users/SellerConnected/index.tsx:221
-msgid "Your Profile"
-msgstr "Your Profile"
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
-msgstr "Your Wallet Address:"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
+msgstr "You will be taken to KlimaDAO.finance to complete this transaction."
 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:412
@@ -2014,6 +2641,15 @@ msgstr "Your balance:"
 msgid "Your display name"
 msgstr "Your display name"
 
+#: components/pages/Users/SellerConnected/index.tsx:221
+msgid "Your Profile"
+msgstr "Your Profile"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
 msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
@@ -2023,6 +2659,11 @@ msgstr "Your purchase has not been completed yet. To finalize your purchase, ver
 msgid "Your seller data"
 msgstr "Your seller data"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
+msgstr "Your transaction has been successfully processed but is taking longer than normal to index. It will appear in your <0>retirements</0> soon."
+
 #: components/pages/Retirements/SingleRetirement/index.tsx:84
 msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
 msgstr "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
@@ -2031,6 +2672,10 @@ msgstr "Your transaction was successful, but the network is taking longer than e
 msgid "Your unique handle"
 msgstr "Your unique handle"
 
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr "Your Wallet Address:"
+
 #: components/pages/Resources/lib/cmsDataMap.ts:82
 msgid "Z-A"
 msgstr "Z-A"
@@ -2038,540 +2683,3 @@ msgstr "Z-A"
 #: components/pages/Home/index.tsx:437
 msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
 msgstr "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
-
-#: components/Activities/Activity.tsx:34
-msgid "at"
-msgstr "at"
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr "The information provided in this blog post pertaining to KlimaDAO (“KlimaDAO”), its crypto-assets, business assets, strategy, and operations, is for general informational purposes only and is not a formal offer to sell or a solicitation of an offer to buy any securities, options, futures, or other derivatives related to securities in any jurisdiction and its content is not prescribed by securities laws. Information contained in this blog post should not be relied upon as advice to buy or sell or hold such securities or as an offer to sell such securities. This blog post does not take into account nor does it provide any tax, legal or investment advice or opinion regarding the specific investment objectives or financial situation of any person. KlimaDAO and its agents, advisors, directors, officers, employees and shareholders make no representation or warranties, expressed or implied, as to the accuracy of such information and KlimaDAO expressly disclaims any and all liability that may be based on such information or errors or omissions thereof. KlimaDAO reserves the right to amend or replace the information contained herein, in part or entirely, at any time, and undertakes no obligation to provide the recipient with access to the amended information or to notify the recipient thereof. The information contained in this blog post supersedes any prior blog post or conversation concerning the same, similar or related information. Any information, representations or statements not contained herein shall not be relied upon for any purpose. Neither KlimaDAO nor any of its representatives shall have any liability whatsoever, under contract, tort, trust or otherwise, to you or any person resulting from the use of the information in this blog post by you or any of your representatives or for omissions from the information in this blog post. Additionally, KlimaDAO undertakes no obligation to comment on the expectations of, or statements made by, third parties in respect of the matters discussed in this blog post."
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr "Disclaimer:"
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr "bought from"
-
-#: components/Layout/index.tsx:52
-msgid "connect a wallet"
-msgstr "connect a wallet"
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr "created listing"
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr "deleted listing"
-
-#: components/pages/Project/Purchase/Listing/Price.tsx:18
-#: components/pages/Project/Purchase/Pool/Price.tsx:17
-#: components/pages/Project/Retire/Pool/Price.tsx:17
-msgid "each"
-msgstr "each"
-
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr "After you click the button below to continue, you will be asked to connect your wallet and the project you selected here will already be selected for you on KlimaDAO.finance. From there, follow the directions on that page to complete your transaction."
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr "Carbon credits you purchase or any retirements you make on KlimaDAO.finance will also be accessible in your Carbonmark portfolio."
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr "You will be taken to KlimaDAO.finance to complete this transaction."
-
-#: components/Activities/Activity.tsx:112
-msgid "for"
-msgstr "for"
-
-#: components/pages/Retire/index.tsx:52
-msgid "for beneficiary"
-msgstr "for beneficiary"
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr "Marketplace"
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr "Portfolio"
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr "Profile"
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr "Retire"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
-msgid "offset.amount_in_tonnes"
-msgstr "How many tonnes of carbon would you like to offset? <0>* </0>"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
-msgid "offset.default_retirement_address"
-msgstr "Defaults to the connected wallet address"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
-msgid "offset.retire_carbon"
-msgstr "Confirm Retirement"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
-msgid "offset.retirement_credit"
-msgstr "Who will this retirement be credited to?"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
-msgid "offset.retirement_message"
-msgstr "Retirement message"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr "Thank you for supporting the planet! View transaction on <0> PolygonScan.</0>"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr "Thank you for supporting the planet!"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr "Your transaction has been successfully processed but is taking longer than normal to index. It will appear in your <0>retirements</0> soon."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
-msgid "offset_disclaimer"
-msgstr "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr "Balances"
-
-#: components/CreateListing/Form/index.tsx:136
-msgid "profile.addListing_modal.submit"
-msgstr "Create Listing"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
-msgid "profile.edit_modal.submit"
-msgstr "Save Changes"
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr "Edit your profile to add a description."
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
-msgid "profile.listing.edit.delete_listing"
-msgstr "Delete Listing"
-
-#: components/pages/Purchases/index.tsx:49
-msgid "project.single.button.back_to_project_details"
-msgstr "Back to Project Details"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr "You are about to purchase a carbon asset."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr "Verify all information is correct and click 'approve' to continue."
-
-#: components/pages/Purchases/index.tsx:145
-msgid "purchase.button.view_assets"
-msgstr "View Your Assets"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr "Categories"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr "Select one or more"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr "Clear All"
-
-#: components/pages/Resources/ResourcesList/index.tsx:289
-msgid "resources.mobile_modal.button.show_results"
-msgstr "Show Results"
-
-#: components/pages/Resources/ResourcesList/index.tsx:230
-msgid "resources.page.list.no_search_results.title"
-msgstr "Sorry. We couldn't find any matching results."
-
-#: components/pages/Resources/ResourcesList/index.tsx:222
-msgid "resources.page.list.on_fetch_error"
-msgstr "Sorry! Something went wrong."
-
-#: components/pages/Resources/ResourcesList/index.tsx:243
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr "Please use a different filter combination."
-
-#: components/pages/Resources/ResourcesList/index.tsx:236
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr "Check your search for typos or try a different search term."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
-msgid "retire.back_button"
-msgstr "back"
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr "retired"
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr "With over 20 million verified digital carbon credits from hundreds of projects, Carbonmark offers the largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading. <0>Get started today</0>."
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr "About Carbonmark"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr "{retiree} retired {formattedAmount} Tonnes of carbon"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr "Carbonmark | Carbon Retirement Receipt"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:50
-msgid "retirement.provenance.head.metaDescription"
-msgstr "Transparent, on-chain offsets powered by Carbonmark."
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:46
-msgid "retirement.provenance.head.metaTitle"
-msgstr "{retiree} retired {formattedAmount} Tonnes of carbon"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:42
-msgid "retirement.provenance.head.title"
-msgstr "Carbonmark | Carbon Retirement provenance"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
-msgid "retirement.single.beneficiary.placeholder"
-msgstr "No beneficiary name provided"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.title"
-msgstr "Beneficiary:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
-msgid "retirement.single.beneficiary_address.title"
-msgstr "Beneficiary Address:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr "Carbon Credit Retirement"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
-msgid "retirement.single.country_region.title"
-msgstr "Country/Region:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
-msgid "retirement.single.immutable_public_records.title"
-msgstr "This represents the permanent retirement of a digital carbon asset. This retirement and the associated data are immutable public records."
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr "Retirement Message:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.methodology.title"
-msgstr "Methodology:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
-msgid "retirement.single.moss_offset.description"
-msgstr "MC02 credits are generated by projects that preserve the Amazon Forest, with all sorts of positive externalities such as the creation of local jobs and preservation of local biodiversity. Explore MCO2 on <0>data.klimadao.finance</0>."
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
-msgid "retirement.single.moss_offset.name"
-msgstr "MOSS Earth MC02"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
-msgid "retirement.single.official_certificate.title"
-msgstr "Official Certificate for On-Chain Carbon Retirement Provided by <0>Carbonmark.com</0>"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
-msgid "retirement.single.project.title"
-msgstr "Project:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
-msgid "retirement.single.project_description.title"
-msgstr "Description"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
-msgid "retirement.single.project_details.title"
-msgstr "Project Details"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
-msgid "retirement.single.project_name.title"
-msgstr "Project Name"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr "Proof of"
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr "QUANTITY RETIRED"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
-msgid "retirement.single.share_retirement.title"
-msgstr "Share this retirement"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr "No retirement timestamp provided"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
-msgid "retirement.single.transaction_id.title"
-msgstr "Transaction ID"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
-msgid "retirement.single.transaction_record.title"
-msgstr "Immutable transaction record"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.type.title"
-msgstr "Type:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr "Verified tonnes of carbon retired"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
-msgid "retirement.single.vintage.title"
-msgstr "Vintage:"
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr "No retirements found"
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr "All Retirements"
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr "Carbonmark - Carbon Retirements for beneficiary {0}"
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr "Carbonmark - Carbon Retirements for beneficiary {0}"
-
-#: components/pages/Retirements/index.tsx:60
-msgid "retirement.totals.page_headline"
-msgstr "Carbon Retirements"
-
-#: components/pages/Retirements/index.tsx:66
-msgid "retirement.totals.page_subline"
-msgstr "for beneficiary"
-
-#: components/pages/Retirements/index.tsx:90
-msgid "retirement.totals.retired_assets"
-msgstr "Retired Assets"
-
-#: components/pages/Retirements/index.tsx:106
-msgid "retirement.totals.retirements"
-msgstr "Retirements"
-
-#: components/pages/Retirements/index.tsx:98
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr "Total Carbon Tonnes Retired"
-
-#: components/pages/Retirements/index.tsx:112
-msgid "retirement.totals.total_retirement_transactions"
-msgstr "Total Retirement Transactions"
-
-#: components/pages/Users/SellerUnconnected/index.tsx:70
-msgid "seller.listing.buy"
-msgstr "Buy"
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr "Quantity Available:"
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr "Resource Center"
-
-#: components/pages/Resources/ResourcesList/index.tsx:197
-msgid "shared.resources.sort_by.header"
-msgstr "Sort by:"
-
-#: components/Layout/index.tsx:51
-msgid "social or email"
-msgstr "social or email"
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr "sold to"
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
-msgid "something went wrong loading the allowance"
-msgstr "something went wrong loading the allowance"
-
-#: components/pages/Retire/Activity/Overview.tsx:77
-#: components/pages/Retire/Activity/Quotes.tsx:76
-#: components/pages/Retire/Activity/Table.tsx:65
-msgid "t"
-msgstr "t"
-
-#: components/Activities/Activity.tsx:119
-msgid "to"
-msgstr "to"
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
-msgid "tonnes"
-msgstr "tonnes"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr "You are about to retire a carbon asset."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr "Verify all information is correct and click 'approve' to continue."
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr "Confirm amount"
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr "Contract address"
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr "Confirm price per tonne"
-
-#: components/CreateListing/Transaction/index.tsx:83
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr "Go back"
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr "Close"
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr "Next"
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr "Submit amount"
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr "Submit"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr "To finalize your retirement, verify all information is correct and then click 'submit' below."
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr "Contract address"
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr "Submit price per tonne:"
-
-#: components/CreateListing/Transaction/index.tsx:47
-#: components/Transaction/index.tsx:45
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Approve"
-
-#: components/CreateListing/Transaction/index.tsx:57
-#: components/Transaction/index.tsx:55
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Submit"
-
-#: components/Activities/Activities.constants.ts:10
-msgid "updated expiration"
-msgstr "updated expiration"
-
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr "updated price"
-
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr "updated quantity"
-
-#: components/Activities/index.tsx:29
-msgid "user.activities.empty_state"
-msgstr "No activity to show"
-
-#: components/LoginCard/index.tsx:24
-msgid "user.login.description"
-msgstr "This feature is available only to users who are logged in. You can log in or create an account via the button below."
-
-#: components/CreateListing/Transaction/Approve.tsx:51
-#: components/CreateListing/Transaction/index.tsx:62
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
-msgid "{0}"
-msgstr "{0}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
-msgid "{0} maximum for credit cards"
-msgstr "{0} maximum for credit cards"
-
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr "{0} | Profile | Carbonmark"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-
-#: components/pages/Purchases/index.tsx:29
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr "{amount} tonnes were purchased for project {0}"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
-#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
-msgid "{formattedAmount} Tonnes"
-msgstr "{formattedAmount} Tonnes"
-
-#: components/Quantity/index.tsx:28
-msgid "{formattedAmount} tonnes"
-msgstr "{formattedAmount} tonnes"
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
-msgid "{tokenSymbol}"
-msgstr "{tokenSymbol}"
-
-#: lib/statusMessage.ts:23
-msgid "❌ Error: something went wrong..."
-msgstr "❌ Error: something went wrong..."

--- a/carbonmark/locale/es/messages.po
+++ b/carbonmark/locale/es/messages.po
@@ -6,10 +6,85 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: es\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/CreateListing/Transaction/Approve.tsx:51
+#: components/CreateListing/Transaction/index.tsx:62
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
+msgid "{0}"
+msgstr "{0}"
+
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr "{0} | Perfil | Carbonmark"
+
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
+msgid "{0} maximum for credit cards"
+msgstr "{0} máximo para tarjetas de crédito"
+
+#: components/pages/Purchases/index.tsx:29
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr "Se compraron {amount} toneladas para el proyecto {0}"
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr "{DEFAULT_EXPIRATION_DAYS} dias ({expirationDatestring})"
+
+#: components/Quantity/index.tsx:28
+msgid "{formattedAmount} tonnes"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
+#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
+msgid "{formattedAmount} Tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:46
+msgid "retirement.provenance.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
+msgid "{tokenSymbol}"
+msgstr "{tokenSymbol}"
+
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "@Username (note: this can not be changed!)"
+msgstr "@Nombredeusuario (nota: ¡no se puede cambiar!)"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
+msgid "<0>* </0> Required Field"
+msgstr "<0>* </0> Campo obligatorio"
+
+#: lib/statusMessage.ts:23
+msgid "❌ Error: something went wrong..."
+msgstr "❌ Error: algo ha salido mal..."
 
 #: components/pages/Home/index.tsx:358
 msgid "0% listing fee"
 msgstr "0% de comisión"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:47
+#: components/Transaction/index.tsx:45
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:57
+#: components/Transaction/index.tsx:55
+msgid "transaction_modal.view.submit.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:193
 msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
@@ -32,14 +107,6 @@ msgstr "500 - Se ha producido un error en el servidor"
 msgid "500 - Server error occurred"
 msgstr "500 - Se ha producido un error en el servidor"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
-msgid "<0>* </0> Required Field"
-msgstr "<0>* </0> Campo obligatorio"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "@Username (note: this can not be changed!)"
-msgstr "@Nombredeusuario (nota: ¡no se puede cambiar!)"
-
 #: components/pages/Project/PayWithBank/index.tsx:153
 msgid "A valid email address is required"
 msgstr "Se requiere una dirección de correo electrónico válida"
@@ -54,6 +121,11 @@ msgstr "A-Z"
 msgid "About"
 msgstr "Acerca de"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr ""
+
 #: components/Stats/StatsListings.tsx:49
 msgid "Active listings:"
 msgstr "Listados activos:"
@@ -62,6 +134,11 @@ msgstr "Listados activos:"
 msgid "Activity"
 msgstr "Actividad"
 
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr ""
+
 #: lib/getCategoryInfo.ts:53
 msgid "Agriculture"
 msgstr "Agricultura"
@@ -69,6 +146,11 @@ msgstr "Agricultura"
 #: components/pages/Home/index.tsx:362
 msgid "All assets sourced from major registries"
 msgstr "Todos los activos proceden de los principales registros"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:41
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
@@ -111,6 +193,10 @@ msgstr "Aprobar"
 msgid "Asset"
 msgstr "Activo"
 
+#: components/AssetDetails/index.tsx:53
+msgid "Asset details"
+msgstr "Detalles del activo"
+
 #: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:24
 msgid "Asset Details"
 msgstr "Detalles del activo"
@@ -119,9 +205,13 @@ msgstr "Detalles del activo"
 msgid "Asset ID"
 msgstr "Identificación de activos"
 
-#: components/AssetDetails/index.tsx:53
-msgid "Asset details"
-msgstr "Detalles del activo"
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:32
+msgid "Asset moved from one account to another, either via sale or inter-account transfer."
+msgstr ""
+
+#: components/Activities/Activity.tsx:34
+msgid "at"
+msgstr "a"
 
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:131
 msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
@@ -133,11 +223,6 @@ msgid ""
 "exceeding {0}. Please adjust the\n"
 "quantity and try again later."
 msgstr "En este momento, Carbonmark no puede procesar pagos con tarjeta de crédito superiores a {0}. Por favor, ajuste la cantidad e inténtelo de nuevo más tarde."
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
-msgstr "Toneladas Disponibles:"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:116
 msgid "Available balance exceeded"
@@ -163,6 +248,11 @@ msgstr "Disponible para comprar"
 msgid "Available to retire"
 msgstr "Disponible para retirar"
 
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr "Toneladas Disponibles:"
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:219
 msgid "Available:"
 msgstr "Disponible:"
@@ -176,14 +266,20 @@ msgstr "Disponible: {0}"
 msgid "Available: {unlistedBalance}"
 msgstr "Disponible: {unlistedBalance}"
 
-#: components/BetaBadge/index.tsx:18
-msgid "BETA"
-msgstr "BETA"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
+msgid "retire.back_button"
+msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:44
 #: components/pages/Project/Retire/index.tsx:35
 msgid "Back to Project"
 msgstr "Volver al proyecto"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:49
+msgid "project.single.button.back_to_project_details"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:397
 msgid "Balance"
@@ -199,6 +295,16 @@ msgstr "Saldo excedido"
 msgid "Balance: {0}"
 msgstr "Saldo: {0}"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
+msgid "offset_disclaimer"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:450
 msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
 msgstr "Tenga cuidado de no incluir ninguna información personal sensible (como una dirección de correo electrónico) en su nombre de retiro o mensaje. La información que introduzca aquí no podrá editarse una vez enviada y existirá permanentemente en una blockchain pública."
@@ -207,13 +313,18 @@ msgstr "Tenga cuidado de no incluir ninguna información personal sensible (como
 msgid "Beneficiary Address"
 msgstr "Dirección del beneficiario"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
-msgid "Beneficiary Name"
-msgstr "Nombre del beneficiario"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
+msgid "retirement.single.beneficiary_address.title"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:263
 msgid "Beneficiary name"
 msgstr "Nombre del Beneficiario"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
+msgid "Beneficiary Name"
+msgstr "Nombre del beneficiario"
 
 #: components/pages/Project/PayWithBank/index.tsx:232
 #: components/pages/Project/PayWithBank/index.tsx:349
@@ -225,11 +336,20 @@ msgstr "Dirección del monedero del beneficiario"
 msgid "Beneficiary wallet address (optional)"
 msgstr "Dirección del monedero del beneficiario (opcional)"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:34
 #: components/pages/Project/BuyOptions/SellerListing.tsx:67
 #: components/pages/Project/index.tsx:137
 msgid "Best Price"
 msgstr "Mejor precio"
+
+#: components/BetaBadge/index.tsx:18
+msgid "BETA"
+msgstr "BETA"
 
 #: lib/getCategoryInfo.ts:65
 msgid "Blue Carbon"
@@ -239,9 +359,9 @@ msgstr "Carbono azul"
 msgid "Book a demo"
 msgstr "Reservar una demostración"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:35
-msgid "Bridge"
-msgstr "Bridge"
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
+msgstr "comprado en"
 
 #: components/pages/Home/index.tsx:157
 #: components/pages/Home/index.tsx:188
@@ -256,6 +376,11 @@ msgstr "Explorar proyectos"
 #: components/pages/Project/BuyOptions/SellerListing.tsx:98
 msgid "Buy"
 msgstr "Comprar"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:70
+msgid "seller.listing.buy"
+msgstr ""
 
 #: components/pages/Home/index.tsx:168
 msgid "Buy or retire carbon"
@@ -273,6 +398,25 @@ msgstr "¿Podemos recordarle más adelante acerca de esta nueva función?"
 msgid "Cancel"
 msgstr "Cancelar"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr ""
+
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr "Los activos de carbono que adquiera pueden ponerse a la venta en Carbonmark en cualquier momento desde su <0>portafolio</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:30
 msgid "Carbon Pool"
 msgstr "Fondo de carbono"
@@ -280,6 +424,10 @@ msgstr "Fondo de carbono"
 #: components/Layout/NavDropdown/index.tsx:117
 msgid "Carbon Portfolio"
 msgstr "Portafolio de Carbono"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
+msgid "Carbon provenance"
+msgstr "Procedencia del carbono"
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:60
 msgid "Carbon Provenance"
@@ -289,17 +437,35 @@ msgstr "Procedencia del Carbono"
 msgid "Carbon Retirements"
 msgstr "Retiradas de carbono"
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-msgstr "Los activos de carbono que adquiera pueden ponerse a la venta en Carbonmark en cualquier momento desde su <0>portafolio</0>."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:60
+msgid "retirement.totals.page_headline"
+msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
-msgid "Carbon provenance"
-msgstr "Procedencia del carbono"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
+msgstr ""
 
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
-msgstr "Visión general de Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:42
+msgid "retirement.provenance.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:51
+#: components/pages/Home/index.tsx:52
+msgid "Carbonmark | The Universal Carbon Marketplace"
+msgstr "Carbonmark | El mercado universal del carbono"
 
 #: components/pages/Home/index.tsx:174
 msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
@@ -315,14 +481,18 @@ msgstr "Tasa Carbonmark"
 msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 msgstr "Carbonmark ofrece ahora la posibilidad de pagar las operaciones de retiro mediante transferencia bancaria. Solo tiene que rellenar el siguiente formulario y nos pondremos en contacto con usted en un plazo de 2 días laborables (tras recibir toda la información necesaria) para recabar más datos y enviarle una factura."
 
-#: components/pages/Home/index.tsx:51
-#: components/pages/Home/index.tsx:52
-msgid "Carbonmark | The Universal Carbon Marketplace"
-msgstr "Carbonmark | El mercado universal del carbono"
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
+msgstr "Visión general de Carbonmark"
 
 #: components/pages/Home/index.tsx:488
 msgid "Carbonmark's role"
 msgstr "El papel de Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
+msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:130
 msgid "Category"
@@ -333,6 +503,11 @@ msgstr "Categoría"
 msgid "Change language"
 msgstr "Cambiar idioma"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:236
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
 #: components/pages/Home/index.tsx:206
 msgid "Choose a project and quantity"
 msgstr "Elija un proyecto y cantidad"
@@ -341,8 +516,13 @@ msgstr "Elija un proyecto y cantidad"
 msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 msgstr "Elija entre más de 20 millones de créditos de carbono digitales verificados de cientos de proyectos: compre, venda o retire carbono ahora."
 
-#: components/ProjectFilterModal/index.tsx:162
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
 #: components/pages/Projects/ProjectSearch/index.tsx:55
+#: components/ProjectFilterModal/index.tsx:162
 msgid "Clear Filters"
 msgstr "Despejar filtros"
 
@@ -353,6 +533,11 @@ msgstr "Haga clic en el botón \"crear perfil\" para personalizar esta página y
 #: components/CreateListing/Transaction/Submit.tsx:98
 msgid "Close"
 msgstr "Cerrar"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
+msgstr ""
 
 #: components/Footer/index.tsx:32
 msgid "Code of Ethics"
@@ -379,6 +564,16 @@ msgstr "Comparar precios entre todos los vendedores y grupos de negociación"
 msgid "Compiling Results ..."
 msgstr "Compilando resultados ..."
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr ""
+
 #: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:83
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
 #: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
@@ -386,9 +581,18 @@ msgstr "Compilando resultados ..."
 msgid "Confirm Purchase"
 msgstr "Confirmar compra"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
+msgid "offset.retire_carbon"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:75
 msgid "Confirm Retirement"
 msgstr "Confirmar Retiro"
+
+#: components/Layout/index.tsx:52
+msgid "connect a wallet"
+msgstr "conectar un monedero"
 
 #: components/pages/Portfolio/ConnectedWallet/index.tsx:33
 msgid "Connected Wallet"
@@ -414,6 +618,16 @@ msgstr "Contacto"
 msgid "Continue"
 msgstr "Continuar"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
 #: components/CopyAddressButton/index.tsx:37
 msgid "Copy"
 msgstr "Copiar"
@@ -431,15 +645,10 @@ msgstr "No se ha podido eliminar el anuncio. Por favor, inténtelo de nuevo."
 msgid "Country"
 msgstr "País"
 
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr "Crear nuevo listado"
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Create Profile"
-msgstr "Crear perfil"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
+msgid "retirement.single.country_region.title"
+msgstr ""
 
 #: components/CreateListing/index.tsx:165
 msgid "Create a listing"
@@ -457,6 +666,21 @@ msgstr "Crear un perfil de vendedor"
 msgid "Create and edit listings, and track your activity with your Carbonmark profile."
 msgstr "Cree y edite anuncios, y siga su actividad con su perfil Carbonmark."
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:136
+msgid "profile.addListing_modal.submit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr "Crear nuevo listado"
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Create Profile"
+msgstr "Crear perfil"
+
 #: components/pages/Home/index.tsx:313
 msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
 msgstr "Cree su propio escaparate del carbono. Venda directamente tanto a organizaciones como a particulares."
@@ -465,25 +689,29 @@ msgstr "Cree su propio escaparate del carbono. Venda directamente tanto a organi
 msgid "Create your own retirement"
 msgstr "Cree su propia retirada"
 
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr "listado creado"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:87
 msgid "Created:"
 msgstr "Creado:"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
-msgid "Credit ID"
-msgstr "ID de crédito"
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
-msgstr "La compra mínima con tarjeta de crédito es ${formattedFiatMinimum}"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:77
 msgid "Credit card minimum purchase is {0}"
 msgstr "La compra mínima con tarjeta de crédito es {0}"
 
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr "La compra mínima con tarjeta de crédito es ${formattedFiatMinimum}"
+
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:247
 msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
 msgstr "Los pagos con tarjeta de crédito conllevan una tarifa de procesamiento adicional. <0>Vea la documentación para obtener más información.</0>"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
+msgid "Credit ID"
+msgstr "ID de crédito"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:435
 msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
@@ -493,10 +721,6 @@ msgstr "ctualmente, Carbonmark sólo acepta USDC de Polygon o pagos con tarjeta 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
 msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
 msgstr "Actualmente, Carbonmark sólo acepta pagos con USDC en Polygon. <0>Aprenda cómo adquirir USDC en Polygon.</0>"
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
-msgstr "FECHA"
 
 #: components/pages/Project/index.tsx:234
 msgid "Data for this project and vintage"
@@ -511,9 +735,27 @@ msgstr "Datos de este vendedor"
 msgid "Date"
 msgstr "Fecha"
 
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr "FECHA"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
+msgid "offset.default_retirement_address"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:296
 msgid "Defaults to the connected wallet address"
 msgstr "Por defecto, la dirección del monedero conectado"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
+msgid "profile.listing.edit.delete_listing"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
+msgstr "listado eliminado"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:307
 msgid "Describe the purpose of this retirement"
@@ -523,6 +765,11 @@ msgstr "Describa el objetivo de esta retirada"
 msgid "Description"
 msgstr "Descripción"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
+msgid "retirement.single.project_description.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:51
 msgid "Digital Carbon"
 msgstr "Carbono digital"
@@ -530,6 +777,11 @@ msgstr "Carbono digital"
 #: components/pages/Home/index.tsx:264
 msgid "Digitize your carbon by using a supported bridge"
 msgstr "Digitalice su carbono utilizando un puente soportado"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
 msgid "Display name"
@@ -555,18 +807,29 @@ msgstr "Descargando ..."
 msgid "Drive climate action and earn rewards with a carbon-backed digital currency."
 msgstr "Impulsa la acción climática y gana recompensas con una moneda digital respaldada por carbono."
 
+#: components/pages/Project/Purchase/Listing/Price.tsx:18
+#: components/pages/Project/Purchase/Pool/Price.tsx:17
+#: components/pages/Project/Retire/Pool/Price.tsx:17
+msgid "each"
+msgstr "cada"
+
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:195
 msgid "Edit"
 msgstr "Editar"
+
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
+msgid "Edit listing"
+msgstr "Editar listado"
 
 #: components/pages/Users/SellerConnected/index.tsx:113
 #: components/pages/Users/SellerConnected/index.tsx:138
 msgid "Edit Profile"
 msgstr "Editar perfil"
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
-msgid "Edit listing"
-msgstr "Editar listado"
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:143
 #: components/pages/Project/PayWithBank/index.tsx:307
@@ -626,6 +889,19 @@ msgstr "El nombre no debe contener números ni caracteres especiales"
 msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
 msgstr "Primeramente, apruebe que el sistema Carbonmark transfiera este activo en su nombre."
 
+#: components/Activities/Activity.tsx:112
+msgid "for"
+msgstr "para"
+
+#: components/pages/Retire/index.tsx:52
+msgid "for beneficiary"
+msgstr "para el beneficiario"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:66
+msgid "retirement.totals.page_subline"
+msgstr ""
+
 #: components/pages/Home/index.tsx:340
 msgid "For carbon traders"
 msgstr "Para los comerciantes de carbono"
@@ -642,20 +918,26 @@ msgstr "Ingeniería Forestal"
 msgid "Form complete"
 msgstr "Formulario completo"
 
-#: components/pages/Home/index.tsx:76
-msgid "Get Started"
-msgstr "Cómo empezar"
-
 #: components/pages/Home/index.tsx:390
 msgid "Get paid immediately: transactions are resolved in seconds"
 msgstr "Cobre inmediatamente: las transacciones se resuelven en segundos"
 
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
-msgstr "Volver"
+#: components/pages/Home/index.tsx:76
+msgid "Get Started"
+msgstr "Cómo empezar"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:83
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
 msgid "Go back"
+msgstr "Volver"
+
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
 msgstr "Volver"
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:145
@@ -681,8 +963,8 @@ msgid "Here’s a list of readily available, discounted carbon tokens to retire 
 msgstr "He aquí una lista de tokens de carbono fácilmente disponibles y con descuento para retirarse rápida y fácilmente."
 
 #: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:48
-msgid "Hide {numberOfTransfers} transfers"
-msgstr "Ocultar {numberOfTransfers} transferencias"
+msgid "Hide {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:80
 msgid "How many tonnes do you want to list for sale?"
@@ -696,6 +978,11 @@ msgstr "¿Cuántas toneladas de carbono quiere comprar?"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:249
 msgid "How many tonnes of carbon do you want to retire?"
 msgstr "¿Cuántas toneladas de carbono quiere retirar?"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
+msgid "offset.amount_in_tonnes"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:215
 msgid "How many tonnes of carbon would you like to retire?"
@@ -720,6 +1007,11 @@ msgstr ""
 #: components/pages/Purchases/index.tsx:93
 msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
 msgstr "Si desea retirar algunos o todos los créditos de carbono de esta compra, vaya a su <0>cartera</0>, haga clic en el botón \"retirar\" y siga las instrucciones."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
+msgid "retirement.single.transaction_record.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:116
 msgid "Indicates required field"
@@ -775,14 +1067,14 @@ msgstr "El apellido no debe contener números ni caracteres especiales."
 msgid "Latest First"
 msgstr "Lo más reciente primero"
 
+#: components/pages/Home/index.tsx:417
+msgid "Learn more"
+msgstr "Aprende más"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:92
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:103
 msgid "Learn More"
 msgstr "Más información"
-
-#: components/pages/Home/index.tsx:417
-msgid "Learn more"
-msgstr "Aprende más"
 
 #: components/pages/Home/index.tsx:491
 msgid "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
@@ -815,11 +1107,11 @@ msgid "Loading your assets"
 msgstr "Cargando sus activos"
 
 #: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:295
 #: components/pages/Retire/Activity/Overview.tsx:73
 #: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
 msgid "Loading..."
 msgstr "Cargando..."
 
@@ -859,6 +1151,11 @@ msgstr ""
 msgid "Marketplace"
 msgstr "Marketplace"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr ""
+
 #: components/pages/Projects/index.tsx:73
 #: components/pages/Projects/index.tsx:74
 msgid "Marketplace | Carbonmark"
@@ -868,20 +1165,35 @@ msgstr "Marketplace | Carbonmark"
 msgid "Maximize your climate impact."
 msgstr "Maximice su impacto climático."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.moss_offset.description"
+msgstr ""
+
 #: components/pages/Project/index.tsx:144
 msgid "Methodology"
 msgstr "Metodología"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.methodology.title"
+msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:54
 msgid "Moss"
 msgstr "Moss"
 
-#: components/FeatureBanner/index.tsx:33
-msgid "NEW FEATURE:"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
+msgid "retirement.single.moss_offset.name"
 msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:171
 msgid "Navigation Menu"
+msgstr ""
+
+#: components/FeatureBanner/index.tsx:33
+msgid "NEW FEATURE:"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
@@ -896,18 +1208,28 @@ msgstr "Nuevo precio unitario (USDC)"
 msgid "Next"
 msgstr "Siguiente"
 
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
-msgstr "No hay actividad para mostrar."
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:197
 #: components/pages/Users/SellerUnconnected/index.tsx:83
 msgid "No active listings."
 msgstr "No hay listados activos."
 
+#. js-lingui-explicit-id
+#: components/Activities/index.tsx:29
+msgid "user.activities.empty_state"
+msgstr ""
+
 #: components/pages/Retire/Activity/Quotes.tsx:38
 msgid "No activity to show"
 msgstr "No hay actividad para mostrar"
+
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
+msgstr "No hay actividad para mostrar."
 
 #: components/pages/Home/index.tsx:400
 msgid "No barriers to entry for verified carbon projects"
@@ -916,6 +1238,11 @@ msgstr "No hay barreras de entrada para los proyectos de carbono verificado"
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:40
 msgid "No beneficiary address available"
 msgstr "No se dispone de la dirección del beneficiario"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
+msgid "retirement.single.beneficiary.placeholder"
+msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:62
 msgid "No data to show"
@@ -950,24 +1277,39 @@ msgstr ""
 msgid "No retirement message provided."
 msgstr "No se proporcionó ningún mensaje de retiro."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
 msgid "No transaction id available"
 msgstr "No hay identificador de transacción disponible"
-
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
-msgstr "No conectado"
 
 #: components/pages/Project/PayWithBank/index.tsx:240
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:288
 msgid "Not a valid polygon address"
 msgstr "No es una dirección de polygon válida"
 
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr "No conectado"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
+msgid "retirement.single.official_certificate.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:72
 msgid "Oldest First"
 msgstr "Los más viejos primero"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:185
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:188
 msgid "On the Verra page, search for the specific serial number."
 msgstr ""
 
@@ -991,22 +1333,18 @@ msgstr "Nuestro sistema está tardando más de lo previsto. La retirada debería
 msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 msgstr "Más de 20 millones de créditos de carbono digitales verificados de cientos de proyectos, con más de 4.000 millones de dólares negociados hasta la fecha."
 
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr "PROYECTO"
-
 #: components/pages/Projects/Banners/BankTransfer.tsx:74
 msgid "Pay via Bank Transfer / Wire"
 msgstr ""
+
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
+msgstr "Pagar con transferencia bancaria"
 
 #: components/pages/Project/PayWithBank/index.tsx:89
 #: components/pages/Project/PayWithBank/index.tsx:90
 msgid "Pay with Bank Transfer | Carbonmark"
 msgstr "Pagar con Transferencia Bancaria | Carbonmark"
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
-msgstr "Pagar con transferencia bancaria"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:94
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:112
@@ -1014,22 +1352,18 @@ msgstr "Pagar con transferencia bancaria"
 msgid "Pay with:"
 msgstr "Pagar con:"
 
-#: components/pages/Purchases/index.tsx:62
-msgid "Payment Successful"
-msgstr "Pago exitoso"
-
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:243
 msgid "Payment processing fee"
 msgstr "Tasa de procesamiento de pagos"
+
+#: components/pages/Purchases/index.tsx:62
+msgid "Payment Successful"
+msgstr "Pago exitoso"
 
 #: components/pages/Project/PayWithBank/index.tsx:161
 #: components/pages/Project/PayWithBank/index.tsx:313
 msgid "Phone number"
 msgstr "Número de teléfono"
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
-msgstr "Por favor Iniciar sesión"
 
 #: lib/statusMessage.ts:27
 msgid "Please click 'confirm' in your wallet to continue."
@@ -1039,11 +1373,25 @@ msgstr "Por favor, haga clic en \"confirmar\" en su cartera para continuar."
 msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr "Rellene el formulario protegido de la página siguiente y le enviaremos una factura en un plazo de 2 días laborables (tras recibir toda la información necesaria)."
 
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr "Por favor Iniciar sesión"
+
 #: components/pages/Portfolio/index.tsx:66
 #: components/pages/Users/SellerConnected/index.tsx:75
 #: components/pages/Users/SellerConnected/index.tsx:101
 msgid "Please refresh the page. There was an error updating your data: {e}."
 msgstr "Por favor, actualice la página. Se ha producido un error al actualizar sus datos: {e}."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:243
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:76
 #: components/pages/Portfolio/index.tsx:77
@@ -1062,10 +1410,6 @@ msgstr "Comunicados de prensa"
 msgid "Price Highest"
 msgstr "Precio más alto"
 
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr "Precio más bajo"
-
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:180
@@ -1075,6 +1419,10 @@ msgstr "El precio incluye las tarifas de red. <0>Vea la documentación para obte
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:160
 msgid "Price is required"
 msgstr "Se requiere precio"
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
+msgstr "Precio más bajo"
 
 #: components/CreateListing/Transaction/Submit.tsx:62
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
@@ -1110,19 +1458,48 @@ msgstr "Procesando la retirada..."
 msgid "Profile"
 msgstr "Perfil"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:192
 msgid "Profile picture"
 msgstr "Foto de perfil"
+
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr "PROYECTO"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
+msgid "retirement.single.project_name.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:253
 #: components/pages/Project/PayWithBank/index.tsx:357
 msgid "Project names of interest"
 msgstr "Nombres de proyectos de interés"
 
-#: components/pages/Purchases/index.tsx:36
-#: components/pages/Purchases/index.tsx:37
-msgid "Purchase Receipt | Carbonmark"
-msgstr "Recibo de compra | Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
+msgid "retirement.single.project.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr ""
+
+#: components/pages/Project/Purchase/index.tsx:32
+#: components/pages/Project/Purchase/index.tsx:33
+msgid "Purchase {0} | Carbonmark"
+msgstr "Compra {0} | Carbonmark"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:53
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
@@ -1133,6 +1510,11 @@ msgstr "Cantidad de compra (toneladas):"
 msgid "Purchase more Carbon"
 msgstr "Comprar más carbono"
 
+#: components/pages/Purchases/index.tsx:36
+#: components/pages/Purchases/index.tsx:37
+msgid "Purchase Receipt | Carbonmark"
+msgstr "Recibo de compra | Carbonmark"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:79
 msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer."
 msgstr ""
@@ -1140,11 +1522,6 @@ msgstr ""
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
 msgid "Purchase successful"
 msgstr "Compra exitosa"
-
-#: components/pages/Project/Purchase/index.tsx:32
-#: components/pages/Project/Purchase/index.tsx:33
-msgid "Purchase {0} | Carbonmark"
-msgstr "Compra {0} | Carbonmark"
 
 #: components/pages/Retire/Activity/Table.tsx:47
 msgid "QTY"
@@ -1160,6 +1537,11 @@ msgstr "Cantidad"
 msgid "Quantity Available:"
 msgstr "Cantidad disponible:"
 
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:240
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:108
 msgid "Quantity is required"
@@ -1173,21 +1555,18 @@ msgstr "Cantidad listada: {listedQuantity}, Cantidad no listada: {unlistedQuanti
 msgid "Quantity purchased:"
 msgstr "Cantidad comprada:"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr ""
+
 #: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr "Retiro rápido"
 
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr "RETIRA CARBONO"
-
 #: components/pages/Project/index.tsx:198
 msgid "Read Less"
 msgstr "Leer menos"
-
-#: components/pages/Project/index.tsx:198
-msgid "Read More"
-msgstr "Leer más"
 
 #: components/pages/Home/index.tsx:445
 #: components/pages/Home/index.tsx:472
@@ -1195,6 +1574,10 @@ msgstr "Leer más"
 #: components/pages/Resources/BlogPostCard/index.tsx:38
 #: components/pages/Resources/FeaturedArticles/Article.tsx:45
 msgid "Read more"
+msgstr "Leer más"
+
+#: components/pages/Project/index.tsx:198
+msgid "Read More"
 msgstr "Leer más"
 
 #: components/pages/Home/index.tsx:351
@@ -1213,14 +1596,14 @@ msgstr "Suministro restante:"
 msgid "Renewable Energy"
 msgstr "Energía renovable"
 
+#: lib/constants.ts:82
+msgid "Request already processing. Please open your wallet and complete the request."
+msgstr "Solicitud ya en trámite. Por favor, abra su monedero y complete la solicitud."
+
 #: components/pages/Home/index.tsx:301
 #: components/pages/Home/index.tsx:325
 msgid "Request Demo"
 msgstr "Solicitar demostración"
-
-#: lib/constants.ts:82
-msgid "Request already processing. Please open your wallet and complete the request."
-msgstr "Solicitud ya en trámite. Por favor, abra su monedero y complete la solicitud."
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:210
 msgid "Required Field"
@@ -1230,6 +1613,11 @@ msgstr "Campo requerido"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:311
 msgid "Required when proceeding with Credit Card"
 msgstr "Requerido al proceder con Tarjeta de Crédito"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
+msgstr ""
 
 #: components/Footer/index.tsx:38
 #: components/pages/Home/index.tsx:508
@@ -1257,15 +1645,36 @@ msgstr "Resultados"
 msgid "Retire"
 msgstr "Retirar"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/index.tsx:88
+#: components/pages/Portfolio/Retire/index.tsx:89
+#: components/pages/Retire/index.tsx:38
+#: components/pages/Retire/index.tsx:39
+msgid "Retire | Carbonmark"
+msgstr "Retirar | Carbonmark"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:388
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
 msgid "Retire Carbon"
 msgstr "RETIRA CARBONO"
 
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr "RETIRA CARBONO"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:233
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "Retire créditos de carbono para usted mismo o en nombre de otra persona u organización."
+
+#: components/pages/Project/Retire/index.tsx:23
+#: components/pages/Project/Retire/index.tsx:24
+msgid "Retire from {fullProjectid} | Carbonmark"
+msgstr "Retirar de {fullProjectid} | Carbonmark"
 
 #: components/pages/Retire/index.tsx:72
 msgid "Retire from a featured project"
@@ -1275,24 +1684,19 @@ msgstr "Retirarse de un proyecto destacado"
 msgid "Retire from your portfolio"
 msgstr "Retire desde su portafolio"
 
-#: components/pages/Project/Retire/index.tsx:23
-#: components/pages/Project/Retire/index.tsx:24
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr "Retirar de {fullProjectid} | Carbonmark"
-
 #: components/pages/Home/index.tsx:232
 msgid "Retire instantly, or purchase and hold digital carbon"
 msgstr "Retire al instante, o compre y retenga carbono digital"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
-msgstr "Retirar más Carbono"
 
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
 msgid "Retire more carbon"
 msgstr "Retirar más carbono"
+
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
+msgstr "Retirar más Carbono"
 
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:56
 #: components/pages/Project/BuyOptions/SellerListing.tsx:106
@@ -1307,14 +1711,16 @@ msgstr "Retire ahora o adquiera carbono para retirar más tarde: usted decide qu
 msgid "Retire your carbon via bank transfer."
 msgstr "Retira tu carbón vía transferencia bancaria."
 
-#: components/pages/Portfolio/Retire/index.tsx:88
-#: components/pages/Portfolio/Retire/index.tsx:89
-#: components/pages/Retire/index.tsx:38
-#: components/pages/Retire/index.tsx:39
-msgid "Retire | Carbonmark"
-msgstr "Retirar | Carbonmark"
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
+msgstr "retirados"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:13
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:90
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:16
 msgid "Retirement"
 msgstr ""
 
@@ -1322,33 +1728,53 @@ msgstr ""
 msgid "Retirement Activity"
 msgstr "Actividad de Retiro"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
-msgid "Retirement Message"
-msgstr "Mensaje de Retiro"
-
-#: components/pages/Retire/Activity/Overview.tsx:60
-#: components/pages/Retire/Activity/Overview.tsx:70
-msgid "Retirement Overview"
-msgstr "Visión general de la retirada"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr "¡Retiro exitoso!"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
+msgid "offset.retirement_message"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:264
 #: components/pages/Project/PayWithBank/index.tsx:363
 msgid "Retirement message"
 msgstr "Mensaje de Retiro"
 
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
+msgid "Retirement Message"
+msgstr "Mensaje de Retiro"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr ""
+
+#: components/pages/Retire/Activity/Overview.tsx:60
+#: components/pages/Retire/Activity/Overview.tsx:70
+msgid "Retirement Overview"
+msgstr "Visión general de la retirada"
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:74
 msgid "Retirement successful"
 msgstr "Retiro exitoso"
 
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr "¡Retiro exitoso!"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:106
+msgid "retirement.totals.retirements"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:384
 msgid "Retiring Token"
 msgstr "Token de retiro"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
+msgid "profile.edit_modal.submit"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:201
 msgid "Say a few words about yourself. This will be visible in your seller profile."
@@ -1385,6 +1811,11 @@ msgstr "Seleccione"
 msgid "Select a language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr ""
+
 #: components/pages/Portfolio/AssetProject/index.tsx:100
 #: components/pages/Portfolio/AssetProject/index.tsx:108
 msgid "Sell"
@@ -1402,12 +1833,26 @@ msgstr "Vende tu carbono digital directamente a los compradores"
 msgid "Seller Listing"
 msgstr "Listado de vendedores"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:159
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:29
+msgid "Send"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:161
 msgid "Serial Number"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:76
 msgid "Share this page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
+msgid "retirement.single.share_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:289
+msgid "resources.mobile_modal.button.show_results"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
@@ -1423,6 +1868,19 @@ msgstr "Se requiere precio único"
 #: components/CreateListing/Form/index.tsx:130
 msgid "Single unit price"
 msgstr "Precio por unidad"
+
+#: components/Layout/index.tsx:51
+msgid "social or email"
+msgstr "Correo electrónico o redes sociales"
+
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr "vendido a"
+
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
+msgid "something went wrong loading the allowance"
+msgstr "algo ha ido mal al cargar el subsidio"
 
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
 msgid "Something went wrong loading the allowance"
@@ -1448,13 +1906,28 @@ msgstr "Perdón, algo salió mal."
 msgid "Sorry, this handle already exists"
 msgstr "Lo sentimos, este nombre ya existe"
 
-#: components/pages/Resources/ResourcesList/index.tsx:265
-msgid "Sort By"
-msgstr "Ordenar por"
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:222
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:230
+msgid "resources.page.list.no_search_results.title"
+msgstr ""
 
 #: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "Sort by"
 msgstr "Ordenar por"
+
+#: components/pages/Resources/ResourcesList/index.tsx:265
+msgid "Sort By"
+msgstr "Ordenar por"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:197
+msgid "shared.resources.sort_by.header"
+msgstr ""
 
 #: components/Stats/index.tsx:23
 msgid "Stats"
@@ -1480,6 +1953,21 @@ msgstr "Paso 3"
 msgid "Submit"
 msgstr "Enviar"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr ""
+
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:88
 msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
 msgstr "¡Éxito! Su nuevo anuncio aparecerá en unos instantes en su <0>Profile page</0>."
@@ -1492,13 +1980,25 @@ msgstr ""
 msgid "Switch to Polygon"
 msgstr "Cambiar a Polygon"
 
-#: components/BetaBadge/index.tsx:16
-msgid "TESTNET"
-msgstr ""
+#: components/pages/Retire/Activity/Overview.tsx:77
+#: components/pages/Retire/Activity/Quotes.tsx:76
+#: components/pages/Retire/Activity/Table.tsx:65
+msgid "t"
+msgstr "t"
 
 #: components/Footer/index.tsx:29
 msgid "Terms of Use"
 msgstr "Condiciones de uso"
+
+#: components/BetaBadge/index.tsx:16
+msgid "TESTNET"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
 msgid "Thank you for supporting the planet!"
@@ -1508,21 +2008,32 @@ msgstr "¡Gracias por apoyar al planeta!"
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr "¡Gracias por apoyar al planeta! Ver detalles de compra más abajo."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:292
 msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr "Gracias por apoyar al planeta. En breve nos pondremos en contacto contigo para confirmar algunos detalles y enviarte una factura."
-
-#: components/pages/Home/index.tsx:65
-msgid "The Universal Carbon Marketplace"
-msgstr "El Mercado Universal del Carbono"
 
 #: components/CreateListing/Transaction/Approve.tsx:44
 msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 msgstr "Los activos sólo se transferirán fuera de su cartera cuando se complete una venta. Puedes revocar esta autorización en cualquier momento."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:34
 msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
 msgstr "El primer paso es conceder la aprobación para transferir su activo de carbono de su monedero a Carbonmark, el siguiente paso es aprobar la transferencia real y completar su retiro."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
 msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
@@ -1531,6 +2042,12 @@ msgstr "El primer paso es conceder la aprobación para transferir su activo de p
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
 msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
 msgstr "La información que figura a continuación se difundirá públicamente para verificar su declaración medioambiental. Esta transacción es permanente; la información no puede modificarse una vez completada su transacción."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
+msgstr ""
 
 #: components/pages/Home/index.tsx:53
 #: components/pages/Home/index.tsx:68
@@ -1570,13 +2087,27 @@ msgstr "El precio mínimo por tonelada es {0}"
 msgid "The minimum quantity to sell is 1 tonne"
 msgstr "La cantidad mínima a vender es de 1 tonelada"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:53
 msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 msgstr "El paso anterior concedió la aprobación para transferir su activo de carbono de su monedero a Carbonmark, su retiro aún no se ha completado."
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
 msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
 msgstr "El paso anterior concedió la aprobación para transferir su activo de pago de su monedero a Carbonmark."
+
+#: components/pages/Home/index.tsx:65
+msgid "The Universal Carbon Marketplace"
+msgstr "El Mercado Universal del Carbono"
 
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:208
 msgid "There was an error during the checkout process. Please try again."
@@ -1599,6 +2130,11 @@ msgstr "Se ha producido un error al cargar el coste total."
 msgid "This app only works on Polygon Mainnet."
 msgstr "Esta aplicación sólo funciona en Polygon Mainnet."
 
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:24
+msgid "user.login.description"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
 msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
 msgstr "Esta es su carpeta. Aquí encontrarás los activos de carbono que posees. Los activos que se muestran aquí se pueden retirar o poner a la venta en el mercado una vez que tenga un perfil."
@@ -1619,13 +2155,27 @@ msgstr "Esta oferta ya no existe."
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr "Este producto aún está en fase Beta y todavía no se han completado las auditorías."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
+msgid "retirement.single.immutable_public_records.title"
+msgstr ""
+
 #: components/pages/Users/ProfileHeader/index.tsx:46
 msgid "This user has not yet created a carbonmark profile."
 msgstr "Este usuario aún no ha creado un perfil de carbonmark."
 
+#: components/Activities/Activity.tsx:119
+msgid "to"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr "Para completar su transacción con tarjeta de crédito, será redirigido a Stripe, nuestro socio de procesamiento de pagos."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:60
 msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
@@ -1639,22 +2189,22 @@ msgstr "Para empezar, asegúrate de completar tu <0>profile</0> y luego diríget
 msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr "Para pagar por transferencia bancaria, necesitaremos que nos facilite algunos datos."
 
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr "Activar Seleccionar proyecto"
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr "Activar la clasificación por menú"
-
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
 msgid "Toggle payment method"
 msgstr "Alternar método de pago"
 
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr "Activar Seleccionar proyecto"
+
 #: components/pages/Projects/ProjectSort/index.tsx:29
 msgid "Toggle sort menu"
 msgstr "Alternar menú de clasificación"
+
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
+msgstr "Activar la clasificación por menú"
 
 #: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:209
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
@@ -1664,6 +2214,10 @@ msgstr "Token que recibirás"
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
 msgid "Tokens received:"
 msgstr "Tokens recibidos:"
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
+msgid "tonnes"
+msgstr "toneladas"
 
 #: components/AssetDetails/index.tsx:63
 #: components/pages/Project/PayWithBank/index.tsx:125
@@ -1684,22 +2238,6 @@ msgstr "Toneladas listadas:"
 msgid "Tonnes sold:"
 msgstr "Toneladas vendidas:"
 
-#: components/CreateListing/Form/index.tsx:85
-msgid "Total Amount to Sell is required"
-msgstr "Se requiere el importe total a vender"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
-msgid "Total Cost is required"
-msgstr "Se requiere el costo total"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr "Precio total"
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr "Total de retiros"
-
 #: components/CreateListing/Transaction/Approve.tsx:61
 msgid "Total allowance"
 msgstr "Prestación total"
@@ -1708,9 +2246,18 @@ msgstr "Prestación total"
 msgid "Total amount of tonnes to retire is required"
 msgstr "Se requiere la cantidad total de toneladas a retirar"
 
+#: components/CreateListing/Form/index.tsx:85
+msgid "Total Amount to Sell is required"
+msgstr "Se requiere el importe total a vender"
+
 #: components/pages/Retire/Activity/Overview.tsx:72
 msgid "Total carbon tonnes retired"
 msgstr "Total de toneladas de carbono retiradas"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:98
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr ""
 
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
@@ -1718,9 +2265,17 @@ msgstr "Total de toneladas de carbono retiradas"
 msgid "Total cost"
 msgstr "Coste total"
 
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
+msgid "Total Cost is required"
+msgstr "Se requiere el costo total"
+
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:166
 msgid "Total price"
+msgstr "Precio total"
+
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
 msgstr "Precio total"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:103
@@ -1731,6 +2286,15 @@ msgstr "Cantidad total a poner a la venta"
 msgid "Total retirement transactions"
 msgstr "Total operaciones de retirada"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:112
+msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
+msgstr "Total de retiros"
+
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
 msgid "Total sale cost"
@@ -1740,25 +2304,32 @@ msgstr "Coste total de venta"
 msgid "Transaction complete."
 msgstr "Transacción completa."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
+msgid "retirement.single.transaction_id.title"
+msgstr ""
+
 #: lib/statusMessage.ts:29
 msgid "Transaction initiated. Waiting for network confirmation."
 msgstr "Transacción iniciada. Esperando confirmación de la red."
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:24
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:48
 msgid "Transfer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:50
+msgid "retirement.provenance.head.metaDescription"
 msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:128
 msgid "Transparent, on-chain offsets powered by Carbonmark."
 msgstr "Compensaciones transparentes en el Blockchain, impulsadas por Carbonmark."
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "USDC per ton"
-msgstr "USDC por tonelada"
-
-#: components/CreateListing/Form/index.tsx:110
-msgid "USDC per tonne"
-msgstr "USDC por tonelada"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.type.title"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:115
 msgid "Unit price is required"
@@ -1776,6 +2347,18 @@ msgstr "Transparencia sin precedentes en el mercado digital del carbono."
 msgid "Update listing"
 msgstr "Actualizar listado"
 
+#: components/Activities/Activities.constants.ts:10
+msgid "updated expiration"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr "precio actualizado"
+
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr "cantidad actualizada"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:91
 msgid "Updated:"
 msgstr "Actualizado:"
@@ -1783,6 +2366,14 @@ msgstr "Actualizado:"
 #: components/pages/Users/SellerConnected/index.tsx:191
 msgid "Updating your data..."
 msgstr "Actualizando tus datos..."
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "USDC per ton"
+msgstr "USDC por tonelada"
+
+#: components/CreateListing/Form/index.tsx:110
+msgid "USDC per tonne"
+msgstr "USDC por tonelada"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:61
 msgid "User Guides"
@@ -1797,6 +2388,21 @@ msgstr "Perfil de usuario | Carbonmark"
 msgid "User refused connection."
 msgstr "El usuario rechazó la conexión."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:41
 msgid "Verify all information is correct and click 'approve' to continue."
@@ -1806,17 +2412,9 @@ msgstr "Compruebe que toda la información es correcta y haga clic en \"aprobar\
 msgid "View"
 msgstr "Vista"
 
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
-msgid "View Carbonmark Profile"
-msgstr "Ver el perfil de Carbonmark"
-
-#: components/pages/Project/index.tsx:207
-msgid "View Registry Details <0/>"
-msgstr "Ver detalles del registro <0/>"
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
-msgstr "Ver resultados"
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
+msgid "View {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:78
 msgid "View a complete overview of the digital carbon that you own in your Portfolio."
@@ -1851,9 +2449,17 @@ msgstr "Vea y compre este proyecto de compensación de carbono en Carbonmark"
 msgid "View and share certificate"
 msgstr "Ver y compartir el certificado"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:180
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
+msgid "View Carbonmark Profile"
+msgstr "Ver el perfil de Carbonmark"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:183
 msgid "View issuance on Verra"
 msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
+msgid "View on Polygonscan"
+msgstr "Ver en Polygonscan"
 
 #: components/AssetDetails/index.tsx:69
 msgid "View on PolygonScan"
@@ -1863,9 +2469,13 @@ msgstr "Ver en PolygonScan"
 msgid "View on PolygonScan <0/>"
 msgstr "Ver en PolygonScan <0/>"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
-msgid "View on Polygonscan"
-msgstr "Ver en Polygonscan"
+#: components/pages/Project/index.tsx:207
+msgid "View Registry Details <0/>"
+msgstr "Ver detalles del registro <0/>"
+
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
+msgstr "Ver resultados"
 
 #: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:99
 msgid "View retirement"
@@ -1879,8 +2489,9 @@ msgstr ""
 msgid "View the project details and other info for this purchase."
 msgstr "View the project details and other info for this purchase."
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
-msgid "View {numberOfTransfers} transfers"
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:145
+msgid "purchase.button.view_assets"
 msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:141
@@ -1894,6 +2505,11 @@ msgstr "Vintage mas nuevo"
 #: components/ProjectFilterModal/constants.tsx:15
 msgid "Vintage Oldest"
 msgstr "Vintage mas viejo"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
+msgid "retirement.single.vintage.title"
+msgstr ""
 
 #: components/pages/Purchases/index.tsx:66
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
@@ -1915,12 +2531,22 @@ msgstr "Hemos seleccionado a mano algunos de los mejores proyectos basándonos e
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr "¿Qué es Carbonmark? Respuestas a preguntas comunes sobre la interfaz del Mercado Digital del Carbono que conecta fácilmente a compradores y vendedores de créditos de carbono verificados."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
+msgid "offset.retirement_credit"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:257
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
 msgid "Who will this retirement be credited to?"
 msgstr "¿A quién se acreditará esta retirada?"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
+msgstr ""
 
 #: components/shared/InvalidNetworkModal/index.tsx:64
 msgid "Wrong Network"
@@ -1932,9 +2558,19 @@ msgstr "Red incorrecta"
 msgid "You"
 msgstr "Tú"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
 msgid "You are about to purchase a carbon asset."
 msgstr "Está a punto de comprar un activo de carbono."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:31
 msgid "You are about to retire a carbon asset."
@@ -1982,13 +2618,10 @@ msgstr "Debe tener un perfil creado para ver los activos de carbono que posee en
 msgid "You successfully acquired carbon!"
 msgstr "¡Has adquirido carbono con éxito!"
 
-#: components/pages/Users/SellerConnected/index.tsx:221
-msgid "Your Profile"
-msgstr "Tu perfil"
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
-msgstr "La dirección de su monedero"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:412
@@ -2005,6 +2638,15 @@ msgstr "Tu balance:"
 msgid "Your display name"
 msgstr "Su nombre para mostrar"
 
+#: components/pages/Users/SellerConnected/index.tsx:221
+msgid "Your Profile"
+msgstr "Tu perfil"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
 msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr "Su compra aún no se ha completado. Para finalizar su compra, compruebe que toda la información es correcta y haga clic en \"Enviar\"."
@@ -2014,6 +2656,11 @@ msgstr "Su compra aún no se ha completado. Para finalizar su compra, compruebe 
 msgid "Your seller data"
 msgstr "Tus datos de vendedor"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/index.tsx:84
 msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
 msgstr "Su transacción se ha realizado correctamente, pero la red está tardando más de lo previsto en procesar los datos. Sus datos de jubilación deberían aparecer aquí en unos segundos."
@@ -2022,6 +2669,10 @@ msgstr "Su transacción se ha realizado correctamente, pero la red está tardand
 msgid "Your unique handle"
 msgstr "Tu nombre unico"
 
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr "La dirección de su monedero"
+
 #: components/pages/Resources/lib/cmsDataMap.ts:82
 msgid "Z-A"
 msgstr "Z-A"
@@ -2029,542 +2680,3 @@ msgstr "Z-A"
 #: components/pages/Home/index.tsx:437
 msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
 msgstr "Comercio de créditos de carbono sin comisiones: instantáneo, transparente y siempre disponible. Obtenga más información sobre lo que Carbonmark puede hacer por usted como negociador de créditos de carbono."
-
-#: components/Activities/Activity.tsx:34
-msgid "at"
-msgstr "a"
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr ""
-"La información proporcionada en este post relativo a KlimaDAO (\"KlimaDAO\"), sus criptoactivos, activos comerciales, estrategia y operaciones, tiene únicamente fines informativos generales y no es una oferta formal de venta ni una solicitud de oferta de compra de valores, opciones, futuros u otros derivados relacionados con valores en ninguna jurisdicción y su contenido no está prescrito por las leyes de valores.\n"
-" La información contenida en este post no debe ser considerada como un consejo para comprar o vender o mantener dichos valores o como una oferta para venderlos. Esta post no tiene en cuenta ni proporciona ningún tipo de asesoramiento fiscal, jurídico o de inversión, ni opinión sobre los objetivos de inversión específicos o la situación financiera de ninguna persona.  KlimaDAO y sus agentes, asesores, directores, funcionarios, empleados y accionistas no ofrecen ninguna declaración ni garantía, expresa o implícita, en cuanto a la exactitud de dicha información y KlimaDAO renuncia expresamente a toda responsabilidad que pueda basarse en dicha información o en errores u omisiones de la misma. KlimaDAO se reserva el derecho de modificar o sustituir la información contenida en este documento, en parte o en su totalidad, en cualquier momento, y no se compromete a facilitar al destinatario el acceso a la información modificada ni a notificárselo. La información contenida en este post sustituye a cualquier post o conversación anterior relativa a la misma información, similar o relacionada. Cualquier información, representación o declaración que no esté contenida en el presente documento no deberá ser considerada para ningún propósito. Ni KlimaDAO ni ninguno de sus representantes tendrán responsabilidad alguna, contractual, extracontractual, fiduciaria o de otro tipo, frente a usted o a cualquier persona que resulte del uso de la información contenida en esta entrada de blog por parte de usted o de cualquiera de sus representantes, o por las omisiones de la información contenida en este post. Además, KlimaDAO no asume ninguna obligación de comentar las expectativas o declaraciones de terceros con respecto a los asuntos tratados en este post."
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr "Aviso legal:"
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr "comprado en"
-
-#: components/Layout/index.tsx:52
-msgid "connect a wallet"
-msgstr "conectar un monedero"
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr "listado creado"
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr "listado eliminado"
-
-#: components/pages/Project/Purchase/Listing/Price.tsx:18
-#: components/pages/Project/Purchase/Pool/Price.tsx:17
-#: components/pages/Project/Retire/Pool/Price.tsx:17
-msgid "each"
-msgstr "cada"
-
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr "Después de hacer clic en el botón de abajo para continuar, se le pedirá que conecte su monedero y el proyecto que ha seleccionado aquí ya estará seleccionado para usted en KlimaDAO.finance. A partir de ahí, siga las instrucciones de esa página para completar su transacción."
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr "Los créditos de carbono que adquiera o las retiradas que realice en KlimaDAO.finance también estarán accesibles en su portafolio de Carbonmark."
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr "Será redirigido a KlimaDAO.finance para completar esta transacción."
-
-#: components/Activities/Activity.tsx:112
-msgid "for"
-msgstr "para"
-
-#: components/pages/Retire/index.tsx:52
-msgid "for beneficiary"
-msgstr "para el beneficiario"
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr "Marketplace"
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr "Portfolio"
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr "Perfil"
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr "Retirar"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
-msgid "offset.amount_in_tonnes"
-msgstr "¿Cuántas toneladas de carbono desea compensar? <0>* </0>"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
-msgid "offset.default_retirement_address"
-msgstr "Por defecto, la dirección del monedero conectado"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
-msgid "offset.retire_carbon"
-msgstr "Confirmar Retiro"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
-msgid "offset.retirement_credit"
-msgstr "¿A quién se acreditará esta retirada?"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
-msgid "offset.retirement_message"
-msgstr "Mensaje de Retiro"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr "¡Gracias por apoyar al planeta! Ver transacción en <0> PolygonScan.</0>"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr "¡Gracias por apoyar al planeta!"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr "Su transacción se ha procesado correctamente pero está tardando más de lo normal en indexarse. Pronto aparecerá en tus <0>jubilaciones</0>."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
-msgid "offset_disclaimer"
-msgstr "Tenga cuidado de no incluir ninguna información personal sensible (como una dirección de correo electrónico) en su nombre de retiro o mensaje. La información que introduzca aquí no podrá editarse una vez enviada y existirá permanentemente en una blockchain pública."
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr "Saldos"
-
-#: components/CreateListing/Form/index.tsx:136
-msgid "profile.addListing_modal.submit"
-msgstr "Crear listado"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
-msgid "profile.edit_modal.submit"
-msgstr "Guardar cambios"
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr "Edita tu perfil para añadir una descripción."
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
-msgid "profile.listing.edit.delete_listing"
-msgstr "Eliminar listado"
-
-#: components/pages/Purchases/index.tsx:49
-msgid "project.single.button.back_to_project_details"
-msgstr "Volver a los detalles del proyecto"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr "Está a punto de comprar un activo de carbono."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr "El primer paso es conceder la aprobación para transferir su activo de pago desde su monedero a Carbonmark, el siguiente paso es aprobar la transferencia real y completar su compra."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr "Los activos de carbono que adquiera pueden ponerse a la venta en Carbonmark en cualquier momento desde su <0>portafolio</0>."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr "Compruebe que toda la información es correcta y haga clic en \"aprobar\" para continuar."
-
-#: components/pages/Purchases/index.tsx:145
-msgid "purchase.button.view_assets"
-msgstr "Ver sus activos"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr "El paso anterior concedió la aprobación para transferir su activo de pago de su monedero a Carbonmark."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr "Su compra aún no se ha completado. Para finalizar su compra, compruebe que toda la información es correcta y haga clic en \"Enviar\"."
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr "Categorías"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr "Seleccione uno o más"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr "Borrar todo"
-
-#: components/pages/Resources/ResourcesList/index.tsx:289
-msgid "resources.mobile_modal.button.show_results"
-msgstr "Mostrar resultados"
-
-#: components/pages/Resources/ResourcesList/index.tsx:230
-msgid "resources.page.list.no_search_results.title"
-msgstr "Lo sentimos. No hemos podido encontrar ningún resultado que coincida."
-
-#: components/pages/Resources/ResourcesList/index.tsx:222
-msgid "resources.page.list.on_fetch_error"
-msgstr "¡Lo siento! Algo salió mal."
-
-#: components/pages/Resources/ResourcesList/index.tsx:243
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr "Por favor, utilice una combinación de filtros diferente."
-
-#: components/pages/Resources/ResourcesList/index.tsx:236
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr "Compruebe si hay errores tipográficos en su búsqueda o pruebe con otro término de búsqueda."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
-msgid "retire.back_button"
-msgstr "atrás"
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr "retirados"
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr "Con más de 20 millones de créditos de carbono digitales verificados de cientos de proyectos, Carbonmark ofrece la mayor selección de créditos de carbono digitales de todo el mundo. Compre, venda y retire carbono digital de cualquier proyecto al instante sin comisiones. <0>Comience hoy mismo</0>."
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr "Acerca de Carbonmark"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr "{retiree} ha retirado {formattedAmount} Toneladas de carbono"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr "Carbonmark | Recibo de retirada de carbono"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:50
-msgid "retirement.provenance.head.metaDescription"
-msgstr "Compensaciones transparentes en el Blockchain, impulsadas por Carbonmark."
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:46
-msgid "retirement.provenance.head.metaTitle"
-msgstr "{retiree} ha retirado {formattedAmount} Toneladas de carbono"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:42
-msgid "retirement.provenance.head.title"
-msgstr "Carbonmark | Procedencia de la retirada de carbono"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
-msgid "retirement.single.beneficiary.placeholder"
-msgstr "No se ha facilitado el nombre del beneficiario"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.title"
-msgstr "Beneficiario:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
-msgid "retirement.single.beneficiary_address.title"
-msgstr "Dirección del beneficiario:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr "Retirada de créditos de carbono"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
-msgid "retirement.single.country_region.title"
-msgstr "País/Región:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
-msgid "retirement.single.immutable_public_records.title"
-msgstr "Esto representa la retirada permanente de un activo digital de carbono. Esta retirada y los datos asociados son registros públicos inmutables."
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr "Mensaje de retirada:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.methodology.title"
-msgstr "Metodología:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
-msgid "retirement.single.moss_offset.description"
-msgstr "Los créditos MCO2 son generados por proyectos que preservan la selva amazónica, con todo tipo de externalidades positivas como la creación de empleos locales y la preservación de la biodiversidad local. Explore MCO2 en <0>data.klimadao.finance</0>."
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
-msgid "retirement.single.moss_offset.name"
-msgstr "MOSS Earth MC02"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
-msgid "retirement.single.official_certificate.title"
-msgstr "Certificado oficial de retirada de carbono On-Chain proporcionado por <0>Carbonmark.com</0>"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
-msgid "retirement.single.project.title"
-msgstr "Proyecto:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
-msgid "retirement.single.project_description.title"
-msgstr "Descripción"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
-msgid "retirement.single.project_details.title"
-msgstr "Detalles del proyecto"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
-msgid "retirement.single.project_name.title"
-msgstr "Nombre del proyecto"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr "Prueba de"
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr "CANTIDAD RETIRADA"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
-msgid "retirement.single.share_retirement.title"
-msgstr "Compartir este retiro"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr "No se proporcionó una marca de tiempo de retiro"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
-msgid "retirement.single.transaction_id.title"
-msgstr "ID de transacción"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
-msgid "retirement.single.transaction_record.title"
-msgstr "Registro de transacciones inmutable"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.type.title"
-msgstr "Tipo:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr "Toneladas verificadas de carbono retiradas"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
-msgid "retirement.single.vintage.title"
-msgstr "Vintage:"
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr "No se han encontrado retiros"
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr "Todos los retiros"
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr "Carbonmark - Retiradas de carbono para el beneficiario {0}"
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr "Carbonmark - Retiradas de carbono para el beneficiario {0}"
-
-#: components/pages/Retirements/index.tsx:60
-msgid "retirement.totals.page_headline"
-msgstr "Retiradas de carbono"
-
-#: components/pages/Retirements/index.tsx:66
-msgid "retirement.totals.page_subline"
-msgstr "para el beneficiario"
-
-#: components/pages/Retirements/index.tsx:90
-msgid "retirement.totals.retired_assets"
-msgstr "Activos retirados"
-
-#: components/pages/Retirements/index.tsx:106
-msgid "retirement.totals.retirements"
-msgstr "Retiros"
-
-#: components/pages/Retirements/index.tsx:98
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr "Total de toneladas de carbono retiradas"
-
-#: components/pages/Retirements/index.tsx:112
-msgid "retirement.totals.total_retirement_transactions"
-msgstr "Total de transacciones de retirada"
-
-#: components/pages/Users/SellerUnconnected/index.tsx:70
-msgid "seller.listing.buy"
-msgstr "Comprar"
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr "Cantidad disponible:"
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr "Centro de Recursos"
-
-#: components/pages/Resources/ResourcesList/index.tsx:197
-msgid "shared.resources.sort_by.header"
-msgstr "Ordenar por:"
-
-#: components/Layout/index.tsx:51
-msgid "social or email"
-msgstr "Correo electrónico o redes sociales"
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr "vendido a"
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
-msgid "something went wrong loading the allowance"
-msgstr "algo ha ido mal al cargar el subsidio"
-
-#: components/pages/Retire/Activity/Overview.tsx:77
-#: components/pages/Retire/Activity/Quotes.tsx:76
-#: components/pages/Retire/Activity/Table.tsx:65
-msgid "t"
-msgstr "t"
-
-#: components/Activities/Activity.tsx:119
-msgid "to"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
-msgid "tonnes"
-msgstr "toneladas"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr "Está a punto de retirar un activo de carbono."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr "El primer paso es conceder la aprobación para transferir su activo de carbono de su monedero a Carbonmark, el siguiente paso es aprobar la transferencia real y completar su retiro."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr "Compruebe que toda la información es correcta y haga clic en \"aprobar\" para continuar."
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr "Confirmar cantidad"
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr "Dirección del contrato"
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr "Confirmar precio por tonelada"
-
-#: components/CreateListing/Transaction/index.tsx:83
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr "Volver"
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr "Cerrar"
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr "Siguiente"
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr "Enviar importe"
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr "Enviar"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr "El paso anterior concedió la aprobación para transferir su activo de carbono de su monedero a Carbonmark, su retiro aún no se ha completado."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr "Para finalizar su jubilación, verifique que toda la información sea correcta y, a continuación, haga clic en \"enviar\"."
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr "Dirección del contrato"
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr "Presentar precio por tonelada:"
-
-#: components/CreateListing/Transaction/index.tsx:47
-#: components/Transaction/index.tsx:45
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Aprobar"
-
-#: components/CreateListing/Transaction/index.tsx:57
-#: components/Transaction/index.tsx:55
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Enviar"
-
-#: components/Activities/Activities.constants.ts:10
-msgid "updated expiration"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr "precio actualizado"
-
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr "cantidad actualizada"
-
-#: components/Activities/index.tsx:29
-msgid "user.activities.empty_state"
-msgstr "No hay actividad para mostrar"
-
-#: components/LoginCard/index.tsx:24
-msgid "user.login.description"
-msgstr "Esta función sólo está disponible para usuarios que hayan iniciado sesión. Puede iniciar sesión o crear una cuenta a través del siguiente botón."
-
-#: components/CreateListing/Transaction/Approve.tsx:51
-#: components/CreateListing/Transaction/index.tsx:62
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
-msgid "{0}"
-msgstr "{0}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
-msgid "{0} maximum for credit cards"
-msgstr "{0} máximo para tarjetas de crédito"
-
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr "{0} | Perfil | Carbonmark"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr "{DEFAULT_EXPIRATION_DAYS} dias ({expirationDatestring})"
-
-#: components/pages/Purchases/index.tsx:29
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr "Se compraron {amount} toneladas para el proyecto {0}"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
-#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
-msgid "{formattedAmount} Tonnes"
-msgstr ""
-
-#: components/Quantity/index.tsx:28
-msgid "{formattedAmount} tonnes"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
-msgid "{tokenSymbol}"
-msgstr "{tokenSymbol}"
-
-#: lib/statusMessage.ts:23
-msgid "❌ Error: something went wrong..."
-msgstr "❌ Error: algo ha salido mal..."

--- a/carbonmark/locale/fr/messages.po
+++ b/carbonmark/locale/fr/messages.po
@@ -6,10 +6,85 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/CreateListing/Transaction/Approve.tsx:51
+#: components/CreateListing/Transaction/index.tsx:62
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
+msgid "{0}"
+msgstr "{0}"
+
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr "{0} | Profil | Carbonmark"
+
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
+msgid "{0} maximum for credit cards"
+msgstr "Maximum de {0} pour les cartes de crédit"
+
+#: components/pages/Purchases/index.tsx:29
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr "{amount} tonnes ont été achetées pour le projet {0}"
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr "{DEFAULT_EXPIRATION_DAYS} jours ({expirationDatestring})"
+
+#: components/Quantity/index.tsx:28
+msgid "{formattedAmount} tonnes"
+msgstr "{formattedAmount} tonnes"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
+#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
+msgid "{formattedAmount} Tonnes"
+msgstr "{formattedAmount} Tonnes"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:46
+msgid "retirement.provenance.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
+msgid "{tokenSymbol}"
+msgstr "{tokenSymbol}"
+
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "@Username (note: this can not be changed!)"
+msgstr "@Nom d'utilisateur (note : ceci ne peut pas être changé !)"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
+msgid "<0>* </0> Required Field"
+msgstr "<0>* </0> Champ requis"
+
+#: lib/statusMessage.ts:23
+msgid "❌ Error: something went wrong..."
+msgstr "❌ Erreur : quelque chose s'est mal passé..."
 
 #: components/pages/Home/index.tsx:358
 msgid "0% listing fee"
 msgstr "0% de frais de mise en vente"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:47
+#: components/Transaction/index.tsx:45
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:57
+#: components/Transaction/index.tsx:55
+msgid "transaction_modal.view.submit.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:193
 msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
@@ -32,14 +107,6 @@ msgstr "500 - Erreur du Serveur"
 msgid "500 - Server error occurred"
 msgstr "500 - Une erreur de serveur est survenue"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
-msgid "<0>* </0> Required Field"
-msgstr "<0>* </0> Champ requis"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "@Username (note: this can not be changed!)"
-msgstr "@Nom d'utilisateur (note : ceci ne peut pas être changé !)"
-
 #: components/pages/Project/PayWithBank/index.tsx:153
 msgid "A valid email address is required"
 msgstr "Une adresse email valide est requise"
@@ -54,6 +121,11 @@ msgstr "A-Z"
 msgid "About"
 msgstr "À propos"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr ""
+
 #: components/Stats/StatsListings.tsx:49
 msgid "Active listings:"
 msgstr "Annonces actives :"
@@ -62,6 +134,11 @@ msgstr "Annonces actives :"
 msgid "Activity"
 msgstr "Activité"
 
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr ""
+
 #: lib/getCategoryInfo.ts:53
 msgid "Agriculture"
 msgstr "Agriculture"
@@ -69,6 +146,11 @@ msgstr "Agriculture"
 #: components/pages/Home/index.tsx:362
 msgid "All assets sourced from major registries"
 msgstr "Tous les actifs issus des plus importants registres"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:41
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
@@ -111,6 +193,10 @@ msgstr "Approuver"
 msgid "Asset"
 msgstr "Actif"
 
+#: components/AssetDetails/index.tsx:53
+msgid "Asset details"
+msgstr "Détails de l'actif"
+
 #: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:24
 msgid "Asset Details"
 msgstr "Détails de l'Actif"
@@ -119,9 +205,13 @@ msgstr "Détails de l'Actif"
 msgid "Asset ID"
 msgstr "Identifiant de l'Actif"
 
-#: components/AssetDetails/index.tsx:53
-msgid "Asset details"
-msgstr "Détails de l'actif"
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:32
+msgid "Asset moved from one account to another, either via sale or inter-account transfer."
+msgstr ""
+
+#: components/Activities/Activity.tsx:34
+msgid "at"
+msgstr "à"
 
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:131
 msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
@@ -135,11 +225,6 @@ msgid ""
 msgstr ""
 "Actuellement, Carbonmark ne peut pas traiter les paiements par carte de crédit supérieurs à {0}.\n"
 "Veuillez ajuster la quantité et réessayer plus tard."
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
-msgstr "Tonnes disponibles :"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:116
 msgid "Available balance exceeded"
@@ -165,6 +250,11 @@ msgstr "Disponible à l'achat"
 msgid "Available to retire"
 msgstr "Disponible au retrait du marché"
 
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr "Tonnes disponibles :"
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:219
 msgid "Available:"
 msgstr "Disponible :"
@@ -178,14 +268,20 @@ msgstr "Disponible : {0}"
 msgid "Available: {unlistedBalance}"
 msgstr "Disponible : {unlistedBalance}"
 
-#: components/BetaBadge/index.tsx:18
-msgid "BETA"
-msgstr "BETA"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
+msgid "retire.back_button"
+msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:44
 #: components/pages/Project/Retire/index.tsx:35
 msgid "Back to Project"
 msgstr "Retour au projet"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:49
+msgid "project.single.button.back_to_project_details"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:397
 msgid "Balance"
@@ -201,6 +297,16 @@ msgstr "Solde dépassé"
 msgid "Balance: {0}"
 msgstr "Solde : {0}"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
+msgid "offset_disclaimer"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:450
 msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
 msgstr "Veillez à ne pas inclure d'informations personnelles sensibles (telles qu'une adresse électronique) dans votre nom de retrait ou votre message. Les informations que vous saisissez ici ne peuvent pas être modifiées une fois qu'elles ont été soumises et existeront de manière permanente sur une blockchain publique."
@@ -209,13 +315,18 @@ msgstr "Veillez à ne pas inclure d'informations personnelles sensibles (telles 
 msgid "Beneficiary Address"
 msgstr "Adresse du bénéficiaire"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
-msgid "Beneficiary Name"
-msgstr "Nom du Bénéficiaire"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
+msgid "retirement.single.beneficiary_address.title"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:263
 msgid "Beneficiary name"
 msgstr "Nom du bénéficiaire"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
+msgid "Beneficiary Name"
+msgstr "Nom du Bénéficiaire"
 
 #: components/pages/Project/PayWithBank/index.tsx:232
 #: components/pages/Project/PayWithBank/index.tsx:349
@@ -227,11 +338,20 @@ msgstr "Adresse du portefeuille du bénéficiaire"
 msgid "Beneficiary wallet address (optional)"
 msgstr "Adresse du portefeuille du bénéficiaire (facultatif)"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:34
 #: components/pages/Project/BuyOptions/SellerListing.tsx:67
 #: components/pages/Project/index.tsx:137
 msgid "Best Price"
 msgstr "Meilleur prix"
+
+#: components/BetaBadge/index.tsx:18
+msgid "BETA"
+msgstr "BETA"
 
 #: lib/getCategoryInfo.ts:65
 msgid "Blue Carbon"
@@ -241,9 +361,9 @@ msgstr "Carbone bleu"
 msgid "Book a demo"
 msgstr "Réserver une démo"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:35
-msgid "Bridge"
-msgstr "Pont"
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
+msgstr "acheté à"
 
 #: components/pages/Home/index.tsx:157
 #: components/pages/Home/index.tsx:188
@@ -258,6 +378,11 @@ msgstr "Parcourir les projets"
 #: components/pages/Project/BuyOptions/SellerListing.tsx:98
 msgid "Buy"
 msgstr "Acheter"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:70
+msgid "seller.listing.buy"
+msgstr ""
 
 #: components/pages/Home/index.tsx:168
 msgid "Buy or retire carbon"
@@ -275,6 +400,25 @@ msgstr "Pouvons-nous vous rappeler cette nouveauté plus tard ?"
 msgid "Cancel"
 msgstr "Annuler"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr ""
+
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr "Vous pouvez à tout moment mettre en vente les actifs carbone que vous achetez sur Carbonmark à partir de votre <0>portefeuille</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:30
 msgid "Carbon Pool"
 msgstr "Réserve de Carbone"
@@ -282,6 +426,10 @@ msgstr "Réserve de Carbone"
 #: components/Layout/NavDropdown/index.tsx:117
 msgid "Carbon Portfolio"
 msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
+msgid "Carbon provenance"
+msgstr "Provenance du carbone"
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:60
 msgid "Carbon Provenance"
@@ -291,17 +439,35 @@ msgstr "Provenance du Carbone"
 msgid "Carbon Retirements"
 msgstr "Retraits de Crédits Carbone"
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-msgstr "Vous pouvez à tout moment mettre en vente les actifs carbone que vous achetez sur Carbonmark à partir de votre <0>portefeuille</0>."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:60
+msgid "retirement.totals.page_headline"
+msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
-msgid "Carbon provenance"
-msgstr "Provenance du carbone"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
+msgstr ""
 
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
-msgstr "Vue d'ensemble de Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:42
+msgid "retirement.provenance.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:51
+#: components/pages/Home/index.tsx:52
+msgid "Carbonmark | The Universal Carbon Marketplace"
+msgstr "Carbonmark |  Le Marché Universel du Carbone"
 
 #: components/pages/Home/index.tsx:174
 msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
@@ -317,14 +483,18 @@ msgstr "Frais de Carbonmark"
 msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 msgstr "Carbonmark offre maintenant la possibilité de payer les transactions de retrait du marché par virement bancaire. Remplissez simplement le formulaire ci-dessous et nous vous contacterons dans les 2 jours ouvrés (après avoir reçu toutes les informations requises) pour recueillir des informations supplémentaires et vous envoyer une facture."
 
-#: components/pages/Home/index.tsx:51
-#: components/pages/Home/index.tsx:52
-msgid "Carbonmark | The Universal Carbon Marketplace"
-msgstr "Carbonmark |  Le Marché Universel du Carbone"
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
+msgstr "Vue d'ensemble de Carbonmark"
 
 #: components/pages/Home/index.tsx:488
 msgid "Carbonmark's role"
 msgstr "Rôle de Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
+msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:130
 msgid "Category"
@@ -335,6 +505,11 @@ msgstr "Catégorie"
 msgid "Change language"
 msgstr "Changer de langue"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:236
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
 #: components/pages/Home/index.tsx:206
 msgid "Choose a project and quantity"
 msgstr "Choisissez un projet et une quantité"
@@ -343,8 +518,13 @@ msgstr "Choisissez un projet et une quantité"
 msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 msgstr "Choisissez parmi plus de 20 millions de crédits carbone numériques vérifiés provenant de centaines de projets - achetez, vendez ou retirer du carbone dès maintenant."
 
-#: components/ProjectFilterModal/index.tsx:162
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
 #: components/pages/Projects/ProjectSearch/index.tsx:55
+#: components/ProjectFilterModal/index.tsx:162
 msgid "Clear Filters"
 msgstr "Effacer les filtres"
 
@@ -355,6 +535,11 @@ msgstr "Cliquez sur le bouton \"créer un profil\" pour personnaliser cette page
 #: components/CreateListing/Transaction/Submit.tsx:98
 msgid "Close"
 msgstr "Fermer"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
+msgstr ""
 
 #: components/Footer/index.tsx:32
 msgid "Code of Ethics"
@@ -381,6 +566,16 @@ msgstr "Comparez les prix de tous les vendeurs et pools d'échange"
 msgid "Compiling Results ..."
 msgstr "Compilation des résultats..."
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr ""
+
 #: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:83
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
 #: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
@@ -388,9 +583,18 @@ msgstr "Compilation des résultats..."
 msgid "Confirm Purchase"
 msgstr "Confirmer l'achat"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
+msgid "offset.retire_carbon"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:75
 msgid "Confirm Retirement"
 msgstr "Confirmer le Retrait"
+
+#: components/Layout/index.tsx:52
+msgid "connect a wallet"
+msgstr "connecter un portefeuille"
 
 #: components/pages/Portfolio/ConnectedWallet/index.tsx:33
 msgid "Connected Wallet"
@@ -416,6 +620,16 @@ msgstr "Nous contacter"
 msgid "Continue"
 msgstr "Continuer"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
 #: components/CopyAddressButton/index.tsx:37
 msgid "Copy"
 msgstr "Copier"
@@ -433,15 +647,10 @@ msgstr "Impossible de supprimer l'annonce. Veuillez réessayer."
 msgid "Country"
 msgstr "Pays"
 
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr "Créer une nouvelle annonce"
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Create Profile"
-msgstr "Créer un profil"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
+msgid "retirement.single.country_region.title"
+msgstr ""
 
 #: components/CreateListing/index.tsx:165
 msgid "Create a listing"
@@ -459,6 +668,21 @@ msgstr "Créez un profil vendeur"
 msgid "Create and edit listings, and track your activity with your Carbonmark profile."
 msgstr "Créez et modifiez vos annonces et suivez votre activité grâce à votre profil Carbonmark."
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:136
+msgid "profile.addListing_modal.submit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr "Créer une nouvelle annonce"
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Create Profile"
+msgstr "Créer un profil"
+
 #: components/pages/Home/index.tsx:313
 msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
 msgstr "Créez votre propre vitrine carbone. Vendez directement aux organisations et aux particuliers."
@@ -467,25 +691,29 @@ msgstr "Créez votre propre vitrine carbone. Vendez directement aux organisation
 msgid "Create your own retirement"
 msgstr "Créer votre propre retrait du marché"
 
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr "annonce créée"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:87
 msgid "Created:"
 msgstr "Créé :"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
-msgid "Credit ID"
-msgstr "Identifiant de crédit"
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
-msgstr "Le montant minimum d'achat par carte de crédit est de {formattedFiatMinimum} $"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:77
 msgid "Credit card minimum purchase is {0}"
 msgstr "L'achat minimum par carte de crédit est de {0}"
 
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr "Le montant minimum d'achat par carte de crédit est de {formattedFiatMinimum} $"
+
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:247
 msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
 msgstr "Les paiements par carte de crédit entraînent des frais de traitement supplémentaires. <0>Voir la documentation pour en savoir plus.</0>"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
+msgid "Credit ID"
+msgstr "Identifiant de crédit"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:435
 msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
@@ -495,10 +723,6 @@ msgstr "Actuellement, Carbonmark n'accepte que les paiements par carte de crédi
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
 msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
 msgstr "Actuellement, Carbonmark n'accepte que les paiements en USDC sur Polygon. <0>Découvrir comment acquérir des USDC sur Polygon.</0>"
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
-msgstr "DATE"
 
 #: components/pages/Project/index.tsx:234
 msgid "Data for this project and vintage"
@@ -513,9 +737,27 @@ msgstr "Données pour ce vendeur"
 msgid "Date"
 msgstr "Date"
 
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr "DATE"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
+msgid "offset.default_retirement_address"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:296
 msgid "Defaults to the connected wallet address"
 msgstr "Par défaut, l'adresse du portefeuille connecté"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
+msgid "profile.listing.edit.delete_listing"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
+msgstr "annonce supprimée"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:307
 msgid "Describe the purpose of this retirement"
@@ -525,6 +767,11 @@ msgstr "Décrivez le but de ce retrait du marché"
 msgid "Description"
 msgstr "Description"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
+msgid "retirement.single.project_description.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:51
 msgid "Digital Carbon"
 msgstr "Carbone Numérique"
@@ -532,6 +779,11 @@ msgstr "Carbone Numérique"
 #: components/pages/Home/index.tsx:264
 msgid "Digitize your carbon by using a supported bridge"
 msgstr "Numérisez votre carbone en utilisant un pont compatible"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
 msgid "Display name"
@@ -557,18 +809,29 @@ msgstr "Téléchargement en cours ..."
 msgid "Drive climate action and earn rewards with a carbon-backed digital currency."
 msgstr "Combattez le changement climatique et soyez récompensés avec une monnaie numérique garantie par du carbone."
 
+#: components/pages/Project/Purchase/Listing/Price.tsx:18
+#: components/pages/Project/Purchase/Pool/Price.tsx:17
+#: components/pages/Project/Retire/Pool/Price.tsx:17
+msgid "each"
+msgstr "chacun"
+
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:195
 msgid "Edit"
 msgstr "Modifier"
+
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
+msgid "Edit listing"
+msgstr "Modifier l'annonce"
 
 #: components/pages/Users/SellerConnected/index.tsx:113
 #: components/pages/Users/SellerConnected/index.tsx:138
 msgid "Edit Profile"
 msgstr "Modifier votre profil"
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
-msgid "Edit listing"
-msgstr "Modifier l'annonce"
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:143
 #: components/pages/Project/PayWithBank/index.tsx:307
@@ -628,6 +891,19 @@ msgstr "Le prénom ne doit pas contenir de chiffres ni de caractères spéciaux"
 msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
 msgstr "Tout d'abord, vous devez donner l'autorisation au système Carbonmark de transférer cet actif en votre nom."
 
+#: components/Activities/Activity.tsx:112
+msgid "for"
+msgstr "pour"
+
+#: components/pages/Retire/index.tsx:52
+msgid "for beneficiary"
+msgstr "pour le bénéficiaire"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:66
+msgid "retirement.totals.page_subline"
+msgstr ""
+
 #: components/pages/Home/index.tsx:340
 msgid "For carbon traders"
 msgstr "Pour les négociants en carbone"
@@ -644,20 +920,26 @@ msgstr "Forêts"
 msgid "Form complete"
 msgstr "Formulaire rempli"
 
-#: components/pages/Home/index.tsx:76
-msgid "Get Started"
-msgstr "Commencer"
-
 #: components/pages/Home/index.tsx:390
 msgid "Get paid immediately: transactions are resolved in seconds"
 msgstr "Soyez payé immédiatement : les transactions sont exécutées en quelques secondes"
 
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
-msgstr "Retour"
+#: components/pages/Home/index.tsx:76
+msgid "Get Started"
+msgstr "Commencer"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:83
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
 msgid "Go back"
+msgstr "Retour"
+
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
 msgstr "Retour"
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:145
@@ -683,8 +965,8 @@ msgid "Here’s a list of readily available, discounted carbon tokens to retire 
 msgstr "Voici une liste de jetons de carbone immédiatement disponibles et à prix réduit pour prendre sa retraite rapidement et facilement."
 
 #: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:48
-msgid "Hide {numberOfTransfers} transfers"
-msgstr "Masquer {numberOfTransfers} transferts"
+msgid "Hide {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:80
 msgid "How many tonnes do you want to list for sale?"
@@ -698,6 +980,11 @@ msgstr "Combien de tonnes de carbone voulez-vous acheter ?"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:249
 msgid "How many tonnes of carbon do you want to retire?"
 msgstr "Combien de tonnes de carbone voulez-vous retirer du marché ?"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
+msgid "offset.amount_in_tonnes"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:215
 msgid "How many tonnes of carbon would you like to retire?"
@@ -722,6 +1009,11 @@ msgstr "Les crédits ICR ne peuvent être retirés que par tonnes entières"
 #: components/pages/Purchases/index.tsx:93
 msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
 msgstr "Si vous souhaitez retirer du marché une partie ou la totalité des crédits carbone de cet achat, allez dans votre <0>portefeuille</0>, cliquez sur le bouton \"retirer du marché\" et suivez les instructions."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
+msgid "retirement.single.transaction_record.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:116
 msgid "Indicates required field"
@@ -777,13 +1069,13 @@ msgstr "Le nom ne doit pas contenir de chiffres ou de caractères spéciaux"
 msgid "Latest First"
 msgstr "Le plus récent en premier"
 
+#: components/pages/Home/index.tsx:417
+msgid "Learn more"
+msgstr "En savoir plus"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:92
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:103
 msgid "Learn More"
-msgstr "En savoir plus"
-
-#: components/pages/Home/index.tsx:417
-msgid "Learn more"
 msgstr "En savoir plus"
 
 #: components/pages/Home/index.tsx:491
@@ -817,11 +1109,11 @@ msgid "Loading your assets"
 msgstr "Chargement de vos actifs"
 
 #: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:295
 #: components/pages/Retire/Activity/Overview.tsx:73
 #: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
 msgid "Loading..."
 msgstr "Chargement..."
 
@@ -861,6 +1153,11 @@ msgstr ""
 msgid "Marketplace"
 msgstr "Place de Marché"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr ""
+
 #: components/pages/Projects/index.tsx:73
 #: components/pages/Projects/index.tsx:74
 msgid "Marketplace | Carbonmark"
@@ -870,21 +1167,36 @@ msgstr "Place de Marché | Carbonmark"
 msgid "Maximize your climate impact."
 msgstr "Maximisez votre impact climatique."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.moss_offset.description"
+msgstr ""
+
 #: components/pages/Project/index.tsx:144
 msgid "Methodology"
 msgstr "Méthodologie"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.methodology.title"
+msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:54
 msgid "Moss"
 msgstr "Moss"
 
-#: components/FeatureBanner/index.tsx:33
-msgid "NEW FEATURE:"
-msgstr "NOUVELLE FONCTIONNALITÉ:"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
+msgid "retirement.single.moss_offset.name"
+msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:171
 msgid "Navigation Menu"
 msgstr ""
+
+#: components/FeatureBanner/index.tsx:33
+msgid "NEW FEATURE:"
+msgstr "NOUVELLE FONCTIONNALITÉ:"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
 msgid "New Quantity"
@@ -898,17 +1210,27 @@ msgstr "Nouveau Prix Unitaire (USDC)"
 msgid "Next"
 msgstr "Suivant"
 
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
-msgstr "Aucune activité à montrer"
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:197
 #: components/pages/Users/SellerUnconnected/index.tsx:83
 msgid "No active listings."
 msgstr "Aucune annonce active."
 
+#. js-lingui-explicit-id
+#: components/Activities/index.tsx:29
+msgid "user.activities.empty_state"
+msgstr ""
+
 #: components/pages/Retire/Activity/Quotes.tsx:38
 msgid "No activity to show"
+msgstr "Aucune activité à montrer"
+
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
 msgstr "Aucune activité à montrer"
 
 #: components/pages/Home/index.tsx:400
@@ -918,6 +1240,11 @@ msgstr "Aucune barrière à l'entrée pour les projets carbone vérifiés"
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:40
 msgid "No beneficiary address available"
 msgstr "Aucune adresse de bénéficiaire disponible"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
+msgid "retirement.single.beneficiary.placeholder"
+msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:62
 msgid "No data to show"
@@ -952,24 +1279,39 @@ msgstr "Aucun enregistrement trouvé"
 msgid "No retirement message provided."
 msgstr "Aucun message de retrait du marché fourni."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
 msgid "No transaction id available"
 msgstr "Aucun identifiant de transaction disponible"
-
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
-msgstr "Non connecté"
 
 #: components/pages/Project/PayWithBank/index.tsx:240
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:288
 msgid "Not a valid polygon address"
 msgstr "Adresse Polygon invalide"
 
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr "Non connecté"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
+msgid "retirement.single.official_certificate.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:72
 msgid "Oldest First"
 msgstr "Le plus ancien en premier"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:185
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:188
 msgid "On the Verra page, search for the specific serial number."
 msgstr "Sur la page Verra, recherchez le numéro de série spécifique."
 
@@ -993,22 +1335,18 @@ msgstr "Notre système met plus de temps que prévu. Le retrait devrait bientôt
 msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 msgstr "Plus de 20 millions de crédits carbone numériques vérifiés provenant de centaines de projets, avec plus de 4 milliards de dollars échangés à ce jour."
 
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr "PROJET"
-
 #: components/pages/Projects/Banners/BankTransfer.tsx:74
 msgid "Pay via Bank Transfer / Wire"
 msgstr "Payer par Virement Bancaire / Wire"
+
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
+msgstr "Payer par virement bancaire"
 
 #: components/pages/Project/PayWithBank/index.tsx:89
 #: components/pages/Project/PayWithBank/index.tsx:90
 msgid "Pay with Bank Transfer | Carbonmark"
 msgstr "Payer par Virement Bancaire | Carbonmark"
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
-msgstr "Payer par virement bancaire"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:94
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:112
@@ -1016,22 +1354,18 @@ msgstr "Payer par virement bancaire"
 msgid "Pay with:"
 msgstr "Payer avec :"
 
-#: components/pages/Purchases/index.tsx:62
-msgid "Payment Successful"
-msgstr "Paiement réussi"
-
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:243
 msgid "Payment processing fee"
 msgstr "Frais de traitement du paiement"
+
+#: components/pages/Purchases/index.tsx:62
+msgid "Payment Successful"
+msgstr "Paiement réussi"
 
 #: components/pages/Project/PayWithBank/index.tsx:161
 #: components/pages/Project/PayWithBank/index.tsx:313
 msgid "Phone number"
 msgstr "Numéro de téléphone"
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
-msgstr "Veuillez vous connecter"
 
 #: lib/statusMessage.ts:27
 msgid "Please click 'confirm' in your wallet to continue."
@@ -1041,11 +1375,25 @@ msgstr "Veuillez cliquer sur « confirmer » dans votre portefeuille pour cont
 msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr "Veuillez remplir le formulaire sécurisé sur la page suivante et nous vous enverrons une facture dans les deux jours ouvrés (après réception de toutes les informations requises)."
 
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr "Veuillez vous connecter"
+
 #: components/pages/Portfolio/index.tsx:66
 #: components/pages/Users/SellerConnected/index.tsx:75
 #: components/pages/Users/SellerConnected/index.tsx:101
 msgid "Please refresh the page. There was an error updating your data: {e}."
 msgstr "Veuillez actualiser la page. Une erreur s'est produite lors de la mise à jour de vos données : {e}."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:243
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:76
 #: components/pages/Portfolio/index.tsx:77
@@ -1064,10 +1412,6 @@ msgstr "Communiqués de presse"
 msgid "Price Highest"
 msgstr "Prix le plus élevé"
 
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr "Prix le plus bas"
-
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:180
@@ -1077,6 +1421,10 @@ msgstr "Le prix comprend les frais de réseau. <0>Voir la documentation pour en 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:160
 msgid "Price is required"
 msgstr "Le prix est requis"
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
+msgstr "Prix le plus bas"
 
 #: components/CreateListing/Transaction/Submit.tsx:62
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
@@ -1112,19 +1460,48 @@ msgstr "Retrait du marché en cours..."
 msgid "Profile"
 msgstr "Profil"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:192
 msgid "Profile picture"
 msgstr "Photo de profil"
+
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr "PROJET"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
+msgid "retirement.single.project_name.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:253
 #: components/pages/Project/PayWithBank/index.tsx:357
 msgid "Project names of interest"
 msgstr "Noms de projets d'intérêt"
 
-#: components/pages/Purchases/index.tsx:36
-#: components/pages/Purchases/index.tsx:37
-msgid "Purchase Receipt | Carbonmark"
-msgstr "Reçu d'achat | Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
+msgid "retirement.single.project.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr ""
+
+#: components/pages/Project/Purchase/index.tsx:32
+#: components/pages/Project/Purchase/index.tsx:33
+msgid "Purchase {0} | Carbonmark"
+msgstr "Achat {0} | Carbonmark"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:53
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
@@ -1135,6 +1512,11 @@ msgstr "Quantité achetée (tonnes) :"
 msgid "Purchase more Carbon"
 msgstr "Acheter plus de Carbone"
 
+#: components/pages/Purchases/index.tsx:36
+#: components/pages/Purchases/index.tsx:37
+msgid "Purchase Receipt | Carbonmark"
+msgstr "Reçu d'achat | Carbonmark"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:79
 msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer."
 msgstr "Achetez des retraits de n'importe quel projet sur Carbonmark et payez par virement bancaire."
@@ -1142,11 +1524,6 @@ msgstr "Achetez des retraits de n'importe quel projet sur Carbonmark et payez pa
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
 msgid "Purchase successful"
 msgstr "Achat réussi"
-
-#: components/pages/Project/Purchase/index.tsx:32
-#: components/pages/Project/Purchase/index.tsx:33
-msgid "Purchase {0} | Carbonmark"
-msgstr "Achat {0} | Carbonmark"
 
 #: components/pages/Retire/Activity/Table.tsx:47
 msgid "QTY"
@@ -1162,6 +1539,11 @@ msgstr "Quantité"
 msgid "Quantity Available:"
 msgstr "Quantité Disponible :"
 
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:240
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:108
 msgid "Quantity is required"
@@ -1175,21 +1557,18 @@ msgstr "Quantité en vente : {listedQuantity}, Quantité non vendue : {unlistedQ
 msgid "Quantity purchased:"
 msgstr "Quantité achetée :"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr ""
+
 #: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr "Retrait Rapide"
 
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr "RETIRER DU CARBONE"
-
 #: components/pages/Project/index.tsx:198
 msgid "Read Less"
 msgstr "En lire moins"
-
-#: components/pages/Project/index.tsx:198
-msgid "Read More"
-msgstr "En savoir plus"
 
 #: components/pages/Home/index.tsx:445
 #: components/pages/Home/index.tsx:472
@@ -1197,6 +1576,10 @@ msgstr "En savoir plus"
 #: components/pages/Resources/BlogPostCard/index.tsx:38
 #: components/pages/Resources/FeaturedArticles/Article.tsx:45
 msgid "Read more"
+msgstr "En savoir plus"
+
+#: components/pages/Project/index.tsx:198
+msgid "Read More"
 msgstr "En savoir plus"
 
 #: components/pages/Home/index.tsx:351
@@ -1215,14 +1598,14 @@ msgstr "Quantité restante :"
 msgid "Renewable Energy"
 msgstr "Énergie Renouvelable"
 
+#: lib/constants.ts:82
+msgid "Request already processing. Please open your wallet and complete the request."
+msgstr "Requête en cours de traitement. Veuillez ouvrir votre portefeuille et valider la requête."
+
 #: components/pages/Home/index.tsx:301
 #: components/pages/Home/index.tsx:325
 msgid "Request Demo"
 msgstr "Demander une démo"
-
-#: lib/constants.ts:82
-msgid "Request already processing. Please open your wallet and complete the request."
-msgstr "Requête en cours de traitement. Veuillez ouvrir votre portefeuille et valider la requête."
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:210
 msgid "Required Field"
@@ -1232,6 +1615,11 @@ msgstr "Champs requis"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:311
 msgid "Required when proceeding with Credit Card"
 msgstr "Requis lors de paiement par carte de crédit"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
+msgstr ""
 
 #: components/Footer/index.tsx:38
 #: components/pages/Home/index.tsx:508
@@ -1259,15 +1647,36 @@ msgstr "Résultats"
 msgid "Retire"
 msgstr "Retirer du marché"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/index.tsx:88
+#: components/pages/Portfolio/Retire/index.tsx:89
+#: components/pages/Retire/index.tsx:38
+#: components/pages/Retire/index.tsx:39
+msgid "Retire | Carbonmark"
+msgstr "Retirer - Carbonmark"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:388
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
 msgid "Retire Carbon"
 msgstr "Retirer du marché des crédits Carbone"
 
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr "RETIRER DU CARBONE"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:233
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "Retirer du marché des crédits carbone pour vous-même ou pour le compte d'une autre personne ou entreprise."
+
+#: components/pages/Project/Retire/index.tsx:23
+#: components/pages/Project/Retire/index.tsx:24
+msgid "Retire from {fullProjectid} | Carbonmark"
+msgstr "Retrait du marché de {fullProjectid} | Carbonmark"
 
 #: components/pages/Retire/index.tsx:72
 msgid "Retire from a featured project"
@@ -1277,24 +1686,19 @@ msgstr "Retirer du marché à partir d'un projet phare"
 msgid "Retire from your portfolio"
 msgstr "Retirer à partir de votre portefeuille"
 
-#: components/pages/Project/Retire/index.tsx:23
-#: components/pages/Project/Retire/index.tsx:24
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr "Retrait du marché de {fullProjectid} | Carbonmark"
-
 #: components/pages/Home/index.tsx:232
 msgid "Retire instantly, or purchase and hold digital carbon"
 msgstr "Retirez du marché instantanément ou achetez et conservez du carbone numérique."
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
-msgstr "Retirer plus de Carbone"
 
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
 msgid "Retire more carbon"
 msgstr "Retirer plus de carbone"
+
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
+msgstr "Retirer plus de Carbone"
 
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:56
 #: components/pages/Project/BuyOptions/SellerListing.tsx:106
@@ -1309,14 +1713,16 @@ msgstr "Retirez maintenant ou acquérez du carbone pour le retirer plus tard - c
 msgid "Retire your carbon via bank transfer."
 msgstr "Retirer du marché votre carbone par virement bancaire."
 
-#: components/pages/Portfolio/Retire/index.tsx:88
-#: components/pages/Portfolio/Retire/index.tsx:89
-#: components/pages/Retire/index.tsx:38
-#: components/pages/Retire/index.tsx:39
-msgid "Retire | Carbonmark"
-msgstr "Retirer - Carbonmark"
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
+msgstr "retirées"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:13
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:90
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:16
 msgid "Retirement"
 msgstr "Retrait"
 
@@ -1324,33 +1730,53 @@ msgstr "Retrait"
 msgid "Retirement Activity"
 msgstr "Activité des retraits"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
-msgid "Retirement Message"
-msgstr "Message de Retrait du marché"
-
-#: components/pages/Retire/Activity/Overview.tsx:60
-#: components/pages/Retire/Activity/Overview.tsx:70
-msgid "Retirement Overview"
-msgstr "Vue d'ensemble des Retraits"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr "Retrait du marché réussi !"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
+msgid "offset.retirement_message"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:264
 #: components/pages/Project/PayWithBank/index.tsx:363
 msgid "Retirement message"
 msgstr "Message de retrait du marché"
 
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
+msgid "Retirement Message"
+msgstr "Message de Retrait du marché"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr ""
+
+#: components/pages/Retire/Activity/Overview.tsx:60
+#: components/pages/Retire/Activity/Overview.tsx:70
+msgid "Retirement Overview"
+msgstr "Vue d'ensemble des Retraits"
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:74
 msgid "Retirement successful"
 msgstr "Retrait du marché réussi"
 
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr "Retrait du marché réussi !"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:106
+msgid "retirement.totals.retirements"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:384
 msgid "Retiring Token"
 msgstr "Retrait du Jeton"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
+msgid "profile.edit_modal.submit"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:201
 msgid "Say a few words about yourself. This will be visible in your seller profile."
@@ -1387,6 +1813,11 @@ msgstr "Sélectionner"
 msgid "Select a language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr ""
+
 #: components/pages/Portfolio/AssetProject/index.tsx:100
 #: components/pages/Portfolio/AssetProject/index.tsx:108
 msgid "Sell"
@@ -1404,13 +1835,27 @@ msgstr "Vendez votre carbone numérique directement aux acheteurs"
 msgid "Seller Listing"
 msgstr "Annonces du vendeur"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:159
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:29
+msgid "Send"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:161
 msgid "Serial Number"
 msgstr "Numéro de Série"
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:76
 msgid "Share this page"
 msgstr "Partager cette page"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
+msgid "retirement.single.share_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:289
+msgid "resources.mobile_modal.button.show_results"
+msgstr ""
 
 #: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
 #: components/pages/Project/Purchase/Pool/SubmitButton.tsx:31
@@ -1425,6 +1870,19 @@ msgstr "Le Prix à l'unité est requis"
 #: components/CreateListing/Form/index.tsx:130
 msgid "Single unit price"
 msgstr "Prix unitaire"
+
+#: components/Layout/index.tsx:51
+msgid "social or email"
+msgstr "réseau social ou email"
+
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr "vendu à"
+
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
+msgid "something went wrong loading the allowance"
+msgstr "quelque chose s'est mal passé lors du chargement de l'autorisation"
 
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
 msgid "Something went wrong loading the allowance"
@@ -1450,13 +1908,28 @@ msgstr "Désolé, un problème est survenu."
 msgid "Sorry, this handle already exists"
 msgstr "Désolé, ce pseudonyme existe déjà"
 
-#: components/pages/Resources/ResourcesList/index.tsx:265
-msgid "Sort By"
-msgstr "Trier par"
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:222
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:230
+msgid "resources.page.list.no_search_results.title"
+msgstr ""
 
 #: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "Sort by"
 msgstr "Trier par"
+
+#: components/pages/Resources/ResourcesList/index.tsx:265
+msgid "Sort By"
+msgstr "Trier par"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:197
+msgid "shared.resources.sort_by.header"
+msgstr ""
 
 #: components/Stats/index.tsx:23
 msgid "Stats"
@@ -1482,6 +1955,21 @@ msgstr "Étape 3"
 msgid "Submit"
 msgstr "Envoyer"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr ""
+
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:88
 msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
 msgstr "Succès ! Votre nouvelle annonce apparaîtra dans quelques instants sur votre <0>page de profil</0>."
@@ -1494,13 +1982,25 @@ msgstr "Bien sûr"
 msgid "Switch to Polygon"
 msgstr "Passer sur le réseau Polygon"
 
-#: components/BetaBadge/index.tsx:16
-msgid "TESTNET"
-msgstr ""
+#: components/pages/Retire/Activity/Overview.tsx:77
+#: components/pages/Retire/Activity/Quotes.tsx:76
+#: components/pages/Retire/Activity/Table.tsx:65
+msgid "t"
+msgstr "t"
 
 #: components/Footer/index.tsx:29
 msgid "Terms of Use"
 msgstr "Conditions d'Utilisation"
+
+#: components/BetaBadge/index.tsx:16
+msgid "TESTNET"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
 msgid "Thank you for supporting the planet!"
@@ -1510,21 +2010,32 @@ msgstr "Merci de soutenir la planète !"
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr "Merci de votre contribution pour la planète ! Vous pouvez voir les détails d'achat ci-dessous."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:292
 msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr "Merci de soutenir la planète ! Nous vous contacterons bientôt pour confirmer certains détails et vous fournir une facture."
-
-#: components/pages/Home/index.tsx:65
-msgid "The Universal Carbon Marketplace"
-msgstr "Le Marché Universel du Carbone"
 
 #: components/CreateListing/Transaction/Approve.tsx:44
 msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 msgstr "Les actifs ne seront transférés hors de votre portefeuille que lorsqu'une vente sera conclue. Vous pouvez révoquer cette autorisation de limite à tout moment."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:34
 msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
 msgstr "La première étape consiste à donner l'autoriser à Carbonmark de transférer l'actif carbone de votre portefeuille, l'étape suivante consiste à approuver le transfert en lui-même et à finaliser votre retraite."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
 msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
@@ -1533,6 +2044,12 @@ msgstr "La première étape est de donner l'autorisation à Carbonmark de transf
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
 msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
 msgstr "Les informations ci-dessous seront diffusées publiquement pour vérifier votre déclaration environnementale. Cette transaction est permanente ; les informations ne peuvent pas être modifiées une fois la transaction terminée."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
+msgstr ""
 
 #: components/pages/Home/index.tsx:53
 #: components/pages/Home/index.tsx:68
@@ -1572,13 +2089,27 @@ msgstr "Le prix minimum par tonne est de {0}"
 msgid "The minimum quantity to sell is 1 tonne"
 msgstr "La quantité minimale à vendre est de 1 tonne"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:53
 msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 msgstr "L'étape précédente a donné l'autorisation de transférer votre actif carbone de votre portefeuille à Carbonmark, votre retrait n'a pas encore été effectué."
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
 msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
 msgstr "L'étape précédente a accordé l'autorisation à Carbonmark de transférer votre actif de paiement de votre portefeuille ."
+
+#: components/pages/Home/index.tsx:65
+msgid "The Universal Carbon Marketplace"
+msgstr "Le Marché Universel du Carbone"
 
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:208
 msgid "There was an error during the checkout process. Please try again."
@@ -1601,6 +2132,11 @@ msgstr "Une erreur s'est produite lors du calcul du coût total."
 msgid "This app only works on Polygon Mainnet."
 msgstr "Cette application fonctionne uniquement sur le réseau Polygon principal."
 
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:24
+msgid "user.login.description"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
 msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
 msgstr "Voici votre portefeuille. Vous y trouverez les actifs carbone supportés que vous possédez. Les actifs présentés ici peuvent être retirés du marché ou mis en vente sur le marché une fois que vous aurez un profil."
@@ -1621,13 +2157,27 @@ msgstr "Cette offre n'existe plus."
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr "Ce produit est encore en version bêta et des audits n'ont pas encore été réalisés."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
+msgid "retirement.single.immutable_public_records.title"
+msgstr ""
+
 #: components/pages/Users/ProfileHeader/index.tsx:46
 msgid "This user has not yet created a carbonmark profile."
 msgstr "Cet utilisateur n'a pas encore créé de profil Carbonmark."
 
+#: components/Activities/Activity.tsx:119
+msgid "to"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr "Pour effectuer votre transaction par carte de crédit, vous serez redirigé vers Stripe, notre partenaire de traitement des paiements."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:60
 msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
@@ -1641,22 +2191,22 @@ msgstr "Pour commencer, veillez à compléter votre <0>profil</0>, puis rendez-v
 msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr "Pour payer par virement bancaire, nous aurons besoin de quelques informations."
 
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr "Activer ou désactiver la sélection de projet"
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr "Basculer vers le menu \"Trié par\""
-
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
 msgid "Toggle payment method"
 msgstr "Basculer de mode de paiement"
 
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr "Activer ou désactiver la sélection de projet"
+
 #: components/pages/Projects/ProjectSort/index.tsx:29
 msgid "Toggle sort menu"
 msgstr "Afficher le menu de tri"
+
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
+msgstr "Basculer vers le menu \"Trié par\""
 
 #: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:209
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
@@ -1666,6 +2216,10 @@ msgstr "Jeton que vous recevrez"
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
 msgid "Tokens received:"
 msgstr "Jetons reçus :"
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
+msgid "tonnes"
+msgstr "tonnes"
 
 #: components/AssetDetails/index.tsx:63
 #: components/pages/Project/PayWithBank/index.tsx:125
@@ -1686,22 +2240,6 @@ msgstr "Tonnes vendues :"
 msgid "Tonnes sold:"
 msgstr "Tonnes vendues :"
 
-#: components/CreateListing/Form/index.tsx:85
-msgid "Total Amount to Sell is required"
-msgstr "Le Montant Total à Vendre est requis"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
-msgid "Total Cost is required"
-msgstr "Le Coût Total est requis"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr "Prix Total"
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr "Total des retraits du marché :"
-
 #: components/CreateListing/Transaction/Approve.tsx:61
 msgid "Total allowance"
 msgstr "Autorisation totale"
@@ -1710,9 +2248,18 @@ msgstr "Autorisation totale"
 msgid "Total amount of tonnes to retire is required"
 msgstr "La quantité totale en tonnes à retirer est requise"
 
+#: components/CreateListing/Form/index.tsx:85
+msgid "Total Amount to Sell is required"
+msgstr "Le Montant Total à Vendre est requis"
+
 #: components/pages/Retire/Activity/Overview.tsx:72
 msgid "Total carbon tonnes retired"
 msgstr "Total des tonnes de carbone retirées du marché"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:98
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr ""
 
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
@@ -1720,10 +2267,18 @@ msgstr "Total des tonnes de carbone retirées du marché"
 msgid "Total cost"
 msgstr "Coût total"
 
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
+msgid "Total Cost is required"
+msgstr "Le Coût Total est requis"
+
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:166
 msgid "Total price"
 msgstr "Prix total"
+
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
+msgstr "Prix Total"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:103
 msgid "Total quantity to list for sale"
@@ -1732,6 +2287,15 @@ msgstr "Quantité totale à mettre en vente"
 #: components/pages/Retire/Activity/Overview.tsx:83
 msgid "Total retirement transactions"
 msgstr "Total des transactions de retrait du marché"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:112
+msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
+msgstr "Total des retraits du marché :"
 
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
@@ -1742,25 +2306,32 @@ msgstr "Coût total de la vente"
 msgid "Transaction complete."
 msgstr "Transaction terminée."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
+msgid "retirement.single.transaction_id.title"
+msgstr ""
+
 #: lib/statusMessage.ts:29
 msgid "Transaction initiated. Waiting for network confirmation."
 msgstr "Transaction initiée. En attente de confirmation du réseau."
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:24
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:48
 msgid "Transfer"
 msgstr "Transfert"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:50
+msgid "retirement.provenance.head.metaDescription"
+msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:128
 msgid "Transparent, on-chain offsets powered by Carbonmark."
 msgstr "Des compensations transparentes et sur la chaîne, réalisées par Carbonmark."
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "USDC per ton"
-msgstr "USDC par tonne"
-
-#: components/CreateListing/Form/index.tsx:110
-msgid "USDC per tonne"
-msgstr "USDC par tonne"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.type.title"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:115
 msgid "Unit price is required"
@@ -1778,6 +2349,18 @@ msgstr "Une transparence sans précédent sur le marché numérique du carbone."
 msgid "Update listing"
 msgstr "Mettre à jour l'annonce"
 
+#: components/Activities/Activities.constants.ts:10
+msgid "updated expiration"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr "prix mis à jour"
+
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr "quantité mise à jour"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:91
 msgid "Updated:"
 msgstr "Mis à jour :"
@@ -1785,6 +2368,14 @@ msgstr "Mis à jour :"
 #: components/pages/Users/SellerConnected/index.tsx:191
 msgid "Updating your data..."
 msgstr "Mise à jour de vos données..."
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "USDC per ton"
+msgstr "USDC par tonne"
+
+#: components/CreateListing/Form/index.tsx:110
+msgid "USDC per tonne"
+msgstr "USDC par tonne"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:61
 msgid "User Guides"
@@ -1799,6 +2390,21 @@ msgstr "Profil utilisateur | Carbonmark"
 msgid "User refused connection."
 msgstr "L'utilisateur a refusé la connexion."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:41
 msgid "Verify all information is correct and click 'approve' to continue."
@@ -1808,17 +2414,9 @@ msgstr "Vérifiez que toutes les informations sont correctes et cliquez sur \"ap
 msgid "View"
 msgstr "Voir"
 
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
-msgid "View Carbonmark Profile"
-msgstr "Voir le profil Carbonmark"
-
-#: components/pages/Project/index.tsx:207
-msgid "View Registry Details <0/>"
-msgstr "Voir les détails du registre <0/>"
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
-msgstr "Voir les résultats"
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
+msgid "View {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:78
 msgid "View a complete overview of the digital carbon that you own in your Portfolio."
@@ -1853,9 +2451,17 @@ msgstr "Voir et acheter ce projet de compensation carbone sur Carbonmark"
 msgid "View and share certificate"
 msgstr "Voir et partager le certificat"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:180
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
+msgid "View Carbonmark Profile"
+msgstr "Voir le profil Carbonmark"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:183
 msgid "View issuance on Verra"
 msgstr "Voir l'émission sur Verra"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
+msgid "View on Polygonscan"
+msgstr "Voir sur Polygonscan"
 
 #: components/AssetDetails/index.tsx:69
 msgid "View on PolygonScan"
@@ -1865,9 +2471,13 @@ msgstr "Voir sur PolygonScan"
 msgid "View on PolygonScan <0/>"
 msgstr "Voir sur PolygonScan <0/>"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
-msgid "View on Polygonscan"
-msgstr "Voir sur Polygonscan"
+#: components/pages/Project/index.tsx:207
+msgid "View Registry Details <0/>"
+msgstr "Voir les détails du registre <0/>"
+
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
+msgstr "Voir les résultats"
 
 #: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:99
 msgid "View retirement"
@@ -1881,9 +2491,10 @@ msgstr "Visualiser l'historique complet de la transaction - depuis l'événement
 msgid "View the project details and other info for this purchase."
 msgstr "Voir les détails du projet et d'autres informations concernant cet achat."
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
-msgid "View {numberOfTransfers} transfers"
-msgstr "Voir {numberOfTransfers} transferts"
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:145
+msgid "purchase.button.view_assets"
+msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:141
 msgid "Vintage"
@@ -1896,6 +2507,11 @@ msgstr "Les Plus Récents"
 #: components/ProjectFilterModal/constants.tsx:15
 msgid "Vintage Oldest"
 msgstr "Les Plus Anciens"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
+msgid "retirement.single.vintage.title"
+msgstr ""
 
 #: components/pages/Purchases/index.tsx:66
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
@@ -1917,12 +2533,22 @@ msgstr "Nous avons soigneusement sélectionné les meilleurs projets sur la base
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr "Qu'est-ce que Carbonmark ? Les réponses aux questions les plus courantes sur l'interface du marché numérique du carbone qui met facilement en relation les acheteurs et les vendeurs de crédits carbone vérifiés."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
+msgid "offset.retirement_credit"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:257
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
 msgid "Who will this retirement be credited to?"
 msgstr "A qui ce retrait du marché carbone sera-t-elle créditée ?"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
+msgstr ""
 
 #: components/shared/InvalidNetworkModal/index.tsx:64
 msgid "Wrong Network"
@@ -1934,9 +2560,19 @@ msgstr "Mauvais réseau"
 msgid "You"
 msgstr "Vous"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
 msgid "You are about to purchase a carbon asset."
 msgstr "Vous êtes sur le point d'acheter un actif carbone."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:31
 msgid "You are about to retire a carbon asset."
@@ -1984,13 +2620,10 @@ msgstr "Vous devez avoir créé un profil pour visualiser les actifs carbone que
 msgid "You successfully acquired carbon!"
 msgstr "Vous avez acquis du carbone avec succès !"
 
-#: components/pages/Users/SellerConnected/index.tsx:221
-msgid "Your Profile"
-msgstr "Votre Profil"
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
-msgstr "Votre Adresse de Portefeuille"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:412
@@ -2007,6 +2640,15 @@ msgstr "Votre solde :"
 msgid "Your display name"
 msgstr "Votre Nom d'Utilisateur"
 
+#: components/pages/Users/SellerConnected/index.tsx:221
+msgid "Your Profile"
+msgstr "Votre Profil"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
 msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr "Votre achat n'a pas encore été finalisé. Pour finaliser votre achat, vérifiez que toutes les informations sont correctes et cliquez sur \"envoyer\" ci-dessous."
@@ -2016,6 +2658,11 @@ msgstr "Votre achat n'a pas encore été finalisé. Pour finaliser votre achat, 
 msgid "Your seller data"
 msgstr "Vos données de vendeur"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/index.tsx:84
 msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
 msgstr "Votre transaction a été réalisée avec succès, mais le réseau prend plus de temps que prévu pour traiter les données. Les données relatives à votre retrait devraient apparaître ici dans quelques secondes !"
@@ -2024,6 +2671,10 @@ msgstr "Votre transaction a été réalisée avec succès, mais le réseau prend
 msgid "Your unique handle"
 msgstr "Votre pseudonyme unique"
 
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr "Votre Adresse de Portefeuille"
+
 #: components/pages/Resources/lib/cmsDataMap.ts:82
 msgid "Z-A"
 msgstr "Z-A"
@@ -2031,540 +2682,3 @@ msgstr "Z-A"
 #: components/pages/Home/index.tsx:437
 msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
 msgstr "Échange de crédits carbone sans frais - instantané, transparent et toujours disponible. En savoir plus sur ce que Carbonmark peut faire pour vous en tant que négociant de crédits carbone."
-
-#: components/Activities/Activity.tsx:34
-msgid "at"
-msgstr "à"
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr "Les informations fournies dans cet article de blog concernant KlimaDAO (\"KlimaDAO\"), ses crypto-actifs, ses actifs commerciaux, sa stratégie et ses opérations, sont fournis uniquement à des fins d'information générale et ne constituent pas une offre formelle de vente ou une sollicitation d'offre visant à l'achat de valeurs mobilières, d'options, de contrats à terme ou d'autres dérivés liés à des valeurs mobilières dans quelque juridiction que ce soit et dont le contenu n'est pas prescrit par les lois sur les valeurs mobilières. Les informations contenues dans cet article de blog ne constituent pas des conseils pour acheter, vendre ou détenir des titres ou une proposition de vente de titres. Cet article de blog ne prend pas en compte et ne fournit aucun conseil ou avis fiscal, juridique ou d'investissement concernant les objectifs d'investissement spécifiques ou la situation financière particulière d'un individu. KlimaDAO et ses agents, conseillers, administrateurs, dirigeants, employés et actionnaires ne font aucune déclaration ni ne promettent aucune garantie, expresse ou implicite, quant à l'exactitude de ces informations et KlimaDAO décline expressément toute responsabilité concernant des erreurs ou des oublis pouvant y être présentes. KlimaDAO se réserve le droit de modifier ou de remplacer à tout moment tout ou partie des informations contenues dans ce document, et n'assume aucune obligation d'en prévenir le lecteur ni de lui fournir l'accès aux informations modifiées. Les informations contenues dans cet article de blog remplacent tout article de blog ou conversation antérieure concernant des informations identiques, similaires ou connexes. Toute information, ou déclaration non contenue dans le présent document ne pourra être invoquée à quelque fin que ce soit. La responsabilité contractuelle, délictuelle, fiduciaire ou autre de KlimaDAO ni d'aucun de ses représentants ne pourra être invoquée, par vous ou toute autre personne dans le cas de l'utilisation des informations contenues dans ce blog ou en regard a des oublis d'informations dans cet article de blog. De plus, KlimaDAO n'assume aucune obligation de commenter sur les attentes ou de commenter les déclarations faites par un tiers concernant les sujets abordés dans cet article de blog."
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr "Avertissement légal"
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr "acheté à"
-
-#: components/Layout/index.tsx:52
-msgid "connect a wallet"
-msgstr "connecter un portefeuille"
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr "annonce créée"
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr "annonce supprimée"
-
-#: components/pages/Project/Purchase/Listing/Price.tsx:18
-#: components/pages/Project/Purchase/Pool/Price.tsx:17
-#: components/pages/Project/Retire/Pool/Price.tsx:17
-msgid "each"
-msgstr "chacun"
-
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr "Après avoir cliqué sur le bouton ci-dessous pour continuer, il vous sera demandé de connecter votre portefeuille, le projet que vous avez sélectionné sera déjà sélectionné pour vous sur KlimaDAO.finance. À partir de là, suivez les instructions de cette page pour terminer votre transaction."
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr "Les crédits carbone que vous achetez ou les retraits du marché que vous effectuez sur KlimaDAO.finance seront également accessibles dans votre portefeuille Carbonmark."
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr "Vous serez redirigé vers KlimaDAO.finance pour compléter cette transaction."
-
-#: components/Activities/Activity.tsx:112
-msgid "for"
-msgstr "pour"
-
-#: components/pages/Retire/index.tsx:52
-msgid "for beneficiary"
-msgstr "pour le bénéficiaire"
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr "Place de Marché"
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr "Portefeuille"
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr "Profil"
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr "Retirer du marché"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
-msgid "offset.amount_in_tonnes"
-msgstr "Combien de tonnes de carbone souhaitez-vous compenser ? <0>*</0>"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
-msgid "offset.default_retirement_address"
-msgstr "Par défaut, l'adresse du portefeuille connecté"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
-msgid "offset.retire_carbon"
-msgstr "Confirmer le Retrait"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
-msgid "offset.retirement_credit"
-msgstr "A qui ce retrait du marché carbone sera-t-elle créditée ?"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
-msgid "offset.retirement_message"
-msgstr "Message de retrait du marché"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr "Merci de soutenir la planète ! Voir la transaction sur <0>PolygonScan.</0>"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr "Merci de soutenir la planète !"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr "Votre transaction a été traitée avec succès, mais son indexation prend plus de temps que d'habitude. Elle apparaîtra bientôt dans vos <0>retraits</0>."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
-msgid "offset_disclaimer"
-msgstr "Veillez à ne pas inclure d'informations personnelles sensibles (telles qu'une adresse électronique) dans votre nom de retrait ou votre message. Les informations que vous saisissez ici ne peuvent pas être modifiées une fois qu'elles ont été soumises et existeront de manière permanente sur une blockchain publique."
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr "Soldes"
-
-#: components/CreateListing/Form/index.tsx:136
-msgid "profile.addListing_modal.submit"
-msgstr "Créer l'annonce"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
-msgid "profile.edit_modal.submit"
-msgstr "Sauvegarder les modifications"
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr "Modifier votre profil pour ajouter une description."
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
-msgid "profile.listing.edit.delete_listing"
-msgstr "Supprimer l'annonce"
-
-#: components/pages/Purchases/index.tsx:49
-msgid "project.single.button.back_to_project_details"
-msgstr "Retour aux détails du projet"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr "Vous êtes sur le point d'acheter un actif carbone."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr "La première étape est de donner l'autorisation à Carbonmark de transférer le type d'actif utilisé lors du paiement de votre portefeuille, l'étape suivante est d'approuver le transfert et de finaliser votre achat."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr "Vous pouvez à tout moment mettre en vente les actifs carbone que vous achetez sur Carbonmark à partir de votre <0>portefeuille</0>."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr "Vérifiez que toutes les informations sont correctes et cliquez sur \"approuver\" pour continuer."
-
-#: components/pages/Purchases/index.tsx:145
-msgid "purchase.button.view_assets"
-msgstr "Voir vos actifs"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr "L'étape précédente a accordé l'autorisation à Carbonmark de transférer votre actif de paiement de votre portefeuille ."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr "Votre achat n'a pas encore été finalisé. Pour finaliser votre achat, vérifiez que toutes les informations sont correctes et cliquez sur \"envoyer\" ci-dessous."
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr "Catégories"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr "Sélectionner un ou plusieurs"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr "Tout effacer"
-
-#: components/pages/Resources/ResourcesList/index.tsx:289
-msgid "resources.mobile_modal.button.show_results"
-msgstr "Afficher les résultats"
-
-#: components/pages/Resources/ResourcesList/index.tsx:230
-msgid "resources.page.list.no_search_results.title"
-msgstr "Désolé. Nous n'avons pas trouvé de résultats correspondants."
-
-#: components/pages/Resources/ResourcesList/index.tsx:222
-msgid "resources.page.list.on_fetch_error"
-msgstr "Désolé ! Un problème est survenu."
-
-#: components/pages/Resources/ResourcesList/index.tsx:243
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr "Veuillez utiliser une autre combinaison de filtres."
-
-#: components/pages/Resources/ResourcesList/index.tsx:236
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr "Vérifiez que votre recherche ne comporte pas de fautes de frappe ou essayez un autre terme de recherche."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
-msgid "retire.back_button"
-msgstr "précédent"
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr "retirées"
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr "Avec plus de 20 millions de crédits carbone vérifiés provenant de centaines de projets, Carbonmark offre la plus grande sélection de crédits carbone numériques au monde. Achetez, vendez et retirez du carbone numérique de n'importe quel projet instantanément avec zéro frais de courtage. <0>Commencez dès aujourd'hui</0>."
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr "À propos de Carbonmark"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr "{retiree} a retiré du marché {formattedAmount} Tonnes de carbone"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr "Carbonmark | Reçu de Retrait du Marché Carbone"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:50
-msgid "retirement.provenance.head.metaDescription"
-msgstr "Des compensations transparentes et sur la chaîne, réalisées par Carbonmark."
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:46
-msgid "retirement.provenance.head.metaTitle"
-msgstr "{retiree} a retiré du marché {formattedAmount} Tonnes de carbone"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:42
-msgid "retirement.provenance.head.title"
-msgstr "Carbonmark | Provenance des Retraits du marché de Carbone"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
-msgid "retirement.single.beneficiary.placeholder"
-msgstr "Aucun bénéficiaire associé"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.title"
-msgstr "Bénéficiaire :"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
-msgid "retirement.single.beneficiary_address.title"
-msgstr "Adresse du Bénéficiaire :"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr "Retrait des Crédits Carbone"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
-msgid "retirement.single.country_region.title"
-msgstr "Pays/Région :"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
-msgid "retirement.single.immutable_public_records.title"
-msgstr "Il s'agit du retrait permanent du marché d'un actif carbone numérique. Ce retrait et les données associées sont des documents publics immuables."
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr "Message de Retrait :"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.methodology.title"
-msgstr "Méthodologie :"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
-msgid "retirement.single.moss_offset.description"
-msgstr "Les crédits MC02 sont générés par des projets qui préservent la forêt amazonienne, avec toutes sortes d'externalités positives telles que la création d'emplois locaux et la préservation de la biodiversité locale. Découvrez MCO2 sur <0>data.klimadao.finance</0>."
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
-msgid "retirement.single.moss_offset.name"
-msgstr "MOSS Earth MC02"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
-msgid "retirement.single.official_certificate.title"
-msgstr "Certificat Officiel de Retrait du marché Carbone réalisé sur la chaîne de blocs fourni par <0>Carbonmark.com</0>"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
-msgid "retirement.single.project.title"
-msgstr "Projet :"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
-msgid "retirement.single.project_description.title"
-msgstr "Description"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
-msgid "retirement.single.project_details.title"
-msgstr "Détails du projet"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
-msgid "retirement.single.project_name.title"
-msgstr "Nom du Projet"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr "Preuve de"
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr "QUANTITÉ RETIRÉE DU MARCHÉ"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
-msgid "retirement.single.share_retirement.title"
-msgstr "Partagez ce retrait"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr "Retrait non horodatée"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
-msgid "retirement.single.transaction_id.title"
-msgstr "Identifiant de Transaction"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
-msgid "retirement.single.transaction_record.title"
-msgstr "Enregistrement immuable de la transaction"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.type.title"
-msgstr "Type :"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr "Tonnes de carbone vérifiées retirées du marché"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
-msgid "retirement.single.vintage.title"
-msgstr "Année :"
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr "Aucune retrait trouvée"
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr "Tous les Retraits du Marché"
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr "Carbonmark - Retraits du Marché Carbone pour le bénéficiaire {0}"
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr "Carbonmark - Retraits du Marché Carbone pour le bénéficiaire {0}"
-
-#: components/pages/Retirements/index.tsx:60
-msgid "retirement.totals.page_headline"
-msgstr "Retraits de Crédits Carbone"
-
-#: components/pages/Retirements/index.tsx:66
-msgid "retirement.totals.page_subline"
-msgstr "pour le bénéficiaire"
-
-#: components/pages/Retirements/index.tsx:90
-msgid "retirement.totals.retired_assets"
-msgstr "Actifs Retirés du marché"
-
-#: components/pages/Retirements/index.tsx:106
-msgid "retirement.totals.retirements"
-msgstr "Retraits du marché"
-
-#: components/pages/Retirements/index.tsx:98
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr "Total des Tonnes de Carbone Retirées du Marché"
-
-#: components/pages/Retirements/index.tsx:112
-msgid "retirement.totals.total_retirement_transactions"
-msgstr "Total des Transactions de Retraits du marché"
-
-#: components/pages/Users/SellerUnconnected/index.tsx:70
-msgid "seller.listing.buy"
-msgstr "Acheter"
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr "Quantité Disponible :"
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr "Centre de Ressources"
-
-#: components/pages/Resources/ResourcesList/index.tsx:197
-msgid "shared.resources.sort_by.header"
-msgstr "Trier par :"
-
-#: components/Layout/index.tsx:51
-msgid "social or email"
-msgstr "réseau social ou email"
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr "vendu à"
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
-msgid "something went wrong loading the allowance"
-msgstr "quelque chose s'est mal passé lors du chargement de l'autorisation"
-
-#: components/pages/Retire/Activity/Overview.tsx:77
-#: components/pages/Retire/Activity/Quotes.tsx:76
-#: components/pages/Retire/Activity/Table.tsx:65
-msgid "t"
-msgstr "t"
-
-#: components/Activities/Activity.tsx:119
-msgid "to"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
-msgid "tonnes"
-msgstr "tonnes"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr "Vous êtes sur le point de retirer un actif carbone du marché."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr "La première étape consiste à donner l'autoriser à Carbonmark de transférer l'actif carbone de votre portefeuille, l'étape suivante consiste à approuver le transfert en lui-même et à finaliser votre retraite."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr "Vérifiez que toutes les informations sont correctes et cliquez sur \"approuver\" pour continuer."
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr "Confirmer le montant"
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr "Adresse du contrat"
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr "Confirmer le prix par tonne"
-
-#: components/CreateListing/Transaction/index.tsx:83
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr "Retour"
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr "Fermer"
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr "Suivant"
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr "Envoyer le montant"
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr "Envoyer"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr "L'étape précédente a donné l'autorisation de transférer votre actif carbone de votre portefeuille à Carbonmark, votre retrait n'a pas encore été effectué."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr "Pour finaliser votre retrait du marché, vérifiez que toutes les informations sont correctes et cliquez sur \"envoyer\" ci-dessous."
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr "Adresse du contrat"
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr "Indiquer le prix par tonne :"
-
-#: components/CreateListing/Transaction/index.tsx:47
-#: components/Transaction/index.tsx:45
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Approuver"
-
-#: components/CreateListing/Transaction/index.tsx:57
-#: components/Transaction/index.tsx:55
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Envoyer"
-
-#: components/Activities/Activities.constants.ts:10
-msgid "updated expiration"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr "prix mis à jour"
-
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr "quantité mise à jour"
-
-#: components/Activities/index.tsx:29
-msgid "user.activities.empty_state"
-msgstr "Aucune activité à montrer"
-
-#: components/LoginCard/index.tsx:24
-msgid "user.login.description"
-msgstr "Cette fonction n'est disponible que pour les utilisateurs qui sont connectés. Vous pouvez vous connecter ou créer un compte en cliquant sur le bouton ci-dessous."
-
-#: components/CreateListing/Transaction/Approve.tsx:51
-#: components/CreateListing/Transaction/index.tsx:62
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
-msgid "{0}"
-msgstr "{0}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
-msgid "{0} maximum for credit cards"
-msgstr "Maximum de {0} pour les cartes de crédit"
-
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr "{0} | Profil | Carbonmark"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr "{DEFAULT_EXPIRATION_DAYS} jours ({expirationDatestring})"
-
-#: components/pages/Purchases/index.tsx:29
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr "{amount} tonnes ont été achetées pour le projet {0}"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
-#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
-msgid "{formattedAmount} Tonnes"
-msgstr "{formattedAmount} Tonnes"
-
-#: components/Quantity/index.tsx:28
-msgid "{formattedAmount} tonnes"
-msgstr "{formattedAmount} tonnes"
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
-msgid "{tokenSymbol}"
-msgstr "{tokenSymbol}"
-
-#: lib/statusMessage.ts:23
-msgid "❌ Error: something went wrong..."
-msgstr "❌ Erreur : quelque chose s'est mal passé..."

--- a/carbonmark/locale/hi/messages.po
+++ b/carbonmark/locale/hi/messages.po
@@ -6,10 +6,85 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: hi\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/CreateListing/Transaction/Approve.tsx:51
+#: components/CreateListing/Transaction/index.tsx:62
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
+msgid "{0}"
+msgstr "{0}"
+
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr "{0} | प्रोफ़ाइल | कार्बनमार्क"
+
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
+msgid "{0} maximum for credit cards"
+msgstr "{0} क्रेडिट कार्ड के लिए अधिकतम"
+
+#: components/pages/Purchases/index.tsx:29
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr "{amount} टन {0} प्रॉजेक्ट के लिए ख़रीदे गए थे"
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr "{DEFAULT_EXPIRATION_DAYS} दिन ({expirationDatestring})"
+
+#: components/Quantity/index.tsx:28
+msgid "{formattedAmount} tonnes"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
+#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
+msgid "{formattedAmount} Tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:46
+msgid "retirement.provenance.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
+msgid "{tokenSymbol}"
+msgstr "{tokenSymbol}"
+
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "@Username (note: this can not be changed!)"
+msgstr "@यूज़रनेम (ध्यान रहे: इसे बदला नहीं जा सकता!)"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
+msgid "<0>* </0> Required Field"
+msgstr "<0>*</0> आवश्यक क्षेत्र"
+
+#: lib/statusMessage.ts:23
+msgid "❌ Error: something went wrong..."
+msgstr "❌ एरर: कुछ गड़बड़ हो गयी..."
 
 #: components/pages/Home/index.tsx:358
 msgid "0% listing fee"
 msgstr "0% लिस्टिंग शुल्क"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:47
+#: components/Transaction/index.tsx:45
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:57
+#: components/Transaction/index.tsx:55
+msgid "transaction_modal.view.submit.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:193
 msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
@@ -32,14 +107,6 @@ msgstr "500 - सर्वर त्रुटि"
 msgid "500 - Server error occurred"
 msgstr "500 - सर्वर त्रुटि हो गई"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
-msgid "<0>* </0> Required Field"
-msgstr "<0>*</0> आवश्यक क्षेत्र"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "@Username (note: this can not be changed!)"
-msgstr "@यूज़रनेम (ध्यान रहे: इसे बदला नहीं जा सकता!)"
-
 #: components/pages/Project/PayWithBank/index.tsx:153
 msgid "A valid email address is required"
 msgstr ""
@@ -54,6 +121,11 @@ msgstr "A-Z"
 msgid "About"
 msgstr "बारे में"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr ""
+
 #: components/Stats/StatsListings.tsx:49
 msgid "Active listings:"
 msgstr "सक्रिय सूचीकरण"
@@ -62,6 +134,11 @@ msgstr "सक्रिय सूचीकरण"
 msgid "Activity"
 msgstr "गतिविधि"
 
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr ""
+
 #: lib/getCategoryInfo.ts:53
 msgid "Agriculture"
 msgstr "कृषि"
@@ -69,6 +146,11 @@ msgstr "कृषि"
 #: components/pages/Home/index.tsx:362
 msgid "All assets sourced from major registries"
 msgstr "सभी संपत्तियां प्रमुख रजिस्ट्रियों से प्राप्त की गईं है"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:41
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
@@ -111,6 +193,10 @@ msgstr "मंज़ूरी दें"
 msgid "Asset"
 msgstr "एसेट"
 
+#: components/AssetDetails/index.tsx:53
+msgid "Asset details"
+msgstr "एसेट विवरण"
+
 #: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:24
 msgid "Asset Details"
 msgstr "एसेट विवरण"
@@ -119,9 +205,13 @@ msgstr "एसेट विवरण"
 msgid "Asset ID"
 msgstr "एसेट आईडी"
 
-#: components/AssetDetails/index.tsx:53
-msgid "Asset details"
-msgstr "एसेट विवरण"
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:32
+msgid "Asset moved from one account to another, either via sale or inter-account transfer."
+msgstr ""
+
+#: components/Activities/Activity.tsx:34
+msgid "at"
+msgstr "पर"
 
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:131
 msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
@@ -133,11 +223,6 @@ msgid ""
 "exceeding {0}. Please adjust the\n"
 "quantity and try again later."
 msgstr "इस समय, कार्बनमार्क {0} से अधिक क्रेडिट कार्ड भुगतान संसाधित नहीं कर सकता है। कृपया मात्रा समायोजित करें और बाद में पुनः प्रयास करें।"
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
-msgstr "उपलब्ध टन:"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:116
 msgid "Available balance exceeded"
@@ -163,6 +248,11 @@ msgstr "खरीदने के लिए उपलब्ध है"
 msgid "Available to retire"
 msgstr "रिटायर होने के लिए उपलब्ध है"
 
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr "उपलब्ध टन:"
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:219
 msgid "Available:"
 msgstr "उपलब्ध:"
@@ -176,14 +266,20 @@ msgstr "उपलब्ध: {0}"
 msgid "Available: {unlistedBalance}"
 msgstr ""
 
-#: components/BetaBadge/index.tsx:18
-msgid "BETA"
-msgstr "बीटा"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
+msgid "retire.back_button"
+msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:44
 #: components/pages/Project/Retire/index.tsx:35
 msgid "Back to Project"
 msgstr "वापस प्रॉजेक्ट पर"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:49
+msgid "project.single.button.back_to_project_details"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:397
 msgid "Balance"
@@ -199,6 +295,16 @@ msgstr "उपलब्ध जमाराशि पार हो गई"
 msgid "Balance: {0}"
 msgstr "जमाराशि: {0}"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
+msgid "offset_disclaimer"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:450
 msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
 msgstr "अपने रिटायरमैंट नाम या संदेश में किसी भी संवेदनशील व्यक्तिगत जानकारी (जैसे ईमेल पता) को शामिल करते सयय सावधान रहें। आपके द्वारा यहां दर्ज की गई जानकारी को एक बार जमा करने के बाद संपादित नहीं किया जा सकता है और सार्वजनिक ब्लॉकचेन पर स्थायी रूप से मौजूद रहेगा।"
@@ -207,12 +313,17 @@ msgstr "अपने रिटायरमैंट नाम या संद�
 msgid "Beneficiary Address"
 msgstr "लाभार्थी का पता"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
-msgid "Beneficiary Name"
-msgstr "लाभार्थी का नाम"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
+msgid "retirement.single.beneficiary_address.title"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:263
 msgid "Beneficiary name"
+msgstr "लाभार्थी का नाम"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
+msgid "Beneficiary Name"
 msgstr "लाभार्थी का नाम"
 
 #: components/pages/Project/PayWithBank/index.tsx:232
@@ -225,11 +336,20 @@ msgstr ""
 msgid "Beneficiary wallet address (optional)"
 msgstr "लाभार्थी वॉलेट पता (वैकल्पिक)"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:34
 #: components/pages/Project/BuyOptions/SellerListing.tsx:67
 #: components/pages/Project/index.tsx:137
 msgid "Best Price"
 msgstr "सर्वोत्तम क़ीमत"
+
+#: components/BetaBadge/index.tsx:18
+msgid "BETA"
+msgstr "बीटा"
 
 #: lib/getCategoryInfo.ts:65
 msgid "Blue Carbon"
@@ -239,9 +359,9 @@ msgstr "ब्लू कार्बन"
 msgid "Book a demo"
 msgstr "एक डेमो बुक करें"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:35
-msgid "Bridge"
-msgstr ""
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
+msgstr "से ख़रीदा गया"
 
 #: components/pages/Home/index.tsx:157
 #: components/pages/Home/index.tsx:188
@@ -256,6 +376,11 @@ msgstr "प्रॉजेक्ट्स ब्राउज़ करें"
 #: components/pages/Project/BuyOptions/SellerListing.tsx:98
 msgid "Buy"
 msgstr "ख़रीदें"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:70
+msgid "seller.listing.buy"
+msgstr ""
 
 #: components/pages/Home/index.tsx:168
 msgid "Buy or retire carbon"
@@ -273,12 +398,35 @@ msgstr ""
 msgid "Cancel"
 msgstr "रद्द करें"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr ""
+
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr "आपके द्वारा ख़रीदे गए कार्बन ऐसेट्स आपके <0>पोर्टफोलियो</0> से बिक्री के लिए कार्बनमार्क पर कभी भी सूचीबद्ध किए जा सकते हैं।"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:30
 msgid "Carbon Pool"
 msgstr "कार्बन पूल"
 
 #: components/Layout/NavDropdown/index.tsx:117
 msgid "Carbon Portfolio"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
+msgid "Carbon provenance"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:60
@@ -289,17 +437,35 @@ msgstr ""
 msgid "Carbon Retirements"
 msgstr "कार्बन सेवानिवृत्ति"
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-msgstr "आपके द्वारा ख़रीदे गए कार्बन ऐसेट्स आपके <0>पोर्टफोलियो</0> से बिक्री के लिए कार्बनमार्क पर कभी भी सूचीबद्ध किए जा सकते हैं।"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
-msgid "Carbon provenance"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:60
+msgid "retirement.totals.page_headline"
 msgstr ""
 
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
-msgstr "कार्बनमार्क का संक्षिप्त विवरण"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:42
+msgid "retirement.provenance.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:51
+#: components/pages/Home/index.tsx:52
+msgid "Carbonmark | The Universal Carbon Marketplace"
+msgstr "कार्बनमार्क | द यूनिवर्सल कार्बन मार्केटप्लेस"
 
 #: components/pages/Home/index.tsx:174
 msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
@@ -315,14 +481,18 @@ msgstr "कार्बनमार्क शुल्क"
 msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 msgstr ""
 
-#: components/pages/Home/index.tsx:51
-#: components/pages/Home/index.tsx:52
-msgid "Carbonmark | The Universal Carbon Marketplace"
-msgstr "कार्बनमार्क | द यूनिवर्सल कार्बन मार्केटप्लेस"
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
+msgstr "कार्बनमार्क का संक्षिप्त विवरण"
 
 #: components/pages/Home/index.tsx:488
 msgid "Carbonmark's role"
 msgstr "कार्बनमार्क की भूमिका"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
+msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:130
 msgid "Category"
@@ -333,6 +503,11 @@ msgstr "कैटेगरी"
 msgid "Change language"
 msgstr "भाषा बदलें"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:236
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
 #: components/pages/Home/index.tsx:206
 msgid "Choose a project and quantity"
 msgstr "एक प्रोजेक्ट और मात्रा चुनें"
@@ -341,8 +516,13 @@ msgstr "एक प्रोजेक्ट और मात्रा चुन�
 msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 msgstr "सैकड़ों प्रॉजेक्ट्स में से 20 मिलियन से भी अधिक सत्यापित डिजिटल कार्बन क्रेडिट्स में से चुनें - अभी कार्बन ख़रीदें, बेचें या रिटायर करें।"
 
-#: components/ProjectFilterModal/index.tsx:162
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
 #: components/pages/Projects/ProjectSearch/index.tsx:55
+#: components/ProjectFilterModal/index.tsx:162
 msgid "Clear Filters"
 msgstr "फ़िल्टर्स हटाएँ"
 
@@ -353,6 +533,11 @@ msgstr "इस पृष्ठ को अनुकूलित करने औ�
 #: components/CreateListing/Transaction/Submit.tsx:98
 msgid "Close"
 msgstr "बंद करें"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
+msgstr ""
 
 #: components/Footer/index.tsx:32
 msgid "Code of Ethics"
@@ -379,6 +564,16 @@ msgstr "सभी विक्रेताओं और ट्रेडिंग
 msgid "Compiling Results ..."
 msgstr "परिणाम कम्पाईल किए जा रहे हैं..."
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr ""
+
 #: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:83
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
 #: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
@@ -386,9 +581,18 @@ msgstr "परिणाम कम्पाईल किए जा रहे ह�
 msgid "Confirm Purchase"
 msgstr "ख़रीद की पुष्टि करें"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
+msgid "offset.retire_carbon"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:75
 msgid "Confirm Retirement"
 msgstr "रिटायरमेंट की पुष्टि करें"
+
+#: components/Layout/index.tsx:52
+msgid "connect a wallet"
+msgstr "वॉलेट कनेक्ट करें"
 
 #: components/pages/Portfolio/ConnectedWallet/index.tsx:33
 msgid "Connected Wallet"
@@ -414,6 +618,16 @@ msgstr "संपर्क करें"
 msgid "Continue"
 msgstr "जारी रखें"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
 #: components/CopyAddressButton/index.tsx:37
 msgid "Copy"
 msgstr ""
@@ -433,15 +647,10 @@ msgstr "सूची मिटायी नहीं जा सकी। कृ�
 msgid "Country"
 msgstr "देश"
 
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr "नयी सूची बनाएँ"
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Create Profile"
-msgstr "प्रोफ़ाइल बनाएँ"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
+msgid "retirement.single.country_region.title"
+msgstr ""
 
 #: components/CreateListing/index.tsx:165
 msgid "Create a listing"
@@ -459,6 +668,21 @@ msgstr "एक विक्रेता प्रोफ़ाइल बनाए
 msgid "Create and edit listings, and track your activity with your Carbonmark profile."
 msgstr "सूची बनाएँ और संपादित करें, और अपनी कार्बनमार्क प्रोफ़ाइल के माध्यम से अपनी गतिविधि को ट्रैक करें।"
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:136
+msgid "profile.addListing_modal.submit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr "नयी सूची बनाएँ"
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Create Profile"
+msgstr "प्रोफ़ाइल बनाएँ"
+
 #: components/pages/Home/index.tsx:313
 msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
 msgstr "अपना खुद का कार्बन स्टोरफ्रंट बनाएं। संगठनों और व्यक्तियों को समान रूप से सीधा बेचें।"
@@ -467,25 +691,29 @@ msgstr "अपना खुद का कार्बन स्टोरफ्�
 msgid "Create your own retirement"
 msgstr "अपनी खुद की रिटयरमेंट बनाएँ"
 
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr "सूची बनाएँ"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:87
 msgid "Created:"
 msgstr "बन गई:"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
-msgid "Credit ID"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
-msgstr "क्रेडिट कार्ड से न्यूनतम खरीदारी ${formattedFiatMinimum} है"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:77
 msgid "Credit card minimum purchase is {0}"
 msgstr "क्रेडिट कार्ड से न्यूनतम खरीदारी {0} है"
 
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr "क्रेडिट कार्ड से न्यूनतम खरीदारी ${formattedFiatMinimum} है"
+
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:247
 msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
 msgstr "क्रेडिट कार्ड से भुगतान पर अतिरिक्त प्रोसेसिंग शुल्क लगता है। <0>अधिक जानने के लिए दस्तावेज़ देखें।</0>"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
+msgid "Credit ID"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:435
 msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
@@ -495,10 +723,6 @@ msgstr "वर्तमान में, कार्बनमार्क क�
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
 msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
 msgstr "वर्तमान में, कार्बनमार्क केवल पॉलीगॉन यूएसडीसी भुगतान स्वीकार करता है। <0>पॉलीगॉन पर यूएसडीसी प्राप्त करने का तरीका जानें।</0>"
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
-msgstr "दिनांक"
 
 #: components/pages/Project/index.tsx:234
 msgid "Data for this project and vintage"
@@ -513,9 +737,27 @@ msgstr "इस विक्रेता संबंधी डेटा"
 msgid "Date"
 msgstr "दिनांक"
 
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr "दिनांक"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
+msgid "offset.default_retirement_address"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:296
 msgid "Defaults to the connected wallet address"
 msgstr "कनेक्टेड वॉलेट का पते पर किए गए डिफ़ॉल्ट"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
+msgid "profile.listing.edit.delete_listing"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
+msgstr "सूची मिटाएँ"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:307
 msgid "Describe the purpose of this retirement"
@@ -525,6 +767,11 @@ msgstr "इस रिटायरमेंट के उद्देश्य �
 msgid "Description"
 msgstr "विवरण"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
+msgid "retirement.single.project_description.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:51
 msgid "Digital Carbon"
 msgstr "डिजिटल कार्बन"
@@ -532,6 +779,11 @@ msgstr "डिजिटल कार्बन"
 #: components/pages/Home/index.tsx:264
 msgid "Digitize your carbon by using a supported bridge"
 msgstr "समर्थित ब्रिज का उपयोग करके अपने कार्बन को डिजिटाइज़ करें"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
 msgid "Display name"
@@ -557,20 +809,31 @@ msgstr "डाउनलोड हो रहा है..."
 msgid "Drive climate action and earn rewards with a carbon-backed digital currency."
 msgstr "क्लआीमेट ऐक्शन प्रयत्न करें और कार्बन-समर्थित डिजिटल मुद्रा के रूप में पुरस्कार अर्जित करें।"
 
+#: components/pages/Project/Purchase/Listing/Price.tsx:18
+#: components/pages/Project/Purchase/Pool/Price.tsx:17
+#: components/pages/Project/Retire/Pool/Price.tsx:17
+msgid "each"
+msgstr "प्रत्येक"
+
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:195
 msgid "Edit"
 msgstr "संपादित करें"
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Edit Profile"
-msgstr "प्रोफ़ाइल संपादित करें"
 
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:206
 msgid "Edit listing"
 msgstr ""
 "सूची बदलें\n"
 ""
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Edit Profile"
+msgstr "प्रोफ़ाइल संपादित करें"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:143
 #: components/pages/Project/PayWithBank/index.tsx:307
@@ -630,6 +893,19 @@ msgstr ""
 msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
 msgstr "सबसे पहले, अपनी ओर से इस संपत्ति को स्थानांतरित करने के लिए कार्बनमार्क प्रणाली को मंजूरी दें।"
 
+#: components/Activities/Activity.tsx:112
+msgid "for"
+msgstr "के लिए"
+
+#: components/pages/Retire/index.tsx:52
+msgid "for beneficiary"
+msgstr "लाभार्थी के लिए"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:66
+msgid "retirement.totals.page_subline"
+msgstr ""
+
 #: components/pages/Home/index.tsx:340
 msgid "For carbon traders"
 msgstr "कार्बन व्यापारियों के लिए"
@@ -646,21 +922,27 @@ msgstr "वानिकी"
 msgid "Form complete"
 msgstr ""
 
-#: components/pages/Home/index.tsx:76
-msgid "Get Started"
-msgstr "शुरुआत करें"
-
 #: components/pages/Home/index.tsx:390
 msgid "Get paid immediately: transactions are resolved in seconds"
 msgstr "तुरंत भुगतान प्राप्त करें: लेन-देन सेकंडों में हल हो जाते हैं"
 
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
+#: components/pages/Home/index.tsx:76
+msgid "Get Started"
+msgstr "शुरुआत करें"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:83
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
 msgid "Go back"
 msgstr "वापस जाएँ"
+
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:145
 msgid "Handle is required"
@@ -685,7 +967,7 @@ msgid "Here’s a list of readily available, discounted carbon tokens to retire 
 msgstr "यहां शीघ्र और आसानी से रिटायर करने के लिए आसानी से उपलब्ध, रियायती कार्बन टोकन की एक सूची दी गई है।"
 
 #: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:48
-msgid "Hide {numberOfTransfers} transfers"
+msgid "Hide {numberOfTransfers} transactions"
 msgstr ""
 
 #: components/CreateListing/Form/index.tsx:80
@@ -700,6 +982,11 @@ msgstr "आप कितने टन कार्बन ख़रीदना च�
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:249
 msgid "How many tonnes of carbon do you want to retire?"
 msgstr "आप कितने टन कार्बन रिटायर करना चाहते हैं?"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
+msgid "offset.amount_in_tonnes"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:215
 msgid "How many tonnes of carbon would you like to retire?"
@@ -724,6 +1011,11 @@ msgstr ""
 #: components/pages/Purchases/index.tsx:93
 msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
 msgstr "अगर आप इस ख़रीदारी में से कुछ या सभी कार्बन क्रेडिट्स रिटायर करना चाहते हैं, तो अपने <0>portfolio</0>पर जाएँ, 'रिटायर' बटन पर क्लिक करें और निर्देशों का पालन करें।"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
+msgid "retirement.single.transaction_record.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:116
 msgid "Indicates required field"
@@ -779,13 +1071,13 @@ msgstr ""
 msgid "Latest First"
 msgstr "नवीनतम पहले"
 
+#: components/pages/Home/index.tsx:417
+msgid "Learn more"
+msgstr "और जानें"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:92
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:103
 msgid "Learn More"
-msgstr "और जानें"
-
-#: components/pages/Home/index.tsx:417
-msgid "Learn more"
 msgstr "और जानें"
 
 #: components/pages/Home/index.tsx:491
@@ -819,11 +1111,11 @@ msgid "Loading your assets"
 msgstr "आपके ऐसेट्स लोड हो रहे हैं"
 
 #: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:295
 #: components/pages/Retire/Activity/Overview.tsx:73
 #: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
 msgid "Loading..."
 msgstr "लोड हो रहा है..."
 
@@ -863,6 +1155,11 @@ msgstr ""
 msgid "Marketplace"
 msgstr "मार्केटप्लेस"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr ""
+
 #: components/pages/Projects/index.tsx:73
 #: components/pages/Projects/index.tsx:74
 msgid "Marketplace | Carbonmark"
@@ -872,20 +1169,35 @@ msgstr "मार्केटप्लेस | कार्बनमार्क
 msgid "Maximize your climate impact."
 msgstr "अपने जलवायु प्रभाव को अधिकतम करें."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.moss_offset.description"
+msgstr ""
+
 #: components/pages/Project/index.tsx:144
 msgid "Methodology"
 msgstr "कार्यप्रणाली"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.methodology.title"
+msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:54
 msgid "Moss"
 msgstr "Moss (मॉस)"
 
-#: components/FeatureBanner/index.tsx:33
-msgid "NEW FEATURE:"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
+msgid "retirement.single.moss_offset.name"
 msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:171
 msgid "Navigation Menu"
+msgstr ""
+
+#: components/FeatureBanner/index.tsx:33
+msgid "NEW FEATURE:"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
@@ -900,18 +1212,28 @@ msgstr "नया यूनिट मूल्य (USDC)"
 msgid "Next"
 msgstr "इसके बाद"
 
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
-msgstr "दिखाने के लिए कोई गतिविधि नहीं।"
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:197
 #: components/pages/Users/SellerUnconnected/index.tsx:83
 msgid "No active listings."
 msgstr "शून्य सक्रिय सूचियाँ"
 
+#. js-lingui-explicit-id
+#: components/Activities/index.tsx:29
+msgid "user.activities.empty_state"
+msgstr ""
+
 #: components/pages/Retire/Activity/Quotes.tsx:38
 msgid "No activity to show"
 msgstr "शून्य गतिविधियाँ मौजूद"
+
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
+msgstr "दिखाने के लिए कोई गतिविधि नहीं।"
 
 #: components/pages/Home/index.tsx:400
 msgid "No barriers to entry for verified carbon projects"
@@ -920,6 +1242,11 @@ msgstr "सत्यापित कार्बन परियोजनाओ�
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:40
 msgid "No beneficiary address available"
 msgstr "कोई लाभार्थी का पता उपलब्ध नहीं है"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
+msgid "retirement.single.beneficiary.placeholder"
+msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:62
 msgid "No data to show"
@@ -954,24 +1281,39 @@ msgstr ""
 msgid "No retirement message provided."
 msgstr "कोई रिटायरमेंट संदेश प्रदान नहीं किया गया"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
 msgid "No transaction id available"
 msgstr "कोई लेनदेन आईडी उपलब्ध नहीं है"
-
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
-msgstr "कनेक्शन नहीं है"
 
 #: components/pages/Project/PayWithBank/index.tsx:240
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:288
 msgid "Not a valid polygon address"
 msgstr "कृपया एक वैध पोलिगोन पता दर्ज करें"
 
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr "कनेक्शन नहीं है"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
+msgid "retirement.single.official_certificate.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:72
 msgid "Oldest First"
 msgstr "प्राचीनतम पहले"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:185
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:188
 msgid "On the Verra page, search for the specific serial number."
 msgstr ""
 
@@ -995,21 +1337,17 @@ msgstr "हमारा सिस्टम अपेक्षा से अध�
 msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 msgstr "सैकड़ों परियोजनाओं से 20 मिलियन से अधिक सत्यापित डिजिटल कार्बन क्रेडिट, अब तक 4 बिलियन डॉलर से अधिक का कारोबार हुआ है"
 
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr "प्रॉजेक्ट"
-
 #: components/pages/Projects/Banners/BankTransfer.tsx:74
 msgid "Pay via Bank Transfer / Wire"
+msgstr ""
+
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:89
 #: components/pages/Project/PayWithBank/index.tsx:90
 msgid "Pay with Bank Transfer | Carbonmark"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:94
@@ -1018,22 +1356,18 @@ msgstr ""
 msgid "Pay with:"
 msgstr "भुगतान यँत्र:"
 
-#: components/pages/Purchases/index.tsx:62
-msgid "Payment Successful"
-msgstr "भुगतान सफल हुआ"
-
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:243
 msgid "Payment processing fee"
 msgstr "रिटायरमेंट प्रोसेसिंग शुल्क"
+
+#: components/pages/Purchases/index.tsx:62
+msgid "Payment Successful"
+msgstr "भुगतान सफल हुआ"
 
 #: components/pages/Project/PayWithBank/index.tsx:161
 #: components/pages/Project/PayWithBank/index.tsx:313
 msgid "Phone number"
 msgstr ""
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
-msgstr "कृपया लॉगिन करें"
 
 #: lib/statusMessage.ts:27
 msgid "Please click 'confirm' in your wallet to continue."
@@ -1043,11 +1377,25 @@ msgstr "जारी रखने के लिए कृपया अपने 
 msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr ""
 
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr "कृपया लॉगिन करें"
+
 #: components/pages/Portfolio/index.tsx:66
 #: components/pages/Users/SellerConnected/index.tsx:75
 #: components/pages/Users/SellerConnected/index.tsx:101
 msgid "Please refresh the page. There was an error updating your data: {e}."
 msgstr "कृपया पृष्ट को रिफ़्रेश करें। आपका डेटा अपडेट करने में गलती हुई: {e}।"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:243
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:76
 #: components/pages/Portfolio/index.tsx:77
@@ -1066,10 +1414,6 @@ msgstr "प्रेस विज्ञप्तियाँ"
 msgid "Price Highest"
 msgstr "मूल्य उच्चतम"
 
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr "मूल्य न्यूनतम"
-
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:180
@@ -1079,6 +1423,10 @@ msgstr "कीमत में नेटवर्क शुल्क शाम�
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:160
 msgid "Price is required"
 msgstr "मूल्य आवश्यक है"
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
+msgstr "मूल्य न्यूनतम"
 
 #: components/CreateListing/Transaction/Submit.tsx:62
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
@@ -1114,19 +1462,48 @@ msgstr ""
 msgid "Profile"
 msgstr "प्रोफ़ाइल"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:192
 msgid "Profile picture"
 msgstr "प्रोफ़ाइल फोटो"
+
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr "प्रॉजेक्ट"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
+msgid "retirement.single.project_name.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:253
 #: components/pages/Project/PayWithBank/index.tsx:357
 msgid "Project names of interest"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:36
-#: components/pages/Purchases/index.tsx:37
-msgid "Purchase Receipt | Carbonmark"
-msgstr "विक्रय रसीद | कार्बनमार्क"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
+msgid "retirement.single.project.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr ""
+
+#: components/pages/Project/Purchase/index.tsx:32
+#: components/pages/Project/Purchase/index.tsx:33
+msgid "Purchase {0} | Carbonmark"
+msgstr "ख़रीद {0} | कार्बनमार्क"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:53
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
@@ -1137,6 +1514,11 @@ msgstr "खरीद मात्रा (टन):"
 msgid "Purchase more Carbon"
 msgstr "अधिक कार्बन खरीदें"
 
+#: components/pages/Purchases/index.tsx:36
+#: components/pages/Purchases/index.tsx:37
+msgid "Purchase Receipt | Carbonmark"
+msgstr "विक्रय रसीद | कार्बनमार्क"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:79
 msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer."
 msgstr ""
@@ -1144,11 +1526,6 @@ msgstr ""
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
 msgid "Purchase successful"
 msgstr "खरीदारी सफल"
-
-#: components/pages/Project/Purchase/index.tsx:32
-#: components/pages/Project/Purchase/index.tsx:33
-msgid "Purchase {0} | Carbonmark"
-msgstr "ख़रीद {0} | कार्बनमार्क"
 
 #: components/pages/Retire/Activity/Table.tsx:47
 msgid "QTY"
@@ -1164,6 +1541,11 @@ msgstr "मात्रा"
 msgid "Quantity Available:"
 msgstr "उपलब्ध मात्रा:"
 
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:240
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:108
 msgid "Quantity is required"
@@ -1177,21 +1559,18 @@ msgstr "सूचीबद्ध मात्रा: {listedQuantity}, असू
 msgid "Quantity purchased:"
 msgstr "विक्रीत मात्रा:"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr ""
+
 #: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr "शीघ्र रिटायर करें"
 
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr "कार्बन रिटायर करें"
-
 #: components/pages/Project/index.tsx:198
 msgid "Read Less"
 msgstr "कम पढ़ें"
-
-#: components/pages/Project/index.tsx:198
-msgid "Read More"
-msgstr "और पढ़ें"
 
 #: components/pages/Home/index.tsx:445
 #: components/pages/Home/index.tsx:472
@@ -1199,6 +1578,10 @@ msgstr "और पढ़ें"
 #: components/pages/Resources/BlogPostCard/index.tsx:38
 #: components/pages/Resources/FeaturedArticles/Article.tsx:45
 msgid "Read more"
+msgstr "और पढ़ें"
+
+#: components/pages/Project/index.tsx:198
+msgid "Read More"
 msgstr "और पढ़ें"
 
 #: components/pages/Home/index.tsx:351
@@ -1217,14 +1600,14 @@ msgstr "शेष आपूर्त्ति"
 msgid "Renewable Energy"
 msgstr "नवीकरणीय ऊर्जा"
 
+#: lib/constants.ts:82
+msgid "Request already processing. Please open your wallet and complete the request."
+msgstr "अनुरोध पहले से ही प्रोसेस हो रही है। कृपया अपना वॉलेट ओपन करें और अनुरोध पूरा करें।"
+
 #: components/pages/Home/index.tsx:301
 #: components/pages/Home/index.tsx:325
 msgid "Request Demo"
 msgstr "डेमो का अनुरोध करें"
-
-#: lib/constants.ts:82
-msgid "Request already processing. Please open your wallet and complete the request."
-msgstr "अनुरोध पहले से ही प्रोसेस हो रही है। कृपया अपना वॉलेट ओपन करें और अनुरोध पूरा करें।"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:210
 msgid "Required Field"
@@ -1234,6 +1617,11 @@ msgstr "आवश्यक क्षेत्र"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:311
 msgid "Required when proceeding with Credit Card"
 msgstr "क्रेडिट कार्ड के साथ आगे बढ़ते समय आवश्यक"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
+msgstr ""
 
 #: components/Footer/index.tsx:38
 #: components/pages/Home/index.tsx:508
@@ -1261,15 +1649,36 @@ msgstr "परिणाम"
 msgid "Retire"
 msgstr "रिटायर"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/index.tsx:88
+#: components/pages/Portfolio/Retire/index.tsx:89
+#: components/pages/Retire/index.tsx:38
+#: components/pages/Retire/index.tsx:39
+msgid "Retire | Carbonmark"
+msgstr "रिटायर | कार्बनमार्क"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:388
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
 msgid "Retire Carbon"
 msgstr "कार्बन रिटायर करें"
 
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr "कार्बन रिटायर करें"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:233
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "अपने लिए या किसी अन्य व्यक्ति या संगठन की ओर से कार्बन क्रेडिट रिटायर करें।"
+
+#: components/pages/Project/Retire/index.tsx:23
+#: components/pages/Project/Retire/index.tsx:24
+msgid "Retire from {fullProjectid} | Carbonmark"
+msgstr "{fullProjectid} से रिटायर करें | कार्बनमार्क"
 
 #: components/pages/Retire/index.tsx:72
 msgid "Retire from a featured project"
@@ -1279,23 +1688,18 @@ msgstr "एक विशेष परियोजना से रिटाय�
 msgid "Retire from your portfolio"
 msgstr "अपने पोर्टफोलियो से रिटायर हो जाओ"
 
-#: components/pages/Project/Retire/index.tsx:23
-#: components/pages/Project/Retire/index.tsx:24
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr "{fullProjectid} से रिटायर करें | कार्बनमार्क"
-
 #: components/pages/Home/index.tsx:232
 msgid "Retire instantly, or purchase and hold digital carbon"
 msgstr "तुरंत रिटायर हो जाएं, या डिजिटल कार्बन खरीदकर रख लें"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
-msgstr "अधिक कार्बन रिटायर करें"
 
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
 msgid "Retire more carbon"
+msgstr "अधिक कार्बन रिटायर करें"
+
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
 msgstr "अधिक कार्बन रिटायर करें"
 
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:56
@@ -1311,14 +1715,16 @@ msgstr "अभी रिटायर हो जाएं, या बाद म�
 msgid "Retire your carbon via bank transfer."
 msgstr ""
 
-#: components/pages/Portfolio/Retire/index.tsx:88
-#: components/pages/Portfolio/Retire/index.tsx:89
-#: components/pages/Retire/index.tsx:38
-#: components/pages/Retire/index.tsx:39
-msgid "Retire | Carbonmark"
-msgstr "रिटायर | कार्बनमार्क"
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
+msgstr "रिटायर्ड"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:13
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:90
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:16
 msgid "Retirement"
 msgstr ""
 
@@ -1326,33 +1732,53 @@ msgstr ""
 msgid "Retirement Activity"
 msgstr "रिटयरमेंट गतिविधि"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
-msgid "Retirement Message"
-msgstr "रिटायरमेंट सन्देश"
-
-#: components/pages/Retire/Activity/Overview.tsx:60
-#: components/pages/Retire/Activity/Overview.tsx:70
-msgid "Retirement Overview"
-msgstr "रिटयरमेंट अवलोकन"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr "रिटायरमेंट सफल हुआ!"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
+msgid "offset.retirement_message"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:264
 #: components/pages/Project/PayWithBank/index.tsx:363
 msgid "Retirement message"
 msgstr "रिटायरमेंट संदेश"
 
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
+msgid "Retirement Message"
+msgstr "रिटायरमेंट सन्देश"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr ""
+
+#: components/pages/Retire/Activity/Overview.tsx:60
+#: components/pages/Retire/Activity/Overview.tsx:70
+msgid "Retirement Overview"
+msgstr "रिटयरमेंट अवलोकन"
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:74
 msgid "Retirement successful"
 msgstr "रिटायरमेंट सफल"
 
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr "रिटायरमेंट सफल हुआ!"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:106
+msgid "retirement.totals.retirements"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:384
 msgid "Retiring Token"
 msgstr "रिटायरिंग टोकन"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
+msgid "profile.edit_modal.submit"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:201
 msgid "Say a few words about yourself. This will be visible in your seller profile."
@@ -1389,6 +1815,11 @@ msgstr "चुने"
 msgid "Select a language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr ""
+
 #: components/pages/Portfolio/AssetProject/index.tsx:100
 #: components/pages/Portfolio/AssetProject/index.tsx:108
 msgid "Sell"
@@ -1406,12 +1837,26 @@ msgstr "अपना डिजिटल कार्बन सीधे खर�
 msgid "Seller Listing"
 msgstr "विक्रय सूचीकरण"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:159
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:29
+msgid "Send"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:161
 msgid "Serial Number"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:76
 msgid "Share this page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
+msgid "retirement.single.share_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:289
+msgid "resources.mobile_modal.button.show_results"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
@@ -1427,6 +1872,19 @@ msgstr "एकल मूल्य आवश्यक है"
 #: components/CreateListing/Form/index.tsx:130
 msgid "Single unit price"
 msgstr "एकल यूनिट मूल्य"
+
+#: components/Layout/index.tsx:51
+msgid "social or email"
+msgstr "सामाजिक या ईमेल"
+
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr "को बेचा गया"
+
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
+msgid "something went wrong loading the allowance"
+msgstr "कुछ गड़बड़ हो गई जानकारी लोड हो रही है"
 
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
 msgid "Something went wrong loading the allowance"
@@ -1452,13 +1910,28 @@ msgstr "क्षमा करें, कुछ गड़बड़ हो गई।"
 msgid "Sorry, this handle already exists"
 msgstr "क्षमा करें, यह हैंडल पहले से मौजूद है"
 
-#: components/pages/Resources/ResourcesList/index.tsx:265
-msgid "Sort By"
-msgstr "इसके अनुसार क्रमबद्ध करें"
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:222
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:230
+msgid "resources.page.list.no_search_results.title"
+msgstr ""
 
 #: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "Sort by"
 msgstr "इसके अनुसार क्रमबद्ध करें"
+
+#: components/pages/Resources/ResourcesList/index.tsx:265
+msgid "Sort By"
+msgstr "इसके अनुसार क्रमबद्ध करें"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:197
+msgid "shared.resources.sort_by.header"
+msgstr ""
 
 #: components/Stats/index.tsx:23
 msgid "Stats"
@@ -1484,6 +1957,21 @@ msgstr "चरण 3"
 msgid "Submit"
 msgstr "सबमिट करें"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr ""
+
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:88
 msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
 msgstr "सफलता! आपकी नई लिस्टिंग कुछ ही पलों में आपके <0>प्रोफ़ाइल पेज</0> पर दिखाई देगी।"
@@ -1496,13 +1984,25 @@ msgstr ""
 msgid "Switch to Polygon"
 msgstr "पॉलिगॉन पर स्विच करें"
 
-#: components/BetaBadge/index.tsx:16
-msgid "TESTNET"
-msgstr ""
+#: components/pages/Retire/Activity/Overview.tsx:77
+#: components/pages/Retire/Activity/Quotes.tsx:76
+#: components/pages/Retire/Activity/Table.tsx:65
+msgid "t"
+msgstr "टी"
 
 #: components/Footer/index.tsx:29
 msgid "Terms of Use"
 msgstr "उपयोग की शर्तें"
+
+#: components/BetaBadge/index.tsx:16
+msgid "TESTNET"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
 msgid "Thank you for supporting the planet!"
@@ -1512,21 +2012,32 @@ msgstr "पृथ्वी का समर्थन करने के लि�
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr "पृथ्वी का समर्थन करने के लिए धन्यवाद! ख़रीद विवरण नीचे देखें।"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:292
 msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr ""
-
-#: components/pages/Home/index.tsx:65
-msgid "The Universal Carbon Marketplace"
-msgstr "यूनिवर्सल कार्बन मार्केटप्लेस"
 
 #: components/CreateListing/Transaction/Approve.tsx:44
 msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 msgstr "बिक्री पूरी होने पर ही संपत्ति आपके वॉलेट से स्थानांतरित की जाएगी। आप इस भत्ते को किसी भी समय रद्द कर सकते हैं।"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:34
 msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
 msgstr "पहला कदम अपनी कार्बन संपत्ति को अपने वॉलेट से कार्बनमार्क में स्थानांतरित करने की स्वीकृति देना है, अगला कदम वास्तविक हस्तांतरण को मंजूरी देना और अपनी सेवानिवृत्ति को पूरा करना है।"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
 msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
@@ -1535,6 +2046,12 @@ msgstr "पहला कदम इस संपत्ति को अपनी 
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
 msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
 msgstr "आपके पर्यावरणीय दावे को सत्यापित करने के लिए नीचे दी गई जानकारी सार्वजनिक रूप से प्रसारित की जाएगी। यह लेन-देन स्थायी है; आपके लेन-देन पूरे हो जाने के बाद जानकारी को बदला नहीं जा सकता।"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
+msgstr ""
 
 #: components/pages/Home/index.tsx:53
 #: components/pages/Home/index.tsx:68
@@ -1574,13 +2091,27 @@ msgstr "प्रति टन न्यूनतम मूल्य है {0}"
 msgid "The minimum quantity to sell is 1 tonne"
 msgstr "बेचने के लिए न्यूनतम मात्रा 1 टन है"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:53
 msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 msgstr "पिछले चरण में आपकी कार्बन संपत्ति को आपके वॉलेट से कार्बनमार्क में स्थानांतरित करने की स्वीकृति दी गई थी, आपकी रिटायरमैंट अभी तक पूरी नहीं हुई है।"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
 msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
 msgstr "पिछले चरण में आपके भुगतान ऐसेट को आपके वॉलेट से कार्बनमार्क में हस्तांतरण को मंज़ूरी मिली।"
+
+#: components/pages/Home/index.tsx:65
+msgid "The Universal Carbon Marketplace"
+msgstr "यूनिवर्सल कार्बन मार्केटप्लेस"
 
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:208
 msgid "There was an error during the checkout process. Please try again."
@@ -1603,6 +2134,11 @@ msgstr "कुल लागत लोड करने में गलती ह
 msgid "This app only works on Polygon Mainnet."
 msgstr "यह ऐप केवल पॉलीगॉन मेननेट पर ही काम करता है।"
 
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:24
+msgid "user.login.description"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
 msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
 msgstr ""
@@ -1623,13 +2159,27 @@ msgstr "यह ऑफ़र अब मौजूद नहीं है।"
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr "यह उत्पाद अभी भी बीटा चरण में है और अभी तक ऑडिट पूरा नहीं हुआ है।"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
+msgid "retirement.single.immutable_public_records.title"
+msgstr ""
+
 #: components/pages/Users/ProfileHeader/index.tsx:46
 msgid "This user has not yet created a carbonmark profile."
 msgstr "इस उपयोगकर्ता ने अभी तक कार्बनमार्क प्रोफ़ाइल नहीं बनाई है."
 
+#: components/Activities/Activity.tsx:119
+msgid "to"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr "अपना क्रेडिट कार्ड लेनदेन पूरा करने के लिए, आपको हमारे भुगतान प्रसंस्करण भागीदार स्ट्राइप पर पुनः निर्देशित किया जाएगा।"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:60
 msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
@@ -1643,24 +2193,24 @@ msgstr ""
 msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr ""
 
+#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
+#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
+msgid "Toggle payment method"
+msgstr "भुगतान विधि टॉगल करें"
+
 #: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
 msgid "Toggle Select Project"
 msgstr ""
 "प्रोजेक्ट का चयन करें टॉगल \n"
 "करके"
 
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr "मेनू द्वारा क्रमबद्ध टॉगल करें"
-
-#: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
-#: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
-msgid "Toggle payment method"
-msgstr "भुगतान विधि टॉगल करें"
-
 #: components/pages/Projects/ProjectSort/index.tsx:29
 msgid "Toggle sort menu"
 msgstr "सॉर्ट मेनू टॉगल करें"
+
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
+msgstr "मेनू द्वारा क्रमबद्ध टॉगल करें"
 
 #: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:209
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
@@ -1670,6 +2220,10 @@ msgstr "टोकन आपको प्राप्त होगा"
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
 msgid "Tokens received:"
 msgstr "टोकन प्राप्त हुए:"
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
+msgid "tonnes"
+msgstr "टन"
 
 #: components/AssetDetails/index.tsx:63
 #: components/pages/Project/PayWithBank/index.tsx:125
@@ -1690,22 +2244,6 @@ msgstr "सूचीबद्ध टन"
 msgid "Tonnes sold:"
 msgstr "टन बिक्री"
 
-#: components/CreateListing/Form/index.tsx:85
-msgid "Total Amount to Sell is required"
-msgstr "बेची जाने वाली कुल मात्रा आवश्यक है"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
-msgid "Total Cost is required"
-msgstr "कुल लागत आवश्यक है"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr "कुल कीमत"
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr "कुल रिटायरमेन्ट्स:"
-
 #: components/CreateListing/Transaction/Approve.tsx:61
 msgid "Total allowance"
 msgstr "कुल भत्ता"
@@ -1714,9 +2252,18 @@ msgstr "कुल भत्ता"
 msgid "Total amount of tonnes to retire is required"
 msgstr ""
 
+#: components/CreateListing/Form/index.tsx:85
+msgid "Total Amount to Sell is required"
+msgstr "बेची जाने वाली कुल मात्रा आवश्यक है"
+
 #: components/pages/Retire/Activity/Overview.tsx:72
 msgid "Total carbon tonnes retired"
 msgstr "कुल रिटायर किए गए कार्बन टन"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:98
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr ""
 
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
@@ -1724,9 +2271,17 @@ msgstr "कुल रिटायर किए गए कार्बन टन"
 msgid "Total cost"
 msgstr "कुल लागत"
 
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
+msgid "Total Cost is required"
+msgstr "कुल लागत आवश्यक है"
+
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:166
 msgid "Total price"
+msgstr "कुल कीमत"
+
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
 msgstr "कुल कीमत"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:103
@@ -1737,6 +2292,15 @@ msgstr "बिक्री हेतु सूचीबद्ध की जा�
 msgid "Total retirement transactions"
 msgstr "कुल रिटायरमेंट लेनदेन"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:112
+msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
+msgstr "कुल रिटायरमेन्ट्स:"
+
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
 msgid "Total sale cost"
@@ -1746,25 +2310,32 @@ msgstr "कुल बिक्री लागत"
 msgid "Transaction complete."
 msgstr "लेन-देन पूर्ण हुआ।"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
+msgid "retirement.single.transaction_id.title"
+msgstr ""
+
 #: lib/statusMessage.ts:29
 msgid "Transaction initiated. Waiting for network confirmation."
 msgstr "लेन-देन शुरू किया। नेटवर्क पुष्टि की प्रतीक्षा कर रहा है।"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:24
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:48
 msgid "Transfer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:50
+msgid "retirement.provenance.head.metaDescription"
 msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:128
 msgid "Transparent, on-chain offsets powered by Carbonmark."
 msgstr "कार्बनमार्क द्वारा संचालित पारदर्शी, ऑन-चेन ऑफ़सेट।"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "USDC per ton"
-msgstr "USDC प्रति टन"
-
-#: components/CreateListing/Form/index.tsx:110
-msgid "USDC per tonne"
-msgstr "यूएसडीसी प्रति टन"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.type.title"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:115
 msgid "Unit price is required"
@@ -1782,6 +2353,18 @@ msgstr "डिजिटल कार्बन बाज़ार में अ�
 msgid "Update listing"
 msgstr "सूची अपडेट करें"
 
+#: components/Activities/Activities.constants.ts:10
+msgid "updated expiration"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr "अपडेटेड प्राइस"
+
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr "अपडेटेड मात्रा"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:91
 msgid "Updated:"
 msgstr "अपडेटेड:"
@@ -1789,6 +2372,14 @@ msgstr "अपडेटेड:"
 #: components/pages/Users/SellerConnected/index.tsx:191
 msgid "Updating your data..."
 msgstr "आपका डेटा अपडेट हो रहा है..."
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "USDC per ton"
+msgstr "USDC प्रति टन"
+
+#: components/CreateListing/Form/index.tsx:110
+msgid "USDC per tonne"
+msgstr "यूएसडीसी प्रति टन"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:61
 msgid "User Guides"
@@ -1803,6 +2394,21 @@ msgstr "यूज़र प्रोफ़ाइल | कार्बनमार्�
 msgid "User refused connection."
 msgstr "उपयोगकर्ता ने कनेक्शन अस्वीकार कर दिया।"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:41
 msgid "Verify all information is correct and click 'approve' to continue."
@@ -1814,17 +2420,9 @@ msgstr ""
 "\n"
 "आलोकन"
 
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
-msgid "View Carbonmark Profile"
-msgstr "कार्बनमार्क प्रोफ़ाइल देखें"
-
-#: components/pages/Project/index.tsx:207
-msgid "View Registry Details <0/>"
-msgstr "रजिस्ट्री विवरण देखें <0/>"
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
-msgstr "परिणाम देखें"
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
+msgid "View {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:78
 msgid "View a complete overview of the digital carbon that you own in your Portfolio."
@@ -1859,9 +2457,17 @@ msgstr "कार्बनमार्क पर यह कार्बन ऑ�
 msgid "View and share certificate"
 msgstr "प्रमाण पत्र देखें और साझा करें"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:180
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
+msgid "View Carbonmark Profile"
+msgstr "कार्बनमार्क प्रोफ़ाइल देखें"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:183
 msgid "View issuance on Verra"
 msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
+msgid "View on Polygonscan"
+msgstr "Polygonscan पर देखें"
 
 #: components/AssetDetails/index.tsx:69
 msgid "View on PolygonScan"
@@ -1871,9 +2477,13 @@ msgstr "पॉलीगॉनस्कैन पर देखें"
 msgid "View on PolygonScan <0/>"
 msgstr "पॉलीगॉनस्कैन <0/> पर देखें"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
-msgid "View on Polygonscan"
-msgstr "Polygonscan पर देखें"
+#: components/pages/Project/index.tsx:207
+msgid "View Registry Details <0/>"
+msgstr "रजिस्ट्री विवरण देखें <0/>"
+
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
+msgstr "परिणाम देखें"
 
 #: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:99
 msgid "View retirement"
@@ -1887,8 +2497,9 @@ msgstr ""
 msgid "View the project details and other info for this purchase."
 msgstr "इस ख़रीद के लिए प्रॉजेक्ट विवरण व अन्य जानकारी देखें।"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
-msgid "View {numberOfTransfers} transfers"
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:145
+msgid "purchase.button.view_assets"
 msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:141
@@ -1902,6 +2513,11 @@ msgstr "विंटेज नवीनतम"
 #: components/ProjectFilterModal/constants.tsx:15
 msgid "Vintage Oldest"
 msgstr "विंटेज प्राचीनतम"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
+msgid "retirement.single.vintage.title"
+msgstr ""
 
 #: components/pages/Purchases/index.tsx:66
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
@@ -1923,12 +2539,22 @@ msgstr "हमने कीमत, सत्यता और वैश्वि�
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr "कार्बनमार्क क्या है? डिजिटल कार्बन मार्केट इंटरफ़ेस के बारे में सामान्य प्रश्नों के उत्तर जो सत्यापित कार्बन क्रेडिट के खरीदारों और विक्रेताओं को आसानी से जोड़ते हैं।"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
+msgid "offset.retirement_credit"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:257
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
 msgid "Who will this retirement be credited to?"
 msgstr "यह रिटायरमेंट किसके खाते में जाएगी?"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
+msgstr ""
 
 #: components/shared/InvalidNetworkModal/index.tsx:64
 msgid "Wrong Network"
@@ -1940,9 +2566,19 @@ msgstr "ग़लत नेटवर्क"
 msgid "You"
 msgstr "आप"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
 msgid "You are about to purchase a carbon asset."
 msgstr "आप एक कार्बन संपत्ति ख़रीदने वाले हैं।"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:31
 msgid "You are about to retire a carbon asset."
@@ -1990,13 +2626,10 @@ msgstr ""
 msgid "You successfully acquired carbon!"
 msgstr "आपने सफलतापूर्वक कार्बन प्राप्त कर लिया!"
 
-#: components/pages/Users/SellerConnected/index.tsx:221
-msgid "Your Profile"
-msgstr "आपकी प्रोफ़ाइल"
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
-msgstr "आपका वॉलेट पता:"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:412
@@ -2013,6 +2646,15 @@ msgstr "आपका बैलेंस:"
 msgid "Your display name"
 msgstr "आपका प्रदर्शित होने वाला नाम"
 
+#: components/pages/Users/SellerConnected/index.tsx:221
+msgid "Your Profile"
+msgstr "आपकी प्रोफ़ाइल"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
 msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr "आपकी ख़रीदारी अभी पूर्ण नहीं हुई है। अपनी ख़रीदारी को अंतिम रूप देने के लिए, सत्यापित करें कि सब जानकारी सही है और फिर नीचे 'सबमिट' पर क्लिक करें।"
@@ -2022,6 +2664,11 @@ msgstr "आपकी ख़रीदारी अभी पूर्ण नही�
 msgid "Your seller data"
 msgstr "आपका विक्रेता डेटा"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/index.tsx:84
 msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
 msgstr ""
@@ -2030,6 +2677,10 @@ msgstr ""
 msgid "Your unique handle"
 msgstr "आपका यूनिक हैंडल"
 
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr "आपका वॉलेट पता:"
+
 #: components/pages/Resources/lib/cmsDataMap.ts:82
 msgid "Z-A"
 msgstr "Z-A"
@@ -2037,540 +2688,3 @@ msgstr "Z-A"
 #: components/pages/Home/index.tsx:437
 msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
 msgstr "शून्य-शुल्क कार्बन क्रेडिट ट्रेडिंग - तात्कालिक, पारदर्शी और हमेशा उपलब्ध। कार्बन क्रेडिट व्यापारी के रूप में कार्बनमार्क आपके लिए क्या कर सकता है, इसके बारे में और जानें।"
-
-#: components/Activities/Activity.tsx:34
-msgid "at"
-msgstr "पर"
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr "क्लीमाडाओ (“KlimaDAO”), इसकी क्रिप्टो-संपत्ति, व्यावसायिक संपत्ति, रणनीति और संचालन से संबंधित इस ब्लॉग पोस्ट में प्रदान की गई जानकारी केवल सामान्य ज्ञानवर्द्धन संबंधी उद्देश्यों के चलते दी गयी है और यह किसी भी न्यायक्षेत्र में कोई प्रतिभूति, ऑप्शंस, फ़्यूचर्स, या प्रतिभूतियों से संबंधित अन्य डेरिवेटिव्ज़ को ख़रीदने अथवा बेचने हेतु कोई औपचारिक प्रस्ताव या उकसावा नहीं है और इसकी सामग्री प्रतिभूति क़ानूनों पर आधारित नहीं है। इस ब्लॉग पोस्ट में निहित जानकारी पर ऐसी प्रतिभूतियों को ख़रीदने या बेचने या होल्ड करने की सलाह या ऐसी प्रतिभूतियों को बेचने के प्रस्ताव के रूप में भरोसा नहीं किया जाना चाहिए। यह ब्लॉग पोस्ट किसी व्यक्ति के विशिष्ट निवेश उद्देश्यों या वित्तीय स्थिति के बारे में कोई कर, क़ानूनी या निवेश सलाह या राय प्रदान नहीं करता है और न ही इसे ध्यान में रखता है। KlimaDAO और उसके एजेंट, सलाहकार, निदेशक, अधिकारी, कर्मचारी और शेयरधारक ऐसी जानकारी की सटीकता के रूप में व्यक्त या निहित कोई प्रतिनिधित्व या वारंटी नहीं देते हैं और KlimaDAO स्पष्ट रूप से ऐसी जानकारी या त्रुटियों या चूक पर आधारित किसी भी और समस्त दायित्व को अस्वीकार करता है। KlimaDAO किसी भी समय, आंशिक रूप से या पूरी तरह से, इसमें निहित जानकारी को संशोधित करने या बदलने का अधिकार सुरक्षित रखता है, और प्राप्तकर्ता को संशोधित जानकारी तक पहुंच प्रदान करने या उसके प्राप्तकर्ता को सूचित करने का कोई दायित्व नहीं लेता है। इस ब्लॉग पोस्ट में निहित जानकारी समान, मिलती-जुलती या संबंधित जानकारी से संबंधित किसी भी पूर्व ब्लॉग पोस्ट या बातचीत को सुपरसीड करती है। कोई भी सूचना, अभ्यावेदन या कथन जो इसमें शामिल नहीं है, किसी भी उद्देश्य के लिए उस पर भरोसा नहीं किया जाएगा। आपके या आपके किसी प्रतिनिधि द्वारा इस ब्लॉग पोस्ट में दी गई जानकारी के उपयोग के परिणामस्वरूप या आपके द्वारा या आपके किसी भी प्रतिनिधि द्वारा चूक के परिणामस्वरूप न तो क्लीमाडाओ और न ही इसके किसी प्रतिनिधि का, अनुबंध, अपकृत्य, विश्वास या अन्यथा, आपके या किसी भी व्यक्ति के लिए कोई दायित्व नहीं होगा। इसके अतिरिक्त, क्लीमाडाओ इस ब्लॉग पोस्ट में चर्चा किए गए मामलों के संबंध में तृतीय पक्षों की अपेक्षाओं, या उनके द्वारा दिए गए बयानों पर टिप्पणी करने के लिए कोई दायित्व नहीं लेता है।"
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr "अस्वीकरण:"
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr "से ख़रीदा गया"
-
-#: components/Layout/index.tsx:52
-msgid "connect a wallet"
-msgstr "वॉलेट कनेक्ट करें"
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr "सूची बनाएँ"
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr "सूची मिटाएँ"
-
-#: components/pages/Project/Purchase/Listing/Price.tsx:18
-#: components/pages/Project/Purchase/Pool/Price.tsx:17
-#: components/pages/Project/Retire/Pool/Price.tsx:17
-msgid "each"
-msgstr "प्रत्येक"
-
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr "जैसे ही आप कन्टिन्यू बटन क्लिक करते हैं, आपको अपना वॉलेट कनेक्ट करने के लिए कहा जाएगा और आपके द्वारा चुना गया प्रॉजेक्ट KlimaDAO.finance पर पहले से ही चयनित हो जाएगा। वहाँ से, अपना लेन-देन पूरा करने के लिए, उस पृष्ठ पर दिए गए निर्देशों का पालन करें।"
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr "KlimaDAO.finance पर आपके द्वारा ख़रीदे गए कार्बन क्रेडिट्स या आपके द्वारा किया गया कोई भी रिटायरमेंट आपके कार्बनमार्क पोर्टफोलियो में भी उपलब्ध होगा।"
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr "इस लेन-देन को पूरा करने के लिए आपको KlimaDAO.finance पर ले जाया जाएगा।"
-
-#: components/Activities/Activity.tsx:112
-msgid "for"
-msgstr "के लिए"
-
-#: components/pages/Retire/index.tsx:52
-msgid "for beneficiary"
-msgstr "लाभार्थी के लिए"
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr "मार्केटप्लेस"
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr "पोर्टफ़ोलियो"
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr "प्रोफ़ाइल"
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr "रिटायर"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
-msgid "offset.amount_in_tonnes"
-msgstr "आप कितने टन कार्बन को ऑफ़सेट करना चाहेंगे?<0>* </0>"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
-msgid "offset.default_retirement_address"
-msgstr "कनेक्टेड वॉलेट का पते पर किए गए डिफ़ॉल्ट"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
-msgid "offset.retire_carbon"
-msgstr "रिटायरमेंट की पुष्टि करें"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
-msgid "offset.retirement_credit"
-msgstr "यह रिटायरमेंट किसके खाते में जाएगी?"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
-msgid "offset.retirement_message"
-msgstr "रिटायरमेंट संदेश"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr "ग्रह का समर्थन करने के लिए धन्यवाद! <0>पॉलीगॉनस्कैन</0> पर लेनदेन देखें।"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr "पृथ्वी का समर्थन करने के लिए धन्यवाद!"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr "आप की लेन-देन सफलतापूर्वक प्रोसेस हो गयी है लेकिन इन्डेक्स होने में सामान्य से अधिक समय लग रहा है। यह आपकी <0>रिटायरमैंट</0> में जल्द ही दिखाई देगा ।"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
-msgid "offset_disclaimer"
-msgstr "अपने रिटायरमैंट नाम या संदेश में किसी भी संवेदनशील व्यक्तिगत जानकारी (जैसे ईमेल पता) को शामिल करते सयय सावधान रहें। आपके द्वारा यहां दर्ज की गई जानकारी को एक बार जमा करने के बाद संपादित नहीं किया जा सकता है और सार्वजनिक ब्लॉकचेन पर स्थायी रूप से मौजूद रहेगा।"
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr "जमाराशियाँ"
-
-#: components/CreateListing/Form/index.tsx:136
-msgid "profile.addListing_modal.submit"
-msgstr "सूची बनाएँ"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
-msgid "profile.edit_modal.submit"
-msgstr "बदलाव सेव करें"
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr "विवरण जोड़ने के लिए अपनी प्रोफ़ाइल संपादित करें."
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
-msgid "profile.listing.edit.delete_listing"
-msgstr "सूची मिटाएँ"
-
-#: components/pages/Purchases/index.tsx:49
-msgid "project.single.button.back_to_project_details"
-msgstr "वापस प्रॉजेक्ट के विवरण पर"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr "आप एक कार्बन संपत्ति ख़रीदने वाले हैं।"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr "पहला कदम इस संपत्ति को अपनी वॉलेट से कार्बनमार्क में स्थानांतरित करने की स्वीकृति देना है, अगला कदम वास्तविक हस्तांतरण को मंज़ूरी देना और अपनी ख़रीदारी संपन्न करनी है।"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr "आपके द्वारा ख़रीदे गए कार्बन ऐसेट्स आपके <0>पोर्टफोलियो</0> से बिक्री के लिए कार्बनमार्क पर कभी भी सूचीबद्ध किए जा सकते हैं।"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr "सत्यापित करें कि संपूर्ण जानकारी सही है और आगे बढ़ने के लिए 'मंज़ूरी दें' पर क्लिक करें।"
-
-#: components/pages/Purchases/index.tsx:145
-msgid "purchase.button.view_assets"
-msgstr "अपनी संपत्ति देखें"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr "पिछले चरण में आपके भुगतान ऐसेट को आपके वॉलेट से कार्बनमार्क में हस्तांतरण को मंज़ूरी मिली।"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr "आपकी ख़रीदारी अभी पूर्ण नहीं हुई है। अपनी ख़रीदारी को अंतिम रूप देने के लिए, सत्यापित करें कि सब जानकारी सही है और फिर नीचे 'सबमिट' पर क्लिक करें।"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr "कैटेगरीज़"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr "एक या अधिक चुनें"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr "सबकुछ मिटाएँ"
-
-#: components/pages/Resources/ResourcesList/index.tsx:289
-msgid "resources.mobile_modal.button.show_results"
-msgstr "परिणाम दिखाओ"
-
-#: components/pages/Resources/ResourcesList/index.tsx:230
-msgid "resources.page.list.no_search_results.title"
-msgstr "क्षमा करें। हमें कोई मेल खाने वाला परिणाम नहीं मिला।"
-
-#: components/pages/Resources/ResourcesList/index.tsx:222
-msgid "resources.page.list.on_fetch_error"
-msgstr "क्षमा कीजिए! कुछ गड़बड़ हो गयी।"
-
-#: components/pages/Resources/ResourcesList/index.tsx:243
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr "कृपया किसी भिन्न फ़िल्टर कॉम्बिनेशन का उपयोग करें।"
-
-#: components/pages/Resources/ResourcesList/index.tsx:236
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr "टाइपो-त्रुटियों के लिए अपनी खोज की जाँच करें या कोई भिन्न खोज-शब्द आज़माएँ।"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
-msgid "retire.back_button"
-msgstr "वापस"
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr "रिटायर्ड"
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr "सैकड़ों परियोजनाओं से 20 मिलियन से अधिक सत्यापित डिजिटल कार्बन क्रेडिट के साथ, कार्बनमार्क दुनिया भर में डिजिटल कार्बन क्रेडिट का सबसे बड़ा चयन प्रदान करता है। शून्य-कमीशन ट्रेडिंग के साथ तुरंत किसी भी प्रोजेक्ट से डिजिटल कार्बन खरीदें, बेचें और रिटायर करें। <0>आज ही शुरू करें</0> ."
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr "कार्बनमार्क के बारे में"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr "{retiree} रिटायर्ड {formattedAmount} टन कार्बन"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr "कार्बनमार्क | कार्बन रिटायरमेंट रसीद"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:50
-msgid "retirement.provenance.head.metaDescription"
-msgstr "कार्बनमार्क द्वारा संचालित पारदर्शी, ऑन-चेन ऑफ़सेट।"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:46
-msgid "retirement.provenance.head.metaTitle"
-msgstr "{retiree} रिटायर्ड {formattedAmount} टन कार्बन"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:42
-msgid "retirement.provenance.head.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
-msgid "retirement.single.beneficiary.placeholder"
-msgstr "कोई लाभार्थी-नाम प्रदान नहीं किया गया"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.title"
-msgstr "लाभार्थी:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
-msgid "retirement.single.beneficiary_address.title"
-msgstr "लाभार्थी का पता"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr "कार्बन क्रेडिट रिटायरमेंट"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
-msgid "retirement.single.country_region.title"
-msgstr "देश/क्षेत्र:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
-msgid "retirement.single.immutable_public_records.title"
-msgstr "यह एक डिजिटल कार्बन संपत्ति की स्थायी रिटायरमैंट का प्रतिनिधित्व करता है। यह रिटायरमैंट और संबद्ध डेटा अपरिवर्तनीय सार्वजनिक रिकॉर्ड हैं।"
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr "रिटायरमेंट संदेश:"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.methodology.title"
-msgstr "कार्यप्रणाली:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
-msgid "retirement.single.moss_offset.description"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
-msgid "retirement.single.moss_offset.name"
-msgstr "MOSS अर्थ MC02"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
-msgid "retirement.single.official_certificate.title"
-msgstr "<0>Carbonmark.com द्वारा प्रदान किया गया ऑन-चेन कार्बन रिटायरमेंट का आधिकारिक प्रमाणपत्र</0>"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
-msgid "retirement.single.project.title"
-msgstr "प्रॉजेक्ट:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
-msgid "retirement.single.project_description.title"
-msgstr "विवरण"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
-msgid "retirement.single.project_details.title"
-msgstr "प्रॉजेक्ट का विवरण"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
-msgid "retirement.single.project_name.title"
-msgstr "परियोजना का नाम"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr "सबूत"
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr "रिटायर की गयी मात्रा"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
-msgid "retirement.single.share_retirement.title"
-msgstr "इस रिटायरमेंट को साझा करें"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr "कोई रिटायरमेंट टाइमस्टैम्प प्रदान नहीं किया गया"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
-msgid "retirement.single.transaction_id.title"
-msgstr "लेन-देन आईडी"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
-msgid "retirement.single.transaction_record.title"
-msgstr "अपरिवर्तनीय लेनदेन रिकॉर्ड"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.type.title"
-msgstr "प्रकार:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr " कार्बन के सत्यापित रिटायर्ड टन"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
-msgid "retirement.single.vintage.title"
-msgstr "विंटेज:"
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr "कोई रिटायरमेंट नहीं मिला"
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr "कुल रिटायरमेंट्स"
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr "कार्बनमार्क - लाभार्थी के लिए कार्बन रिटायरमेन्ट्स {0}"
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr "कार्बनमार्क - लाभार्थी के लिए कार्बन रिटायरमेन्ट्स {0}"
-
-#: components/pages/Retirements/index.tsx:60
-msgid "retirement.totals.page_headline"
-msgstr "कार्बन रिटायरमेंट्स"
-
-#: components/pages/Retirements/index.tsx:66
-msgid "retirement.totals.page_subline"
-msgstr "लाभार्थी के लिए"
-
-#: components/pages/Retirements/index.tsx:90
-msgid "retirement.totals.retired_assets"
-msgstr "रिटायर की गयी संपत्ति"
-
-#: components/pages/Retirements/index.tsx:106
-msgid "retirement.totals.retirements"
-msgstr "रिटायरमेंट्स"
-
-#: components/pages/Retirements/index.tsx:98
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr "कुल रिटायर किए गए कार्बन टन"
-
-#: components/pages/Retirements/index.tsx:112
-msgid "retirement.totals.total_retirement_transactions"
-msgstr "कुल रिटायरमेंट लेनदेन"
-
-#: components/pages/Users/SellerUnconnected/index.tsx:70
-msgid "seller.listing.buy"
-msgstr "ख़रीदें"
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr "उपलब्ध मात्रा:"
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr "संसाधन केंद्र"
-
-#: components/pages/Resources/ResourcesList/index.tsx:197
-msgid "shared.resources.sort_by.header"
-msgstr "इसके अनुसार क्रमबद्ध करें"
-
-#: components/Layout/index.tsx:51
-msgid "social or email"
-msgstr "सामाजिक या ईमेल"
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr "को बेचा गया"
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
-msgid "something went wrong loading the allowance"
-msgstr "कुछ गड़बड़ हो गई जानकारी लोड हो रही है"
-
-#: components/pages/Retire/Activity/Overview.tsx:77
-#: components/pages/Retire/Activity/Quotes.tsx:76
-#: components/pages/Retire/Activity/Table.tsx:65
-msgid "t"
-msgstr "टी"
-
-#: components/Activities/Activity.tsx:119
-msgid "to"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
-msgid "tonnes"
-msgstr "टन"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr "आप कार्बन एसेट को रिटायर करने वाले हैं।"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr "पहला कदम अपनी कार्बन संपत्ति को अपने वॉलेट से कार्बनमार्क में स्थानांतरित करने की स्वीकृति देना है, अगला कदम वास्तविक हस्तांतरण को मंजूरी देना और अपनी सेवानिवृत्ति को पूरा करना है।"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr "सत्यापित करें कि संपूर्ण जानकारी सही है और आगे बढ़ने के लिए 'मंज़ूरी दें' पर क्लिक करें।"
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr "राशि की पुष्टि करें"
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr "कॉन्ट्रैक्ट पता"
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr "प्रति टन राशि की पुष्टि करें"
-
-#: components/CreateListing/Transaction/index.tsx:83
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr "वापस जाएँ"
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr "बंद करें"
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr "अगला"
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr "जमा की जाने वाली राशि"
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr "सबमिट करें"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr "पिछले चरण में आपकी कार्बन संपत्ति को आपके वॉलेट से कार्बनमार्क में स्थानांतरित करने की स्वीकृति दी गई थी, आपकी रिटायरमैंट अभी तक पूरी नहीं हुई है।"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr "अपनी रिटायरमैंट को अंतिम रूप देने के लिए, सत्यापित करें कि सभी जानकारी सही है और फिर नीचे 'सबमिट' पर क्लिक करें।"
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr "कॉन्ट्रैक्ट पता"
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr "प्रति टन कीमत सबमिट करें:"
-
-#: components/CreateListing/Transaction/index.tsx:47
-#: components/Transaction/index.tsx:45
-msgid "transaction_modal.view.approve.title"
-msgstr "मंज़ूरी दें"
-
-#: components/CreateListing/Transaction/index.tsx:57
-#: components/Transaction/index.tsx:55
-msgid "transaction_modal.view.submit.title"
-msgstr "2. जमा करें"
-
-#: components/Activities/Activities.constants.ts:10
-msgid "updated expiration"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr "अपडेटेड प्राइस"
-
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr "अपडेटेड मात्रा"
-
-#: components/Activities/index.tsx:29
-msgid "user.activities.empty_state"
-msgstr "शून्य गतिविधियाँ मौजूद"
-
-#: components/LoginCard/index.tsx:24
-msgid "user.login.description"
-msgstr "यह सुविधा केवल उन उपयोगकर्ताओं के लिए उपलब्ध है जिन्होंने लॉगिन कर रखा है। आप नीचे दिए गए बटन से लॉग इन कर सकते हैं या खाता बना सकते हैं।"
-
-#: components/CreateListing/Transaction/Approve.tsx:51
-#: components/CreateListing/Transaction/index.tsx:62
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
-msgid "{0}"
-msgstr "{0}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
-msgid "{0} maximum for credit cards"
-msgstr "{0} क्रेडिट कार्ड के लिए अधिकतम"
-
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr "{0} | प्रोफ़ाइल | कार्बनमार्क"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr "{DEFAULT_EXPIRATION_DAYS} दिन ({expirationDatestring})"
-
-#: components/pages/Purchases/index.tsx:29
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr "{amount} टन {0} प्रॉजेक्ट के लिए ख़रीदे गए थे"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
-#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
-msgid "{formattedAmount} Tonnes"
-msgstr ""
-
-#: components/Quantity/index.tsx:28
-msgid "{formattedAmount} tonnes"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
-msgid "{tokenSymbol}"
-msgstr "{tokenSymbol}"
-
-#: lib/statusMessage.ts:23
-msgid "❌ Error: something went wrong..."
-msgstr "❌ एरर: कुछ गड़बड़ हो गयी..."

--- a/carbonmark/locale/ko/messages.po
+++ b/carbonmark/locale/ko/messages.po
@@ -6,9 +6,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ko\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/CreateListing/Transaction/Approve.tsx:51
+#: components/CreateListing/Transaction/index.tsx:62
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
+msgid "{0}"
+msgstr ""
+
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr ""
+
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
+msgid "{0} maximum for credit cards"
+msgstr ""
+
+#: components/pages/Purchases/index.tsx:29
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr ""
+
+#: components/Quantity/index.tsx:28
+msgid "{formattedAmount} tonnes"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
+#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
+msgid "{formattedAmount} Tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:46
+msgid "retirement.provenance.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
+msgid "{tokenSymbol}"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "@Username (note: this can not be changed!)"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
+msgid "<0>* </0> Required Field"
+msgstr ""
+
+#: lib/statusMessage.ts:23
+msgid "❌ Error: something went wrong..."
+msgstr ""
 
 #: components/pages/Home/index.tsx:358
 msgid "0% listing fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:47
+#: components/Transaction/index.tsx:45
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:57
+#: components/Transaction/index.tsx:55
+msgid "transaction_modal.view.submit.title"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:193
@@ -32,14 +107,6 @@ msgstr ""
 msgid "500 - Server error occurred"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
-msgid "<0>* </0> Required Field"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "@Username (note: this can not be changed!)"
-msgstr ""
-
 #: components/pages/Project/PayWithBank/index.tsx:153
 msgid "A valid email address is required"
 msgstr ""
@@ -54,6 +121,11 @@ msgstr ""
 msgid "About"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr ""
+
 #: components/Stats/StatsListings.tsx:49
 msgid "Active listings:"
 msgstr ""
@@ -62,12 +134,22 @@ msgstr ""
 msgid "Activity"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr ""
+
 #: lib/getCategoryInfo.ts:53
 msgid "Agriculture"
 msgstr ""
 
 #: components/pages/Home/index.tsx:362
 msgid "All assets sourced from major registries"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
 msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:41
@@ -111,6 +193,10 @@ msgstr ""
 msgid "Asset"
 msgstr ""
 
+#: components/AssetDetails/index.tsx:53
+msgid "Asset details"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:24
 msgid "Asset Details"
 msgstr ""
@@ -119,8 +205,12 @@ msgstr ""
 msgid "Asset ID"
 msgstr ""
 
-#: components/AssetDetails/index.tsx:53
-msgid "Asset details"
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:32
+msgid "Asset moved from one account to another, either via sale or inter-account transfer."
+msgstr ""
+
+#: components/Activities/Activity.tsx:34
+msgid "at"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:131
@@ -132,11 +222,6 @@ msgid ""
 "At this time, Carbonmark cannot process credit card payments\n"
 "exceeding {0}. Please adjust the\n"
 "quantity and try again later."
-msgstr ""
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:116
@@ -163,6 +248,11 @@ msgstr ""
 msgid "Available to retire"
 msgstr ""
 
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:219
 msgid "Available:"
 msgstr ""
@@ -176,13 +266,19 @@ msgstr ""
 msgid "Available: {unlistedBalance}"
 msgstr ""
 
-#: components/BetaBadge/index.tsx:18
-msgid "BETA"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
+msgid "retire.back_button"
 msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:44
 #: components/pages/Project/Retire/index.tsx:35
 msgid "Back to Project"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:49
+msgid "project.single.button.back_to_project_details"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:397
@@ -199,6 +295,16 @@ msgstr ""
 msgid "Balance: {0}"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
+msgid "offset_disclaimer"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:450
 msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
 msgstr ""
@@ -207,12 +313,17 @@ msgstr ""
 msgid "Beneficiary Address"
 msgstr ""
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
-msgid "Beneficiary Name"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
+msgid "retirement.single.beneficiary_address.title"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:263
 msgid "Beneficiary name"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
+msgid "Beneficiary Name"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:232
@@ -225,10 +336,19 @@ msgstr ""
 msgid "Beneficiary wallet address (optional)"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:34
 #: components/pages/Project/BuyOptions/SellerListing.tsx:67
 #: components/pages/Project/index.tsx:137
 msgid "Best Price"
+msgstr ""
+
+#: components/BetaBadge/index.tsx:18
+msgid "BETA"
 msgstr ""
 
 #: lib/getCategoryInfo.ts:65
@@ -239,8 +359,8 @@ msgstr ""
 msgid "Book a demo"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:35
-msgid "Bridge"
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
 msgstr ""
 
 #: components/pages/Home/index.tsx:157
@@ -255,6 +375,11 @@ msgstr ""
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:45
 #: components/pages/Project/BuyOptions/SellerListing.tsx:98
 msgid "Buy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:70
+msgid "seller.listing.buy"
 msgstr ""
 
 #: components/pages/Home/index.tsx:168
@@ -273,12 +398,35 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr ""
+
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:30
 msgid "Carbon Pool"
 msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:117
 msgid "Carbon Portfolio"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
+msgid "Carbon provenance"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:60
@@ -289,16 +437,34 @@ msgstr ""
 msgid "Carbon Retirements"
 msgstr ""
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:60
+msgid "retirement.totals.page_headline"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
-msgid "Carbon provenance"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
 msgstr ""
 
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:42
+msgid "retirement.provenance.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:51
+#: components/pages/Home/index.tsx:52
+msgid "Carbonmark | The Universal Carbon Marketplace"
 msgstr ""
 
 #: components/pages/Home/index.tsx:174
@@ -315,13 +481,17 @@ msgstr ""
 msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 msgstr ""
 
-#: components/pages/Home/index.tsx:51
-#: components/pages/Home/index.tsx:52
-msgid "Carbonmark | The Universal Carbon Marketplace"
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
 msgstr ""
 
 #: components/pages/Home/index.tsx:488
 msgid "Carbonmark's role"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
 msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:130
@@ -333,6 +503,11 @@ msgstr ""
 msgid "Change language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:236
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
 #: components/pages/Home/index.tsx:206
 msgid "Choose a project and quantity"
 msgstr ""
@@ -341,8 +516,13 @@ msgstr ""
 msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 msgstr ""
 
-#: components/ProjectFilterModal/index.tsx:162
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
 #: components/pages/Projects/ProjectSearch/index.tsx:55
+#: components/ProjectFilterModal/index.tsx:162
 msgid "Clear Filters"
 msgstr ""
 
@@ -352,6 +532,11 @@ msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:98
 msgid "Close"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
 msgstr ""
 
 #: components/Footer/index.tsx:32
@@ -379,6 +564,16 @@ msgstr ""
 msgid "Compiling Results ..."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr ""
+
 #: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:83
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
 #: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
@@ -386,8 +581,17 @@ msgstr ""
 msgid "Confirm Purchase"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
+msgid "offset.retire_carbon"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:75
 msgid "Confirm Retirement"
+msgstr ""
+
+#: components/Layout/index.tsx:52
+msgid "connect a wallet"
 msgstr ""
 
 #: components/pages/Portfolio/ConnectedWallet/index.tsx:33
@@ -414,6 +618,16 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
 #: components/CopyAddressButton/index.tsx:37
 msgid "Copy"
 msgstr ""
@@ -431,14 +645,9 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Create Profile"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
+msgid "retirement.single.country_region.title"
 msgstr ""
 
 #: components/CreateListing/index.tsx:165
@@ -457,6 +666,21 @@ msgstr ""
 msgid "Create and edit listings, and track your activity with your Carbonmark profile."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:136
+msgid "profile.addListing_modal.submit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Create Profile"
+msgstr ""
+
 #: components/pages/Home/index.tsx:313
 msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
 msgstr ""
@@ -465,24 +689,28 @@ msgstr ""
 msgid "Create your own retirement"
 msgstr ""
 
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:87
 msgid "Created:"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
-msgid "Credit ID"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:77
 msgid "Credit card minimum purchase is {0}"
 msgstr ""
 
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:247
 msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
+msgid "Credit ID"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:435
@@ -492,10 +720,6 @@ msgstr ""
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:140
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
 msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
-msgstr ""
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
 msgstr ""
 
 #: components/pages/Project/index.tsx:234
@@ -511,8 +735,26 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
+msgid "offset.default_retirement_address"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:296
 msgid "Defaults to the connected wallet address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
+msgid "profile.listing.edit.delete_listing"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:307
@@ -523,12 +765,22 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
+msgid "retirement.single.project_description.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:51
 msgid "Digital Carbon"
 msgstr ""
 
 #: components/pages/Home/index.tsx:264
 msgid "Digitize your carbon by using a supported bridge"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
@@ -555,8 +807,18 @@ msgstr ""
 msgid "Drive climate action and earn rewards with a carbon-backed digital currency."
 msgstr ""
 
+#: components/pages/Project/Purchase/Listing/Price.tsx:18
+#: components/pages/Project/Purchase/Pool/Price.tsx:17
+#: components/pages/Project/Retire/Pool/Price.tsx:17
+msgid "each"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:195
 msgid "Edit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
+msgid "Edit listing"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:113
@@ -564,8 +826,9 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
-msgid "Edit listing"
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:143
@@ -626,6 +889,19 @@ msgstr ""
 msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
 msgstr ""
 
+#: components/Activities/Activity.tsx:112
+msgid "for"
+msgstr ""
+
+#: components/pages/Retire/index.tsx:52
+msgid "for beneficiary"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:66
+msgid "retirement.totals.page_subline"
+msgstr ""
+
 #: components/pages/Home/index.tsx:340
 msgid "For carbon traders"
 msgstr ""
@@ -642,20 +918,26 @@ msgstr ""
 msgid "Form complete"
 msgstr ""
 
-#: components/pages/Home/index.tsx:76
-msgid "Get Started"
-msgstr ""
-
 #: components/pages/Home/index.tsx:390
 msgid "Get paid immediately: transactions are resolved in seconds"
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
+#: components/pages/Home/index.tsx:76
+msgid "Get Started"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:83
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
 msgid "Go back"
+msgstr ""
+
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:145
@@ -681,7 +963,7 @@ msgid "Here’s a list of readily available, discounted carbon tokens to retire 
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:48
-msgid "Hide {numberOfTransfers} transfers"
+msgid "Hide {numberOfTransfers} transactions"
 msgstr ""
 
 #: components/CreateListing/Form/index.tsx:80
@@ -695,6 +977,11 @@ msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:249
 msgid "How many tonnes of carbon do you want to retire?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
+msgid "offset.amount_in_tonnes"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:215
@@ -719,6 +1006,11 @@ msgstr ""
 
 #: components/pages/Purchases/index.tsx:93
 msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
+msgid "retirement.single.transaction_record.title"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:116
@@ -775,13 +1067,13 @@ msgstr ""
 msgid "Latest First"
 msgstr ""
 
+#: components/pages/Home/index.tsx:417
+msgid "Learn more"
+msgstr ""
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:92
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:103
 msgid "Learn More"
-msgstr ""
-
-#: components/pages/Home/index.tsx:417
-msgid "Learn more"
 msgstr ""
 
 #: components/pages/Home/index.tsx:491
@@ -815,11 +1107,11 @@ msgid "Loading your assets"
 msgstr ""
 
 #: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:295
 #: components/pages/Retire/Activity/Overview.tsx:73
 #: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
 msgid "Loading..."
 msgstr ""
 
@@ -859,6 +1151,11 @@ msgstr ""
 msgid "Marketplace"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr ""
+
 #: components/pages/Projects/index.tsx:73
 #: components/pages/Projects/index.tsx:74
 msgid "Marketplace | Carbonmark"
@@ -868,20 +1165,35 @@ msgstr ""
 msgid "Maximize your climate impact."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.moss_offset.description"
+msgstr ""
+
 #: components/pages/Project/index.tsx:144
 msgid "Methodology"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.methodology.title"
 msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:54
 msgid "Moss"
 msgstr ""
 
-#: components/FeatureBanner/index.tsx:33
-msgid "NEW FEATURE:"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
+msgid "retirement.single.moss_offset.name"
 msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:171
 msgid "Navigation Menu"
+msgstr ""
+
+#: components/FeatureBanner/index.tsx:33
+msgid "NEW FEATURE:"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
@@ -896,8 +1208,9 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:197
@@ -905,8 +1218,17 @@ msgstr ""
 msgid "No active listings."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Activities/index.tsx:29
+msgid "user.activities.empty_state"
+msgstr ""
+
 #: components/pages/Retire/Activity/Quotes.tsx:38
 msgid "No activity to show"
+msgstr ""
+
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
 msgstr ""
 
 #: components/pages/Home/index.tsx:400
@@ -915,6 +1237,11 @@ msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:40
 msgid "No beneficiary address available"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
+msgid "retirement.single.beneficiary.placeholder"
 msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:62
@@ -950,12 +1277,18 @@ msgstr ""
 msgid "No retirement message provided."
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
-msgid "No transaction id available"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
 msgstr ""
 
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
+msgid "No transaction id available"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:240
@@ -963,11 +1296,20 @@ msgstr ""
 msgid "Not a valid polygon address"
 msgstr ""
 
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
+msgid "retirement.single.official_certificate.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:72
 msgid "Oldest First"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:185
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:188
 msgid "On the Verra page, search for the specific serial number."
 msgstr ""
 
@@ -991,21 +1333,17 @@ msgstr ""
 msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 msgstr ""
 
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr ""
-
 #: components/pages/Projects/Banners/BankTransfer.tsx:74
 msgid "Pay via Bank Transfer / Wire"
+msgstr ""
+
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:89
 #: components/pages/Project/PayWithBank/index.tsx:90
 msgid "Pay with Bank Transfer | Carbonmark"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:94
@@ -1014,21 +1352,17 @@ msgstr ""
 msgid "Pay with:"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:62
-msgid "Payment Successful"
-msgstr ""
-
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:243
 msgid "Payment processing fee"
+msgstr ""
+
+#: components/pages/Purchases/index.tsx:62
+msgid "Payment Successful"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:161
 #: components/pages/Project/PayWithBank/index.tsx:313
 msgid "Phone number"
-msgstr ""
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
 msgstr ""
 
 #: lib/statusMessage.ts:27
@@ -1039,10 +1373,24 @@ msgstr ""
 msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr ""
 
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr ""
+
 #: components/pages/Portfolio/index.tsx:66
 #: components/pages/Users/SellerConnected/index.tsx:75
 #: components/pages/Users/SellerConnected/index.tsx:101
 msgid "Please refresh the page. There was an error updating your data: {e}."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:243
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
 msgstr ""
 
 #: components/pages/Portfolio/index.tsx:76
@@ -1062,10 +1410,6 @@ msgstr ""
 msgid "Price Highest"
 msgstr ""
 
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr ""
-
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:180
@@ -1074,6 +1418,10 @@ msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:160
 msgid "Price is required"
+msgstr ""
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
 msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:62
@@ -1110,8 +1458,27 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:192
 msgid "Profile picture"
+msgstr ""
+
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
+msgid "retirement.single.project_name.title"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:253
@@ -1119,9 +1486,19 @@ msgstr ""
 msgid "Project names of interest"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:36
-#: components/pages/Purchases/index.tsx:37
-msgid "Purchase Receipt | Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
+msgid "retirement.single.project.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr ""
+
+#: components/pages/Project/Purchase/index.tsx:32
+#: components/pages/Project/Purchase/index.tsx:33
+msgid "Purchase {0} | Carbonmark"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:53
@@ -1133,17 +1510,17 @@ msgstr ""
 msgid "Purchase more Carbon"
 msgstr ""
 
+#: components/pages/Purchases/index.tsx:36
+#: components/pages/Purchases/index.tsx:37
+msgid "Purchase Receipt | Carbonmark"
+msgstr ""
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:79
 msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer."
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
 msgid "Purchase successful"
-msgstr ""
-
-#: components/pages/Project/Purchase/index.tsx:32
-#: components/pages/Project/Purchase/index.tsx:33
-msgid "Purchase {0} | Carbonmark"
 msgstr ""
 
 #: components/pages/Retire/Activity/Table.tsx:47
@@ -1160,6 +1537,11 @@ msgstr ""
 msgid "Quantity Available:"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:240
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:108
 msgid "Quantity is required"
@@ -1173,20 +1555,17 @@ msgstr ""
 msgid "Quantity purchased:"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr ""
+
 #: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr ""
 
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr ""
-
 #: components/pages/Project/index.tsx:198
 msgid "Read Less"
-msgstr ""
-
-#: components/pages/Project/index.tsx:198
-msgid "Read More"
 msgstr ""
 
 #: components/pages/Home/index.tsx:445
@@ -1195,6 +1574,10 @@ msgstr ""
 #: components/pages/Resources/BlogPostCard/index.tsx:38
 #: components/pages/Resources/FeaturedArticles/Article.tsx:45
 msgid "Read more"
+msgstr ""
+
+#: components/pages/Project/index.tsx:198
+msgid "Read More"
 msgstr ""
 
 #: components/pages/Home/index.tsx:351
@@ -1213,13 +1596,13 @@ msgstr ""
 msgid "Renewable Energy"
 msgstr ""
 
+#: lib/constants.ts:82
+msgid "Request already processing. Please open your wallet and complete the request."
+msgstr ""
+
 #: components/pages/Home/index.tsx:301
 #: components/pages/Home/index.tsx:325
 msgid "Request Demo"
-msgstr ""
-
-#: lib/constants.ts:82
-msgid "Request already processing. Please open your wallet and complete the request."
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:210
@@ -1229,6 +1612,11 @@ msgstr ""
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:267
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:311
 msgid "Required when proceeding with Credit Card"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
 msgstr ""
 
 #: components/Footer/index.tsx:38
@@ -1257,14 +1645,35 @@ msgstr ""
 msgid "Retire"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/index.tsx:88
+#: components/pages/Portfolio/Retire/index.tsx:89
+#: components/pages/Retire/index.tsx:38
+#: components/pages/Retire/index.tsx:39
+msgid "Retire | Carbonmark"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:388
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
 msgid "Retire Carbon"
 msgstr ""
 
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:233
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
+msgstr ""
+
+#: components/pages/Project/Retire/index.tsx:23
+#: components/pages/Project/Retire/index.tsx:24
+msgid "Retire from {fullProjectid} | Carbonmark"
 msgstr ""
 
 #: components/pages/Retire/index.tsx:72
@@ -1275,23 +1684,18 @@ msgstr ""
 msgid "Retire from your portfolio"
 msgstr ""
 
-#: components/pages/Project/Retire/index.tsx:23
-#: components/pages/Project/Retire/index.tsx:24
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr ""
-
 #: components/pages/Home/index.tsx:232
 msgid "Retire instantly, or purchase and hold digital carbon"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
 msgstr ""
 
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
 msgid "Retire more carbon"
+msgstr ""
+
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
 msgstr ""
 
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:56
@@ -1307,19 +1711,31 @@ msgstr ""
 msgid "Retire your carbon via bank transfer."
 msgstr ""
 
-#: components/pages/Portfolio/Retire/index.tsx:88
-#: components/pages/Portfolio/Retire/index.tsx:89
-#: components/pages/Retire/index.tsx:38
-#: components/pages/Retire/index.tsx:39
-msgid "Retire | Carbonmark"
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:13
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:90
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:16
 msgid "Retirement"
 msgstr ""
 
 #: components/pages/Retire/Activity/Quotes.tsx:32
 msgid "Retirement Activity"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
+msgid "offset.retirement_message"
+msgstr ""
+
+#: components/pages/Project/PayWithBank/index.tsx:264
+#: components/pages/Project/PayWithBank/index.tsx:363
+msgid "Retirement message"
 msgstr ""
 
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
@@ -1328,26 +1744,36 @@ msgstr ""
 msgid "Retirement Message"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr ""
+
 #: components/pages/Retire/Activity/Overview.tsx:60
 #: components/pages/Retire/Activity/Overview.tsx:70
 msgid "Retirement Overview"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:264
-#: components/pages/Project/PayWithBank/index.tsx:363
-msgid "Retirement message"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:74
 msgid "Retirement successful"
 msgstr ""
 
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:106
+msgid "retirement.totals.retirements"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:384
 msgid "Retiring Token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
+msgid "profile.edit_modal.submit"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:201
@@ -1385,6 +1811,11 @@ msgstr ""
 msgid "Select a language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr ""
+
 #: components/pages/Portfolio/AssetProject/index.tsx:100
 #: components/pages/Portfolio/AssetProject/index.tsx:108
 msgid "Sell"
@@ -1402,12 +1833,26 @@ msgstr ""
 msgid "Seller Listing"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:159
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:29
+msgid "Send"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:161
 msgid "Serial Number"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:76
 msgid "Share this page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
+msgid "retirement.single.share_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:289
+msgid "resources.mobile_modal.button.show_results"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
@@ -1422,6 +1867,19 @@ msgstr ""
 
 #: components/CreateListing/Form/index.tsx:130
 msgid "Single unit price"
+msgstr ""
+
+#: components/Layout/index.tsx:51
+msgid "social or email"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr ""
+
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
+msgid "something went wrong loading the allowance"
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
@@ -1448,12 +1906,27 @@ msgstr ""
 msgid "Sorry, this handle already exists"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:265
-msgid "Sort By"
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:222
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:230
+msgid "resources.page.list.no_search_results.title"
 msgstr ""
 
 #: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "Sort by"
+msgstr ""
+
+#: components/pages/Resources/ResourcesList/index.tsx:265
+msgid "Sort By"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:197
+msgid "shared.resources.sort_by.header"
 msgstr ""
 
 #: components/Stats/index.tsx:23
@@ -1480,6 +1953,21 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr ""
+
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:88
 msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
 msgstr ""
@@ -1492,12 +1980,24 @@ msgstr ""
 msgid "Switch to Polygon"
 msgstr ""
 
-#: components/BetaBadge/index.tsx:16
-msgid "TESTNET"
+#: components/pages/Retire/Activity/Overview.tsx:77
+#: components/pages/Retire/Activity/Quotes.tsx:76
+#: components/pages/Retire/Activity/Table.tsx:65
+msgid "t"
 msgstr ""
 
 #: components/Footer/index.tsx:29
 msgid "Terms of Use"
+msgstr ""
+
+#: components/BetaBadge/index.tsx:16
+msgid "TESTNET"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
@@ -1508,20 +2008,31 @@ msgstr ""
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr ""
 
-#: components/pages/Project/PayWithBank/index.tsx:292
-msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
 msgstr ""
 
-#: components/pages/Home/index.tsx:65
-msgid "The Universal Carbon Marketplace"
+#: components/pages/Project/PayWithBank/index.tsx:292
+msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr ""
 
 #: components/CreateListing/Transaction/Approve.tsx:44
 msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:34
 msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
@@ -1530,6 +2041,12 @@ msgstr ""
 
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
 msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
+msgstr ""
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
 msgstr ""
 
 #: components/pages/Home/index.tsx:53
@@ -1570,12 +2087,26 @@ msgstr ""
 msgid "The minimum quantity to sell is 1 tonne"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:53
 msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
 msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
+msgstr ""
+
+#: components/pages/Home/index.tsx:65
+msgid "The Universal Carbon Marketplace"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:208
@@ -1599,6 +2130,11 @@ msgstr ""
 msgid "This app only works on Polygon Mainnet."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:24
+msgid "user.login.description"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
 msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
 msgstr ""
@@ -1619,12 +2155,26 @@ msgstr ""
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
+msgid "retirement.single.immutable_public_records.title"
+msgstr ""
+
 #: components/pages/Users/ProfileHeader/index.tsx:46
 msgid "This user has not yet created a carbonmark profile."
 msgstr ""
 
+#: components/Activities/Activity.tsx:119
+msgid "to"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:60
@@ -1639,21 +2189,21 @@ msgstr ""
 msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr ""
 
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr ""
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr ""
-
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
 msgid "Toggle payment method"
 msgstr ""
 
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr ""
+
 #: components/pages/Projects/ProjectSort/index.tsx:29
 msgid "Toggle sort menu"
+msgstr ""
+
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:209
@@ -1663,6 +2213,10 @@ msgstr ""
 
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
 msgid "Tokens received:"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
+msgid "tonnes"
 msgstr ""
 
 #: components/AssetDetails/index.tsx:63
@@ -1684,22 +2238,6 @@ msgstr ""
 msgid "Tonnes sold:"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:85
-msgid "Total Amount to Sell is required"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
-msgid "Total Cost is required"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr ""
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr ""
-
 #: components/CreateListing/Transaction/Approve.tsx:61
 msgid "Total allowance"
 msgstr ""
@@ -1708,8 +2246,17 @@ msgstr ""
 msgid "Total amount of tonnes to retire is required"
 msgstr ""
 
+#: components/CreateListing/Form/index.tsx:85
+msgid "Total Amount to Sell is required"
+msgstr ""
+
 #: components/pages/Retire/Activity/Overview.tsx:72
 msgid "Total carbon tonnes retired"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:98
+msgid "retirement.totals.total_carbon_tonnes"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
@@ -1718,9 +2265,17 @@ msgstr ""
 msgid "Total cost"
 msgstr ""
 
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
+msgid "Total Cost is required"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:166
 msgid "Total price"
+msgstr ""
+
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:103
@@ -1729,6 +2284,15 @@ msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:83
 msgid "Total retirement transactions"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:112
+msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
@@ -1740,24 +2304,31 @@ msgstr ""
 msgid "Transaction complete."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
+msgid "retirement.single.transaction_id.title"
+msgstr ""
+
 #: lib/statusMessage.ts:29
 msgid "Transaction initiated. Waiting for network confirmation."
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:24
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:48
 msgid "Transfer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:50
+msgid "retirement.provenance.head.metaDescription"
 msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:128
 msgid "Transparent, on-chain offsets powered by Carbonmark."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "USDC per ton"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:110
-msgid "USDC per tonne"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.type.title"
 msgstr ""
 
 #: components/CreateListing/Form/index.tsx:115
@@ -1776,12 +2347,32 @@ msgstr ""
 msgid "Update listing"
 msgstr ""
 
+#: components/Activities/Activities.constants.ts:10
+msgid "updated expiration"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:91
 msgid "Updated:"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:191
 msgid "Updating your data..."
+msgstr ""
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "USDC per ton"
+msgstr ""
+
+#: components/CreateListing/Form/index.tsx:110
+msgid "USDC per tonne"
 msgstr ""
 
 #: components/pages/Resources/lib/cmsDataMap.ts:61
@@ -1797,6 +2388,21 @@ msgstr ""
 msgid "User refused connection."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:41
 msgid "Verify all information is correct and click 'approve' to continue."
@@ -1806,16 +2412,8 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
-msgid "View Carbonmark Profile"
-msgstr ""
-
-#: components/pages/Project/index.tsx:207
-msgid "View Registry Details <0/>"
-msgstr ""
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
+msgid "View {numberOfTransfers} transactions"
 msgstr ""
 
 #: components/pages/Portfolio/index.tsx:78
@@ -1851,8 +2449,16 @@ msgstr ""
 msgid "View and share certificate"
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:180
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
+msgid "View Carbonmark Profile"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:183
 msgid "View issuance on Verra"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
+msgid "View on Polygonscan"
 msgstr ""
 
 #: components/AssetDetails/index.tsx:69
@@ -1863,8 +2469,12 @@ msgstr ""
 msgid "View on PolygonScan <0/>"
 msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
-msgid "View on Polygonscan"
+#: components/pages/Project/index.tsx:207
+msgid "View Registry Details <0/>"
+msgstr ""
+
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:99
@@ -1879,8 +2489,9 @@ msgstr ""
 msgid "View the project details and other info for this purchase."
 msgstr ""
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
-msgid "View {numberOfTransfers} transfers"
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:145
+msgid "purchase.button.view_assets"
 msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:141
@@ -1893,6 +2504,11 @@ msgstr ""
 
 #: components/ProjectFilterModal/constants.tsx:15
 msgid "Vintage Oldest"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
+msgid "retirement.single.vintage.title"
 msgstr ""
 
 #: components/pages/Purchases/index.tsx:66
@@ -1915,11 +2531,21 @@ msgstr ""
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
+msgid "offset.retirement_credit"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:257
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
 msgid "Who will this retirement be credited to?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
 msgstr ""
 
 #: components/shared/InvalidNetworkModal/index.tsx:64
@@ -1932,8 +2558,18 @@ msgstr ""
 msgid "You"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
 msgid "You are about to purchase a carbon asset."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:31
@@ -1982,12 +2618,9 @@ msgstr ""
 msgid "You successfully acquired carbon!"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:221
-msgid "Your Profile"
-msgstr ""
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
 msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
@@ -2005,6 +2638,15 @@ msgstr ""
 msgid "Your display name"
 msgstr ""
 
+#: components/pages/Users/SellerConnected/index.tsx:221
+msgid "Your Profile"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
 msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr ""
@@ -2012,6 +2654,11 @@ msgstr ""
 #: components/pages/Portfolio/PortfolioSidebar.tsx:29
 #: components/pages/Users/SellerConnected/index.tsx:215
 msgid "Your seller data"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
 msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:84
@@ -2022,547 +2669,14 @@ msgstr ""
 msgid "Your unique handle"
 msgstr ""
 
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:82
 msgid "Z-A"
 msgstr ""
 
 #: components/pages/Home/index.tsx:437
 msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
-msgstr ""
-
-#: components/Activities/Activity.tsx:34
-msgid "at"
-msgstr ""
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr ""
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr ""
-
-#: components/Layout/index.tsx:52
-msgid "connect a wallet"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/Price.tsx:18
-#: components/pages/Project/Purchase/Pool/Price.tsx:17
-#: components/pages/Project/Retire/Pool/Price.tsx:17
-msgid "each"
-msgstr ""
-
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr ""
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr ""
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr ""
-
-#: components/Activities/Activity.tsx:112
-msgid "for"
-msgstr ""
-
-#: components/pages/Retire/index.tsx:52
-msgid "for beneficiary"
-msgstr ""
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr ""
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr ""
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr ""
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
-msgid "offset.amount_in_tonnes"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
-msgid "offset.default_retirement_address"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
-msgid "offset.retire_carbon"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
-msgid "offset.retirement_credit"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
-msgid "offset.retirement_message"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
-msgid "offset_disclaimer"
-msgstr ""
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr ""
-
-#: components/CreateListing/Form/index.tsx:136
-msgid "profile.addListing_modal.submit"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
-msgid "profile.edit_modal.submit"
-msgstr ""
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
-msgid "profile.listing.edit.delete_listing"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:49
-msgid "project.single.button.back_to_project_details"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:145
-msgid "purchase.button.view_assets"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr ""
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:289
-msgid "resources.mobile_modal.button.show_results"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:230
-msgid "resources.page.list.no_search_results.title"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:222
-msgid "resources.page.list.on_fetch_error"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:243
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:236
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
-msgid "retire.back_button"
-msgstr ""
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr ""
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr ""
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:50
-msgid "retirement.provenance.head.metaDescription"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:46
-msgid "retirement.provenance.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:42
-msgid "retirement.provenance.head.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
-msgid "retirement.single.beneficiary.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
-msgid "retirement.single.beneficiary_address.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
-msgid "retirement.single.country_region.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
-msgid "retirement.single.immutable_public_records.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.methodology.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
-msgid "retirement.single.moss_offset.description"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
-msgid "retirement.single.moss_offset.name"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
-msgid "retirement.single.official_certificate.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
-msgid "retirement.single.project.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
-msgid "retirement.single.project_description.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
-msgid "retirement.single.project_details.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
-msgid "retirement.single.project_name.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
-msgid "retirement.single.share_retirement.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
-msgid "retirement.single.transaction_id.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
-msgid "retirement.single.transaction_record.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.type.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
-msgid "retirement.single.vintage.title"
-msgstr ""
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr ""
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:60
-msgid "retirement.totals.page_headline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:66
-msgid "retirement.totals.page_subline"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:90
-msgid "retirement.totals.retired_assets"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:106
-msgid "retirement.totals.retirements"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:98
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr ""
-
-#: components/pages/Retirements/index.tsx:112
-msgid "retirement.totals.total_retirement_transactions"
-msgstr ""
-
-#: components/pages/Users/SellerUnconnected/index.tsx:70
-msgid "seller.listing.buy"
-msgstr ""
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr ""
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr ""
-
-#: components/pages/Resources/ResourcesList/index.tsx:197
-msgid "shared.resources.sort_by.header"
-msgstr ""
-
-#: components/Layout/index.tsx:51
-msgid "social or email"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr ""
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
-msgid "something went wrong loading the allowance"
-msgstr ""
-
-#: components/pages/Retire/Activity/Overview.tsx:77
-#: components/pages/Retire/Activity/Quotes.tsx:76
-#: components/pages/Retire/Activity/Table.tsx:65
-msgid "t"
-msgstr ""
-
-#: components/Activities/Activity.tsx:119
-msgid "to"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
-msgid "tonnes"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr ""
-
-#: components/CreateListing/Transaction/index.tsx:83
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr ""
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr ""
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr ""
-
-#: components/CreateListing/Transaction/index.tsx:47
-#: components/Transaction/index.tsx:45
-msgid "transaction_modal.view.approve.title"
-msgstr ""
-
-#: components/CreateListing/Transaction/index.tsx:57
-#: components/Transaction/index.tsx:55
-msgid "transaction_modal.view.submit.title"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:10
-msgid "updated expiration"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr ""
-
-#: components/Activities/index.tsx:29
-msgid "user.activities.empty_state"
-msgstr ""
-
-#: components/LoginCard/index.tsx:24
-msgid "user.login.description"
-msgstr ""
-
-#: components/CreateListing/Transaction/Approve.tsx:51
-#: components/CreateListing/Transaction/index.tsx:62
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
-msgid "{0}"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
-msgid "{0} maximum for credit cards"
-msgstr ""
-
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr ""
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr ""
-
-#: components/pages/Purchases/index.tsx:29
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr ""
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
-#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
-msgid "{formattedAmount} Tonnes"
-msgstr ""
-
-#: components/Quantity/index.tsx:28
-msgid "{formattedAmount} tonnes"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
-msgid "{tokenSymbol}"
-msgstr ""
-
-#: lib/statusMessage.ts:23
-msgid "❌ Error: something went wrong..."
 msgstr ""

--- a/carbonmark/locale/ru/messages.po
+++ b/carbonmark/locale/ru/messages.po
@@ -6,10 +6,85 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ru\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/CreateListing/Transaction/Approve.tsx:51
+#: components/CreateListing/Transaction/index.tsx:62
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
+msgid "{0}"
+msgstr "{0}"
+
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr "{0} | Профиль | Carbonmark"
+
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
+msgid "{0} maximum for credit cards"
+msgstr "{0} максимальная сумма по кредитным картам"
+
+#: components/pages/Purchases/index.tsx:29
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr "{amount} тонн было закуплено для проекта {0}"
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr "{DEFAULT_EXPIRATION_DAYS} дней ({expirationDatestring})"
+
+#: components/Quantity/index.tsx:28
+msgid "{formattedAmount} tonnes"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
+#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
+msgid "{formattedAmount} Tonnes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:46
+msgid "retirement.provenance.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
+msgid "{tokenSymbol}"
+msgstr "{tokenSymbol}"
+
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "@Username (note: this can not be changed!)"
+msgstr "@Username (внимание: это нельзя изменить!)"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
+msgid "<0>* </0> Required Field"
+msgstr "<0>*</0> Обязательное поле"
+
+#: lib/statusMessage.ts:23
+msgid "❌ Error: something went wrong..."
+msgstr "❌ Ошибка: что-то пошло не так..."
 
 #: components/pages/Home/index.tsx:358
 msgid "0% listing fee"
 msgstr "0% листинговый сбор"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:47
+#: components/Transaction/index.tsx:45
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:57
+#: components/Transaction/index.tsx:55
+msgid "transaction_modal.view.submit.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:193
 msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
@@ -32,14 +107,6 @@ msgstr "500 - Ошибка сервера"
 msgid "500 - Server error occurred"
 msgstr "500 - Произошла ошибка сервера"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
-msgid "<0>* </0> Required Field"
-msgstr "<0>*</0> Обязательное поле"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "@Username (note: this can not be changed!)"
-msgstr "@Username (внимание: это нельзя изменить!)"
-
 #: components/pages/Project/PayWithBank/index.tsx:153
 msgid "A valid email address is required"
 msgstr ""
@@ -54,6 +121,11 @@ msgstr "А-Я"
 msgid "About"
 msgstr "О Carbonmark"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr ""
+
 #: components/Stats/StatsListings.tsx:49
 msgid "Active listings:"
 msgstr "Активные объявления:"
@@ -62,6 +134,11 @@ msgstr "Активные объявления:"
 msgid "Activity"
 msgstr "Деятельность"
 
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr ""
+
 #: lib/getCategoryInfo.ts:53
 msgid "Agriculture"
 msgstr "Сельское хозяйство"
@@ -69,6 +146,11 @@ msgstr "Сельское хозяйство"
 #: components/pages/Home/index.tsx:362
 msgid "All assets sourced from major registries"
 msgstr "Все активы получены из основных реестров"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:41
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
@@ -111,6 +193,10 @@ msgstr "Одобрить"
 msgid "Asset"
 msgstr "Активы"
 
+#: components/AssetDetails/index.tsx:53
+msgid "Asset details"
+msgstr "Сведения об активах"
+
 #: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:24
 msgid "Asset Details"
 msgstr "Сведения об активах"
@@ -119,9 +205,13 @@ msgstr "Сведения об активах"
 msgid "Asset ID"
 msgstr "ID актива"
 
-#: components/AssetDetails/index.tsx:53
-msgid "Asset details"
-msgstr "Сведения об активах"
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:32
+msgid "Asset moved from one account to another, either via sale or inter-account transfer."
+msgstr ""
+
+#: components/Activities/Activity.tsx:34
+msgid "at"
+msgstr "на"
 
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:131
 msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
@@ -133,11 +223,6 @@ msgid ""
 "exceeding {0}. Please adjust the\n"
 "quantity and try again later."
 msgstr "В настоящее время Carbonmark не может обрабатывать платежи по кредитным картам, сумма которых превышает {0}. Пожалуйста, отрегулируйте количество и повторите попытку позже."
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
-msgstr "Доступные тонны:"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:116
 msgid "Available balance exceeded"
@@ -163,6 +248,11 @@ msgstr "Доступно для покупки"
 msgid "Available to retire"
 msgstr "Доступно для выбивания"
 
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr "Доступные тонны:"
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:219
 msgid "Available:"
 msgstr "Доступно: "
@@ -176,14 +266,20 @@ msgstr "Доступно: {0}"
 msgid "Available: {unlistedBalance}"
 msgstr ""
 
-#: components/BetaBadge/index.tsx:18
-msgid "BETA"
-msgstr "БЕТА"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
+msgid "retire.back_button"
+msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:44
 #: components/pages/Project/Retire/index.tsx:35
 msgid "Back to Project"
 msgstr "Вернуться к проекту"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:49
+msgid "project.single.button.back_to_project_details"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:397
 msgid "Balance"
@@ -199,6 +295,16 @@ msgstr "Баланс превышен"
 msgid "Balance: {0}"
 msgstr "Баланс: {0}"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
+msgid "offset_disclaimer"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:450
 msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
 msgstr "Будьте осторожны, чтобы не включать какую-либо конфиденциальную личную информацию (например, адрес электронной почты) в ваше сообщение на выбивание. Информация, которую вы вводите здесь, не может быть отредактирована после ее отправки и будет постоянно существовать в общедоступной цепочке блоков."
@@ -207,12 +313,17 @@ msgstr "Будьте осторожны, чтобы не включать как
 msgid "Beneficiary Address"
 msgstr "Адрес получателя"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
-msgid "Beneficiary Name"
-msgstr "Имя Получателя"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
+msgid "retirement.single.beneficiary_address.title"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:263
 msgid "Beneficiary name"
+msgstr "Имя Получателя"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
+msgid "Beneficiary Name"
 msgstr "Имя Получателя"
 
 #: components/pages/Project/PayWithBank/index.tsx:232
@@ -225,11 +336,20 @@ msgstr ""
 msgid "Beneficiary wallet address (optional)"
 msgstr "Адрес кошелька получателя (необязательно)"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:34
 #: components/pages/Project/BuyOptions/SellerListing.tsx:67
 #: components/pages/Project/index.tsx:137
 msgid "Best Price"
 msgstr "Лучшая цена"
+
+#: components/BetaBadge/index.tsx:18
+msgid "BETA"
+msgstr "БЕТА"
 
 #: lib/getCategoryInfo.ts:65
 msgid "Blue Carbon"
@@ -239,9 +359,9 @@ msgstr "Синий углерод"
 msgid "Book a demo"
 msgstr "Заказать демонстрацию"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:35
-msgid "Bridge"
-msgstr ""
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
+msgstr "купил у"
 
 #: components/pages/Home/index.tsx:157
 #: components/pages/Home/index.tsx:188
@@ -256,6 +376,11 @@ msgstr "Обзор проектов"
 #: components/pages/Project/BuyOptions/SellerListing.tsx:98
 msgid "Buy"
 msgstr "Купить"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:70
+msgid "seller.listing.buy"
+msgstr ""
 
 #: components/pages/Home/index.tsx:168
 msgid "Buy or retire carbon"
@@ -273,12 +398,35 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отмена"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr ""
+
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr "Приобретенные вами углеродные активы могут быть выставлены на продажу на Carbonmark в любое время из вашего <0>портфолио</0>."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:30
 msgid "Carbon Pool"
 msgstr "Углеродный пул"
 
 #: components/Layout/NavDropdown/index.tsx:117
 msgid "Carbon Portfolio"
+msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
+msgid "Carbon provenance"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:60
@@ -289,17 +437,35 @@ msgstr ""
 msgid "Carbon Retirements"
 msgstr "Выведено углерода"
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-msgstr "Приобретенные вами углеродные активы могут быть выставлены на продажу на Carbonmark в любое время из вашего <0>портфолио</0>."
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
-msgid "Carbon provenance"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:60
+msgid "retirement.totals.page_headline"
 msgstr ""
 
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
-msgstr "Обзор Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:42
+msgid "retirement.provenance.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:51
+#: components/pages/Home/index.tsx:52
+msgid "Carbonmark | The Universal Carbon Marketplace"
+msgstr "Carbonmark | Универсальный углеродный рынок"
 
 #: components/pages/Home/index.tsx:174
 msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
@@ -315,14 +481,18 @@ msgstr "Carbonmark комиссия"
 msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 msgstr ""
 
-#: components/pages/Home/index.tsx:51
-#: components/pages/Home/index.tsx:52
-msgid "Carbonmark | The Universal Carbon Marketplace"
-msgstr "Carbonmark | Универсальный углеродный рынок"
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
+msgstr "Обзор Carbonmark"
 
 #: components/pages/Home/index.tsx:488
 msgid "Carbonmark's role"
 msgstr "Роль Carbonmark"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
+msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:130
 msgid "Category"
@@ -333,6 +503,11 @@ msgstr "Категория"
 msgid "Change language"
 msgstr "измененить язык"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:236
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
 #: components/pages/Home/index.tsx:206
 msgid "Choose a project and quantity"
 msgstr "Выберите проект и количество"
@@ -341,8 +516,13 @@ msgstr "Выберите проект и количество"
 msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 msgstr "Выбирайте из более чем 20 миллионов проверенных цифровых углеродных кредитов от сотен проектов - покупайте, продавайте или выводите углерод на пенсию прямо сейчас"
 
-#: components/ProjectFilterModal/index.tsx:162
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
 #: components/pages/Projects/ProjectSearch/index.tsx:55
+#: components/ProjectFilterModal/index.tsx:162
 msgid "Clear Filters"
 msgstr "Очистить фильтры"
 
@@ -353,6 +533,11 @@ msgstr "Нажмите кнопку «Создать профиль», чтоб�
 #: components/CreateListing/Transaction/Submit.tsx:98
 msgid "Close"
 msgstr "Закрыть"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
+msgstr ""
 
 #: components/Footer/index.tsx:32
 msgid "Code of Ethics"
@@ -379,6 +564,16 @@ msgstr "Сравните цены у всех продавцов и торгов
 msgid "Compiling Results ..."
 msgstr "Компиляция результатов ..."
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr ""
+
 #: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:83
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
 #: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
@@ -386,9 +581,18 @@ msgstr "Компиляция результатов ..."
 msgid "Confirm Purchase"
 msgstr "Подтвердить покупку"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
+msgid "offset.retire_carbon"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:75
 msgid "Confirm Retirement"
 msgstr "Подтвердить выбивание"
+
+#: components/Layout/index.tsx:52
+msgid "connect a wallet"
+msgstr "подключите кошелек"
 
 #: components/pages/Portfolio/ConnectedWallet/index.tsx:33
 msgid "Connected Wallet"
@@ -414,6 +618,16 @@ msgstr "Связаться"
 msgid "Continue"
 msgstr "Продолжить"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
 #: components/CopyAddressButton/index.tsx:37
 msgid "Copy"
 msgstr "Скопировать"
@@ -431,15 +645,10 @@ msgstr "Не удалось удалить объявление. Пожалуй�
 msgid "Country"
 msgstr "Страна"
 
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr "Создать новое объявление"
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Create Profile"
-msgstr "Создать профиль"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
+msgid "retirement.single.country_region.title"
+msgstr ""
 
 #: components/CreateListing/index.tsx:165
 msgid "Create a listing"
@@ -457,6 +666,21 @@ msgstr "Создать профиль продавца"
 msgid "Create and edit listings, and track your activity with your Carbonmark profile."
 msgstr "Создавайте и редактируйте объявления, а также отслеживайте свою активность с помощью профиля Carbonmark."
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:136
+msgid "profile.addListing_modal.submit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr "Создать новое объявление"
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Create Profile"
+msgstr "Создать профиль"
+
 #: components/pages/Home/index.tsx:313
 msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
 msgstr "Создайте собственный дашборд углеродных продуктов. Продавайте напрямую как организациям, так и частным лицам."
@@ -465,25 +689,29 @@ msgstr "Создайте собственный дашборд углеродн�
 msgid "Create your own retirement"
 msgstr "Создайте свою собственную замену"
 
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr "созданное объявление"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:87
 msgid "Created:"
 msgstr "Создан:"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
-msgid "Credit ID"
-msgstr ""
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
-msgstr "Минимальная сумма покупки по кредитной карте ${formattedFiatMinimum}"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:77
 msgid "Credit card minimum purchase is {0}"
 msgstr "Минимальная сумма покупки по кредитной карте — {0}."
 
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr "Минимальная сумма покупки по кредитной карте ${formattedFiatMinimum}"
+
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:247
 msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
 msgstr "При оплате кредитной картой взимается дополнительная плата за обработку. <0>Подробнее см. в документации.</0>"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
+msgid "Credit ID"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:435
 msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
@@ -493,10 +721,6 @@ msgstr "В настоящее время Carbonmark принимает толь�
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
 msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
 msgstr "В настоящее время Carbonmark принимает только платежи Polygon USDC. <0>Узнайте, как приобрести USDC на Polygon.</0>"
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
-msgstr "ДАТА"
 
 #: components/pages/Project/index.tsx:234
 msgid "Data for this project and vintage"
@@ -511,9 +735,27 @@ msgstr "Данные по этому продавцу"
 msgid "Date"
 msgstr "Дата"
 
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr "ДАТА"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
+msgid "offset.default_retirement_address"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:296
 msgid "Defaults to the connected wallet address"
 msgstr "По умолчанию используется адрес подключенного кошелька"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
+msgid "profile.listing.edit.delete_listing"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
+msgstr "удаленное объявление"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:307
 msgid "Describe the purpose of this retirement"
@@ -523,6 +765,11 @@ msgstr "Опишите цель этого вывода"
 msgid "Description"
 msgstr "Описание"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
+msgid "retirement.single.project_description.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:51
 msgid "Digital Carbon"
 msgstr "Цифровой углерод"
@@ -530,6 +777,11 @@ msgstr "Цифровой углерод"
 #: components/pages/Home/index.tsx:264
 msgid "Digitize your carbon by using a supported bridge"
 msgstr "Оцифруйте свой углерод с помощью поддерживаемого моста"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
 msgid "Display name"
@@ -555,18 +807,29 @@ msgstr "Загрузка ..."
 msgid "Drive climate action and earn rewards with a carbon-backed digital currency."
 msgstr "Стимулируйте действия по защите климата и получайте вознаграждения с цифровой валютой обеспеченной реальными углеродными активами."
 
+#: components/pages/Project/Purchase/Listing/Price.tsx:18
+#: components/pages/Project/Purchase/Pool/Price.tsx:17
+#: components/pages/Project/Retire/Pool/Price.tsx:17
+msgid "each"
+msgstr "каждый"
+
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:195
 msgid "Edit"
 msgstr "Редактировать"
+
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
+msgid "Edit listing"
+msgstr "Редактировать объявление"
 
 #: components/pages/Users/SellerConnected/index.tsx:113
 #: components/pages/Users/SellerConnected/index.tsx:138
 msgid "Edit Profile"
 msgstr "Редактировать профиль"
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
-msgid "Edit listing"
-msgstr "Редактировать объявление"
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:143
 #: components/pages/Project/PayWithBank/index.tsx:307
@@ -626,6 +889,19 @@ msgstr ""
 msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
 msgstr "Сначала одобрите Carbonmark для передачи этого актива от вашего имени."
 
+#: components/Activities/Activity.tsx:112
+msgid "for"
+msgstr "для"
+
+#: components/pages/Retire/index.tsx:52
+msgid "for beneficiary"
+msgstr "для бенефициара"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:66
+msgid "retirement.totals.page_subline"
+msgstr ""
+
 #: components/pages/Home/index.tsx:340
 msgid "For carbon traders"
 msgstr "Для торговцев углеродом"
@@ -642,21 +918,27 @@ msgstr "Лесное хозяйство"
 msgid "Form complete"
 msgstr ""
 
-#: components/pages/Home/index.tsx:76
-msgid "Get Started"
-msgstr "С чего начать"
-
 #: components/pages/Home/index.tsx:390
 msgid "Get paid immediately: transactions are resolved in seconds"
 msgstr "Получайте оплату немедленно: транзакции поступают за считанные секунды"
 
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
+#: components/pages/Home/index.tsx:76
+msgid "Get Started"
+msgstr "С чего начать"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:83
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
 msgstr ""
 
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
 msgid "Go back"
 msgstr "Вернуться назад"
+
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:145
 msgid "Handle is required"
@@ -681,7 +963,7 @@ msgid "Here’s a list of readily available, discounted carbon tokens to retire 
 msgstr "Вот список легкодоступных углеродных токенов со скидкой, позволяющих быстро и легко вывести углерод."
 
 #: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:48
-msgid "Hide {numberOfTransfers} transfers"
+msgid "Hide {numberOfTransfers} transactions"
 msgstr ""
 
 #: components/CreateListing/Form/index.tsx:80
@@ -696,6 +978,11 @@ msgstr "Сколько тонн углерода вы хотите купить?
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:249
 msgid "How many tonnes of carbon do you want to retire?"
 msgstr "Сколько тонн углерода вы хотите выбить?"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
+msgid "offset.amount_in_tonnes"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:215
 msgid "How many tonnes of carbon would you like to retire?"
@@ -720,6 +1007,11 @@ msgstr ""
 #: components/pages/Purchases/index.tsx:93
 msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
 msgstr "Если вы хотите отказаться от части или всех углеродных кредитов, полученных от этой покупки, перейдите в свой <0>портфолио.</0> , нажмите кнопку «Снять с учета» и следуйте инструкциям."
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
+msgid "retirement.single.transaction_record.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:116
 msgid "Indicates required field"
@@ -775,14 +1067,14 @@ msgstr ""
 msgid "Latest First"
 msgstr "Последние Первые"
 
+#: components/pages/Home/index.tsx:417
+msgid "Learn more"
+msgstr "Подробнее"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:92
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:103
 msgid "Learn More"
 msgstr "Узнать больше"
-
-#: components/pages/Home/index.tsx:417
-msgid "Learn more"
-msgstr "Подробнее"
 
 #: components/pages/Home/index.tsx:491
 msgid "Learn more about Carbonmark's role in improving the Digital Carbon Market - and the Voluntary Carbon Market as a whole."
@@ -815,11 +1107,11 @@ msgid "Loading your assets"
 msgstr "Загрузка ваших активов"
 
 #: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:295
 #: components/pages/Retire/Activity/Overview.tsx:73
 #: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
 msgid "Loading..."
 msgstr "Загрузка..."
 
@@ -859,6 +1151,11 @@ msgstr ""
 msgid "Marketplace"
 msgstr "Торговая площадка"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr ""
+
 #: components/pages/Projects/index.tsx:73
 #: components/pages/Projects/index.tsx:74
 msgid "Marketplace | Carbonmark"
@@ -868,20 +1165,35 @@ msgstr "Торговая площадка | Carbonmark"
 msgid "Maximize your climate impact."
 msgstr "Максимизируйте свое воздействие на климат."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.moss_offset.description"
+msgstr ""
+
 #: components/pages/Project/index.tsx:144
 msgid "Methodology"
 msgstr "Методология"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.methodology.title"
+msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:54
 msgid "Moss"
 msgstr "Moss "
 
-#: components/FeatureBanner/index.tsx:33
-msgid "NEW FEATURE:"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
+msgid "retirement.single.moss_offset.name"
 msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:171
 msgid "Navigation Menu"
+msgstr ""
+
+#: components/FeatureBanner/index.tsx:33
+msgid "NEW FEATURE:"
 msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
@@ -896,18 +1208,28 @@ msgstr "Новая цена за единицу (USDC)"
 msgid "Next"
 msgstr "Следующий"
 
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
-msgstr "Нет активности для отображения."
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:197
 #: components/pages/Users/SellerUnconnected/index.tsx:83
 msgid "No active listings."
 msgstr "Нет активных объявлений."
 
+#. js-lingui-explicit-id
+#: components/Activities/index.tsx:29
+msgid "user.activities.empty_state"
+msgstr ""
+
 #: components/pages/Retire/Activity/Quotes.tsx:38
 msgid "No activity to show"
 msgstr "Нет активности для показа"
+
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
+msgstr "Нет активности для отображения."
 
 #: components/pages/Home/index.tsx:400
 msgid "No barriers to entry for verified carbon projects"
@@ -916,6 +1238,11 @@ msgstr "Нет барьеров для входа для проверенных 
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:40
 msgid "No beneficiary address available"
 msgstr "Адрес получателя не указан"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
+msgid "retirement.single.beneficiary.placeholder"
+msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:62
 msgid "No data to show"
@@ -950,24 +1277,39 @@ msgstr ""
 msgid "No retirement message provided."
 msgstr "Сообщение о выводе не предоставляется."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
 msgid "No transaction id available"
 msgstr "Идентификатор транзакции отсутствует"
-
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
-msgstr "Не подключен"
 
 #: components/pages/Project/PayWithBank/index.tsx:240
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:288
 msgid "Not a valid polygon address"
 msgstr "Недействительный адрес полигона"
 
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr "Не подключен"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
+msgid "retirement.single.official_certificate.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:72
 msgid "Oldest First"
 msgstr "Сначала старые"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:185
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:188
 msgid "On the Verra page, search for the specific serial number."
 msgstr ""
 
@@ -991,21 +1333,17 @@ msgstr "Наша система работает дольше, чем ожида
 msgid "Over 20 million verified digital carbon credits from hundreds of projects, with over $4 billion traded to date"
 msgstr "Более 20 млн. верифицированных цифровых углеродных кредитов, полученных в результате реализации сотен проектов, с оборотом более 4 млрд. долл."
 
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr "ПРОЕКТ"
-
 #: components/pages/Projects/Banners/BankTransfer.tsx:74
 msgid "Pay via Bank Transfer / Wire"
+msgstr ""
+
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
 msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:89
 #: components/pages/Project/PayWithBank/index.tsx:90
 msgid "Pay with Bank Transfer | Carbonmark"
-msgstr ""
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:94
@@ -1014,22 +1352,18 @@ msgstr ""
 msgid "Pay with:"
 msgstr "Оплатить с:"
 
-#: components/pages/Purchases/index.tsx:62
-msgid "Payment Successful"
-msgstr "Оплата прошла успешно"
-
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:243
 msgid "Payment processing fee"
 msgstr "Комиссия за обработку платежа"
+
+#: components/pages/Purchases/index.tsx:62
+msgid "Payment Successful"
+msgstr "Оплата прошла успешно"
 
 #: components/pages/Project/PayWithBank/index.tsx:161
 #: components/pages/Project/PayWithBank/index.tsx:313
 msgid "Phone number"
 msgstr ""
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
-msgstr "Пожалуйста, войдите"
 
 #: lib/statusMessage.ts:27
 msgid "Please click 'confirm' in your wallet to continue."
@@ -1039,11 +1373,25 @@ msgstr "Пожалуйста, нажмите \"подтвердить\" в ва�
 msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr ""
 
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr "Пожалуйста, войдите"
+
 #: components/pages/Portfolio/index.tsx:66
 #: components/pages/Users/SellerConnected/index.tsx:75
 #: components/pages/Users/SellerConnected/index.tsx:101
 msgid "Please refresh the page. There was an error updating your data: {e}."
 msgstr "Пожалуйста, обновите страницу. При обновлении данных произошла ошибка: {e}."
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:243
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:76
 #: components/pages/Portfolio/index.tsx:77
@@ -1062,10 +1410,6 @@ msgstr "Пресс-релизы"
 msgid "Price Highest"
 msgstr "Наивысшая цена"
 
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr "Самая низкая цена"
-
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:180
@@ -1075,6 +1419,10 @@ msgstr "Цена включает сетевые сборы. <0>Подробне
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:160
 msgid "Price is required"
 msgstr "Укажите цену"
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
+msgstr "Самая низкая цена"
 
 #: components/CreateListing/Transaction/Submit.tsx:62
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
@@ -1110,19 +1458,48 @@ msgstr ""
 msgid "Profile"
 msgstr "Профиль"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:192
 msgid "Profile picture"
 msgstr "Изображение профиля"
+
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr "ПРОЕКТ"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
+msgid "retirement.single.project_name.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:253
 #: components/pages/Project/PayWithBank/index.tsx:357
 msgid "Project names of interest"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:36
-#: components/pages/Purchases/index.tsx:37
-msgid "Purchase Receipt | Carbonmark"
-msgstr "Квитанция о покупке | Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
+msgid "retirement.single.project.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr ""
+
+#: components/pages/Project/Purchase/index.tsx:32
+#: components/pages/Project/Purchase/index.tsx:33
+msgid "Purchase {0} | Carbonmark"
+msgstr "Купить {0} | Carbonmark"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:53
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
@@ -1133,6 +1510,11 @@ msgstr "Сумма закупки (тонн):"
 msgid "Purchase more Carbon"
 msgstr "Купите больше углерода"
 
+#: components/pages/Purchases/index.tsx:36
+#: components/pages/Purchases/index.tsx:37
+msgid "Purchase Receipt | Carbonmark"
+msgstr "Квитанция о покупке | Carbonmark"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:79
 msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer."
 msgstr ""
@@ -1140,11 +1522,6 @@ msgstr ""
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
 msgid "Purchase successful"
 msgstr "Покупка прошла успешно"
-
-#: components/pages/Project/Purchase/index.tsx:32
-#: components/pages/Project/Purchase/index.tsx:33
-msgid "Purchase {0} | Carbonmark"
-msgstr "Купить {0} | Carbonmark"
 
 #: components/pages/Retire/Activity/Table.tsx:47
 msgid "QTY"
@@ -1160,6 +1537,11 @@ msgstr "Количество"
 msgid "Quantity Available:"
 msgstr "Доступное количество:"
 
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:240
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:108
 msgid "Quantity is required"
@@ -1173,21 +1555,18 @@ msgstr "Количество в списке: {listedQuantity}, Количест
 msgid "Quantity purchased:"
 msgstr "Количество куплено:"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr ""
+
 #: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr "Быстрый вывод"
 
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr "ВЫВЕДЕНО УГЛЕРОДА"
-
 #: components/pages/Project/index.tsx:198
 msgid "Read Less"
 msgstr "Читать меньше"
-
-#: components/pages/Project/index.tsx:198
-msgid "Read More"
-msgstr "Подробнее"
 
 #: components/pages/Home/index.tsx:445
 #: components/pages/Home/index.tsx:472
@@ -1195,6 +1574,10 @@ msgstr "Подробнее"
 #: components/pages/Resources/BlogPostCard/index.tsx:38
 #: components/pages/Resources/FeaturedArticles/Article.tsx:45
 msgid "Read more"
+msgstr "Подробнее"
+
+#: components/pages/Project/index.tsx:198
+msgid "Read More"
 msgstr "Подробнее"
 
 #: components/pages/Home/index.tsx:351
@@ -1213,14 +1596,14 @@ msgstr "Оставшийся запас:"
 msgid "Renewable Energy"
 msgstr "Возобновляемая энергия"
 
+#: lib/constants.ts:82
+msgid "Request already processing. Please open your wallet and complete the request."
+msgstr "Запрос уже обрабатывается. Пожалуйста, откройте свой кошелек и завершите запрос."
+
 #: components/pages/Home/index.tsx:301
 #: components/pages/Home/index.tsx:325
 msgid "Request Demo"
 msgstr "Запросить демо-версии"
-
-#: lib/constants.ts:82
-msgid "Request already processing. Please open your wallet and complete the request."
-msgstr "Запрос уже обрабатывается. Пожалуйста, откройте свой кошелек и завершите запрос."
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:210
 msgid "Required Field"
@@ -1230,6 +1613,11 @@ msgstr "Обязательное поле"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:311
 msgid "Required when proceeding with Credit Card"
 msgstr "Требуется при оплате кредитной картой"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
+msgstr ""
 
 #: components/Footer/index.tsx:38
 #: components/pages/Home/index.tsx:508
@@ -1257,15 +1645,36 @@ msgstr "Результаты"
 msgid "Retire"
 msgstr "Выбито"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/index.tsx:88
+#: components/pages/Portfolio/Retire/index.tsx:89
+#: components/pages/Retire/index.tsx:38
+#: components/pages/Retire/index.tsx:39
+msgid "Retire | Carbonmark"
+msgstr "Выбивание | Carbonmark"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:388
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
 msgid "Retire Carbon"
 msgstr "Вывод карбона"
 
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr "ВЫВЕДЕНО УГЛЕРОДА"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:233
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "Отмените углеродные кредиты для себя или от имени другого лица или организации."
+
+#: components/pages/Project/Retire/index.tsx:23
+#: components/pages/Project/Retire/index.tsx:24
+msgid "Retire from {fullProjectid} | Carbonmark"
+msgstr "Выбивание из {fullProjectid} | Carbonmark"
 
 #: components/pages/Retire/index.tsx:72
 msgid "Retire from a featured project"
@@ -1275,23 +1684,18 @@ msgstr "Выйти из рекомендуемого проекта"
 msgid "Retire from your portfolio"
 msgstr "Вывести из вашего портфеля"
 
-#: components/pages/Project/Retire/index.tsx:23
-#: components/pages/Project/Retire/index.tsx:24
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr "Выбивание из {fullProjectid} | Carbonmark"
-
 #: components/pages/Home/index.tsx:232
 msgid "Retire instantly, or purchase and hold digital carbon"
 msgstr "Немедленно вывидете или купите и сохраните цифровой углерод"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
-msgstr "Выбейте больше углерода"
 
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
 msgid "Retire more carbon"
+msgstr "Выбейте больше углерода"
+
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
 msgstr "Выбейте больше углерода"
 
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:56
@@ -1307,14 +1711,16 @@ msgstr "Вывести сейчас или приобрести углерод, 
 msgid "Retire your carbon via bank transfer."
 msgstr ""
 
-#: components/pages/Portfolio/Retire/index.tsx:88
-#: components/pages/Portfolio/Retire/index.tsx:89
-#: components/pages/Retire/index.tsx:38
-#: components/pages/Retire/index.tsx:39
-msgid "Retire | Carbonmark"
-msgstr "Выбивание | Carbonmark"
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
+msgstr "Выбито"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:13
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:90
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:16
 msgid "Retirement"
 msgstr ""
 
@@ -1322,33 +1728,53 @@ msgstr ""
 msgid "Retirement Activity"
 msgstr "Деятельность по выбиванию"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
-msgid "Retirement Message"
-msgstr "Сообщение о использовании"
-
-#: components/pages/Retire/Activity/Overview.tsx:60
-#: components/pages/Retire/Activity/Overview.tsx:70
-msgid "Retirement Overview"
-msgstr "Обзор Вывода"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr "Использование успешно!"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
+msgid "offset.retirement_message"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:264
 #: components/pages/Project/PayWithBank/index.tsx:363
 msgid "Retirement message"
 msgstr "Сообщение о выводе"
 
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
+msgid "Retirement Message"
+msgstr "Сообщение о использовании"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr ""
+
+#: components/pages/Retire/Activity/Overview.tsx:60
+#: components/pages/Retire/Activity/Overview.tsx:70
+msgid "Retirement Overview"
+msgstr "Обзор Вывода"
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:74
 msgid "Retirement successful"
 msgstr "Выбивание успешно"
 
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr "Использование успешно!"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:106
+msgid "retirement.totals.retirements"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:384
 msgid "Retiring Token"
 msgstr "Устаревший токен"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
+msgid "profile.edit_modal.submit"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:201
 msgid "Say a few words about yourself. This will be visible in your seller profile."
@@ -1385,6 +1811,11 @@ msgstr "Выбрать"
 msgid "Select a language"
 msgstr ""
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr ""
+
 #: components/pages/Portfolio/AssetProject/index.tsx:100
 #: components/pages/Portfolio/AssetProject/index.tsx:108
 msgid "Sell"
@@ -1402,12 +1833,26 @@ msgstr "Продавайте свой цифровой углерод напря
 msgid "Seller Listing"
 msgstr "Объявление продавца"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:159
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:29
+msgid "Send"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:161
 msgid "Serial Number"
 msgstr ""
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:76
 msgid "Share this page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
+msgid "retirement.single.share_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:289
+msgid "resources.mobile_modal.button.show_results"
 msgstr ""
 
 #: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
@@ -1423,6 +1868,19 @@ msgstr "Необходимая сумма"
 #: components/CreateListing/Form/index.tsx:130
 msgid "Single unit price"
 msgstr "Цена за единицу"
+
+#: components/Layout/index.tsx:51
+msgid "social or email"
+msgstr "соцсети или электронная почта"
+
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr "проданный"
+
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
+msgid "something went wrong loading the allowance"
+msgstr "что-то пошло не так при загрузке пособия"
 
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
 msgid "Something went wrong loading the allowance"
@@ -1448,13 +1906,28 @@ msgstr "Извините, что-то пошло не так."
 msgid "Sorry, this handle already exists"
 msgstr "Извините, этот никнейм уже существует"
 
-#: components/pages/Resources/ResourcesList/index.tsx:265
-msgid "Sort By"
-msgstr "Сортировать по"
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:222
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:230
+msgid "resources.page.list.no_search_results.title"
+msgstr ""
 
 #: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "Sort by"
 msgstr "Сортировать по"
+
+#: components/pages/Resources/ResourcesList/index.tsx:265
+msgid "Sort By"
+msgstr "Сортировать по"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:197
+msgid "shared.resources.sort_by.header"
+msgstr ""
 
 #: components/Stats/index.tsx:23
 msgid "Stats"
@@ -1480,6 +1953,21 @@ msgstr "Шаг 3"
 msgid "Submit"
 msgstr "Отправить"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr ""
+
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:88
 msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
 msgstr "Успех! Ваше новое объявление появится через несколько секунд на странице вашего <0>профиля.</0> ."
@@ -1492,13 +1980,25 @@ msgstr ""
 msgid "Switch to Polygon"
 msgstr "Переключиться на Polygon"
 
-#: components/BetaBadge/index.tsx:16
-msgid "TESTNET"
-msgstr ""
+#: components/pages/Retire/Activity/Overview.tsx:77
+#: components/pages/Retire/Activity/Quotes.tsx:76
+#: components/pages/Retire/Activity/Table.tsx:65
+msgid "t"
+msgstr "т"
 
 #: components/Footer/index.tsx:29
 msgid "Terms of Use"
 msgstr "Условия использования"
+
+#: components/BetaBadge/index.tsx:16
+msgid "TESTNET"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
 msgid "Thank you for supporting the planet!"
@@ -1508,21 +2008,32 @@ msgstr "Спасибо за поддержку планеты!"
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr "Спасибо за поддержку планеты! Подробности покупки смотрите ниже."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:292
 msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr ""
-
-#: components/pages/Home/index.tsx:65
-msgid "The Universal Carbon Marketplace"
-msgstr "Универсальный углеродный рынок"
 
 #: components/CreateListing/Transaction/Approve.tsx:44
 msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 msgstr "Активы будут выведены из Вашего кошелька только после завершения продажи. Вы можете в любой момент отменить это разрешение."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:34
 msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
 msgstr "Первым шагом является предоставление разрешения на перевод вашего углеродного актива из вашего кошелька в Carbonmark, следующим шагом является утверждение фактического перевода и завершение выхода на пенсию."
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
 msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
@@ -1531,6 +2042,12 @@ msgstr "Первый шаг - дать разрешение на перевод 
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
 msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
 msgstr "Приведенная ниже информация будет опубликована для проверки вашего заявления об охране окружающей среды. Эта транзакция является постоянной; информация не может быть изменена после завершения транзакции."
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
+msgstr ""
 
 #: components/pages/Home/index.tsx:53
 #: components/pages/Home/index.tsx:68
@@ -1570,13 +2087,27 @@ msgstr "Минимальная цена за тонну: {0}"
 msgid "The minimum quantity to sell is 1 tonne"
 msgstr "Минимальное количество для продажи 1 тонна"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:53
 msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 msgstr "Предыдущий шаг дал разрешение на перевод вашего углеродного актива из вашего кошелька в Carbonmark, ваш выход на пенсию еще не завершен."
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
 msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
 msgstr "На предыдущем этапе было получено разрешение на перевод платежного актива из вашего кошелька в Carbonmark."
+
+#: components/pages/Home/index.tsx:65
+msgid "The Universal Carbon Marketplace"
+msgstr "Универсальный углеродный рынок"
 
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:208
 msgid "There was an error during the checkout process. Please try again."
@@ -1599,6 +2130,11 @@ msgstr "Не удалось загрузить общую стоимость."
 msgid "This app only works on Polygon Mainnet."
 msgstr "Это приложение работает только в Polygon Mainnet."
 
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:24
+msgid "user.login.description"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
 msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
 msgstr ""
@@ -1619,13 +2155,27 @@ msgstr "Это предложение больше не существует."
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr "Этот продукт все еще находится в стадии бета-тестирования, и аудиты еще не завершены."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
+msgid "retirement.single.immutable_public_records.title"
+msgstr ""
+
 #: components/pages/Users/ProfileHeader/index.tsx:46
 msgid "This user has not yet created a carbonmark profile."
 msgstr "Этот пользователь еще не создал профиль Carbonmark."
 
+#: components/Activities/Activity.tsx:119
+msgid "to"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr "Для завершения операции с кредитной картой вы будете перенаправлены на сайт Stripe, нашего партнера по обработке платежей."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:60
 msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
@@ -1639,22 +2189,22 @@ msgstr ""
 msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr ""
 
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr "Переключить выбор проекта"
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr "Переключение Сортировка по меню"
-
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
 msgid "Toggle payment method"
 msgstr "Сменить способ оплаты"
 
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr "Переключить выбор проекта"
+
 #: components/pages/Projects/ProjectSort/index.tsx:29
 msgid "Toggle sort menu"
 msgstr "Переключить меню сортировки"
+
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
+msgstr "Переключение Сортировка по меню"
 
 #: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:209
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
@@ -1664,6 +2214,10 @@ msgstr "Токен, который вы получите"
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
 msgid "Tokens received:"
 msgstr "Получено токенов:"
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
+msgid "tonnes"
+msgstr "тонны"
 
 #: components/AssetDetails/index.tsx:63
 #: components/pages/Project/PayWithBank/index.tsx:125
@@ -1684,22 +2238,6 @@ msgstr "Перечислены тонны:"
 msgid "Tonnes sold:"
 msgstr "Продано тонн:"
 
-#: components/CreateListing/Form/index.tsx:85
-msgid "Total Amount to Sell is required"
-msgstr "Требуется общая сумма для продажи"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
-msgid "Total Cost is required"
-msgstr "Необходима общая стоимость"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr "Итоговая цена"
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr "Итого выведено"
-
 #: components/CreateListing/Transaction/Approve.tsx:61
 msgid "Total allowance"
 msgstr "Общая сумма резерва"
@@ -1708,9 +2246,18 @@ msgstr "Общая сумма резерва"
 msgid "Total amount of tonnes to retire is required"
 msgstr ""
 
+#: components/CreateListing/Form/index.tsx:85
+msgid "Total Amount to Sell is required"
+msgstr "Требуется общая сумма для продажи"
+
 #: components/pages/Retire/Activity/Overview.tsx:72
 msgid "Total carbon tonnes retired"
 msgstr "Всего выведено из эксплуатации тонн углерода"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:98
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr ""
 
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
@@ -1718,9 +2265,17 @@ msgstr "Всего выведено из эксплуатации тонн уг�
 msgid "Total cost"
 msgstr "Общая стоимость"
 
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
+msgid "Total Cost is required"
+msgstr "Необходима общая стоимость"
+
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:166
 msgid "Total price"
+msgstr "Итоговая цена"
+
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
 msgstr "Итоговая цена"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:103
@@ -1731,6 +2286,15 @@ msgstr "Общее количество для продажи"
 msgid "Total retirement transactions"
 msgstr "Всего транзакций выбивания"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:112
+msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
+msgstr "Итого выведено"
+
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
 msgid "Total sale cost"
@@ -1740,25 +2304,32 @@ msgstr "Общая стоимость продажи"
 msgid "Transaction complete."
 msgstr "Транзакция завершена."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
+msgid "retirement.single.transaction_id.title"
+msgstr ""
+
 #: lib/statusMessage.ts:29
 msgid "Transaction initiated. Waiting for network confirmation."
 msgstr "Транзакция инициирована. Ожидание подтверждения сети."
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:24
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:48
 msgid "Transfer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:50
+msgid "retirement.provenance.head.metaDescription"
 msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:128
 msgid "Transparent, on-chain offsets powered by Carbonmark."
 msgstr "Прозрачные компенсации по цепочке на базе KlimaDAO."
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "USDC per ton"
-msgstr "USDC за тонну"
-
-#: components/CreateListing/Form/index.tsx:110
-msgid "USDC per tonne"
-msgstr "USDC за тонну"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.type.title"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:115
 msgid "Unit price is required"
@@ -1776,6 +2347,18 @@ msgstr "Беспрецедентная прозрачность на цифро�
 msgid "Update listing"
 msgstr "Обновить список"
 
+#: components/Activities/Activities.constants.ts:10
+msgid "updated expiration"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr "обновленная цена"
+
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr "обновленное количество"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:91
 msgid "Updated:"
 msgstr "Обновлено:"
@@ -1783,6 +2366,14 @@ msgstr "Обновлено:"
 #: components/pages/Users/SellerConnected/index.tsx:191
 msgid "Updating your data..."
 msgstr "Обновление данных..."
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "USDC per ton"
+msgstr "USDC за тонну"
+
+#: components/CreateListing/Form/index.tsx:110
+msgid "USDC per tonne"
+msgstr "USDC за тонну"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:61
 msgid "User Guides"
@@ -1797,6 +2388,21 @@ msgstr "Профиль пользователя | Carbonmark"
 msgid "User refused connection."
 msgstr "Пользователь отказался от подключения."
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:41
 msgid "Verify all information is correct and click 'approve' to continue."
@@ -1806,17 +2412,9 @@ msgstr "Убедитесь, что вся информация верна, и н
 msgid "View"
 msgstr "Просмотр"
 
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
-msgid "View Carbonmark Profile"
-msgstr "Посмотреть профиль Carbonmark"
-
-#: components/pages/Project/index.tsx:207
-msgid "View Registry Details <0/>"
-msgstr "Просмотр сведений о реестре <0/>"
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
-msgstr "Посмотреть Результаты"
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
+msgid "View {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:78
 msgid "View a complete overview of the digital carbon that you own in your Portfolio."
@@ -1851,9 +2449,17 @@ msgstr "Посмотреть и приобрести этот проект ко�
 msgid "View and share certificate"
 msgstr "Посмотреть и поделиться сертификатом"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:180
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
+msgid "View Carbonmark Profile"
+msgstr "Посмотреть профиль Carbonmark"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:183
 msgid "View issuance on Verra"
 msgstr ""
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
+msgid "View on Polygonscan"
+msgstr "Посмотреть на Polygonscan"
 
 #: components/AssetDetails/index.tsx:69
 msgid "View on PolygonScan"
@@ -1863,9 +2469,13 @@ msgstr "Посмотреть на PolygonScan "
 msgid "View on PolygonScan <0/>"
 msgstr "Посмотреть на PolygonScan <0/>"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
-msgid "View on Polygonscan"
-msgstr "Посмотреть на Polygonscan"
+#: components/pages/Project/index.tsx:207
+msgid "View Registry Details <0/>"
+msgstr "Просмотр сведений о реестре <0/>"
+
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
+msgstr "Посмотреть Результаты"
 
 #: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:99
 msgid "View retirement"
@@ -1879,8 +2489,9 @@ msgstr ""
 msgid "View the project details and other info for this purchase."
 msgstr "Просмотрите детали проекта и другую информацию по этой покупке."
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
-msgid "View {numberOfTransfers} transfers"
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:145
+msgid "purchase.button.view_assets"
 msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:141
@@ -1894,6 +2505,11 @@ msgstr "Винтаж новейший"
 #: components/ProjectFilterModal/constants.tsx:15
 msgid "Vintage Oldest"
 msgstr "Старейшие Винтаж"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
+msgid "retirement.single.vintage.title"
+msgstr ""
 
 #: components/pages/Purchases/index.tsx:66
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
@@ -1915,12 +2531,22 @@ msgstr "Мы вручную отобрали несколько лучших п�
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr "Что такое Карбонмарк? Ответы на распространенные вопросы об интерфейсе цифрового углеродного рынка, который легко связывает покупателей и продавцов проверенных углеродных кредитов."
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
+msgid "offset.retirement_credit"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:257
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
 msgid "Who will this retirement be credited to?"
 msgstr "Кому будет зачислено это выбивание?"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
+msgstr ""
 
 #: components/shared/InvalidNetworkModal/index.tsx:64
 msgid "Wrong Network"
@@ -1932,9 +2558,19 @@ msgstr "Неверная сеть"
 msgid "You"
 msgstr "Вы"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
 msgid "You are about to purchase a carbon asset."
 msgstr "Вы собираетесь приобрести углеродный актив."
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:31
 msgid "You are about to retire a carbon asset."
@@ -1982,13 +2618,10 @@ msgstr ""
 msgid "You successfully acquired carbon!"
 msgstr "Вы успешно приобрели углерод!"
 
-#: components/pages/Users/SellerConnected/index.tsx:221
-msgid "Your Profile"
-msgstr "Ваш профиль"
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
-msgstr "Адрес вашего кошелька:"
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:412
@@ -2005,6 +2638,15 @@ msgstr "Ваш баланс:"
 msgid "Your display name"
 msgstr "Ваше отображаемое имя"
 
+#: components/pages/Users/SellerConnected/index.tsx:221
+msgid "Your Profile"
+msgstr "Ваш профиль"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
 msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr "Ваша покупка еще не завершена. Чтобы завершить покупку, убедитесь, что вся информация верна, а затем нажмите «Отправить» ниже."
@@ -2014,6 +2656,11 @@ msgstr "Ваша покупка еще не завершена. Чтобы за�
 msgid "Your seller data"
 msgstr "Ваши данные продавца"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/index.tsx:84
 msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
 msgstr ""
@@ -2022,6 +2669,10 @@ msgstr ""
 msgid "Your unique handle"
 msgstr "Ваша уникальный никнейм"
 
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr "Адрес вашего кошелька:"
+
 #: components/pages/Resources/lib/cmsDataMap.ts:82
 msgid "Z-A"
 msgstr "Я-А"
@@ -2029,542 +2680,3 @@ msgstr "Я-А"
 #: components/pages/Home/index.tsx:437
 msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
 msgstr "Торговля квотами на выбросы углерода с нулевой комиссией — мгновенная, прозрачная и всегда доступная. Узнайте больше о том, что Carbonmark может сделать для вас как продавца углеродных кредитов."
-
-#: components/Activities/Activity.tsx:34
-msgid "at"
-msgstr "на"
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr "Информация, представленная в данном блоге, касающаяся KlimaDAO («KlimaDAO»), ее криптоактивов, бизнес-активов, стратегии и операций, предназначена исключительно для общих информационных целей и не является официальным предложением о продаже или предложением оферты. о покупке любых ценных бумаг, опционов, фьючерсов или других производных инструментов, связанных с ценными бумагами, в любой юрисдикции, и ее содержание не предусмотрено законодательством о ценных бумагах. Информация, содержащаяся в этом блоге, не должна рассматриваться как совет купить или продать или держать такие ценные бумаги или как предложение продать такие ценные бумаги. Данная статья в блоге не учитывает и не предоставляет никаких налоговых, юридических или инвестиционных консультаций или мнений относительно конкретных инвестиционных целей или финансового положения любого лица. KlimaDAO и ее агенты, советники, директора, должностные лица, сотрудники и акционеры не делают никаких заявлений или гарантий, выраженных или подразумеваемых, в отношении точности такой информации, и KlimaDAO в данной форме отказывается от любой ответственности, которая может быть основана на такой информации или ошибках или упущениях в ней. KlimaDAO оставляет за собой право в любое время частично или полностью изменять или заменять содержащуюся здесь информацию и не берет на себя никаких обязательств по предоставлению получателю доступа к измененной информации или уведомлению получателя об этом. Информация, содержащаяся в этом сообщении в блоге, заменяет собой любое предыдущее сообщение в блоге или обсуждение, касающееся той же, похожей или связанной информации. Любая информация, утверждения или заявления, не содержащиеся в настоящем документе, не должны приниматься во внимание для каких-либо целей. Ни KlimaDAO, ни кто-либо из ее представителей не несут никакой ответственности по контракту, гражданскому правонарушению, доверительному праву или иным образом перед вами или любым лицом в результате использования информации в этом сообщении в блоге вами или любым из ваших представителей или за упущения в информация в этом сообщении в блоге. Кроме того, KlimaDAO не берет на себя обязательств комментировать ожидания или заявления третьих лиц в отношении вопросов, обсуждаемых в этом сообщении в блоге."
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr "Отказ от ответственности"
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr "купил у"
-
-#: components/Layout/index.tsx:52
-msgid "connect a wallet"
-msgstr "подключите кошелек"
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr "созданное объявление"
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr "удаленное объявление"
-
-#: components/pages/Project/Purchase/Listing/Price.tsx:18
-#: components/pages/Project/Purchase/Pool/Price.tsx:17
-#: components/pages/Project/Retire/Pool/Price.tsx:17
-msgid "each"
-msgstr "каждый"
-
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr "После того, как вы нажмете на кнопку ниже, чтобы продолжить, вам будет предложено подключить ваш кошелек, и проект, который вы выбрали здесь, уже будет выбран для вас на сайте KlimaDAO.finance. Далее следуйте указаниям на этой странице, чтобы завершить транзакцию.."
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr "Углеродные кредиты, которые вы приобретаете, или любые выбытия, которые вы делаете на KlimaDAO.finance, также будут доступны в вашем портфеле Carbonmark."
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr "Вы будете перенаправлены на KlimaDAO.finance для завершения этой транзакции."
-
-#: components/Activities/Activity.tsx:112
-msgid "for"
-msgstr "для"
-
-#: components/pages/Retire/index.tsx:52
-msgid "for beneficiary"
-msgstr "для бенефициара"
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr "Торговая площадка"
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr "Портфолио"
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr "Профиль"
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr "Выбито"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
-msgid "offset.amount_in_tonnes"
-msgstr "Сколько тонн углерода вы хотели бы компенсировать? <0>*</0>"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
-msgid "offset.default_retirement_address"
-msgstr "По умолчанию используется адрес подключенного кошелька"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
-msgid "offset.retire_carbon"
-msgstr "Подтвердить выбивание"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
-msgid "offset.retirement_credit"
-msgstr "Кому будет зачислено это выбивание?"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
-msgid "offset.retirement_message"
-msgstr "Сообщение о выводе"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr "Спасибо за поддержку планеты! Просмотр транзакции на <0> PolygonScan.</0>"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr "Спасибо за поддержку планеты!"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr "Ваша транзакция была успешно обработана, но ее индексация занимает больше времени, чем обычно. В ближайшее время она появится в вашем  <0>retirements</0>."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
-msgid "offset_disclaimer"
-msgstr "Будьте осторожны, чтобы не включать какую-либо конфиденциальную личную информацию (например, адрес электронной почты) в ваше сообщение на выбивание. Информация, которую вы вводите здесь, не может быть отредактирована после ее отправки и будет постоянно существовать в общедоступной цепочке блоков."
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr "Балансы"
-
-#: components/CreateListing/Form/index.tsx:136
-msgid "profile.addListing_modal.submit"
-msgstr "Создать объявление"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
-msgid "profile.edit_modal.submit"
-msgstr "Сохранить изменения"
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr "Отредактируйте свой профиль, чтобы добавить описание."
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
-msgid "profile.listing.edit.delete_listing"
-msgstr "Удалить объявление"
-
-#: components/pages/Purchases/index.tsx:49
-msgid "project.single.button.back_to_project_details"
-msgstr "Вернуться к деталям проекта"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr "Вы собираетесь приобрести углеродный актив."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr "Первый шаг - дать разрешение на перевод платежного актива из вашего кошелька в Carbonmark, следующий шаг - одобрить фактический перевод и завершить покупку."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr "Приобретенные вами углеродные активы могут быть выставлены на продажу на Carbonmark в любое время из вашего <0>портфолио</0>."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr "Убедитесь, что вся информация верна, и нажмите кнопку \"Одобрить\", чтобы продолжить."
-
-#: components/pages/Purchases/index.tsx:145
-msgid "purchase.button.view_assets"
-msgstr "Просмотрите свои активы"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr "На предыдущем этапе было получено разрешение на перевод платежного актива из вашего кошелька в Carbonmark."
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr "Ваша покупка еще не завершена. Чтобы завершить покупку, убедитесь, что вся информация верна, а затем нажмите «Отправить» ниже."
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr "Категории"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr "Выберите один или несколько"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr "Очистить все"
-
-#: components/pages/Resources/ResourcesList/index.tsx:289
-msgid "resources.mobile_modal.button.show_results"
-msgstr "Показать результаты"
-
-#: components/pages/Resources/ResourcesList/index.tsx:230
-msgid "resources.page.list.no_search_results.title"
-msgstr "Извините. Мы не смогли найти подходящих результатов."
-
-#: components/pages/Resources/ResourcesList/index.tsx:222
-msgid "resources.page.list.on_fetch_error"
-msgstr "❌ Ошибка: что-то пошло не так..."
-
-#: components/pages/Resources/ResourcesList/index.tsx:243
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr "Пожалуйста, используйте другую комбинацию фильтров."
-
-#: components/pages/Resources/ResourcesList/index.tsx:236
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr "Проверьте свой запрос на наличие опечаток или попробуйте другой поисковый запрос."
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
-msgid "retire.back_button"
-msgstr "назад"
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr "Выбито"
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr "Имея более 20 миллионов подтвержденных цифровых углеродных кредитов из сотен проектов, Carbonmark предлагает самый большой выбор цифровых углеродных кредитов по всему миру. Покупайте, продавайте и выводите цифровой углерод из любого проекта мгновенно с нулевой комиссией. <0>Начните сегодня</0> ."
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr "О Carbonmark"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr "{retiree} изъято из эксплуатации {formattedAmount} тонн углерода"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr "Карбонмарк | Квитанция о выводе"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:50
-msgid "retirement.provenance.head.metaDescription"
-msgstr "Прозрачные компенсации по цепочке на базе KlimaDAO."
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:46
-msgid "retirement.provenance.head.metaTitle"
-msgstr "{retiree} изъято из эксплуатации {formattedAmount} тонн углерода"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:42
-msgid "retirement.provenance.head.title"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
-msgid "retirement.single.beneficiary.placeholder"
-msgstr "Имя получателя не указано"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.title"
-msgstr "Получатель"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
-msgid "retirement.single.beneficiary_address.title"
-msgstr "Адрес получателя:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr "Выбивание по углеродному кредиту"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
-msgid "retirement.single.country_region.title"
-msgstr "Страна/регион:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
-msgid "retirement.single.immutable_public_records.title"
-msgstr "Это представляет собой окончательное выбытие цифрового углеродного актива. Это выбивание и связанные с ним данные являются неизменяемыми общедоступными записями."
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr "Сообщение о выбивании"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.methodology.title"
-msgstr "Методология:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
-msgid "retirement.single.moss_offset.description"
-msgstr ""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
-msgid "retirement.single.moss_offset.name"
-msgstr ""
-"MOSS Earth MC02\n"
-""
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
-msgid "retirement.single.official_certificate.title"
-msgstr "Официальный сертификат об отказе от использования углерода в сети, предоставленный <0>Carbonmark.com</0>"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
-msgid "retirement.single.project.title"
-msgstr "Проект:"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
-msgid "retirement.single.project_description.title"
-msgstr "Описание"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
-msgid "retirement.single.project_details.title"
-msgstr "Детали проекта"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
-msgid "retirement.single.project_name.title"
-msgstr "Название проекта"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr "Доказательство"
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr "КОЛИЧЕСТВО УПОТРЕБЛЕННЫХ"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
-msgid "retirement.single.share_retirement.title"
-msgstr "Поделитесь этим выбиванием"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr "Не предоставлена время использования"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
-msgid "retirement.single.transaction_id.title"
-msgstr "ID транзакции"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
-msgid "retirement.single.transaction_record.title"
-msgstr "Неизменяемая запись транзакции"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.type.title"
-msgstr "Тип:"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr "Подтвержденные тонны отмененного углерода"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
-msgid "retirement.single.vintage.title"
-msgstr "Винтаж:"
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr "Выбиваний не найдено"
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr "Итого выведено"
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr "Carbonmark - Углеродные отчисления для бенефициара {0}"
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr "Carbonmark - Углеродные отчисления для бенефициара {0}"
-
-#: components/pages/Retirements/index.tsx:60
-msgid "retirement.totals.page_headline"
-msgstr "Выведено углерода"
-
-#: components/pages/Retirements/index.tsx:66
-msgid "retirement.totals.page_subline"
-msgstr "для бенефициара"
-
-#: components/pages/Retirements/index.tsx:90
-msgid "retirement.totals.retired_assets"
-msgstr "Выбывшие активы"
-
-#: components/pages/Retirements/index.tsx:106
-msgid "retirement.totals.retirements"
-msgstr "Выбытия"
-
-#: components/pages/Retirements/index.tsx:98
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr "Всего выбыло тонн углерода"
-
-#: components/pages/Retirements/index.tsx:112
-msgid "retirement.totals.total_retirement_transactions"
-msgstr "Всего транзакции выбивания"
-
-#: components/pages/Users/SellerUnconnected/index.tsx:70
-msgid "seller.listing.buy"
-msgstr "Купить"
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr "Доступное количество:"
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr "Информационный центр"
-
-#: components/pages/Resources/ResourcesList/index.tsx:197
-msgid "shared.resources.sort_by.header"
-msgstr "Сортировать по"
-
-#: components/Layout/index.tsx:51
-msgid "social or email"
-msgstr "соцсети или электронная почта"
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr "проданный"
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
-msgid "something went wrong loading the allowance"
-msgstr "что-то пошло не так при загрузке пособия"
-
-#: components/pages/Retire/Activity/Overview.tsx:77
-#: components/pages/Retire/Activity/Quotes.tsx:76
-#: components/pages/Retire/Activity/Table.tsx:65
-msgid "t"
-msgstr "т"
-
-#: components/Activities/Activity.tsx:119
-msgid "to"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
-msgid "tonnes"
-msgstr "тонны"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr "Вы собираетесь списать углеродный актив."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr "Первым шагом является предоставление разрешения на перевод вашего углеродного актива из вашего кошелька в Carbonmark, следующим шагом является утверждение фактического перевода и завершение выхода на пенсию."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr "Убедитесь, что вся информация верна, и нажмите кнопку \"Одобрить\", чтобы продолжить."
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr "Подтвердить сумму"
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr "Адрес контракта"
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr "Подтвердить цену за тонну"
-
-#: components/CreateListing/Transaction/index.tsx:83
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr "Вернуться назад"
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr "Закрыть"
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr "Следующий"
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr "Подтвердить сумму"
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr "Отправить"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr "Предыдущий шаг дал разрешение на перевод вашего углеродного актива из вашего кошелька в Carbonmark, ваш выход на пенсию еще не завершен."
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr "Чтобы завершить выбивание, убедитесь, что вся информация верна, а затем нажмите «Отправить» ниже."
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr "Адрес контракта"
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr "Укажите цену за тонну:"
-
-#: components/CreateListing/Transaction/index.tsx:47
-#: components/Transaction/index.tsx:45
-msgid "transaction_modal.view.approve.title"
-msgstr "1. Одобрить"
-
-#: components/CreateListing/Transaction/index.tsx:57
-#: components/Transaction/index.tsx:55
-msgid "transaction_modal.view.submit.title"
-msgstr "2. Отправить"
-
-#: components/Activities/Activities.constants.ts:10
-msgid "updated expiration"
-msgstr ""
-
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr "обновленная цена"
-
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr "обновленное количество"
-
-#: components/Activities/index.tsx:29
-msgid "user.activities.empty_state"
-msgstr "Нет активности для показа"
-
-#: components/LoginCard/index.tsx:24
-msgid "user.login.description"
-msgstr "Эта функция доступна только для пользователей, которые вошли в систему. Вы можете войти или создать учетную запись с помощью кнопки ниже."
-
-#: components/CreateListing/Transaction/Approve.tsx:51
-#: components/CreateListing/Transaction/index.tsx:62
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
-msgid "{0}"
-msgstr "{0}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
-msgid "{0} maximum for credit cards"
-msgstr "{0} максимальная сумма по кредитным картам"
-
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr "{0} | Профиль | Carbonmark"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr "{DEFAULT_EXPIRATION_DAYS} дней ({expirationDatestring})"
-
-#: components/pages/Purchases/index.tsx:29
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr "{amount} тонн было закуплено для проекта {0}"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
-#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
-msgid "{formattedAmount} Tonnes"
-msgstr ""
-
-#: components/Quantity/index.tsx:28
-msgid "{formattedAmount} tonnes"
-msgstr ""
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
-msgid "{tokenSymbol}"
-msgstr "{tokenSymbol}"
-
-#: lib/statusMessage.ts:23
-msgid "❌ Error: something went wrong..."
-msgstr "❌ Ошибка: что-то пошло не так..."

--- a/carbonmark/locale/zh-CN/messages.po
+++ b/carbonmark/locale/zh-CN/messages.po
@@ -6,10 +6,85 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/CreateListing/Transaction/Approve.tsx:51
+#: components/CreateListing/Transaction/index.tsx:62
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
+msgid "{0}"
+msgstr "{0}"
+
+#: components/pages/Users/index.tsx:30
+msgid "{0} | Profile | Carbonmark"
+msgstr "{0} | 简介 | Carbonmark"
+
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
+msgid "{0} maximum for credit cards"
+msgstr "{0} 信用卡最高限额"
+
+#: components/pages/Purchases/index.tsx:29
+msgid "{amount} tonnes were purchased for project {0}"
+msgstr "为项目 {0} 购买了 {amount} 吨"
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
+msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
+msgstr "{DEFAULT_EXPIRATION_DAYS} 天 ({expirationDatestring})"
+
+#: components/Quantity/index.tsx:28
+msgid "{formattedAmount} tonnes"
+msgstr "{formattedAmount} 吨"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
+#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
+msgid "{formattedAmount} Tonnes"
+msgstr "{formattedAmount} 吨"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:46
+msgid "retirement.provenance.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:124
+msgid "retirement.head.metaTitle"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
+msgid "{tokenSymbol}"
+msgstr "{tokenSymbol}"
+
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+msgid "@Username (note: this can not be changed!)"
+msgstr "@用户名（注意：用户名不可修改！）"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
+msgid "<0>* </0> Required Field"
+msgstr "<0>*</0>必填项目"
+
+#: lib/statusMessage.ts:23
+msgid "❌ Error: something went wrong..."
+msgstr "❌ 错误：出了点问题..."
 
 #: components/pages/Home/index.tsx:358
 msgid "0% listing fee"
 msgstr "0% 挂牌费"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:47
+#: components/Transaction/index.tsx:45
+msgid "transaction_modal.view.approve.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:57
+#: components/Transaction/index.tsx:55
+msgid "transaction_modal.view.submit.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:193
 msgid "200x200 PNG recommended. Upload your image to a host like imgur.com or postimages.org, and paste the full URL. Direct photo upload is coming soon!"
@@ -32,14 +107,6 @@ msgstr "500 - 服务器错误"
 msgid "500 - Server error occurred"
 msgstr "500 - 服务器发生错误"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:247
-msgid "<0>* </0> Required Field"
-msgstr "<0>*</0>必填项目"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
-msgid "@Username (note: this can not be changed!)"
-msgstr "@用户名（注意：用户名不可修改！）"
-
 #: components/pages/Project/PayWithBank/index.tsx:153
 msgid "A valid email address is required"
 msgstr "有效的电子邮箱地址为必填项"
@@ -54,6 +121,11 @@ msgstr "A - Z"
 msgid "About"
 msgstr "关于"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:11
+msgid "retirement.footer.about_carbonmark.title"
+msgstr ""
+
 #: components/Stats/StatsListings.tsx:49
 msgid "Active listings:"
 msgstr "活动列表："
@@ -62,6 +134,11 @@ msgstr "活动列表："
 msgid "Activity"
 msgstr "活动"
 
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:22
+msgid "exitmodal.after_you_click"
+msgstr ""
+
 #: lib/getCategoryInfo.ts:53
 msgid "Agriculture"
 msgstr "农业"
@@ -69,6 +146,11 @@ msgstr "农业"
 #: components/pages/Home/index.tsx:362
 msgid "All assets sourced from major registries"
 msgstr "所有资产均来自主要注册机构"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:24
+msgid "retirement.totals.all_retirements_list.headline"
+msgstr ""
 
 #: components/CreateListing/Transaction/Submit.tsx:41
 msgid "Almost finished! The last step is to create the listing and submit it to the system. Please verify the quantity and price below."
@@ -111,6 +193,10 @@ msgstr "批准"
 msgid "Asset"
 msgstr "资产"
 
+#: components/AssetDetails/index.tsx:53
+msgid "Asset details"
+msgstr "资产详情"
+
 #: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:24
 msgid "Asset Details"
 msgstr "资产详情"
@@ -119,9 +205,13 @@ msgstr "资产详情"
 msgid "Asset ID"
 msgstr "资产编号"
 
-#: components/AssetDetails/index.tsx:53
-msgid "Asset details"
-msgstr "资产详情"
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:32
+msgid "Asset moved from one account to another, either via sale or inter-account transfer."
+msgstr ""
+
+#: components/Activities/Activity.tsx:34
+msgid "at"
+msgstr "在"
 
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:131
 msgid "At this time Carbonmark cannot process credit card payments exceeding: {fiatBalance}"
@@ -133,11 +223,6 @@ msgid ""
 "exceeding {0}. Please adjust the\n"
 "quantity and try again later."
 msgstr "目前，Carbonmark 无法处理超过 {0} 的信用卡付款。请调整数量并稍后重试。"
-
-#: components/ProjectCard/index.tsx:47
-#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
-msgid "Available Tonnes:"
-msgstr "可用吨数："
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:116
 msgid "Available balance exceeded"
@@ -163,6 +248,11 @@ msgstr "可供购买"
 msgid "Available to retire"
 msgstr "可停用"
 
+#: components/pages/Retire/FromPortfolio/AssetProject/index.tsx:50
+#: components/ProjectCard/index.tsx:47
+msgid "Available Tonnes:"
+msgstr "可用吨数："
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:219
 msgid "Available:"
 msgstr "可用的："
@@ -176,14 +266,20 @@ msgstr "可用：{0}"
 msgid "Available: {unlistedBalance}"
 msgstr "可用：{unlistedBalance}"
 
-#: components/BetaBadge/index.tsx:18
-msgid "BETA"
-msgstr "测试版"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
+msgid "retire.back_button"
+msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:44
 #: components/pages/Project/Retire/index.tsx:35
 msgid "Back to Project"
 msgstr "返回项目"
+
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:49
+msgid "project.single.button.back_to_project_details"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:397
 msgid "Balance"
@@ -199,6 +295,16 @@ msgstr "余额超出"
 msgid "Balance: {0}"
 msgstr "余额：{0}"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Balances/index.tsx:49
+msgid "portfolio.balances.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
+msgid "offset_disclaimer"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:450
 msgid "Be careful not to include any sensitive personal information (such as an email address) in your retirement name or message. The information you enter here cannot be edited once it is submitted and will permanently exist on a public blockchain."
 msgstr "请注意不要在您的碳停用姓名或消息中包含任何敏感的个人信息（例如电子邮件地址）。您在此处输入的信息一旦提交将无法更改，并将永久存在于公共区块链上。"
@@ -207,12 +313,17 @@ msgstr "请注意不要在您的碳停用姓名或消息中包含任何敏感的
 msgid "Beneficiary Address"
 msgstr "受益人地址"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
-msgid "Beneficiary Name"
-msgstr "受益人姓名"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
+msgid "retirement.single.beneficiary_address.title"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:263
 msgid "Beneficiary name"
+msgstr "受益人姓名"
+
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:306
+msgid "Beneficiary Name"
 msgstr "受益人姓名"
 
 #: components/pages/Project/PayWithBank/index.tsx:232
@@ -225,11 +336,20 @@ msgstr "受益人钱包地址"
 msgid "Beneficiary wallet address (optional)"
 msgstr "收益人钱包地址（可选）"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
+msgid "retirement.single.beneficiary.title"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:34
 #: components/pages/Project/BuyOptions/SellerListing.tsx:67
 #: components/pages/Project/index.tsx:137
 msgid "Best Price"
 msgstr "最优价格"
+
+#: components/BetaBadge/index.tsx:18
+msgid "BETA"
+msgstr "测试版"
 
 #: lib/getCategoryInfo.ts:65
 msgid "Blue Carbon"
@@ -239,9 +359,9 @@ msgstr "蓝碳"
 msgid "Book a demo"
 msgstr "预约演示"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:35
-msgid "Bridge"
-msgstr "桥接"
+#: components/Activities/Activities.constants.ts:6
+msgid "bought from"
+msgstr "买自"
 
 #: components/pages/Home/index.tsx:157
 #: components/pages/Home/index.tsx:188
@@ -256,6 +376,11 @@ msgstr "浏览项目"
 #: components/pages/Project/BuyOptions/SellerListing.tsx:98
 msgid "Buy"
 msgstr "购买"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerUnconnected/index.tsx:70
+msgid "seller.listing.buy"
+msgstr ""
 
 #: components/pages/Home/index.tsx:168
 msgid "Buy or retire carbon"
@@ -273,6 +398,25 @@ msgstr "我们可以稍后提醒您这项新功能吗？"
 msgid "Cancel"
 msgstr "取消"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
+msgid "purchase.approval_3"
+msgstr ""
+
+#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
+msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
+msgstr "您购买的碳资产可随时从您的<0>投资组合</0>中挂牌，在Carbonmark上出售"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
+msgid "retirement.single.carbon_credit_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:31
+msgid "exitmodal.carbon_credits_you_purchase"
+msgstr ""
+
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:30
 msgid "Carbon Pool"
 msgstr "碳池"
@@ -280,6 +424,10 @@ msgstr "碳池"
 #: components/Layout/NavDropdown/index.tsx:117
 msgid "Carbon Portfolio"
 msgstr "碳投资组合"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
+msgid "Carbon provenance"
+msgstr "碳来源"
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:60
 msgid "Carbon Provenance"
@@ -289,17 +437,35 @@ msgstr "碳来源"
 msgid "Carbon Retirements"
 msgstr "碳停用"
 
-#: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:42
-msgid "Carbon assets you purchase can be listed for sale on Carbonmark at any time from your <0>portfolio</0>."
-msgstr "您购买的碳资产可随时从您的<0>投资组合</0>中挂牌，在Carbonmark上出售"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:60
+msgid "retirement.totals.page_headline"
+msgstr ""
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:144
-msgid "Carbon provenance"
-msgstr "碳来源"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:39
+msgid "retirement.totals.head.title"
+msgstr ""
 
-#: components/pages/Resources/lib/cmsDataMap.ts:46
-msgid "Carbonmark Overview"
-msgstr "Carbonmark 概览"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:45
+msgid "retirement.totals.head.metaTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:42
+msgid "retirement.provenance.head.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/index.tsx:120
+msgid "retirement.head.title"
+msgstr ""
+
+#: components/pages/Home/index.tsx:51
+#: components/pages/Home/index.tsx:52
+msgid "Carbonmark | The Universal Carbon Marketplace"
+msgstr "Carbonmark  | 通用碳市场"
 
 #: components/pages/Home/index.tsx:174
 msgid "Carbonmark doesn't charge an additional transaction fee and offers best-in-the-market pricing. Explore hundreds of verified carbon projects."
@@ -315,14 +481,18 @@ msgstr "Carbonmark 费"
 msgid "Carbonmark now offers the ability to pay for retirement transactions via bank transfer. Simply fill out the form below and we'll reach out within 2 business days (upon receiving all required information) to collect some further information and send you an invoice."
 msgstr "Carbonmark 现在提供通过银行转账支付的碳停用交易功能。只需填写下方表格，我们将在 2 个工作日内（收到所有必需信息后）与您联系，需要收集更多的信息并向您发送发票。"
 
-#: components/pages/Home/index.tsx:51
-#: components/pages/Home/index.tsx:52
-msgid "Carbonmark | The Universal Carbon Marketplace"
-msgstr "Carbonmark  | 通用碳市场"
+#: components/pages/Resources/lib/cmsDataMap.ts:46
+msgid "Carbonmark Overview"
+msgstr "Carbonmark 概览"
 
 #: components/pages/Home/index.tsx:488
 msgid "Carbonmark's role"
 msgstr "Carbonmark的角色"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
+msgid "resources.form.categories.header"
+msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:130
 msgid "Category"
@@ -333,6 +503,11 @@ msgstr "类别"
 msgid "Change language"
 msgstr "变更语言"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:236
+msgid "resources.page.list.search_submit.no_search_results"
+msgstr ""
+
 #: components/pages/Home/index.tsx:206
 msgid "Choose a project and quantity"
 msgstr "选择项目和数量"
@@ -341,8 +516,13 @@ msgstr "选择项目和数量"
 msgid "Choose from over 20 million verified digital carbon credits from hundreds of projects - buy, sell, or retire carbon now."
 msgstr "从数百个项目中选择超过 2000 万个经过验证的数字碳信用额度 - 现在购买、出售或停用碳。"
 
-#: components/ProjectFilterModal/index.tsx:162
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
+msgid "resources.form.filters.clear_all"
+msgstr ""
+
 #: components/pages/Projects/ProjectSearch/index.tsx:55
+#: components/ProjectFilterModal/index.tsx:162
 msgid "Clear Filters"
 msgstr "清除过滤器"
 
@@ -353,6 +533,11 @@ msgstr "单击“创建个人资料”按钮自定义此页面并开始。"
 #: components/CreateListing/Transaction/Submit.tsx:98
 msgid "Close"
 msgstr "关闭"
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:108
+msgid "transaction_modal.close"
+msgstr ""
 
 #: components/Footer/index.tsx:32
 msgid "Code of Ethics"
@@ -379,6 +564,16 @@ msgstr "比较所有卖家和交易池的价格"
 msgid "Compiling Results ..."
 msgstr "编译结果..."
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:57
+msgid "transaction_modal.approve.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:71
+msgid "transaction_modal.approve.price"
+msgstr ""
+
 #: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:83
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:85
 #: components/pages/Project/Retire/Pool/BankTransferModal.tsx:18
@@ -386,9 +581,18 @@ msgstr "编译结果..."
 msgid "Confirm Purchase"
 msgstr "确认购买"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
+msgid "offset.retire_carbon"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:75
 msgid "Confirm Retirement"
 msgstr "确认退休"
+
+#: components/Layout/index.tsx:52
+msgid "connect a wallet"
+msgstr "连接钱包"
 
 #: components/pages/Portfolio/ConnectedWallet/index.tsx:33
 msgid "Connected Wallet"
@@ -414,6 +618,16 @@ msgstr "联系方式"
 msgid "Continue"
 msgstr "继续"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:47
+msgid "transaction_modal.approve.contract_address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:48
+msgid "transaction_modal.submit.contract_address"
+msgstr ""
+
 #: components/CopyAddressButton/index.tsx:37
 msgid "Copy"
 msgstr "复制"
@@ -431,15 +645,10 @@ msgstr "无法删除挂牌。请再试一次。"
 msgid "Country"
 msgstr "国家"
 
-#: components/pages/Users/SellerConnected/index.tsx:148
-#: components/pages/Users/SellerConnected/index.tsx:172
-msgid "Create New Listing"
-msgstr "创建新挂牌"
-
-#: components/pages/Users/SellerConnected/index.tsx:113
-#: components/pages/Users/SellerConnected/index.tsx:138
-msgid "Create Profile"
-msgstr "创建个人资料"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
+msgid "retirement.single.country_region.title"
+msgstr ""
 
 #: components/CreateListing/index.tsx:165
 msgid "Create a listing"
@@ -457,6 +666,21 @@ msgstr "创建卖家资料"
 msgid "Create and edit listings, and track your activity with your Carbonmark profile."
 msgstr "创建和编辑列表，并使用您的 Carbonmark 个人资料跟踪您的活动。"
 
+#. js-lingui-explicit-id
+#: components/CreateListing/Form/index.tsx:136
+msgid "profile.addListing_modal.submit"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:148
+#: components/pages/Users/SellerConnected/index.tsx:172
+msgid "Create New Listing"
+msgstr "创建新挂牌"
+
+#: components/pages/Users/SellerConnected/index.tsx:113
+#: components/pages/Users/SellerConnected/index.tsx:138
+msgid "Create Profile"
+msgstr "创建个人资料"
+
 #: components/pages/Home/index.tsx:313
 msgid "Create your own carbon storefront. Sell directly to organizations and individuals alike."
 msgstr "创建您自己的碳店面。直接销售给组织和个人。"
@@ -465,25 +689,29 @@ msgstr "创建您自己的碳店面。直接销售给组织和个人。"
 msgid "Create your own retirement"
 msgstr "创造你自己的碳停用"
 
+#: components/Activities/Activities.constants.ts:4
+msgid "created listing"
+msgstr "创建列表"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:87
 msgid "Created:"
 msgstr "已创建："
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
-msgid "Credit ID"
-msgstr "信用证号"
-
-#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
-msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
-msgstr "信用卡最低购买金额为 ${formattedFiatMinimum}"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:77
 msgid "Credit card minimum purchase is {0}"
 msgstr "信用卡最低购买金额为 {0}"
 
+#: components/pages/Project/Retire/Pool/TotalValues.tsx:113
+msgid "Credit card minimum purchase is ${formattedFiatMinimum}"
+msgstr "信用卡最低购买金额为 ${formattedFiatMinimum}"
+
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:247
 msgid "Credit card payments incur an additional processing fee. <0>See docs to learn more.</0>"
 msgstr "信用卡付款需支付额外的手续费。<0>请参阅文档以了解更多信息</0>"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:47
+msgid "Credit ID"
+msgstr "信用证号"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:435
 msgid "Currently, Carbonmark only accepts Polygon USDC or Credit Card Payments. <0>Learn how to acquire USDC on Polygon.</0>"
@@ -493,10 +721,6 @@ msgstr "目前，Carbonmark 仅接受 Polygon USDC 或信用卡付款。 <0> 了
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:170
 msgid "Currently, Carbonmark only accepts Polygon USDC payments. <0>Learn how to acquire USDC on Polygon.</0>"
 msgstr "目前，Carbonmark 仅接受 Polygon USDC 或信用卡付款。 <0> 了解如何在 Polygon 上获取 USDC </0>"
-
-#: components/pages/Retire/Activity/Table.tsx:48
-msgid "DATE"
-msgstr "日期"
 
 #: components/pages/Project/index.tsx:234
 msgid "Data for this project and vintage"
@@ -511,9 +735,27 @@ msgstr "该卖家的数据"
 msgid "Date"
 msgstr "日期"
 
+#: components/pages/Retire/Activity/Table.tsx:48
+msgid "DATE"
+msgstr "日期"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
+msgid "offset.default_retirement_address"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:296
 msgid "Defaults to the connected wallet address"
 msgstr "默认的已连接钱包地址"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
+msgid "profile.listing.edit.delete_listing"
+msgstr ""
+
+#: components/Activities/Activities.constants.ts:5
+msgid "deleted listing"
+msgstr "删除列表"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:307
 msgid "Describe the purpose of this retirement"
@@ -523,6 +765,11 @@ msgstr "描述本次碳停用的目的"
 msgid "Description"
 msgstr "描述"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
+msgid "retirement.single.project_description.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:51
 msgid "Digital Carbon"
 msgstr "数字碳"
@@ -530,6 +777,11 @@ msgstr "数字碳"
 #: components/pages/Home/index.tsx:264
 msgid "Digitize your carbon by using a supported bridge"
 msgstr "使用平台支持的跨链桥将您的碳数字化"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:97
+msgid "blog.disclaimer.title"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
 msgid "Display name"
@@ -555,18 +807,29 @@ msgstr "正在下载..."
 msgid "Drive climate action and earn rewards with a carbon-backed digital currency."
 msgstr "通过碳支持的数字货币推动气候行动并获得奖励。"
 
+#: components/pages/Project/Purchase/Listing/Price.tsx:18
+#: components/pages/Project/Purchase/Pool/Price.tsx:17
+#: components/pages/Project/Retire/Pool/Price.tsx:17
+msgid "each"
+msgstr "每个"
+
 #: components/pages/Users/SellerConnected/ListingEditable.tsx:195
 msgid "Edit"
 msgstr "编辑"
+
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
+msgid "Edit listing"
+msgstr "编辑挂牌"
 
 #: components/pages/Users/SellerConnected/index.tsx:113
 #: components/pages/Users/SellerConnected/index.tsx:138
 msgid "Edit Profile"
 msgstr "编辑个人资料"
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:206
-msgid "Edit listing"
-msgstr "编辑挂牌"
+#. js-lingui-explicit-id
+#: components/pages/Users/ProfileHeader/index.tsx:54
+msgid "profile.edit_your_profile"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:143
 #: components/pages/Project/PayWithBank/index.tsx:307
@@ -626,6 +889,19 @@ msgstr "名字不可包含数字或特殊字符"
 msgid "First, approve the Carbonmark system to transfer this asset on your behalf."
 msgstr "首先，批准Carbonmark系统，允许其代表您转让该资产。"
 
+#: components/Activities/Activity.tsx:112
+msgid "for"
+msgstr "为了"
+
+#: components/pages/Retire/index.tsx:52
+msgid "for beneficiary"
+msgstr "为受益人"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:66
+msgid "retirement.totals.page_subline"
+msgstr ""
+
 #: components/pages/Home/index.tsx:340
 msgid "For carbon traders"
 msgstr "对于碳交易商"
@@ -642,20 +918,26 @@ msgstr "林业"
 msgid "Form complete"
 msgstr "表格已填写完成"
 
-#: components/pages/Home/index.tsx:76
-msgid "Get Started"
-msgstr "开始"
-
 #: components/pages/Home/index.tsx:390
 msgid "Get paid immediately: transactions are resolved in seconds"
 msgstr "立即付款：交易在几秒钟内解决"
 
-#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
-msgid "Go Back"
-msgstr "返回"
+#: components/pages/Home/index.tsx:76
+msgid "Get Started"
+msgstr "开始"
+
+#. js-lingui-explicit-id
+#: components/CreateListing/Transaction/index.tsx:83
+#: components/Transaction/index.tsx:84
+msgid "transaction_modal.button.go_back"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:35
 msgid "Go back"
+msgstr "返回"
+
+#: components/pages/Project/Retire/Pool/BankTransferModal.tsx:42
+msgid "Go Back"
 msgstr "返回"
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:145
@@ -681,8 +963,8 @@ msgid "Here’s a list of readily available, discounted carbon tokens to retire 
 msgstr "以下是现成的、打折的碳代币列表，可以快速、轻松地停用碳。"
 
 #: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:48
-msgid "Hide {numberOfTransfers} transfers"
-msgstr "隐藏 {numberOfTransfers} 转账"
+msgid "Hide {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:80
 msgid "How many tonnes do you want to list for sale?"
@@ -696,6 +978,11 @@ msgstr "您想购买多少吨碳？"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:249
 msgid "How many tonnes of carbon do you want to retire?"
 msgstr "您想停用多少吨碳？"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
+msgid "offset.amount_in_tonnes"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:215
 msgid "How many tonnes of carbon would you like to retire?"
@@ -720,6 +1007,11 @@ msgstr "ICR 信用额只能以整吨为单位停用碳"
 #: components/pages/Purchases/index.tsx:93
 msgid "If you would like to retire some or all of the carbon credits from this purchase, go to your <0>portfolio</0>, click the 'retire' button and follow the directions."
 msgstr "如果您想取消此次购买的部分或全部碳信用额度，请转至您的<0>投资组合</0>，单击“停用”键并按照说明进行操作。"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
+msgid "retirement.single.transaction_record.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:116
 msgid "Indicates required field"
@@ -775,13 +1067,13 @@ msgstr "姓氏不可包含数字或特殊字符"
 msgid "Latest First"
 msgstr "最新优先"
 
+#: components/pages/Home/index.tsx:417
+msgid "Learn more"
+msgstr "了解更多"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:92
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:103
 msgid "Learn More"
-msgstr "了解更多"
-
-#: components/pages/Home/index.tsx:417
-msgid "Learn more"
 msgstr "了解更多"
 
 #: components/pages/Home/index.tsx:491
@@ -815,11 +1107,11 @@ msgid "Loading your assets"
 msgstr "正在加载您的资产"
 
 #: components/LoginButton/index.tsx:11
-#: components/SpinnerWithLabel/index.tsx:15
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:159
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:295
 #: components/pages/Retire/Activity/Overview.tsx:73
 #: components/pages/Retire/Activity/Overview.tsx:84
+#: components/SpinnerWithLabel/index.tsx:15
 msgid "Loading..."
 msgstr "正在加载..."
 
@@ -859,6 +1151,11 @@ msgstr "登出"
 msgid "Marketplace"
 msgstr "市场"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:35
+msgid "menu.marketplace"
+msgstr ""
+
 #: components/pages/Projects/index.tsx:73
 #: components/pages/Projects/index.tsx:74
 msgid "Marketplace | Carbonmark"
@@ -868,21 +1165,36 @@ msgstr "市场 | Carbonmark"
 msgid "Maximize your climate impact."
 msgstr "最大限度地提高您对气候的影响。"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
+msgid "retirement.single.moss_offset.description"
+msgstr ""
+
 #: components/pages/Project/index.tsx:144
 msgid "Methodology"
 msgstr "方法"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
+msgid "retirement.single.methodology.title"
+msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:54
 msgid "Moss"
 msgstr "Moss"
 
-#: components/FeatureBanner/index.tsx:33
-msgid "NEW FEATURE:"
-msgstr "新功能："
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
+msgid "retirement.single.moss_offset.name"
+msgstr ""
 
 #: components/Layout/NavDropdown/index.tsx:171
 msgid "Navigation Menu"
 msgstr "导航菜单"
+
+#: components/FeatureBanner/index.tsx:33
+msgid "NEW FEATURE:"
+msgstr "新功能："
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:101
 msgid "New Quantity"
@@ -896,18 +1208,28 @@ msgstr "新单价（USDC）"
 msgid "Next"
 msgstr "下一步"
 
-#: components/pages/Retire/Activity/Table.tsx:93
-msgid "No Activity to show."
-msgstr "无可显示活动"
+#. js-lingui-explicit-id
+#: components/Transaction/Approve.tsx:108
+msgid "transaction_modal.next"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/index.tsx:197
 #: components/pages/Users/SellerUnconnected/index.tsx:83
 msgid "No active listings."
 msgstr "无活动列表。"
 
+#. js-lingui-explicit-id
+#: components/Activities/index.tsx:29
+msgid "user.activities.empty_state"
+msgstr ""
+
 #: components/pages/Retire/Activity/Quotes.tsx:38
 msgid "No activity to show"
 msgstr "无可显示的活动"
+
+#: components/pages/Retire/Activity/Table.tsx:93
+msgid "No Activity to show."
+msgstr "无可显示活动"
 
 #: components/pages/Home/index.tsx:400
 msgid "No barriers to entry for verified carbon projects"
@@ -916,6 +1238,11 @@ msgstr "经过验证的碳项目没有准入门槛"
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:40
 msgid "No beneficiary address available"
 msgstr "无可用的受益人地址"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
+msgid "retirement.single.beneficiary.placeholder"
+msgstr ""
 
 #: components/pages/Retire/Activity/Overview.tsx:62
 msgid "No data to show"
@@ -950,24 +1277,39 @@ msgstr "未找到记录"
 msgid "No retirement message provided."
 msgstr "未提供碳停用信息"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
+msgid "retirement.single.timestamp.placeholder"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/List/index.tsx:40
+msgid "retirement.totals.all_retirements_list.empty"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:50
 msgid "No transaction id available"
 msgstr "无可用的交易 ID"
-
-#: components/Layout/AddressSection/index.tsx:30
-msgid "Not Connected"
-msgstr "未连接"
 
 #: components/pages/Project/PayWithBank/index.tsx:240
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:288
 msgid "Not a valid polygon address"
 msgstr "不是polygon的有效地址"
 
+#: components/Layout/AddressSection/index.tsx:30
+msgid "Not Connected"
+msgstr "未连接"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
+msgid "retirement.single.official_certificate.title"
+msgstr ""
+
 #: components/pages/Resources/lib/cmsDataMap.ts:72
 msgid "Oldest First"
 msgstr "最早优先"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:185
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:188
 msgid "On the Verra page, search for the specific serial number."
 msgstr "在 Verra 页面上，搜索特定的序列号。"
 
@@ -993,22 +1335,18 @@ msgstr ""
 "来自数百个项目的超过 2000 万个经过验证的数字碳信用额，\n"
 "迄今为止交易额超过 40 亿美元"
 
-#: components/pages/Retire/Activity/Table.tsx:46
-msgid "PROJECT"
-msgstr "项目"
-
 #: components/pages/Projects/Banners/BankTransfer.tsx:74
 msgid "Pay via Bank Transfer / Wire"
 msgstr "通过银行转账 / 电汇来支付"
+
+#: components/pages/Project/PayWithBank/index.tsx:98
+msgid "Pay with bank transfer"
+msgstr "通过银行转账支付"
 
 #: components/pages/Project/PayWithBank/index.tsx:89
 #: components/pages/Project/PayWithBank/index.tsx:90
 msgid "Pay with Bank Transfer | Carbonmark"
 msgstr "通过银行转账支付 | Carbonmark"
-
-#: components/pages/Project/PayWithBank/index.tsx:98
-msgid "Pay with bank transfer"
-msgstr "通过银行转账支付"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:94
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:112
@@ -1016,22 +1354,18 @@ msgstr "通过银行转账支付"
 msgid "Pay with:"
 msgstr "使用...支付"
 
-#: components/pages/Purchases/index.tsx:62
-msgid "Payment Successful"
-msgstr "支付成功"
-
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:243
 msgid "Payment processing fee"
 msgstr "付款手续费"
+
+#: components/pages/Purchases/index.tsx:62
+msgid "Payment Successful"
+msgstr "支付成功"
 
 #: components/pages/Project/PayWithBank/index.tsx:161
 #: components/pages/Project/PayWithBank/index.tsx:313
 msgid "Phone number"
 msgstr "电话号码"
-
-#: components/LoginCard/index.tsx:21
-msgid "Please Log In"
-msgstr "请登录"
 
 #: lib/statusMessage.ts:27
 msgid "Please click 'confirm' in your wallet to continue."
@@ -1041,11 +1375,25 @@ msgstr "请点击您钱包中的 \"确认\" 以继续。"
 msgid "Please complete the secure form on the next page and we'll provide you an invoice within 2 business days (upon receiving all required information)."
 msgstr "请填写下一页的安全表格，我们将在 2 个工作日内（收到所有必需信息后）向您提供发票。"
 
+#: components/LoginCard/index.tsx:21
+msgid "Please Log In"
+msgstr "请登录"
+
 #: components/pages/Portfolio/index.tsx:66
 #: components/pages/Users/SellerConnected/index.tsx:75
 #: components/pages/Users/SellerConnected/index.tsx:101
 msgid "Please refresh the page. There was an error updating your data: {e}."
 msgstr "请刷新页面。更新您的数据时出错：{e}。"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:243
+msgid "resources.page.list.search_submit.no_filter_results"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:56
+msgid "menu.portfolio"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:76
 #: components/pages/Portfolio/index.tsx:77
@@ -1064,10 +1412,6 @@ msgstr "新闻稿"
 msgid "Price Highest"
 msgstr "最高价格"
 
-#: components/ProjectFilterModal/constants.tsx:12
-msgid "Price Lowest"
-msgstr "最低价格"
-
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:61
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:98
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:180
@@ -1077,6 +1421,10 @@ msgstr "价格包含网络费用。<0>请参阅文档以了解更多信息</0>"
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:160
 msgid "Price is required"
 msgstr "价格为必填项"
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Price Lowest"
+msgstr "最低价格"
 
 #: components/CreateListing/Transaction/Submit.tsx:62
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:57
@@ -1114,19 +1462,48 @@ msgstr "正在处理碳停用"
 msgid "Profile"
 msgstr "个人资料"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:49
+msgid "menu.profile"
+msgstr ""
+
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:192
 msgid "Profile picture"
 msgstr "头像"
+
+#: components/pages/Retire/Activity/Table.tsx:46
+msgid "PROJECT"
+msgstr "项目"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
+msgid "retirement.single.project_details.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
+msgid "retirement.single.project_name.title"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:253
 #: components/pages/Project/PayWithBank/index.tsx:357
 msgid "Project names of interest"
 msgstr "感兴趣的项目名称"
 
-#: components/pages/Purchases/index.tsx:36
-#: components/pages/Purchases/index.tsx:37
-msgid "Purchase Receipt | Carbonmark"
-msgstr "购买收据 | Carbonmark"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
+msgid "retirement.single.project.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
+msgid "retirement.single.proof_of.title"
+msgstr ""
+
+#: components/pages/Project/Purchase/index.tsx:32
+#: components/pages/Project/Purchase/index.tsx:33
+msgid "Purchase {0} | Carbonmark"
+msgstr "购买 {0} | Carbonmark"
 
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:53
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:73
@@ -1137,6 +1514,11 @@ msgstr "采购量（吨）："
 msgid "Purchase more Carbon"
 msgstr "购买更多的碳"
 
+#: components/pages/Purchases/index.tsx:36
+#: components/pages/Purchases/index.tsx:37
+msgid "Purchase Receipt | Carbonmark"
+msgstr "购买收据 | Carbonmark"
+
 #: components/pages/Projects/Banners/BankTransfer.tsx:79
 msgid "Purchase retirements from any project on Carbonmark and pay via bank transfer."
 msgstr "从 Carbonmark 上的任何项目购买停用碳并通过银行转账支付。"
@@ -1144,11 +1526,6 @@ msgstr "从 Carbonmark 上的任何项目购买停用碳并通过银行转账支
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:84
 msgid "Purchase successful"
 msgstr "购买成功"
-
-#: components/pages/Project/Purchase/index.tsx:32
-#: components/pages/Project/Purchase/index.tsx:33
-msgid "Purchase {0} | Carbonmark"
-msgstr "购买 {0} | Carbonmark"
 
 #: components/pages/Retire/Activity/Table.tsx:47
 msgid "QTY"
@@ -1163,6 +1540,11 @@ msgstr "数量"
 #: components/pages/Project/BuyOptions/SellerListing.tsx:83
 msgid "Quantity Available:"
 msgstr "可用数量："
+
+#. js-lingui-explicit-id
+#: components/pages/Users/Listing/index.tsx:59
+msgid "seller.listing.quantity_available"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:240
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:108
@@ -1180,21 +1562,18 @@ msgstr ""
 msgid "Quantity purchased:"
 msgstr "购买数量："
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
+msgid "retirement.single.quantity.title"
+msgstr ""
+
 #: components/pages/Retire/index.tsx:136
 msgid "Quick Retire"
 msgstr "快速停用碳"
 
-#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
-msgid "RETIRE CARBON"
-msgstr "碳停用"
-
 #: components/pages/Project/index.tsx:198
 msgid "Read Less"
 msgstr "简易阅读"
-
-#: components/pages/Project/index.tsx:198
-msgid "Read More"
-msgstr "阅读更多"
 
 #: components/pages/Home/index.tsx:445
 #: components/pages/Home/index.tsx:472
@@ -1202,6 +1581,10 @@ msgstr "阅读更多"
 #: components/pages/Resources/BlogPostCard/index.tsx:38
 #: components/pages/Resources/FeaturedArticles/Article.tsx:45
 msgid "Read more"
+msgstr "阅读更多"
+
+#: components/pages/Project/index.tsx:198
+msgid "Read More"
 msgstr "阅读更多"
 
 #: components/pages/Home/index.tsx:351
@@ -1220,14 +1603,14 @@ msgstr "剩余供应："
 msgid "Renewable Energy"
 msgstr "再生能源"
 
+#: lib/constants.ts:82
+msgid "Request already processing. Please open your wallet and complete the request."
+msgstr "请求已在处理中。请打开您的钱包并完成请求。"
+
 #: components/pages/Home/index.tsx:301
 #: components/pages/Home/index.tsx:325
 msgid "Request Demo"
 msgstr "请求演示"
-
-#: lib/constants.ts:82
-msgid "Request already processing. Please open your wallet and complete the request."
-msgstr "请求已在处理中。请打开您的钱包并完成请求。"
 
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:210
 msgid "Required Field"
@@ -1237,6 +1620,11 @@ msgstr "必填项目"
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:311
 msgid "Required when proceeding with Credit Card"
 msgstr "使用信用卡时需要"
+
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:83
+msgid "shared.resourcecenter"
+msgstr ""
 
 #: components/Footer/index.tsx:38
 #: components/pages/Home/index.tsx:508
@@ -1264,15 +1652,36 @@ msgstr "结果"
 msgid "Retire"
 msgstr "停用"
 
+#. js-lingui-explicit-id
+#: components/Layout/NavMenu/index.tsx:42
+msgid "menu.retire"
+msgstr ""
+
+#: components/pages/Portfolio/Retire/index.tsx:88
+#: components/pages/Portfolio/Retire/index.tsx:89
+#: components/pages/Retire/index.tsx:38
+#: components/pages/Retire/index.tsx:39
+msgid "Retire | Carbonmark"
+msgstr "碳停用 | Carbonmark"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:388
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:32
 #: components/pages/Project/Retire/Pool/SubmitButton.tsx:43
 msgid "Retire Carbon"
 msgstr "碳停用"
 
+#: components/pages/Project/Retire/Pool/SubmitButton.tsx:57
+msgid "RETIRE CARBON"
+msgstr "碳停用"
+
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:233
 msgid "Retire carbon credits for yourself, or on behalf of another person or organization."
 msgstr "为自己或代表其他人或组织停用碳信用额度。"
+
+#: components/pages/Project/Retire/index.tsx:23
+#: components/pages/Project/Retire/index.tsx:24
+msgid "Retire from {fullProjectid} | Carbonmark"
+msgstr "从 {fullProjectid} 停用 | Carbonmark"
 
 #: components/pages/Retire/index.tsx:72
 msgid "Retire from a featured project"
@@ -1282,23 +1691,18 @@ msgstr "从特色项目中停用碳"
 msgid "Retire from your portfolio"
 msgstr "从你的投资组合中停用碳"
 
-#: components/pages/Project/Retire/index.tsx:23
-#: components/pages/Project/Retire/index.tsx:24
-msgid "Retire from {fullProjectid} | Carbonmark"
-msgstr "从 {fullProjectid} 停用 | Carbonmark"
-
 #: components/pages/Home/index.tsx:232
 msgid "Retire instantly, or purchase and hold digital carbon"
 msgstr "立即停用碳，或购买并持有数字碳"
-
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
-msgid "Retire more Carbon"
-msgstr "停用更多的碳"
 
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:57
 #: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:81
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:59
 msgid "Retire more carbon"
+msgstr "停用更多的碳"
+
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:110
+msgid "Retire more Carbon"
 msgstr "停用更多的碳"
 
 #: components/pages/Project/BuyOptions/PoolPrice.tsx:56
@@ -1314,14 +1718,16 @@ msgstr "现在就停用碳，或者获取数字碳待以后停用 - 当您拥有
 msgid "Retire your carbon via bank transfer."
 msgstr "通过银行转账停用碳。"
 
-#: components/pages/Portfolio/Retire/index.tsx:88
-#: components/pages/Portfolio/Retire/index.tsx:89
-#: components/pages/Retire/index.tsx:38
-#: components/pages/Retire/index.tsx:39
-msgid "Retire | Carbonmark"
-msgstr "碳停用 | Carbonmark"
+#: components/pages/Retire/Activity/Quotes.tsx:73
+msgid "retired"
+msgstr "已停用"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:13
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:90
+msgid "retirement.totals.retired_assets"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:16
 msgid "Retirement"
 msgstr "碳停用"
 
@@ -1329,33 +1735,53 @@ msgstr "碳停用"
 msgid "Retirement Activity"
 msgstr "碳停用活动"
 
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
-msgid "Retirement Message"
-msgstr "停用消息"
-
-#: components/pages/Retire/Activity/Overview.tsx:60
-#: components/pages/Retire/Activity/Overview.tsx:70
-msgid "Retirement Overview"
-msgstr "碳停用概览"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
-msgid "Retirement Successful!"
-msgstr "停用成功！"
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
+msgid "offset.retirement_message"
+msgstr ""
 
 #: components/pages/Project/PayWithBank/index.tsx:264
 #: components/pages/Project/PayWithBank/index.tsx:363
 msgid "Retirement message"
 msgstr "停用消息"
 
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:358
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:301
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:315
+msgid "Retirement Message"
+msgstr "停用消息"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
+msgid "retirement.single.message.title"
+msgstr ""
+
+#: components/pages/Retire/Activity/Overview.tsx:60
+#: components/pages/Retire/Activity/Overview.tsx:70
+msgid "Retirement Overview"
+msgstr "碳停用概览"
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:74
 msgid "Retirement successful"
 msgstr "碳停用成功"
 
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:24
+msgid "Retirement Successful!"
+msgstr "停用成功！"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:106
+msgid "retirement.totals.retirements"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:384
 msgid "Retiring Token"
 msgstr "碳停用代币"
+
+#. js-lingui-explicit-id
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
+msgid "profile.edit_modal.submit"
+msgstr ""
 
 #: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:201
 msgid "Say a few words about yourself. This will be visible in your seller profile."
@@ -1392,6 +1818,11 @@ msgstr "选择"
 msgid "Select a language"
 msgstr "选择语言"
 
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
+msgid "resources.form.categories.subheader"
+msgstr ""
+
 #: components/pages/Portfolio/AssetProject/index.tsx:100
 #: components/pages/Portfolio/AssetProject/index.tsx:108
 msgid "Sell"
@@ -1409,13 +1840,27 @@ msgstr "将您的数字碳直接出售给买家"
 msgid "Seller Listing"
 msgstr "卖家挂牌信息"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:159
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:29
+msgid "Send"
+msgstr ""
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:161
 msgid "Serial Number"
 msgstr "序列号"
 
 #: components/pages/Retirements/RetirementProvenance/index.tsx:76
 msgid "Share this page"
 msgstr "分享此页面"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
+msgid "retirement.single.share_retirement.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:289
+msgid "resources.mobile_modal.button.show_results"
+msgstr ""
 
 #: components/pages/Project/Purchase/Listing/SubmitButton.tsx:31
 #: components/pages/Project/Purchase/Pool/SubmitButton.tsx:31
@@ -1430,6 +1875,19 @@ msgstr "单价为必填项"
 #: components/CreateListing/Form/index.tsx:130
 msgid "Single unit price"
 msgstr "单件单价"
+
+#: components/Layout/index.tsx:51
+msgid "social or email"
+msgstr "社交或电子邮件"
+
+#: components/Activities/Activities.constants.ts:7
+msgid "sold to"
+msgstr "卖给"
+
+#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
+#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
+msgid "something went wrong loading the allowance"
+msgstr "加载津贴时出了点问题"
 
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:108
 msgid "Something went wrong loading the allowance"
@@ -1455,13 +1913,28 @@ msgstr "抱歉，出了一些问题。"
 msgid "Sorry, this handle already exists"
 msgstr "抱歉，此用户名已存在"
 
-#: components/pages/Resources/ResourcesList/index.tsx:265
-msgid "Sort By"
-msgstr "排序方式"
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:222
+msgid "resources.page.list.on_fetch_error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:230
+msgid "resources.page.list.no_search_results.title"
+msgstr ""
 
 #: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "Sort by"
 msgstr "排序方式"
+
+#: components/pages/Resources/ResourcesList/index.tsx:265
+msgid "Sort By"
+msgstr "排序方式"
+
+#. js-lingui-explicit-id
+#: components/pages/Resources/ResourcesList/index.tsx:197
+msgid "shared.resources.sort_by.header"
+msgstr ""
 
 #: components/Stats/index.tsx:23
 msgid "Stats"
@@ -1487,6 +1960,21 @@ msgstr "步骤3"
 msgid "Submit"
 msgstr "提交"
 
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:100
+msgid "transaction_modal.submit.button"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:59
+msgid "transaction_modal.submit.amount"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/Transaction/Submit.tsx:70
+msgid "transaction_modal.submit.price"
+msgstr ""
+
 #: components/pages/Portfolio/CarbonmarkAssets.tsx:88
 msgid "Success! Your new listing will appear in a few moments on your <0>Profile page</0>."
 msgstr "成功！稍后您的新列表将显示在您的 <0> 个人资料页面</0> 上。"
@@ -1499,13 +1987,25 @@ msgstr "当然"
 msgid "Switch to Polygon"
 msgstr "切换到 Polygon"
 
-#: components/BetaBadge/index.tsx:16
-msgid "TESTNET"
-msgstr "测试网"
+#: components/pages/Retire/Activity/Overview.tsx:77
+#: components/pages/Retire/Activity/Quotes.tsx:76
+#: components/pages/Retire/Activity/Table.tsx:65
+msgid "t"
+msgstr "t"
 
 #: components/Footer/index.tsx:29
 msgid "Terms of Use"
 msgstr "使用条款"
+
+#: components/BetaBadge/index.tsx:16
+msgid "TESTNET"
+msgstr "测试网"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
+#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
+msgid "offset.successModal.body2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:66
 msgid "Thank you for supporting the planet!"
@@ -1515,21 +2015,32 @@ msgstr "感谢您对地球的支持！"
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr "感谢您对地球的支持！请参阅下面的购买详细信息。"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
+msgid "offset.successModal.body1"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:292
 msgid "Thank you for supporting the planet! We'll reach out soon to confirm some details and provide you with an with an invoice."
 msgstr "感谢您对地球的支持！我们将尽快与您联系以确认一些详细信息并向您提供发票。"
-
-#: components/pages/Home/index.tsx:65
-msgid "The Universal Carbon Marketplace"
-msgstr "通用碳市场"
 
 #: components/CreateListing/Transaction/Approve.tsx:44
 msgid "The assets will only be transferred out of your wallet when a sale is completed. You can revoke this allowance at any time."
 msgstr "资产只会在销售完成时从您的钱包中转出。您可以随时撤销此授权。"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
+msgid "transaction_modal.approve.allow_amount_2"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:34
 msgid "The first step is to grant the approval to transfer your carbon asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your retirement."
 msgstr "第一步是批准将您的碳资产从您的钱包转移到 Carbonmark，下一步是批准实际转移并完成您的碳停用。"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
+msgid "purchase.approval_2"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:35
 msgid "The first step is to grant the approval to transfer your payment asset from your wallet to Carbonmark, the next step is to approve the actual transfer and complete your purchase."
@@ -1538,6 +2049,12 @@ msgstr "第一步是批准将您的支付资产从您的钱包转移到 Carbonma
 #: components/pages/Portfolio/Retire/RetireForm/index.tsx:239
 msgid "The information below will be broadcast publicly to verify your environmental claim. This transaction is permanent; the information cannot be changed once your transaction is complete."
 msgstr "以下信息将公开广播以验证您的环保声明。该交易是永久性的；一旦您的交易完成，信息将无法更改。"
+
+#. Long sentence
+#. js-lingui-explicit-id
+#: components/pages/Blog/Post/index.tsx:100
+msgid "blog.disclaimer.description"
+msgstr ""
 
 #: components/pages/Home/index.tsx:53
 #: components/pages/Home/index.tsx:68
@@ -1577,13 +2094,27 @@ msgstr "每吨最低价格为 {0}"
 msgid "The minimum quantity to sell is 1 tonne"
 msgstr "最低销售量为 1 吨"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
+msgid "transaction_modal.submit.confirm_transaction_1"
+msgstr ""
+
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:53
 msgid "The previous step granted the approval to transfer your carbon asset from your wallet to Carbonmark, your retirement has not been completed yet."
 msgstr "上一步已批准将您的碳资产从您的钱包转移到 Carbonmark，您的碳停用尚未完成。"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
+msgid "purchase.submit_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:64
 msgid "The previous step granted the approval to transfer your payment asset from your wallet to Carbonmark."
 msgstr "上一步已批准将您的支付资产从您的钱包转移到 Carbonmark。"
+
+#: components/pages/Home/index.tsx:65
+msgid "The Universal Carbon Marketplace"
+msgstr "通用碳市场"
 
 #: components/pages/Project/Retire/Pool/RetireForm.tsx:208
 msgid "There was an error during the checkout process. Please try again."
@@ -1606,6 +2137,11 @@ msgstr "加载总费用时出错。"
 msgid "This app only works on Polygon Mainnet."
 msgstr "此应用程序仅适用于 Polygon 主网。"
 
+#. js-lingui-explicit-id
+#: components/LoginCard/index.tsx:24
+msgid "user.login.description"
+msgstr ""
+
 #: components/pages/Portfolio/Retire/UnregisteredMessage/index.tsx:12
 msgid "This is your portfolio. Here you will find supported carbon assets you own. Assets shown here can be retired or listed for sale in the marketplace once you have a profile."
 msgstr "这是您的投资组合。您可以在这里找到您拥有的受支持的碳资产。一旦您拥有个人资料，此处显示的资产就可以停用碳或在市场上挂牌出售。"
@@ -1626,13 +2162,27 @@ msgstr "此优惠已不存在。"
 msgid "This product is still in Beta and audits have not been completed yet."
 msgstr "该产品仍处于测试阶段，审核尚未完成。"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
+msgid "retirement.single.immutable_public_records.title"
+msgstr ""
+
 #: components/pages/Users/ProfileHeader/index.tsx:46
 msgid "This user has not yet created a carbonmark profile."
 msgstr "该用户尚未创建Carbonmark个人资料"
 
+#: components/Activities/Activity.tsx:119
+msgid "to"
+msgstr "到/去"
+
 #: components/pages/Project/Retire/Pool/CreditCardModal.tsx:29
 msgid "To complete your credit card transaction, you will be redirected to Stripe, our payment processing partner."
 msgstr "为了完成您的信用卡交易，您将被重新定向到我们的支付处理合作伙伴 Stripe上。"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
+msgid "transaction_modal.submit.confirm_transaction_2"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:60
 msgid "To finalize your retirement, verify all information is correct and then click 'submit' below."
@@ -1646,22 +2196,22 @@ msgstr "首先，请务必填写您的<0>个人资料</0>然后前往<1>市场</
 msgid "To pay via bank transfer, we'll need to gather some information from you."
 msgstr "要通过银行转帐方式支付，我们需要收集您的一些信息。"
 
-#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
-msgid "Toggle Select Project"
-msgstr "Toggle 选择项目"
-
-#: components/pages/Resources/SortyByDropDown/index.tsx:63
-msgid "Toggle Sorted by menu"
-msgstr "切换按菜单排序"
-
 #: components/pages/Project/Purchase/Listing/PurchaseInputs.tsx:106
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:126
 msgid "Toggle payment method"
 msgstr "切换付款方式"
 
+#: components/CreateListing/Form/ProjectTokenDropDown/index.tsx:70
+msgid "Toggle Select Project"
+msgstr "Toggle 选择项目"
+
 #: components/pages/Projects/ProjectSort/index.tsx:29
 msgid "Toggle sort menu"
 msgstr "切换排序菜单"
+
+#: components/pages/Resources/SortyByDropDown/index.tsx:63
+msgid "Toggle Sorted by menu"
+msgstr "切换按菜单排序"
 
 #: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:209
 #: components/pages/Project/Purchase/Pool/PurchaseForm.tsx:209
@@ -1671,6 +2221,10 @@ msgstr "您将收到的代币"
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:59
 msgid "Tokens received:"
 msgstr "收到的代币："
+
+#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
+msgid "tonnes"
+msgstr "吨"
 
 #: components/AssetDetails/index.tsx:63
 #: components/pages/Project/PayWithBank/index.tsx:125
@@ -1691,22 +2245,6 @@ msgstr "列出的吨数："
 msgid "Tonnes sold:"
 msgstr "售出吨数："
 
-#: components/CreateListing/Form/index.tsx:85
-msgid "Total Amount to Sell is required"
-msgstr "销售总额为必填项"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
-msgid "Total Cost is required"
-msgstr "总成本为必填项"
-
-#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
-msgid "Total Price"
-msgstr "总价"
-
-#: components/Stats/StatsBar.tsx:35
-msgid "Total Retirements:"
-msgstr "总碳停用"
-
 #: components/CreateListing/Transaction/Approve.tsx:61
 msgid "Total allowance"
 msgstr "总授权额"
@@ -1715,9 +2253,18 @@ msgstr "总授权额"
 msgid "Total amount of tonnes to retire is required"
 msgstr "总停用碳吨量为必填项"
 
+#: components/CreateListing/Form/index.tsx:85
+msgid "Total Amount to Sell is required"
+msgstr "销售总额为必填项"
+
 #: components/pages/Retire/Activity/Overview.tsx:72
 msgid "Total carbon tonnes retired"
 msgstr "停用总碳吨"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:98
+msgid "retirement.totals.total_carbon_tonnes"
+msgstr ""
 
 #: components/pages/Project/Purchase/Listing/TotalValues.tsx:103
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:142
@@ -1725,9 +2272,17 @@ msgstr "停用总碳吨"
 msgid "Total cost"
 msgstr "总成本"
 
+#: components/pages/Project/Retire/Pool/RetireInputs.tsx:469
+msgid "Total Cost is required"
+msgstr "总成本为必填项"
+
 #: components/pages/Project/Purchase/Pool/TotalValues.tsx:84
 #: components/pages/Project/Retire/Pool/TotalValues.tsx:166
 msgid "Total price"
+msgstr "总价"
+
+#: components/pages/Project/Purchase/Listing/TotalValues.tsx:46
+msgid "Total Price"
 msgstr "总价"
 
 #: components/pages/Users/SellerConnected/Forms/EditListing.tsx:103
@@ -1738,6 +2293,15 @@ msgstr "待售总数量"
 msgid "Total retirement transactions"
 msgstr "停用碳交易总额"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/index.tsx:112
+msgid "retirement.totals.total_retirement_transactions"
+msgstr ""
+
+#: components/Stats/StatsBar.tsx:35
+msgid "Total Retirements:"
+msgstr "总碳停用"
+
 #: components/pages/Project/Purchase/Pool/SuccessScreen.tsx:78
 #: components/pages/Project/Retire/Pool/SuccessScreen.tsx:82
 msgid "Total sale cost"
@@ -1747,25 +2311,32 @@ msgstr "总销售成本"
 msgid "Transaction complete."
 msgstr "交易完成。"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
+msgid "retirement.single.transaction_id.title"
+msgstr ""
+
 #: lib/statusMessage.ts:29
 msgid "Transaction initiated. Waiting for network confirmation."
 msgstr "交易已启动。等待网络确认。"
 
-#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:24
+#: components/pages/Retirements/RetirementProvenance/RetirementProvenance.constants.tsx:48
 msgid "Transfer"
 msgstr "转账"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/RetirementProvenance/index.tsx:50
+msgid "retirement.provenance.head.metaDescription"
+msgstr ""
 
 #: components/pages/Retirements/SingleRetirement/index.tsx:128
 msgid "Transparent, on-chain offsets powered by Carbonmark."
 msgstr "由 Carbonmark 提供支持的完全透明的链上抵消。"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
-msgid "USDC per ton"
-msgstr "USDC / 吨"
-
-#: components/CreateListing/Form/index.tsx:110
-msgid "USDC per tonne"
-msgstr "USDC 每吨"
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
+msgid "retirement.single.type.title"
+msgstr ""
 
 #: components/CreateListing/Form/index.tsx:115
 msgid "Unit price is required"
@@ -1783,6 +2354,18 @@ msgstr "整个数字碳市场前所未有的透明度。"
 msgid "Update listing"
 msgstr "更新挂牌信息"
 
+#: components/Activities/Activities.constants.ts:10
+msgid "updated expiration"
+msgstr "更新已到期"
+
+#: components/Activities/Activities.constants.ts:8
+msgid "updated price"
+msgstr "更新价格"
+
+#: components/Activities/Activities.constants.ts:9
+msgid "updated quantity"
+msgstr "更新数量"
+
 #: components/pages/Project/BuyOptions/SellerListing.tsx:91
 msgid "Updated:"
 msgstr "已更新："
@@ -1790,6 +2373,14 @@ msgstr "已更新："
 #: components/pages/Users/SellerConnected/index.tsx:191
 msgid "Updating your data..."
 msgstr "正在更新您的数据..."
+
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:136
+msgid "USDC per ton"
+msgstr "USDC / 吨"
+
+#: components/CreateListing/Form/index.tsx:110
+msgid "USDC per tonne"
+msgstr "USDC 每吨"
 
 #: components/pages/Resources/lib/cmsDataMap.ts:61
 msgid "User Guides"
@@ -1804,6 +2395,21 @@ msgstr "用户资料 | Carbonmark"
 msgid "User refused connection."
 msgstr "用户拒绝连接。"
 
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
+msgid "retirement.single.verified_tonnes.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
+msgid "transaction_modal.approve.allow_amount_3"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
+msgid "purchase.approval_4"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:52
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:41
 msgid "Verify all information is correct and click 'approve' to continue."
@@ -1813,17 +2419,9 @@ msgstr "验证所有信息是否正确，然后单击“批准”以继续。"
 msgid "View"
 msgstr "查看"
 
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
-msgid "View Carbonmark Profile"
-msgstr "查看 Carbonmark 配置文件"
-
-#: components/pages/Project/index.tsx:207
-msgid "View Registry Details <0/>"
-msgstr "查看注册表详细信息 <0/>"
-
-#: components/ProjectFilterModal/index.tsx:154
-msgid "View Results"
-msgstr "查看结果"
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
+msgid "View {numberOfTransfers} transactions"
+msgstr ""
 
 #: components/pages/Portfolio/index.tsx:78
 msgid "View a complete overview of the digital carbon that you own in your Portfolio."
@@ -1858,9 +2456,17 @@ msgstr "在 Carbonmark 上查看和购买此碳抵消项目"
 msgid "View and share certificate"
 msgstr "查看和共享证书"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:180
+#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:54
+msgid "View Carbonmark Profile"
+msgstr "查看 Carbonmark 配置文件"
+
+#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:183
 msgid "View issuance on Verra"
 msgstr "查看 Verra 上的发行情况"
+
+#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
+msgid "View on Polygonscan"
+msgstr "在 Polygonscan 上查看"
 
 #: components/AssetDetails/index.tsx:69
 msgid "View on PolygonScan"
@@ -1870,9 +2476,13 @@ msgstr "在 PolygonScan 上查看"
 msgid "View on PolygonScan <0/>"
 msgstr "在 PolygonScan <0/> 上查看"
 
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:135
-msgid "View on Polygonscan"
-msgstr "在 Polygonscan 上查看"
+#: components/pages/Project/index.tsx:207
+msgid "View Registry Details <0/>"
+msgstr "查看注册表详细信息 <0/>"
+
+#: components/ProjectFilterModal/index.tsx:154
+msgid "View Results"
+msgstr "查看结果"
 
 #: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:99
 msgid "View retirement"
@@ -1886,9 +2496,10 @@ msgstr "查看整个交易历史记录——从桥接事件到碳停用——以
 msgid "View the project details and other info for this purchase."
 msgstr "查看此次购买的项目详情和其他信息。"
 
-#: components/pages/Retirements/RetirementProvenance/ProvenanceTimeline/index.tsx:50
-msgid "View {numberOfTransfers} transfers"
-msgstr "查看 {numberOfTransfers} 转账"
+#. js-lingui-explicit-id
+#: components/pages/Purchases/index.tsx:145
+msgid "purchase.button.view_assets"
+msgstr ""
 
 #: components/ProjectFilterModal/index.tsx:141
 msgid "Vintage"
@@ -1901,6 +2512,11 @@ msgstr "最新的历史减排效益"
 #: components/ProjectFilterModal/constants.tsx:15
 msgid "Vintage Oldest"
 msgstr "最早的历史减排效益"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
+msgid "retirement.single.vintage.title"
+msgstr ""
 
 #: components/pages/Purchases/index.tsx:66
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
@@ -1922,12 +2538,22 @@ msgstr "我们根据价格、真实性和全球环境影响等严格标准精心
 msgid "What is Carbonmark? Answers to common questions about the Digital Carbon Market interface that easily connects buyers and sellers of verified carbon credits."
 msgstr "什么是Carbonmark？解答有关数字碳市场界面的常见问题，该界面可轻松连接经过验证的碳信用额的买家和卖家。"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
+msgid "offset.retirement_credit"
+msgstr ""
+
 #: components/pages/Project/PayWithBank/index.tsx:224
 #: components/pages/Project/PayWithBank/index.tsx:343
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:257
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:271
 msgid "Who will this retirement be credited to?"
 msgstr "本次碳停用将归功于谁？"
+
+#. js-lingui-explicit-id
+#: components/pages/Retirements/Footer/index.tsx:17
+msgid "retirement.footer.about_carbonmark.content"
+msgstr ""
 
 #: components/shared/InvalidNetworkModal/index.tsx:64
 msgid "Wrong Network"
@@ -1939,9 +2565,19 @@ msgstr "网络错误"
 msgid "You"
 msgstr "您"
 
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
+msgid "purchase.approval_1"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:32
 msgid "You are about to purchase a carbon asset."
 msgstr "您即将购买一项碳资产。"
+
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
+msgid "transaction_modal.approve.allow_amount_1"
+msgstr ""
 
 #: components/pages/Project/Retire/Pool/RetireModal.tsx:31
 msgid "You are about to retire a carbon asset."
@@ -1989,13 +2625,10 @@ msgstr "您必须先创建个人资料，才能在 Carbonmark 投资组合中查
 msgid "You successfully acquired carbon!"
 msgstr "您已成功获得了碳！"
 
-#: components/pages/Users/SellerConnected/index.tsx:221
-msgid "Your Profile"
-msgstr "您的个人资料"
-
-#: components/Layout/AddressSection/index.tsx:26
-msgid "Your Wallet Address:"
-msgstr "您的钱包地址："
+#. js-lingui-explicit-id
+#: components/ExitModal/index.tsx:16
+msgid "exitmodal.you_will_be_taken"
+msgstr ""
 
 #: components/pages/Project/Purchase/Pool/PurchaseInputs.tsx:159
 #: components/pages/Project/Retire/Pool/RetireInputs.tsx:412
@@ -2012,6 +2645,15 @@ msgstr "您的余额："
 msgid "Your display name"
 msgstr "您的显示名称"
 
+#: components/pages/Users/SellerConnected/index.tsx:221
+msgid "Your Profile"
+msgstr "您的个人资料"
+
+#. js-lingui-explicit-id
+#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
+msgid "purchase.submit_2"
+msgstr ""
+
 #: components/pages/Project/Purchase/Pool/PurchaseModal.tsx:70
 msgid "Your purchase has not been completed yet. To finalize your purchase, verify all information is correct and then click 'submit' below."
 msgstr "您的购买尚未完成。要完成您的购买，请验证所有信息是否正确，然后单击下面的“提交”。"
@@ -2021,6 +2663,11 @@ msgstr "您的购买尚未完成。要完成您的购买，请验证所有信息
 msgid "Your seller data"
 msgstr "您的卖家数据"
 
+#. js-lingui-explicit-id
+#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
+msgid "offset.successModal.body3"
+msgstr ""
+
 #: components/pages/Retirements/SingleRetirement/index.tsx:84
 msgid "Your transaction was successful, but the network is taking longer than expected to process the data. Your retirement details should appear here in just a few seconds!"
 msgstr "您的交易已成功，但网络处理数据的时间比预期要长。您的停用碳的详细信息将在几秒钟内出现在此处！"
@@ -2029,6 +2676,10 @@ msgstr "您的交易已成功，但网络处理数据的时间比预期要长。
 msgid "Your unique handle"
 msgstr "您的唯一用户名"
 
+#: components/Layout/AddressSection/index.tsx:26
+msgid "Your Wallet Address:"
+msgstr "您的钱包地址："
+
 #: components/pages/Resources/lib/cmsDataMap.ts:82
 msgid "Z-A"
 msgstr "Z - A"
@@ -2036,540 +2687,3 @@ msgstr "Z - A"
 #: components/pages/Home/index.tsx:437
 msgid "Zero-fee carbon credit trading - instantaneous, transparent, and always available. Learn more about what Carbonmark can do for you as a carbon credit trader."
 msgstr "零费用碳信用额交易 — 即时、透明且始终可用。详细了解 Carbonmark可以为作为交易者的您，提供哪些碳信用服务。"
-
-#: components/Activities/Activity.tsx:34
-msgid "at"
-msgstr "在"
-
-#. Long sentence
-#: components/pages/Blog/Post/index.tsx:100
-msgid "blog.disclaimer.description"
-msgstr "本博文中提供的有关 KlimaDAO（“KlimaDAO”）、其加密资产、商业资产、战略和运营的信息仅供一般参考之用，并非正式的出售要约或要约邀请在任何司法管辖区购买与证券相关的任何证券、期权、期货或其他衍生品，其内容不受证券法的规定。本博文中包含的信息不应被视为购买或出售或持有此类证券的建议或出售此类证券的要约。本博文不考虑也不提供关于任何人的具体投资目标或财务状况的任何税务、法律或投资建议或意见。 KlimaDAO 及其代理人、顾问、董事、管理人员、员工和股东对此类信息的准确性不作任何明示或暗示的陈述或保证，且 KlimaDAO 明确否认可能基于此类信息或错误或遗漏的任何和所有责任。 KlimaDAO 保留随时部分或全部修改或替换此处包含的信息的权利，并且不承担向接收者提供访问修改后的信息或通知接收者的义务。本博文中包含的信息将取代之前任何关于相同、相似或相关信息的博文或对话。不得出于任何目的依赖此处未包含的任何信息、陈述或声明。 KlimaDAO 或其任何代表，均不对您或任何人因您或您的任何代表使用本博客文章中的信息或遗漏而导致的合同、侵权、信托或其他方式产生的结果承担任何责任。此外，KlimaDAO 不承担评论第三方对本博文中讨论的事项的期望或声明的义务。"
-
-#: components/pages/Blog/Post/index.tsx:97
-msgid "blog.disclaimer.title"
-msgstr "免责声明："
-
-#: components/Activities/Activities.constants.ts:6
-msgid "bought from"
-msgstr "买自"
-
-#: components/Layout/index.tsx:52
-msgid "connect a wallet"
-msgstr "连接钱包"
-
-#: components/Activities/Activities.constants.ts:4
-msgid "created listing"
-msgstr "创建列表"
-
-#: components/Activities/Activities.constants.ts:5
-msgid "deleted listing"
-msgstr "删除列表"
-
-#: components/pages/Project/Purchase/Listing/Price.tsx:18
-#: components/pages/Project/Purchase/Pool/Price.tsx:17
-#: components/pages/Project/Retire/Pool/Price.tsx:17
-msgid "each"
-msgstr "每个"
-
-#: components/ExitModal/index.tsx:22
-msgid "exitmodal.after_you_click"
-msgstr "单击下面的按钮继续后，系统会要求您连接钱包，且您在此处选择的项目已经在 KlimaDAO.finance 上了。然后按照该页面上的说明完成您的交易。"
-
-#: components/ExitModal/index.tsx:31
-msgid "exitmodal.carbon_credits_you_purchase"
-msgstr "您在 KlimaDAO.finance 上购买的碳信用额度或停用碳，都可以在您的 Carbonmark 投资组合中访问。"
-
-#: components/ExitModal/index.tsx:16
-msgid "exitmodal.you_will_be_taken"
-msgstr "您将被带到 KlimaDAO.finance 界面以完成此交易。"
-
-#: components/Activities/Activity.tsx:112
-msgid "for"
-msgstr "为了"
-
-#: components/pages/Retire/index.tsx:52
-msgid "for beneficiary"
-msgstr "为受益人"
-
-#: components/Layout/NavMenu/index.tsx:35
-msgid "menu.marketplace"
-msgstr "市场"
-
-#: components/Layout/NavMenu/index.tsx:56
-msgid "menu.portfolio"
-msgstr "投资组合"
-
-#: components/Layout/NavMenu/index.tsx:49
-msgid "menu.profile"
-msgstr "个人资料"
-
-#: components/Layout/NavMenu/index.tsx:42
-msgid "menu.retire"
-msgstr "停用"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:255
-msgid "offset.amount_in_tonnes"
-msgstr "您想抵消多少吨碳？ <0>*</0>"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:338
-msgid "offset.default_retirement_address"
-msgstr "默认的已连接钱包地址"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:416
-msgid "offset.retire_carbon"
-msgstr "确认退休"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:294
-msgid "offset.retirement_credit"
-msgstr "本次碳停用将归功于谁？"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:347
-msgid "offset.retirement_message"
-msgstr "停用消息"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:63
-msgid "offset.successModal.body1"
-msgstr "感谢您对地球的支持！在 <0> PolygonScan </0> 上查看交易"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:33
-#: components/pages/Project/Retire/Pool/SuccessScreen.tsx:30
-msgid "offset.successModal.body2"
-msgstr "感谢您对地球的支持！"
-
-#: components/pages/Portfolio/Retire/RetirementStatusModal/index.tsx:38
-msgid "offset.successModal.body3"
-msgstr "您的交易已成功处理，但索引所需的时间比正常情况要长。很快它将出现在您的<0>停用碳</0>栏中。"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:376
-msgid "offset_disclaimer"
-msgstr "请注意不要在您的碳停用姓名或消息中包含任何敏感的个人信息（例如电子邮件地址）。您在此处输入的信息一旦提交将无法更改，并将永久存在于公共区块链上。"
-
-#: components/pages/Portfolio/Balances/index.tsx:49
-msgid "portfolio.balances.title"
-msgstr "余额"
-
-#: components/CreateListing/Form/index.tsx:136
-msgid "profile.addListing_modal.submit"
-msgstr "创建挂牌"
-
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:223
-msgid "profile.edit_modal.submit"
-msgstr "保存更改"
-
-#: components/pages/Users/ProfileHeader/index.tsx:54
-msgid "profile.edit_your_profile"
-msgstr "编辑您的个人资料以添加描述。"
-
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:221
-msgid "profile.listing.edit.delete_listing"
-msgstr "删除挂牌"
-
-#: components/pages/Purchases/index.tsx:49
-msgid "project.single.button.back_to_project_details"
-msgstr "返回项目详情"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:30
-msgid "purchase.approval_1"
-msgstr "您即将购买一项碳资产。"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:35
-msgid "purchase.approval_2"
-msgstr "第一步是批准将您的支付资产从您的钱包转移到 Carbonmark，下一步是批准实际转移并完成您的购买。"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:42
-msgid "purchase.approval_3"
-msgstr "您购买的碳资产可随时从您的<0>投资组合</0>中挂牌，在Carbonmark上出售"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:52
-msgid "purchase.approval_4"
-msgstr "验证所有信息是否正确，然后单击“批准”以继续。"
-
-#: components/pages/Purchases/index.tsx:145
-msgid "purchase.button.view_assets"
-msgstr "查看您的资产"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:64
-msgid "purchase.submit_1"
-msgstr "上一步已批准将您的支付资产从您的钱包转移到 Carbonmark。"
-
-#: components/pages/Project/Purchase/Listing/PurchaseModal.tsx:70
-msgid "purchase.submit_2"
-msgstr "您的购买尚未完成。要完成您的购买，请验证所有信息是否正确，然后单击下面的“提交”。"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:22
-msgid "resources.form.categories.header"
-msgstr "类别"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:25
-msgid "resources.form.categories.subheader"
-msgstr "选择一个或多个"
-
-#: components/pages/Resources/ResourcesFilters/index.tsx:39
-msgid "resources.form.filters.clear_all"
-msgstr "全部清除"
-
-#: components/pages/Resources/ResourcesList/index.tsx:289
-msgid "resources.mobile_modal.button.show_results"
-msgstr "显示结果"
-
-#: components/pages/Resources/ResourcesList/index.tsx:230
-msgid "resources.page.list.no_search_results.title"
-msgstr "对不起。我们找不到任何匹配的结果。"
-
-#: components/pages/Resources/ResourcesList/index.tsx:222
-msgid "resources.page.list.on_fetch_error"
-msgstr "对不起！出问题了。"
-
-#: components/pages/Resources/ResourcesList/index.tsx:243
-msgid "resources.page.list.search_submit.no_filter_results"
-msgstr "请组合使用不同的过滤器。"
-
-#: components/pages/Resources/ResourcesList/index.tsx:236
-msgid "resources.page.list.search_submit.no_search_results"
-msgstr "检查您的搜索是否有错别字或尝试不同的搜索词。"
-
-#: components/pages/Portfolio/Retire/RetireForm/index.tsx:394
-msgid "retire.back_button"
-msgstr "返回"
-
-#: components/pages/Retire/Activity/Quotes.tsx:73
-msgid "retired"
-msgstr "已停用"
-
-#: components/pages/Retirements/Footer/index.tsx:17
-msgid "retirement.footer.about_carbonmark.content"
-msgstr "Carbonmark 拥有来自数百个项目的超过 2000 万个经过验证的数字碳信用额度，提供全球范围内最多的数字碳信用额度选择。通过零佣金交易立即从任何项目购买、出售和停用数字碳。 <0>今天开始</0>."
-
-#: components/pages/Retirements/Footer/index.tsx:11
-msgid "retirement.footer.about_carbonmark.title"
-msgstr "关于 Carbonmark"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:124
-msgid "retirement.head.metaTitle"
-msgstr "{retiree} 停用的 {formattedAmount} 碳吨数"
-
-#: components/pages/Retirements/SingleRetirement/index.tsx:120
-msgid "retirement.head.title"
-msgstr "Carbonmark | 碳停用收据"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:50
-msgid "retirement.provenance.head.metaDescription"
-msgstr "由 Carbonmark 提供支持的完全透明的链上抵消。"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:46
-msgid "retirement.provenance.head.metaTitle"
-msgstr "{retiree} 停用的 {formattedAmount} 碳吨数"
-
-#: components/pages/Retirements/RetirementProvenance/index.tsx:42
-msgid "retirement.provenance.head.title"
-msgstr "Carbonmark | 停用碳来源"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:43
-msgid "retirement.single.beneficiary.placeholder"
-msgstr "未提供受益人姓名"
-
-#: components/pages/Retirements/SingleRetirement/BeneficiaryDetails/index.tsx:39
-msgid "retirement.single.beneficiary.title"
-msgstr "受益人："
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:34
-msgid "retirement.single.beneficiary_address.title"
-msgstr "受益人地址："
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:17
-msgid "retirement.single.carbon_credit_retirement.title"
-msgstr "碳信用停用"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:88
-msgid "retirement.single.country_region.title"
-msgstr "国家/地区："
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:123
-msgid "retirement.single.immutable_public_records.title"
-msgstr "这代表数字碳资产的永久停用。该碳停用和相关数据是不可变的公共记录。"
-
-#: components/pages/Retirements/SingleRetirement/RetirementMessage/index.tsx:13
-msgid "retirement.single.message.title"
-msgstr "碳停用信息："
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:74
-msgid "retirement.single.methodology.title"
-msgstr "方法："
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:31
-msgid "retirement.single.moss_offset.description"
-msgstr "MC02 积分由保护亚马逊森林的项目产生，具有各种积极的外部性，比如创造当地就业机会和保护当地生物多样性。在 <0>data.klimadao.finance </0> 上探索 MCO2。"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:73
-msgid "retirement.single.moss_offset.name"
-msgstr "MOSS 地球 MC02"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:116
-msgid "retirement.single.official_certificate.title"
-msgstr "<0>Carbonmark.com</0> 提供的链上碳排放官方证书"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:58
-msgid "retirement.single.project.title"
-msgstr "项目："
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:84
-msgid "retirement.single.project_description.title"
-msgstr "描述"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:44
-msgid "retirement.single.project_details.title"
-msgstr "项目详情"
-
-#: components/pages/Retirements/SingleRetirement/ProjectDetails/index.tsx:67
-msgid "retirement.single.project_name.title"
-msgstr "项目名称"
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:14
-msgid "retirement.single.proof_of.title"
-msgstr "...的证明"
-
-#: components/pages/Retirements/SingleRetirement/RetirementValue/index.tsx:17
-msgid "retirement.single.quantity.title"
-msgstr "停用的数量"
-
-#: components/pages/Retirements/SingleRetirement/ShareDetails/index.tsx:27
-msgid "retirement.single.share_retirement.title"
-msgstr "分享这个碳停用"
-
-#: components/pages/Retirements/SingleRetirement/RetirementDate/index.tsx:28
-msgid "retirement.single.timestamp.placeholder"
-msgstr "未提供碳停用时间戳"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:45
-msgid "retirement.single.transaction_id.title"
-msgstr "交易ID"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:27
-msgid "retirement.single.transaction_record.title"
-msgstr "不可变的交易记录"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:66
-msgid "retirement.single.type.title"
-msgstr "类型："
-
-#: components/pages/Retirements/SingleRetirement/RetirementHeader/index.tsx:27
-msgid "retirement.single.verified_tonnes.title"
-msgstr "核实停用碳吨数"
-
-#: components/pages/Retirements/SingleRetirement/TransactionDetails/index.tsx:101
-msgid "retirement.single.vintage.title"
-msgstr "历史减排效益："
-
-#: components/pages/Retirements/List/index.tsx:40
-msgid "retirement.totals.all_retirements_list.empty"
-msgstr "未找到碳停用信息"
-
-#: components/pages/Retirements/List/index.tsx:24
-msgid "retirement.totals.all_retirements_list.headline"
-msgstr "所有停用"
-
-#: components/pages/Retirements/index.tsx:45
-msgid "retirement.totals.head.metaTitle"
-msgstr "Carbonmark - 受益人的碳停用 {0}"
-
-#: components/pages/Retirements/index.tsx:39
-msgid "retirement.totals.head.title"
-msgstr "Carbonmark - 受益人的碳停用 {0}"
-
-#: components/pages/Retirements/index.tsx:60
-msgid "retirement.totals.page_headline"
-msgstr "碳停用"
-
-#: components/pages/Retirements/index.tsx:66
-msgid "retirement.totals.page_subline"
-msgstr "为受益人"
-
-#: components/pages/Retirements/index.tsx:90
-msgid "retirement.totals.retired_assets"
-msgstr "已停用的资产"
-
-#: components/pages/Retirements/index.tsx:106
-msgid "retirement.totals.retirements"
-msgstr "碳停用"
-
-#: components/pages/Retirements/index.tsx:98
-msgid "retirement.totals.total_carbon_tonnes"
-msgstr "总碳退休吨数"
-
-#: components/pages/Retirements/index.tsx:112
-msgid "retirement.totals.total_retirement_transactions"
-msgstr "总碳停用交易"
-
-#: components/pages/Users/SellerUnconnected/index.tsx:70
-msgid "seller.listing.buy"
-msgstr "购买"
-
-#: components/pages/Users/Listing/index.tsx:59
-msgid "seller.listing.quantity_available"
-msgstr "可用数量："
-
-#: components/pages/Blog/Post/index.tsx:83
-msgid "shared.resourcecenter"
-msgstr "资源中心"
-
-#: components/pages/Resources/ResourcesList/index.tsx:197
-msgid "shared.resources.sort_by.header"
-msgstr "排序方式："
-
-#: components/Layout/index.tsx:51
-msgid "social or email"
-msgstr "社交或电子邮件"
-
-#: components/Activities/Activities.constants.ts:7
-msgid "sold to"
-msgstr "卖给"
-
-#: components/pages/Project/Purchase/Listing/PurchaseForm.tsx:105
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:261
-msgid "something went wrong loading the allowance"
-msgstr "加载津贴时出了点问题"
-
-#: components/pages/Retire/Activity/Overview.tsx:77
-#: components/pages/Retire/Activity/Quotes.tsx:76
-#: components/pages/Retire/Activity/Table.tsx:65
-msgid "t"
-msgstr "t"
-
-#: components/Activities/Activity.tsx:119
-msgid "to"
-msgstr "到/去"
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:40
-msgid "tonnes"
-msgstr "吨"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:52
-msgid "transaction_modal.approve.allow_amount_1"
-msgstr "您即将停用一项碳资产。"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:57
-msgid "transaction_modal.approve.allow_amount_2"
-msgstr "第一步是批准将您的碳资产从您的钱包转移到 Carbonmark，下一步是批准实际转移并完成您的碳停用。"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:64
-msgid "transaction_modal.approve.allow_amount_3"
-msgstr "验证所有信息是否正确，然后单击“批准”以继续。"
-
-#: components/Transaction/Approve.tsx:57
-msgid "transaction_modal.approve.amount"
-msgstr "确认金额"
-
-#: components/Transaction/Approve.tsx:47
-msgid "transaction_modal.approve.contract_address"
-msgstr "合约地址"
-
-#: components/Transaction/Approve.tsx:71
-msgid "transaction_modal.approve.price"
-msgstr "确认每吨价格"
-
-#: components/CreateListing/Transaction/index.tsx:83
-#: components/Transaction/index.tsx:84
-msgid "transaction_modal.button.go_back"
-msgstr "返回"
-
-#: components/Transaction/Submit.tsx:108
-msgid "transaction_modal.close"
-msgstr "关闭"
-
-#: components/Transaction/Approve.tsx:108
-msgid "transaction_modal.next"
-msgstr "下一步"
-
-#: components/Transaction/Submit.tsx:59
-msgid "transaction_modal.submit.amount"
-msgstr "提交金额"
-
-#: components/Transaction/Submit.tsx:100
-msgid "transaction_modal.submit.button"
-msgstr "提交"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:76
-msgid "transaction_modal.submit.confirm_transaction_1"
-msgstr "上一步已批准将您的碳资产从您的钱包转移到 Carbonmark，您的碳停用尚未完成。"
-
-#: components/pages/Portfolio/Retire/RetireModal/index.tsx:83
-msgid "transaction_modal.submit.confirm_transaction_2"
-msgstr "要完成您的碳停用，请验证所有信息是否正确，然后单击下面的“提交”。"
-
-#: components/Transaction/Submit.tsx:48
-msgid "transaction_modal.submit.contract_address"
-msgstr "合约地址"
-
-#: components/Transaction/Submit.tsx:70
-msgid "transaction_modal.submit.price"
-msgstr "提交每吨价格："
-
-#: components/CreateListing/Transaction/index.tsx:47
-#: components/Transaction/index.tsx:45
-msgid "transaction_modal.view.approve.title"
-msgstr "1. 批准"
-
-#: components/CreateListing/Transaction/index.tsx:57
-#: components/Transaction/index.tsx:55
-msgid "transaction_modal.view.submit.title"
-msgstr "2. 提交"
-
-#: components/Activities/Activities.constants.ts:10
-msgid "updated expiration"
-msgstr "更新已到期"
-
-#: components/Activities/Activities.constants.ts:8
-msgid "updated price"
-msgstr "更新价格"
-
-#: components/Activities/Activities.constants.ts:9
-msgid "updated quantity"
-msgstr "更新数量"
-
-#: components/Activities/index.tsx:29
-msgid "user.activities.empty_state"
-msgstr "无可显示的活动"
-
-#: components/LoginCard/index.tsx:24
-msgid "user.login.description"
-msgstr "此功能仅对已登录的用户可用。您可以通过下面的按键登录或创建帐户。"
-
-#: components/CreateListing/Transaction/Approve.tsx:51
-#: components/CreateListing/Transaction/index.tsx:62
-#: components/pages/Project/Retire/Pool/RetireForm.tsx:205
-msgid "{0}"
-msgstr "{0}"
-
-#: components/pages/Project/Retire/Pool/RetireInputs.tsx:331
-msgid "{0} maximum for credit cards"
-msgstr "{0} 信用卡最高限额"
-
-#: components/pages/Users/index.tsx:30
-msgid "{0} | Profile | Carbonmark"
-msgstr "{0} | 简介 | Carbonmark"
-
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:164
-msgid "{DEFAULT_EXPIRATION_DAYS} days ({expirationDatestring})"
-msgstr "{DEFAULT_EXPIRATION_DAYS} 天 ({expirationDatestring})"
-
-#: components/pages/Purchases/index.tsx:29
-msgid "{amount} tonnes were purchased for project {0}"
-msgstr "为项目 {0} 购买了 {amount} 吨"
-
-#: components/pages/Retirements/RetirementProvenance/ProvenanceComponent/index.tsx:64
-#: components/pages/Retirements/RetirementProvenance/RetirementCard/index.tsx:85
-msgid "{formattedAmount} Tonnes"
-msgstr "{formattedAmount} 吨"
-
-#: components/Quantity/index.tsx:28
-msgid "{formattedAmount} tonnes"
-msgstr "{formattedAmount} 吨"
-
-#: components/pages/Portfolio/Retire/RetirementSidebar/index.tsx:32
-msgid "{tokenSymbol}"
-msgstr "{tokenSymbol}"
-
-#: lib/statusMessage.ts:23
-msgid "❌ Error: something went wrong..."
-msgstr "❌ 错误：出了点问题..."


### PR DESCRIPTION
## Description
This PR replaces the string "Bridge" with "Transfer" on the provenance receipt page.

## Related Ticket

Closes #2281 
Also related to <issue-number>

## How to Test
Visit https://carbonmark-git-2281-get-rid-of-bridge-term-klimadao.vercel.app/retirements/0x087a7afb6975a2837453be685eb6272576c0bc06/6/provenance
