### PR TITLE
Add fields for name and category override to ProjectContent

### DIFF
--- a/carbon-projects/lib/categories.ts
+++ b/carbon-projects/lib/categories.ts
@@ -1,0 +1,11 @@
+export const categories = [
+  { title: "Energy Efficiency", value: "Energy Efficiency" },
+  { title: "Forestry", value: "Forestry" },
+  { title: "Industrial Processing", value: "Industrial Processing" },
+  { title: "Renewable Energy", value: "Renewable Energy" },
+  { title: "Blue Carbon", value: "Blue Carbon" },
+  { title: "Agriculture", value: "Agriculture" },
+  { title: "Construction", value: "Construction" },
+  { title: "Biochar", value: "Biochar" },
+  { title: "Other", value: "Other" },
+];

--- a/carbon-projects/schemas/methodology.ts
+++ b/carbon-projects/schemas/methodology.ts
@@ -1,16 +1,5 @@
 import { defineField, defineType } from "sanity";
-
-const categories = [
-  { title: "Energy Efficiency", value: "Energy Efficiency" },
-  { title: "Forestry", value: "Forestry" },
-  { title: "Industrial Processing", value: "Industrial Processing" },
-  { title: "Renewable Energy", value: "Renewable Energy" },
-  { title: "Blue Carbon", value: "Blue Carbon" },
-  { title: "Agriculture", value: "Agriculture" },
-  { title: "Construction", value: "Construction" },
-  { title: "Biochar", value: "Biochar" },
-  { title: "Other", value: "Other" },
-];
+import { categories } from "../lib/categories";
 
 export default defineType({
   name: "methodology",

--- a/carbon-projects/schemas/projectContent.ts
+++ b/carbon-projects/schemas/projectContent.ts
@@ -1,4 +1,5 @@
 import { defineField, defineType } from "sanity";
+import { categories } from "../lib/categories";
 import { sdgs } from "../lib/sdgs";
 
 export default defineType({
@@ -29,6 +30,22 @@ export default defineType({
       description: "The project this content is associated with",
       group: "info",
       validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "nameOverride",
+      description:
+        "Manually modified name to override the official registry name for the project (used to handle formatting issues)",
+      group: "info",
+      type: "string",
+    }),
+    defineField({
+      name: "categoryOverride",
+      description:
+        "For this project, override the methodology's normal category with a different one from our predefined ontology of categories",
+      type: "string",
+      options: {
+        list: categories,
+      },
     }),
     defineField({
       name: "shortDescription",


### PR DESCRIPTION
## Description
After discussion with Drew it has become apparent that we will need to override the name and also the category for projects in some cases

For instance an ICR project with an awkwardly formatted name, that uses a generic ISO methodology (so category defaults to "Other") 

Easiest way to handle this is to have some override logic, but we will need the frontend to respect these overrides and the filtering logic to be aware of them (Esp for methodology category)

This PR simply adds the new fields to the CMS, subsequent work is required to implement FE and filtering changes