### PR TITLE
Reduce default min fill amount and validate with subgraph minFill

### DIFF
--- a/carbonmark/components/pages/Project/Purchase/Listing/PurchaseInputs.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Listing/PurchaseInputs.tsx
@@ -55,7 +55,6 @@ export const PurchaseInputs: FC<Props> = (props) => {
               <Trans>Available: {Number(props.listing.leftToSell)}</Trans>
             </Text>
           </div>
-
           <InputField
             id="amount"
             inputProps={{
@@ -70,8 +69,8 @@ export const PurchaseInputs: FC<Props> = (props) => {
                   message: t`Amount is required`,
                 },
                 min: {
-                  value: 1,
-                  message: t`The minimum amount to buy is 1 Tonne`,
+                  value: Number(props.listing.minFillAmount),
+                  message: t`The minimum amount to buy is ${props.listing.minFillAmount} Tonne`,
                 },
                 max: {
                   value: Number(props.listing.leftToSell),

--- a/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/RetireForm.tsx
@@ -455,10 +455,10 @@ export const RetireForm: FC<Props> = (props) => {
   );
 };
 
-function isPool(product: Product): product is PoolProduct {
+export function isPool(product: Product): product is PoolProduct {
   return product.type === "pool";
 }
 
-function isListing(product: Product): product is ListingProduct {
+export function isListing(product: Product): product is ListingProduct {
   return product.type === "listing";
 }

--- a/carbonmark/components/pages/Project/Retire/Pool/RetireInputs.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/RetireInputs.tsx
@@ -47,80 +47,78 @@ const validations = (
   fiatBalance: string | null,
   fiatMinimum: string | null,
   minFillAmount?: string | null
-) => ({
-  usdc: {
-    quantity: {
-      min: {
-        value: minFillAmount || MINIMUM_TONNE_QUANTITY,
-        message: t`The minimum amount to retire is ${
-          minFillAmount || MINIMUM_TONNE_QUANTITY
-        } Tonnes`,
+) => {
+  const minUsdcValue = Math.max(
+    Number(minFillAmount || 0),
+    MINIMUM_TONNE_QUANTITY
+  );
+  const minBankTransferValue = Math.max(
+    Number(minFillAmount || 0),
+    MINIMUM_TONNE_QUANTITY_BANK_TRANSFER
+  );
+  return {
+    usdc: {
+      quantity: {
+        min: {
+          value: minUsdcValue,
+          message: t`The minimum amount to retire is ${minUsdcValue} Tonnes`,
+        },
+      },
+      totalPrice: {
+        min: {
+          value: minUsdcValue,
+          message: t`The minimum amount to retire is ${minUsdcValue} Tonnes`,
+        },
+        max: {
+          value: Number(userBalance || "0"),
+          message: t`You exceeded your available amount of tokens`,
+        },
       },
     },
-    totalPrice: {
-      min: {
-        value: minFillAmount || MINIMUM_TONNE_QUANTITY,
-        message: t`The minimum amount to retire is ${
-          minFillAmount || MINIMUM_TONNE_QUANTITY
-        } Tonnes`,
+    fiat: {
+      quantity: {
+        min: {
+          value: 1,
+          message: t`The minimum amount to retire is 1 Tonne`,
+        },
       },
-      max: {
-        value: Number(userBalance || "0"),
-        message: t`You exceeded your available amount of tokens`,
-      },
-    },
-  },
-  fiat: {
-    quantity: {
-      min: {
-        value: 1,
-        message: t`The minimum amount to retire is 1 Tonne`,
-      },
-    },
-    totalPrice: {
-      min: {
-        value: Number(fiatMinimum || "0"),
-        message: t`Credit card minimum purchase is ${formatToPrice(
-          fiatMinimum || 0
-        )}`,
-      },
-      max: {
-        value: Number(fiatBalance || "2000"),
-        message: t`
-            At this time, Carbonmark cannot process credit card payments
-            exceeding ${formatToPrice(fiatBalance || 0)}. Please adjust the
-            quantity and try again later.
-          `,
+      totalPrice: {
+        min: {
+          value: Number(fiatMinimum || "0"),
+          message: t`Credit card minimum purchase is ${formatToPrice(
+            fiatMinimum || 0
+          )}`,
+        },
+        max: {
+          value: Number(fiatBalance || "2000"),
+          message: t`
+                At this time, Carbonmark cannot process credit card payments
+                exceeding ${formatToPrice(fiatBalance || 0)}. Please adjust the
+                quantity and try again later.
+              `,
+        },
       },
     },
-  },
-  "bank-transfer": {
-    quantity: {
-      min: {
-        value:
-          minFillAmount &&
-          Number(minFillAmount) > MINIMUM_TONNE_QUANTITY_BANK_TRANSFER
-            ? minFillAmount
-            : MINIMUM_TONNE_QUANTITY_BANK_TRANSFER,
-        message: t`The minimum amount to retire via bank transfer is 100 Tonnes`,
+    "bank-transfer": {
+      quantity: {
+        min: {
+          value: minBankTransferValue,
+          message: t`The minimum amount to retire via bank transfer is ${minBankTransferValue} Tonnes`,
+        },
+      },
+      totalPrice: {
+        min: {
+          value: minBankTransferValue,
+          message: t`The minimum amount to retire via bank transfer is ${minBankTransferValue} Tonnes`,
+        },
+        max: {
+          value: Infinity,
+          message: "",
+        },
       },
     },
-    totalPrice: {
-      min: {
-        value:
-          minFillAmount &&
-          Number(minFillAmount) > MINIMUM_TONNE_QUANTITY_BANK_TRANSFER
-            ? minFillAmount
-            : MINIMUM_TONNE_QUANTITY_BANK_TRANSFER,
-        message: t`The minimum amount to retire via bank transfer is 100 Tonnes`,
-      },
-      max: {
-        value: Infinity,
-        message: "",
-      },
-    },
-  },
-});
+  };
+};
 
 export const RetireInputs: FC<Props> = (props) => {
   const { locale } = useRouter();
@@ -240,7 +238,6 @@ export const RetireInputs: FC<Props> = (props) => {
               inputProps={{
                 placeholder: t`Tonnes`,
                 type: "number",
-                // min: isICR ? 1 : getValidations().quantity.min.value,
                 min: getValidations().quantity.min.value,
                 max: Number(supply),
                 ...register("quantity", {

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -72,7 +72,7 @@ export const LISTABLE_TOKEN_SYMBOL_REGEX = /(VCS-|PURO-|ICR-|GS-)/;
 /** Default number of days until a listing expires */
 export const DEFAULT_EXPIRATION_DAYS = 90;
 /** Default minimum fill for a listing */
-export const DEFAULT_MIN_FILL_AMOUNT = 1;
+export const DEFAULT_MIN_FILL_AMOUNT = 0.001;
 /** Minimum number of tonnes that can be listed for sale */
 export const DEFAULT_MIN_LISTING_QUANTITY = 1;
 


### PR DESCRIPTION
## Description

Adjusts default minFill to .001 so new listings will have that default minFill for purchases or retires.

Retires and Purchases use the minFill amount on the subgraph instead of hardcoded version either in the component or a constant.

one minor issue: the format from the subgraph has on decimal place. so it used to show "1" but now will show "1.0". Should that be trimmed?

## Related Ticket

Closes #2317 

## How to Test
<!--
 Pleas eprovide a shrot description of how a reviewer can confirm the changes
-->

1. Test a fractional retire on a current listing (should not validate as default min is 1)
2. Create a new listing 
3. Do the same as above (new minFill amount should be .001 for new listing)
4. Do the same above for a purchase
