### PR TITLE
Restructure schema to catch captions in GraphQL

### DIFF
--- a/carbon-projects/schemas/index.ts
+++ b/carbon-projects/schemas/index.ts
@@ -1,6 +1,7 @@
 import country from "./country";
 import indexContent from "./indexContent";
 import methodology from "./methodology";
+import captionImage from "./objects/captionImage";
 import externalFile from "./objects/externalFile";
 import project from "./project";
 import projectContent from "./projectContent";
@@ -9,6 +10,7 @@ export const schemaTypes = [
   methodology,
   projectContent,
   externalFile,
+  captionImage,
   country,
   indexContent,
 ];

--- a/carbon-projects/schemas/indexContent.ts
+++ b/carbon-projects/schemas/indexContent.ts
@@ -83,34 +83,14 @@ export default defineType({
       name: "coverImage",
       description: "Primary cover image to be shown on project page",
       group: "media",
-      type: "image",
-      fields: [
-        {
-          name: "caption",
-          description:
-            "English language caption to show below the image. Can include image attribution if needed.",
-          type: "string",
-        },
-      ],
+      type: "captionImage",
     }),
     defineField({
       name: "images",
       description: "Other images associated with this project",
       group: "media",
       type: "array",
-      of: [
-        {
-          type: "image",
-          fields: [
-            {
-              name: "caption",
-              description:
-                "English language caption to show below the image. Can include image attribution if needed.",
-              type: "string",
-            },
-          ],
-        },
-      ],
+      of: [{ type: "captionImage" }],
     }),
     defineField({
       name: "notes",

--- a/carbon-projects/schemas/objects/captionImage.ts
+++ b/carbon-projects/schemas/objects/captionImage.ts
@@ -1,0 +1,14 @@
+import { defineType } from "sanity";
+
+export default defineType({
+  name: "captionImage",
+  type: "image",
+  fields: [
+    {
+      name: "caption",
+      description:
+        "English language caption to show below the image. Can include image attribution if needed.",
+      type: "string",
+    },
+  ],
+});

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -66,7 +66,7 @@ export default defineType({
     {
       name: "registry",
       description:
-        "One of a limited number of approved registries (typically signalted via KlimaDAO governance)",
+        "One of a limited number of approved registries (typically signaled via KlimaDAO governance)",
       group: "info",
       placeholder: "VCS",
       type: "string",

--- a/carbon-projects/schemas/projectContent.ts
+++ b/carbon-projects/schemas/projectContent.ts
@@ -76,50 +76,21 @@ export default defineType({
       name: "coverImage",
       description: "Primary cover image to be shown on project page",
       group: "media",
-      type: "image",
-      fields: [
-        {
-          name: "caption",
-          description:
-            "English language caption to show below the image. Can include image attribution if needed.",
-          type: "string",
-        },
-      ],
+      type: "captionImage",
     }),
     defineField({
       name: "satelliteImage",
       description:
         "Mapbox satellite image based on registry lat/long to be shown on project page",
       group: "media",
-      type: "image",
-      fields: [
-        {
-          name: "caption",
-          description:
-            "English language caption to show below the image. Can include image attribution if needed.",
-          type: "string",
-          placeholder: "Satellite image of the project location",
-        },
-      ],
+      type: "captionImage",
     }),
     defineField({
       name: "images",
       description: "Other images associated with this project",
       group: "media",
       type: "array",
-      of: [
-        {
-          type: "image",
-          fields: [
-            {
-              name: "caption",
-              description:
-                "English language caption to show below the image. Can include image attribution if needed.",
-              type: "string",
-            },
-          ],
-        },
-      ],
+      of: [{ type: "captionImage" }],
     }),
     defineField({
       name: "notes",


### PR DESCRIPTION
## Description

Captions are not showing up in GraphQL because they are defined inline

Defining a custom type resolves this
