### PR TITLE
[CM] only use position: sticky on desktop breakpoints

### DIFF
--- a/carbonmark/components/pages/Project/Purchase/styles.ts
+++ b/carbonmark/components/pages/Project/Purchase/styles.ts
@@ -251,6 +251,10 @@ export const successScreen = css`
 export const stickyContentWrapper = css`
   display: grid;
   gap: 2.4rem;
-  position: sticky;
+  position: initial;
   top: 1rem;
+
+  ${breakpoints.large} {
+    position: sticky;
+  }
 `;

--- a/carbonmark/components/pages/Project/Retire/Pool/styles.ts
+++ b/carbonmark/components/pages/Project/Retire/Pool/styles.ts
@@ -267,8 +267,12 @@ export const disclaimer = css`
 export const stickyContentWrapper = css`
   display: grid;
   gap: 2.4rem;
-  position: sticky;
+  position: initial;
   top: 1rem;
+
+  ${breakpoints.large} {
+    position: sticky;
+  }
 `;
 
 export const buttonWrapper = css`


### PR DESCRIPTION
## Description

"Retire Carbon" and "Continue" button gets hidden on mobile devices. See #2323 for details on the issue, linked videos of the issue and how to test. 

## Related Ticket

Closes #2323 