### PR TITLE
must-be-carbon/feat/2377 add supply endpoint for KLIMA & BCT

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ Also related to <issue-number>
 
 ## How to Test
 <!--
- Pleas eprovide a shrot description of how a reviewer can confirm the changes
+ Please provide a short description of how a reviewer can confirm the changes
 -->
 
 1. _step1_

--- a/app/pages/api/supply.ts
+++ b/app/pages/api/supply.ts
@@ -1,4 +1,8 @@
-import { getContract, getStaticProvider } from "@klimadao/lib/utils";
+import {
+  getContract,
+  getStaticProvider,
+  getTokenDecimals,
+} from "@klimadao/lib/utils";
 import { formatUnits } from "ethers/lib/utils";
 import { DEFAULT_NETWORK } from "lib/constants";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -19,18 +23,7 @@ type APIResponse =
       error: string;
     };
 
-// This can be simplified to be just a string[]
-// but IERC20 ABI doesn't have a decimal exposed
-const DEFAULT_TOKENS = [
-  {
-    name: "klima",
-    decimals: 9,
-  },
-  {
-    name: "bct",
-    decimals: 18,
-  },
-];
+const DEFAULT_TOKENS = ["klima", "bct"];
 
 /**
  * @description fetch total supply for a token
@@ -57,7 +50,7 @@ export default async function handler(
           return res.status(400).send({ error: "Token should be a string" });
         }
 
-        const targetToken = DEFAULT_TOKENS.find((t) => t.name === token);
+        const targetToken = DEFAULT_TOKENS.find((t) => t === token);
 
         if (!targetToken) {
           return res.status(400).send({ error: "Invalid token" });
@@ -69,7 +62,7 @@ export default async function handler(
 
         const contract = getContract({
           // TODO: Improve typing by exporting ContractName type from lib
-          contractName: targetToken.name as "klima" | "bct",
+          contractName: targetToken as "klima" | "bct",
           network: DEFAULT_NETWORK,
           provider,
         });
@@ -81,7 +74,7 @@ export default async function handler(
         }
 
         const totalSupplyNum = Number(
-          formatUnits(totalSupply, targetToken.decimals)
+          formatUnits(totalSupply, getTokenDecimals(targetToken))
         );
 
         if (type) {

--- a/app/pages/api/supply.ts
+++ b/app/pages/api/supply.ts
@@ -29,7 +29,6 @@ const DEFAULT_TOKENS = ["klima", "bct"];
  * @description fetch total supply for a token
  * @param req
  * @param res
- * @example GET /api/supply?token=klima Returns {APIResponse}
  * @example GET /api/supply?type=total&token=klima Returns number
  * @example GET /api/supply?type=circulating&token=klima Return number
  */
@@ -42,8 +41,10 @@ export default async function handler(
       case "GET":
         const { type, token } = req.query;
 
-        if (!token) {
-          return res.status(400).send({ error: "Token missing" });
+        if (!token || !type) {
+          return res
+            .status(400)
+            .send({ error: "Token or type is missing from params" });
         }
 
         if (typeof token !== "string") {
@@ -77,20 +78,14 @@ export default async function handler(
           formatUnits(totalSupply, getTokenDecimals(targetToken))
         );
 
-        if (type) {
-          switch (type) {
-            case "total":
-            case "circulating":
-              return res.status(200).send(totalSupplyNum);
-            default:
-              return res.status(400).send({ error: "Invalid type" });
-          }
+        switch (type) {
+          case "total":
+          case "circulating":
+            return res.status(200).send(totalSupplyNum);
+          default:
+            return res.status(400).send({ error: "Invalid type" });
         }
 
-        return res.status(200).send({
-          totalSupply: totalSupplyNum,
-          circulatingSupply: totalSupplyNum,
-        });
       default:
         res.setHeader("Allow", ["GET"]);
         return res

--- a/app/pages/api/supply.ts
+++ b/app/pages/api/supply.ts
@@ -1,0 +1,79 @@
+import { getContract, getStaticProvider } from "@klimadao/lib/utils";
+import { formatUnits } from "ethers/lib/utils";
+import { DEFAULT_NETWORK } from "lib/constants";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export const config = {
+  api: {},
+  // Specifies the maximum allowed duration for this function to execute (in seconds)
+  maxDuration: 5,
+};
+
+type APIResponse =
+  | number
+  | {
+      totalSupply: number;
+      circulatingSupply: number;
+    }
+  | {
+      error: string;
+    };
+
+/**
+ *
+ * @param req
+ * @param res
+ * @example GET /api/supply Returns {APIResponse}
+ * @example GET /api/supply?type=total-supply Returns number
+ * @example GET /api/supply?type=circulating-supply Return number
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<APIResponse>
+) {
+  try {
+    switch (req.method) {
+      case "GET":
+        const { type } = req.query;
+
+        const provider = getStaticProvider({
+          chain: "polygon",
+        });
+
+        const contract = getContract({
+          contractName: "klima",
+          network: DEFAULT_NETWORK, // TODO; Make dynamic for testnet
+          provider,
+        });
+
+        const totalSupply = await contract.totalSupply();
+
+        if (!totalSupply) {
+          return res.status(500).send({ error: "Failed to get total supply" });
+        }
+
+        const totalSupplyNum = Number(formatUnits(totalSupply, 9));
+
+        if (type) {
+          switch (type) {
+            case "total-supply":
+            case "circulating-supply":
+              return res.status(200).send(totalSupplyNum);
+            default:
+              return res.status(400).end({ error: "Invalid type" });
+          }
+        }
+
+        return res.status(200).send({
+          totalSupply: totalSupplyNum,
+          circulatingSupply: totalSupplyNum,
+        });
+      default:
+        res.setHeader("Allow", ["GET"]);
+        return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+  } catch (error) {
+    console.error(error);
+    return res.status(500).send({ error: "Internal Server Error" });
+  }
+}

--- a/app/pages/api/supply.ts
+++ b/app/pages/api/supply.ts
@@ -37,8 +37,8 @@ const DEFAULT_TOKENS = [
  * @param req
  * @param res
  * @example GET /api/supply?token=klima Returns {APIResponse}
- * @example GET /api/supply?type=total-supply&token=klima Returns number
- * @example GET /api/supply?type=circulating-supply&token=klima Return number
+ * @example GET /api/supply?type=total&token=klima Returns number
+ * @example GET /api/supply?type=circulating&token=klima Return number
  */
 export default async function handler(
   req: NextApiRequest,
@@ -86,8 +86,8 @@ export default async function handler(
 
         if (type) {
           switch (type) {
-            case "total-supply":
-            case "circulating-supply":
+            case "total":
+            case "circulating":
               return res.status(200).send(totalSupplyNum);
             default:
               return res.status(400).send({ error: "Invalid type" });


### PR DESCRIPTION
## Description

This pull request will re-introduce the /supply API URL for KlimaDAO. 
This end-point can then be used in platforms like CoinMarketCap/Coingecko

## Related Ticket

Closes 2377

## How to Test
1. Open terminal 
2. Run `npm run dev-app` from root dir
3. Open a new terminal
4. Run the following commands to test all cases & update port-no before testing 
port-no. can be seen as an output of step(2) 
```
# fetches total supply for a token
curl -X "GET" "localhost:<port-no>/api/supply?type=total-supply&token=<klima|bct>"

# fetches circulating-supply for a token
curl -X "GET" "localhost:<port-no>/api/supply?type=circulating-supply&token=<klima|bct>"
```

Screenshot below
<img width="604" alt="image" src="https://github.com/user-attachments/assets/d0a3c68c-d5d8-4489-b860-6b2035319426">


