### PR TITLE
replaced broken links

### DIFF
--- a/carbonmark/components/pages/Project/Purchase/Listing/PurchaseInputs.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Listing/PurchaseInputs.tsx
@@ -4,7 +4,6 @@ import HelpOutline from "@mui/icons-material/HelpOutline";
 import { Dropdown } from "components/Dropdown";
 import { InputField } from "components/shared/Form/InputField";
 import { Text } from "components/Text";
-import { urls } from "lib/constants";
 import { formatToPrice } from "lib/formatNumbers";
 import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
 import { LO } from "lib/luckyOrange";
@@ -139,9 +138,7 @@ export const PurchaseInputs: FC<Props> = (props) => {
               <Text t="body3">
                 <Trans>
                   Currently, Carbonmark only accepts Polygon USDC payments.{" "}
-                  <Anchor
-                    href={`${urls.docs}/get-started/how-to-get-usdc-or-matic`}
-                  >
+                  <Anchor href="/blog/how-to-get-usdc-or-matic">
                     Learn how to acquire USDC on Polygon.
                   </Anchor>
                 </Trans>

--- a/carbonmark/components/pages/Project/Purchase/Pool/PurchaseInputs.tsx
+++ b/carbonmark/components/pages/Project/Purchase/Pool/PurchaseInputs.tsx
@@ -5,7 +5,6 @@ import HelpOutline from "@mui/icons-material/HelpOutline";
 import { Dropdown } from "components/Dropdown";
 import { InputField } from "components/shared/Form/InputField";
 import { Text } from "components/Text";
-import { urls } from "lib/constants";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { carbonmarkPaymentMethodMap } from "lib/getPaymentMethods";
 import { LO } from "lib/luckyOrange";
@@ -169,9 +168,7 @@ export const PurchaseInputs: FC<Props> = (props) => {
             <Text t="body3">
               <Trans>
                 Currently, Carbonmark only accepts Polygon USDC payments.{" "}
-                <Anchor
-                  href={`${urls.docs}/get-started/how-to-get-usdc-or-matic`}
-                >
+                <Anchor href="/blog/how-to-get-usdc-or-matic">
                   Learn how to acquire USDC on Polygon.
                 </Anchor>
               </Trans>

--- a/carbonmark/components/pages/Project/Retire/Pool/RetireInputs.tsx
+++ b/carbonmark/components/pages/Project/Retire/Pool/RetireInputs.tsx
@@ -11,7 +11,6 @@ import { isAddress } from "ethers-v6";
 import {
   MINIMUM_TONNE_QUANTITY,
   MINIMUM_TONNE_QUANTITY_BANK_TRANSFER,
-  urls as carbonmarkUrls,
 } from "lib/constants";
 import { formatToPrice, formatToTonnes } from "lib/formatNumbers";
 import { carbonmarkRetirePaymentMethodMap } from "lib/getPaymentMethods";
@@ -435,9 +434,7 @@ export const RetireInputs: FC<Props> = (props) => {
               <Trans>
                 Currently, Carbonmark only accepts Polygon USDC or Credit Card
                 Payments.{" "}
-                <Anchor
-                  href={`${carbonmarkUrls.docs}/get-started/how-to-get-usdc-or-matic`}
-                >
+                <Anchor href="/blog/how-to-get-usdc-or-matic">
                   Learn how to acquire USDC on Polygon.
                 </Anchor>
               </Trans>


### PR DESCRIPTION
## Description

Moved the user guide to get USDC.e or MATIC over to the blog CMS and then replaced the broken links.

## Related Ticket

Closes #2307 