### PR TITLE
Makka/2379 replace subgraph url on legacy dapp

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -26,13 +26,10 @@ jobs:
           cut -d ':' -f 2 | tr -d '"' | tr -d ' ' | tr -d ,)" >> $GITHUB_OUTPUT
 
       - name: Install Prettier
-        run: npm install -g prettier@${{ steps.prettier-version.outputs.version }}
+        run: npm install --ignore-scripts prettier@${{ steps.prettier-version.outputs.version }}
 
       - name: Install Prettier plugins
-        run: npm install -g --prefix=$(pwd) prettier-plugin-organize-imports@${{ steps.prettier-org-import-version.outputs.version }}
-
-      - name: Move Prettier plugins
-        run: mv lib/node_modules .
+        run: npm install --ignore-scripts --prefix=$(pwd) prettier-plugin-organize-imports@${{ steps.prettier-org-import-version.outputs.version }}
 
       - name: Get base branch
         id: base-branch

--- a/app/components/views/Offset/ProjectTokenDetails/index.tsx
+++ b/app/components/views/Offset/ProjectTokenDetails/index.tsx
@@ -1,7 +1,8 @@
 import { Anchor, Text } from "@klimadao/lib/components";
-import { goldStandard, subgraphs, verra } from "@klimadao/lib/constants";
+import { goldStandard, verra } from "@klimadao/lib/constants";
 import { Trans, t } from "@lingui/macro";
 import LaunchIcon from "@mui/icons-material/Launch";
+import { subgraphs } from "lib/constants";
 import { useEffect, useState } from "react";
 import * as styles from "./styles";
 

--- a/app/components/views/Offset/SelectiveRetirement/queryProjectDetails.ts
+++ b/app/components/views/Offset/SelectiveRetirement/queryProjectDetails.ts
@@ -1,4 +1,4 @@
-import { subgraphs } from "@klimadao/lib/constants";
+import { subgraphs } from "lib/constants";
 
 export type BalanceAttribute =
   | "balanceBCT"

--- a/app/components/views/Redeem/ProjectTokenDetails/index.tsx
+++ b/app/components/views/Redeem/ProjectTokenDetails/index.tsx
@@ -1,7 +1,8 @@
 import { Anchor, Text } from "@klimadao/lib/components";
-import { subgraphs, verra } from "@klimadao/lib/constants";
+import { verra } from "@klimadao/lib/constants";
 import { Trans, t } from "@lingui/macro";
 import LaunchIcon from "@mui/icons-material/Launch";
+import { subgraphs } from "lib/constants";
 import { RedeemablePoolToken } from "lib/hooks/useRedeemParams";
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -64,3 +64,22 @@ export const DEFAULT_NETWORK = config.networks[ENVIRONMENT] as
 
 /** Exposed via env vars, this is an infura id to be used in the browser, in getStaticProvider, as a fallback for polygon-rpc */
 export const CLIENT_INFURA_ID = process.env.NEXT_PUBLIC_CLIENT_INFURA_ID;
+
+/** Subgraph Ids */
+const GRAPH_API_KEY =
+  process.env.GRAPH_API_KEY ?? process.env.NEXT_PUBLIC_GRAPH_API_KEY;
+
+const BRIDGED_CARBON_ID = "9skh5pMQGRdyJcBe8PjWdDjLoYqoYTMLRDpFh6acSHUu";
+const SUBGRAPH_BASE_URL =
+  "https://gateway-arbitrum.network.thegraph.com/api/" +
+  GRAPH_API_KEY +
+  "/subgraphs/id/";
+
+const SUBGRAPH_DEV_URL = "https://api.studio.thegraph.com/query/78559";
+const SUBGRAPH_VERSION_SUFFIX = "version/latest";
+
+export const subgraphs = {
+  polygonBridgedCarbon: IS_PRODUCTION
+    ? `${SUBGRAPH_BASE_URL}${BRIDGED_CARBON_ID}`
+    : `${SUBGRAPH_DEV_URL}/polygon-bridged-carbon/${SUBGRAPH_VERSION_SUFFIX}`,
+};


### PR DESCRIPTION
## Description

This PR replaces the old subgraph url with a new url. 

**Important:** We will need to set the `GRAPH_API_KEY` env variable and also a `NEXT_PUBLIC_GRAPH_API_KEY` if neither already exist for the legacy app.

This PR also moves the subgraphs endpoints out of `lib` into `app/lib/constants` as we are now using env variables for the api key.

## Related Ticket

Closes #2379 