### PR TITLE
chore: block PRs to CM, CM-API & CMS

### DIFF
--- a/.github/workflows/block_cm_cm_api.yml
+++ b/.github/workflows/block_cm_cm_api.yml
@@ -3,6 +3,7 @@ name: Block PRs for specific folders
 on:
   pull_request:
     paths:
+      - "cms/**"
       - "carbonmark/**"
       - "carbonmark-api/**"
 
@@ -12,5 +13,5 @@ jobs:
     steps:
       - name: Block PR
         run: |
-          echo "Carbonmark and Carbonmark API have been migrated to https://github.com/Carbonmark/monorepo, please raise your pull request there"
+          echo "Carbonmark, Carbonmark API & the CMS have been migrated to https://github.com/Carbonmark/monorepo, please raise your pull request there"
           exit 1

--- a/.github/workflows/block_cm_cm_api.yml
+++ b/.github/workflows/block_cm_cm_api.yml
@@ -1,0 +1,16 @@
+name: Block PRs for specific folders
+
+on:
+  pull_request:
+    paths:
+      - "carbonmark/**"
+      - "carbonmark-api/**"
+
+jobs:
+  block:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block PR
+        run: |
+          echo "Carbonmark and Carbonmark API have been migrated to https://github.com/Carbonmark/monorepo, please raise your pull request there"
+          exit 1


### PR DESCRIPTION
## Description

The Carbonmark, Carbonmark API & CMS projects have been migrated to:

https://github.com/Carbonmark/monorepo

We will keep the projects in this repo as a safety precaution but development work should all be directed to the new repo.