### PR TITLE
Disclaimer Modal - use local storage

### DIFF
--- a/app/components/DisclaimerModal/index.tsx
+++ b/app/components/DisclaimerModal/index.tsx
@@ -11,13 +11,13 @@ export const DisclaimerModal: FC = () => {
   useScrollLock(showModal);
 
   useEffect(() => {
-    if (isNil(window?.sessionStorage?.getItem("disclaimer_accepted"))) {
+    if (isNil(window?.localStorage?.getItem("disclaimer_accepted"))) {
       setShowModal(true);
     }
   }, []);
 
   const setDisclaimer = async () => {
-    window.sessionStorage.setItem("disclaimer_accepted", "");
+    window.localStorage.setItem("disclaimer_accepted", "");
     setShowModal(false);
   };
 

--- a/base/components/DisclaimerModal/index.tsx
+++ b/base/components/DisclaimerModal/index.tsx
@@ -10,13 +10,13 @@ export const DisclaimerModal: FC = () => {
   useScrollLock(showModal);
 
   useEffect(() => {
-    if (isNil(window?.sessionStorage?.getItem("disclaimer_accepted"))) {
+    if (isNil(window?.localStorage?.getItem("disclaimer_accepted"))) {
       setShowModal(true);
     }
   }, []);
 
   const setDisclaimer = async () => {
-    window.sessionStorage.setItem("disclaimer_accepted", "");
+    window.localStorage.setItem("disclaimer_accepted", "");
     setShowModal(false);
   };
 


### PR DESCRIPTION
## Description

To avoid the disclaimer modal popping up so frequently due to using session storage - this PR utilizes local storage for determining to show the modal again as opposed to the current solution which is based on the users session. 

## Related Ticket

Closes #2405 