### PR TITLE
Add country type to carbon projects CMS for tracking centroids and isRemoval boolean for methodologies

### DIFF
--- a/carbon-projects/schemas/country.ts
+++ b/carbon-projects/schemas/country.ts
@@ -1,0 +1,42 @@
+import { defineField, defineType } from "sanity";
+
+export default defineType({
+  name: "country",
+  title: "Country",
+  description: "Country metadata",
+  type: "document",
+  preview: {
+    select: {
+      slug: "id",
+      name: "name",
+    },
+    prepare(selection) {
+      return {
+        title: selection.slug.current || "",
+        subtitle: selection.name || "",
+      };
+    },
+  },
+  fields: [
+    defineField({
+      name: "id",
+      type: "slug",
+      description: "Unique two-letter ISO code for this country e.g. 'AU'",
+
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "name",
+      type: "string",
+      description: "Country common name",
+      placeholder: "Nowheria",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "centroid",
+      description: "Latitude and longitude of the centroid of the country",
+      type: "geopoint",
+      validation: (r) => r.required(),
+    }),
+  ],
+});

--- a/carbon-projects/schemas/index.ts
+++ b/carbon-projects/schemas/index.ts
@@ -1,5 +1,12 @@
+import country from "./country";
 import methodology from "./methodology";
 import externalFile from "./objects/externalFile";
 import project from "./project";
 import projectContent from "./projectContent";
-export const schemaTypes = [project, methodology, projectContent, externalFile];
+export const schemaTypes = [
+  project,
+  methodology,
+  projectContent,
+  externalFile,
+  country,
+];

--- a/carbon-projects/schemas/methodology.ts
+++ b/carbon-projects/schemas/methodology.ts
@@ -61,5 +61,11 @@ export default defineType({
         "https://cdm.unfccc.int/methodologies/DB/5SI1IXDIZBL6OAKIB3JFUFAQ86MBEE",
       validation: (r) => r.required(),
     }),
+    defineField({
+      name: "isRemoval",
+      description: "Is this methodology for carbon removal/sequestration?",
+      type: "boolean",
+      initialValue: false,
+    }),
   ],
 });

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -84,7 +84,8 @@ export default defineType({
     },
     {
       name: "registry",
-      description: "Verra, Gold Standard, or EcoRegistry",
+      description:
+        "One of a limited number of approved registries (typically signalted via KlimaDAO governance)",
       group: "info",
       placeholder: "VCS",
       type: "string",
@@ -94,6 +95,7 @@ export default defineType({
           { title: "Gold Standard", value: "GS" },
           { title: "EcoRegistry", value: "ECO" },
           { title: "International Carbon Registry", value: "ICR" },
+          { title: "Puro", value: "PURO" },
         ],
       },
       validation: (r) => r.required(),
@@ -184,6 +186,14 @@ export default defineType({
       options: {
         list: countries.map((c) => ({ title: c.name, value: c.name })),
       },
+    },
+    {
+      name: "countryDetails",
+      description:
+        "Programmatically linked via ISO-3166 country code with a detail document on the country where the project was implemented",
+      type: "reference",
+      group: "location",
+      to: [{ type: "country" }],
     },
     {
       name: "state",


### PR DESCRIPTION
## Description

Add Country type to track centroids since Puro projects only specify country and we still want to map their locations (even if roughly)

Stretch goal would be to show full country boundaries, but lets start with centroids only first
