### PR TITLE
[CM] Add marketing banner to cm homepage

### DIFF
--- a/carbonmark/components/FeatureBanner/index.tsx
+++ b/carbonmark/components/FeatureBanner/index.tsx
@@ -1,42 +1,45 @@
-import { cx } from "@emotion/css";
-import { t } from "@lingui/macro";
+import { ClassNamesArg, cx } from "@emotion/css";
 import { Celebration, Close } from "@mui/icons-material";
 import { Text } from "components/Text";
+import { isEmpty } from "lodash";
 import React, { FC } from "react";
 import * as styles from "./styles";
 
 type Props = {
-  title: string;
+  title?: string;
   isVisible: boolean;
   showClose?: boolean;
-  description: string;
-  onClose: () => void;
+  description: string | React.ReactNode;
+  onClose?: () => void;
   isInitialBanner: boolean;
-  children: React.ReactNode;
-  showNewFeatureLabel?: boolean;
+  customCss?: ClassNamesArg;
+  children?: React.ReactNode;
+  featureLabel?: React.ReactNode;
 };
 
 const FeatureBanner: FC<Props> = (props) => {
   return (
     <div
-      className={cx(styles.banner, {
+      className={cx(styles.banner, props.customCss, {
         "feature-banner": !!props.isVisible,
         "initial-banner": !!props.isVisible && !!props.isInitialBanner,
       })}
     >
       {props.showClose && <Close className="close" onClick={props.onClose} />}
       <div className="contents">
-        <div className={styles.title}>
-          {props.showNewFeatureLabel && (
+        <div className="title">
+          {!isEmpty(props.featureLabel) && (
             <div className="new-feature">
               <Celebration />
-              <Text>{t`NEW FEATURE:`}</Text>
+              <Text>{props.featureLabel}</Text>
             </div>
           )}
-          <Text>{props.title}</Text>
+          {props.title && <Text>{props.title}</Text>}
         </div>
         <Text>{props.description}</Text>
-        <div className={styles.buttons}>{props.children}</div>
+        {props.children && (
+          <div className={styles.buttons}>{props.children}</div>
+        )}
       </div>
     </div>
   );

--- a/carbonmark/components/FeatureBanner/styles.ts
+++ b/carbonmark/components/FeatureBanner/styles.ts
@@ -21,12 +21,6 @@ export const banner = css`
     transform: translateY(6.4rem);
   }
 
-  ${breakpoints.desktop} {
-    &.feature-banner {
-      transform: translateY(7.2rem);
-    }
-  }
-
   .close {
     top: 1.6rem;
     right: 1.6rem;
@@ -51,53 +45,53 @@ export const banner = css`
       padding: 2rem 5.2rem;
     }
   }
-`;
 
-export const title = css`
-  gap: 1rem;
-  display: flex;
-  align-items: flex-start;
-  flex-direction: column;
-
-  ${breakpoints.desktop} {
-    align-items: center;
-    flex-direction: row;
-  }
-
-  div {
+  .title {
+    gap: 1rem;
     display: flex;
+    align-items: flex-start;
     flex-direction: column;
 
     ${breakpoints.desktop} {
+      align-items: center;
       flex-direction: row;
     }
-  }
 
-  svg {
-    width: 2rem;
-    height: 2rem;
+    div {
+      display: flex;
+      flex-direction: column;
 
-    ${breakpoints.desktop} {
-      margin-left: -3.2rem;
+      ${breakpoints.desktop} {
+        flex-direction: row;
+      }
     }
-  }
 
-  p,
-  svg {
-    font-weight: 700;
-    color: var(--bright-blue);
-  }
+    svg {
+      width: 2rem;
+      height: 2rem;
 
-  .new-feature {
-    gap: 1.2rem;
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-    justify-content: center;
+      ${breakpoints.desktop} {
+        margin-left: -3.2rem;
+      }
+    }
 
-    p {
-      color: var(--black);
-      font-family: var(--font-family-secondary);
+    p,
+    svg {
+      font-weight: 700;
+      color: var(--bright-blue);
+    }
+
+    .new-feature {
+      gap: 1.2rem;
+      display: flex;
+      align-items: center;
+      flex-direction: row;
+      justify-content: center;
+
+      p {
+        color: var(--black);
+        font-family: var(--font-family-secondary);
+      }
     }
   }
 `;

--- a/carbonmark/components/pages/Home/index.tsx
+++ b/carbonmark/components/pages/Home/index.tsx
@@ -20,6 +20,7 @@ import PersonOutlinedIcon from "@mui/icons-material/PersonOutlined";
 import TravelExploreOutlinedIcon from "@mui/icons-material/TravelExploreOutlined";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { Category } from "components/Category";
+import FeatureBanner from "components/FeatureBanner";
 import { Footer } from "components/Footer";
 import { PageHead } from "components/PageHead";
 import { ProjectImage } from "components/ProjectImage";
@@ -51,6 +52,21 @@ export const Home: NextPage<Props> = (props) => {
         title={t`Carbonmark | The Universal Carbon Marketplace`}
         mediaTitle={t`Carbonmark | The Universal Carbon Marketplace`}
         metaDescription={t`The largest selection of digital carbon credits worldwide. Buy, sell, and retire digital carbon from any project instantly with zero-commission trading.`}
+      />
+      <FeatureBanner
+        isVisible
+        isInitialBanner
+        showClose={false}
+        featureLabel={t`JUST RELEASED`}
+        customCss={styles.announcementBanner}
+        description={
+          <>
+            <Trans>Enabling next generation carbon markets.</Trans>{" "}
+            <Link href="https://hub.carbonmark.com/2024-report" target="_blank">
+              <Trans>Download our 2024 report now.</Trans>
+            </Link>
+          </>
+        }
       />
       <Section className={styles.hero}>
         <Image

--- a/carbonmark/components/pages/Home/index.tsx
+++ b/carbonmark/components/pages/Home/index.tsx
@@ -62,7 +62,7 @@ export const Home: NextPage<Props> = (props) => {
         description={
           <>
             <Trans>Enabling next generation carbon markets.</Trans>{" "}
-            <Link href="https://hub.carbonmark.com/2024-report" target="_blank">
+            <Link href={`${carbonmarkUrls.hub}/2024-report`} target="_blank">
               <Trans>Download our 2024 report now.</Trans>
             </Link>
           </>

--- a/carbonmark/components/pages/Home/styles.ts
+++ b/carbonmark/components/pages/Home/styles.ts
@@ -51,12 +51,14 @@ export const hero = css`
     justify-content: end;
     max-width: 100%;
     grid-column: main;
-    margin-top: 8rem;
+    // revert to margin-top: 8rem when no announcement banner
+    margin-top: 14rem;
     margin-bottom: 4rem;
 
     ${breakpoints.desktop} {
       max-width: 70%;
-      margin-bottom: 8.4rem;
+      // revert to margin-top: 8.4rem when no announcement banner
+      margin-bottom: 14.4rem;
     }
 
     & h1 {
@@ -902,5 +904,35 @@ export const footerIcons = css`
 
   & svg path {
     fill: #fff;
+  }
+`;
+
+export const announcementBanner = css`
+  position: absolute;
+
+  ${breakpoints.desktop} {
+    position: relative;
+    &.feature-banner {
+      transform: translateY(0);
+    }
+  }
+
+  .contents {
+    gap: 0.75rem;
+    display: grid;
+    padding: 2rem 0;
+    grid-column: main;
+
+    a {
+      text-decoration: underline;
+    }
+  }
+
+  .title {
+    svg {
+      ${breakpoints.desktop} {
+        margin-left: 0;
+      }
+    }
   }
 `;

--- a/carbonmark/components/pages/Home/styles.ts
+++ b/carbonmark/components/pages/Home/styles.ts
@@ -909,6 +909,7 @@ export const footerIcons = css`
 
 export const announcementBanner = css`
   position: absolute;
+  background: var(--white);
 
   ${breakpoints.desktop} {
     position: relative;

--- a/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
+++ b/carbonmark/components/pages/Projects/Banners/BankTransfer.tsx
@@ -73,7 +73,7 @@ export const BankTransferBanner: FC = () => {
       onClose={onClose}
       title={t`Pay via Bank Transfer / Wire`}
       showClose={isInitialBanner}
-      showNewFeatureLabel={isInitialBanner}
+      featureLabel={isInitialBanner ? t`NEW FEATURE:` : ""}
       description={
         isInitialBanner
           ? t`Purchase retirements from any project on Carbonmark and pay via bank transfer.`

--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -133,6 +133,7 @@ export const urls = {
   },
   blockExplorer: `${config.urls.blockExplorer[ENVIRONMENT]}`,
   baseUrl: config.urls.baseUrl[ENVIRONMENT],
+  hub: "https://hub.carbonmark.com",
   docs: "https://docs.carbonmark.com",
   docsResourcesFees:
     "https://docs.carbonmark.com/get-started/understanding-fees-on-carbonmark",


### PR DESCRIPTION
## Description

Adds a marketing banner to the carbonmark homepage. The banner should match the [figma designs](https://www.figma.com/file/hLlyv2V4SXIwwZoauDnfZN?node-id=0:1&mode=design#709758070)

## Related Ticket

Closes #2315

## How to Test
- Ensure the design of marketing banner matches the banner in the figma designs.
- Ensure the banner is only visible on the carbonmark home page.
- Ensure when clicking on `Download our report now`, a new tab is opened on the page to download the [report](https://hub.carbonmark.com/2024-report)
- Ensure the banner is working as expected on mobile devices. 