### PR TITLE
Add additional fields for direct issuance projects

### DIFF
--- a/.github/workflows/build_cms.yml
+++ b/.github/workflows/build_cms.yml
@@ -1,0 +1,53 @@
+name: Build Sanity CMS
+
+on:
+  push:
+    paths:
+      - "carbon-projects/**"
+    branches: "*"
+  pull_request:
+    paths:
+      - "carbon-projects/**"
+    branches: "*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # Explicit caching instead of using setup-node's built-in cache
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: carbon-projects/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('carbon-projects/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        working-directory: ./carbon-projects
+        run: npm ci
+
+      - name: Build Sanity studio
+        working-directory: ./carbon-projects
+        run: npm run build
+        env:
+          CI: true
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanity-build
+          path: carbon-projects/dist
+          retention-days: 7

--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          # hard-coded to fix issue with this workflow
+          node-version: 20
+          # caches until package-lock.json in the root is changed
+          cache: "npm"
 
       - name: Cache node_modules
         uses: actions/cache@v4

--- a/carbon-projects/lib/fileCategories.ts
+++ b/carbon-projects/lib/fileCategories.ts
@@ -1,0 +1,6 @@
+export const fileCategories = [
+  { title: "Methodology", value: "methodology" },
+  { title: "Project Description Document (PDD)", value: "pdd" },
+  { title: "Verifications", value: "verifications" },
+  { title: "Supporting Documentation", value: "supporting-documentation" },
+];

--- a/carbon-projects/lib/sectors.ts
+++ b/carbon-projects/lib/sectors.ts
@@ -1,3 +1,3 @@
 export const sectors = [
-    { title: "Waste handling and disposal", value: "waste-h-d" }
+  { title: "Waste handling and disposal", value: "waste-h-d" },
 ];

--- a/carbon-projects/lib/sectors.ts
+++ b/carbon-projects/lib/sectors.ts
@@ -1,3 +1,65 @@
 export const sectors = [
-  { title: "Waste handling and disposal", value: "waste-h-d" },
+  {
+    title: "Afforestation and reforestation",
+    value: "afforestation-and-reforestation",
+  },
+  {
+    title: "Energy industries (renewable/non-renewable sources)",
+    value: "energy-industries-renewable-non-renewable-sources",
+  },
+  { title: "Energy demand", value: "energy-demand" },
+  {
+    title: "Agriculture; forestry and fishing",
+    value: "agriculture-forestry-and-fishing",
+  },
+  {
+    title: "Waste handling and disposal",
+    value: "waste-handling-and-disposal",
+  },
+  {
+    title: "Livestock, enteric fermentation, and manure management",
+    value: "livestock-enteric-fermentation-and-manure-management",
+  },
+  { title: "Technical Removal", value: "technical-removal" },
+  { title: "Afforestation", value: "afforestation" },
+  { title: "Transport", value: "transport" },
+  {
+    title: "Landfill Gas Capture/Combustion",
+    value: "landfill-gas-capture-combustion",
+  },
+  { title: "Forestry", value: "forestry" },
+  { title: "Energy Distribution", value: "energy-distribution" },
+  {
+    title:
+      "Water supply; sewerage, waste management and remediation activities",
+    value: "water-supply-sewerage-waste-management-and-remediation-activities",
+  },
+  {
+    title: "Electricity; gas, steam and air conditioning supply",
+    value: "electricity-gas-steam-and-air-conditioning-supply",
+  },
+  { title: "Manufacturing", value: "manufacturing" },
+  { title: "Transportation and storage", value: "transportation-and-storage" },
+  {
+    title: "Fugitive emissions from fuel (solid, oil and gas)",
+    value: "fugitive-emissions-from-fuel-solid-oil-and-gas",
+  },
+  { title: "Manufacturing industries", value: "manufacturing-industries" },
+  { title: "Chemical industries", value: "chemical-industries" },
+  { title: "Energy distribution", value: "energy-distribution" },
+  {
+    title:
+      "Fugitive emissions from production and consumption of halocarbons and sulphur hexafluoride",
+    value:
+      "fugitive-emissions-from-production-and-consumption-of-halocarbons-and-sulphur-hexafluoride",
+  },
+  { title: "Metal production", value: "metal-production" },
+  { title: "Agriculture", value: "agriculture" },
+  { title: "Mining/mineral production", value: "mining-mineral-production" },
+  { title: "Construction", value: "construction" },
+  { title: "Mining and quarrying", value: "mining-and-quarrying" },
+  {
+    title: "Metal production (metallurgy)",
+    value: "metal-production-metallurgy",
+  },
 ];

--- a/carbon-projects/lib/sectors.ts
+++ b/carbon-projects/lib/sectors.ts
@@ -1,0 +1,3 @@
+export const sectors = [
+    { title: "Waste handling and disposal", value: "waste-h-d" }
+];

--- a/carbon-projects/schemas/accreditation.ts
+++ b/carbon-projects/schemas/accreditation.ts
@@ -1,9 +1,9 @@
 import { defineType } from "sanity";
 
 export default defineType({
-  name: "developer",
-  title: "Developer",
-  description: "Information about an organization that develops projects",
+  name: "accreditation",
+  title: "Accreditation",
+  description: "Information about an accreditation that applies to assessors",
   type: "document",
   preview: {
     select: {
@@ -29,14 +29,8 @@ export default defineType({
     },
     {
       type: "image",
-      title: "Avatar",
-      name: "avatar",
-    },
-    {
-      type: "array",
-      title: "Carbonmark Handles",
-      name: "handles",
-      of: [{ type: "string" }],
+      title: "Logo",
+      name: "logo",
     },
   ],
 });

--- a/carbon-projects/schemas/assessor.ts
+++ b/carbon-projects/schemas/assessor.ts
@@ -4,8 +4,6 @@ export default defineType({
   name: "assessor",
   title: "Assessor",
   description: "Information about an organization that assesses projects",
-  description:
-    "A profile containing information about an entity including name, avatar, and link",
   type: "document",
   preview: {
     select: {
@@ -39,8 +37,10 @@ export default defineType({
       title: "Accreditations",
       name: "accreditations",
       of: [
-        { type: "string", name: "name" },
-        { type: "string", name: "link" },
+        {
+          type: "reference",
+          to: [{ type: "accreditation" }],
+        },
       ],
     },
   ],

--- a/carbon-projects/schemas/assessor.ts
+++ b/carbon-projects/schemas/assessor.ts
@@ -1,0 +1,47 @@
+import { defineType } from "sanity";
+
+export default defineType({
+  name: "assessor",
+  title: "Assessor",
+  description: "Information about an organization that assesses projects",
+  description:
+    "A profile containing information about an entity including name, avatar, and link",
+  type: "document",
+  preview: {
+    select: {
+      name: "name",
+    },
+    prepare(selection) {
+      return {
+        title: selection.name || "",
+      };
+    },
+  },
+  fields: [
+    {
+      type: "string",
+      title: "Name",
+      name: "name",
+      validation: (r) => r.required(),
+    },
+    {
+      type: "string",
+      title: "Link",
+      name: "link",
+    },
+    {
+      type: "image",
+      title: "Avatar",
+      name: "avatar",
+    },
+    {
+      type: "array",
+      title: "Accreditations",
+      name: "accreditations",
+      of: [
+        { type: "string", name: "name" },
+        { type: "string", name: "link" },
+      ],
+    },
+  ],
+});

--- a/carbon-projects/schemas/developer.ts
+++ b/carbon-projects/schemas/developer.ts
@@ -1,0 +1,44 @@
+import { defineType } from "sanity";
+
+export default defineType({
+  name: "developer",
+  title: "Developer",
+  description: "Information about an organization that develops projects",
+  description:
+    "A profile containing information about an entity including name, avatar, and link",
+  type: "document",
+  preview: {
+    select: {
+      name: "name",
+    },
+    prepare(selection) {
+      return {
+        title: selection.name || "",
+      };
+    },
+  },
+  fields: [
+    {
+      type: "string",
+      title: "Name",
+      name: "name",
+      validation: (r) => r.required(),
+    },
+    {
+      type: "string",
+      title: "Link",
+      name: "link",
+    },
+    {
+      type: "image",
+      title: "Avatar",
+      name: "avatar",
+    },
+    {
+      type: "array",
+      title: "Carbonmark Handles",
+      name: "handles",
+      of: [{ type: "string" }],
+    },
+  ],
+});

--- a/carbon-projects/schemas/index.ts
+++ b/carbon-projects/schemas/index.ts
@@ -1,3 +1,4 @@
+import accreditation from "./accreditation";
 import assessor from "./assessor";
 import country from "./country";
 import developer from "./developer";
@@ -18,6 +19,7 @@ export const schemaTypes = [
   captionImage,
   country,
   indexContent,
+  accreditation,
   assessor,
   developer,
   standard,

--- a/carbon-projects/schemas/index.ts
+++ b/carbon-projects/schemas/index.ts
@@ -1,4 +1,6 @@
+import assessor from "./assessor";
 import country from "./country";
+import developer from "./developer";
 import indexContent from "./indexContent";
 import methodology from "./methodology";
 import captionImage from "./objects/captionImage";
@@ -6,6 +8,7 @@ import externalFile from "./objects/externalFile";
 import hostedFile from "./objects/hostedFile";
 import project from "./project";
 import projectContent from "./projectContent";
+import standard from "./standard";
 export const schemaTypes = [
   project,
   methodology,
@@ -15,4 +18,7 @@ export const schemaTypes = [
   captionImage,
   country,
   indexContent,
+  assessor,
+  developer,
+  standard,
 ];

--- a/carbon-projects/schemas/index.ts
+++ b/carbon-projects/schemas/index.ts
@@ -3,6 +3,7 @@ import indexContent from "./indexContent";
 import methodology from "./methodology";
 import captionImage from "./objects/captionImage";
 import externalFile from "./objects/externalFile";
+import hostedFile from "./objects/hostedFile";
 import project from "./project";
 import projectContent from "./projectContent";
 export const schemaTypes = [
@@ -10,6 +11,7 @@ export const schemaTypes = [
   methodology,
   projectContent,
   externalFile,
+  hostedFile,
   captionImage,
   country,
   indexContent,

--- a/carbon-projects/schemas/methodology.ts
+++ b/carbon-projects/schemas/methodology.ts
@@ -1,12 +1,12 @@
 import { defineField, defineType } from "sanity";
 import { categories } from "../lib/categories";
+import { sectors } from "../lib/sectors";
 
 export default defineType({
   name: "methodology",
   title: "Methodology",
   description: "Methodology definition",
   type: "document",
-  groups: [{ name: "location" }],
   preview: {
     select: {
       slug: "id",
@@ -42,6 +42,13 @@ export default defineType({
         list: categories,
       },
       validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "sector",
+      type: "string",
+      options: {
+        list: sectors,
+      },
     }),
     defineField({
       name: "link",

--- a/carbon-projects/schemas/objects/hostedFile.ts
+++ b/carbon-projects/schemas/objects/hostedFile.ts
@@ -1,4 +1,5 @@
 import { defineType } from "sanity";
+import { fileCategories } from "../../lib/fileCategories";
 
 export default defineType({
   name: "hostedFile",
@@ -28,6 +29,9 @@ export default defineType({
       type: "string",
       title: "File category",
       name: "category",
+      options: {
+        list: fileCategories,
+      },
     },
     {
       type: "number",

--- a/carbon-projects/schemas/objects/hostedFile.ts
+++ b/carbon-projects/schemas/objects/hostedFile.ts
@@ -4,7 +4,8 @@ export default defineType({
   name: "hostedFile",
   type: "file",
   title: "Hosted file",
-  description: "A file whose content is hosted directly in the Sanity CMS, with associated metadata",
+  description:
+    "A file whose content is hosted directly in the Sanity CMS, with associated metadata",
   fields: [
     {
       type: "string",
@@ -24,12 +25,12 @@ export default defineType({
     {
       type: "string",
       title: "File category",
-      name: "category"
+      name: "category",
     },
     {
       type: "number",
       title: "File size",
-      name: "size"
-    }
+      name: "size",
+    },
   ],
 });

--- a/carbon-projects/schemas/objects/hostedFile.ts
+++ b/carbon-projects/schemas/objects/hostedFile.ts
@@ -19,7 +19,8 @@ export default defineType({
     },
     {
       type: "string",
-      title: "MIME Type",
+      title: "MIME Type (e.g. application/pdf)",
+      description: "Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types",
       name: "mimetype",
     },
     {
@@ -29,7 +30,7 @@ export default defineType({
     },
     {
       type: "number",
-      title: "File size",
+      title: "File size (in bytes)",
       name: "size",
     },
   ],

--- a/carbon-projects/schemas/objects/hostedFile.ts
+++ b/carbon-projects/schemas/objects/hostedFile.ts
@@ -20,7 +20,8 @@ export default defineType({
     {
       type: "string",
       title: "MIME Type (e.g. application/pdf)",
-      description: "Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types",
+      description:
+        "Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types",
       name: "mimetype",
     },
     {

--- a/carbon-projects/schemas/objects/hostedFile.ts
+++ b/carbon-projects/schemas/objects/hostedFile.ts
@@ -1,0 +1,35 @@
+import { defineType } from "sanity";
+
+export default defineType({
+  name: "hostedFile",
+  type: "file",
+  title: "Hosted file",
+  description: "A file whose content is hosted directly in the Sanity CMS, with associated metadata",
+  fields: [
+    {
+      type: "string",
+      title: "File name",
+      name: "filename",
+    },
+    {
+      type: "string",
+      title: "Description or Caption",
+      name: "description",
+    },
+    {
+      type: "string",
+      title: "MIME Type",
+      name: "mimetype",
+    },
+    {
+      type: "string",
+      title: "File category",
+      name: "category"
+    },
+    {
+      type: "number",
+      title: "File size",
+      name: "size"
+    }
+  ],
+});

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -250,5 +250,12 @@ export default defineType({
       type: "array",
       of: [{ type: "externalFile" }],
     }),
+    defineField({
+      name: "hostedDocuments",
+      description: "PDF documents hosted in this CMS associated with this project",
+      group: "media",
+      type: "array",
+      of: [{ type: "hostedFile" }],
+    }),
   ],
 });

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -11,6 +11,16 @@ const ccbs = [
   { title: "CCB Community Gold", value: "CCB-Community Gold" },
 ];
 
+const registries = [
+  { title: "Verra", value: "VCS" },
+  { title: "Gold Standard", value: "GS" },
+  { title: "EcoRegistry", value: "ECO" },
+  { title: "International Carbon Registry", value: "ICR" },
+  { title: "Puro", value: "PUR" },
+  { title: "J-Credit", value: "JCS" },
+  { title: "Carbonmark Direct Issuance", value: "CMARK" },
+];
+
 const subcategories = [
   { title: "Solar Energy", value: "solar" },
   { title: "Wind Energy", value: "wind" },
@@ -19,6 +29,20 @@ const subcategories = [
   { title: "Avoided Deforestation", value: "redd" },
   { title: "Afforestation", value: "afforestation" },
   { title: "Mangrove Restoration", value: "mangroves" },
+];
+
+const statuses = [
+  { title: "Registered", value: "registered" },
+  { title: "Validated", value: "validated" },
+  { title: "Verified", value: "verified" },
+  { title: "Withdrawn", value: "withdrawn" },
+];
+
+const types = [
+  { title: "Avoidance", value: "avoidance" },
+  { title: "Reduction", value: "reduction" },
+  { title: "Removal", value: "removal" },
+  { title: "Hybrid", value: "hybrid" },
 ];
 
 export default defineType({
@@ -71,14 +95,7 @@ export default defineType({
       placeholder: "VCS",
       type: "string",
       options: {
-        list: [
-          { title: "Verra", value: "VCS" },
-          { title: "Gold Standard", value: "GS" },
-          { title: "EcoRegistry", value: "ECO" },
-          { title: "International Carbon Registry", value: "ICR" },
-          { title: "Puro", value: "PUR" },
-          { title: "J-Credit", value: "JCS" },
-        ],
+        list: registries,
       },
       validation: (r) => r.required(),
     },
@@ -118,6 +135,52 @@ export default defineType({
         }),
     }),
     defineField({
+      type: "reference",
+      name: "developer",
+      to: [{ type: "developer" }],
+      description: "The developer of this project",
+      group: "info",
+    }),
+    defineField({
+      type: "reference",
+      name: "assessor",
+      to: [{ type: "assessor" }],
+      description: "The assessor of this project",
+      group: "info",
+    }),
+    defineField({
+      type: "array",
+      name: "standards",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: "standard" }],
+        },
+      ],
+      description: "Standards with which the project conforms",
+      group: "info",
+    }),
+    {
+      name: "status",
+      description:
+        "Project status. Indicates where a project is in its lifecycle from registration to verification and issuance",
+      group: "info",
+      type: "string",
+      options: {
+        list: statuses,
+      },
+    },
+    {
+      name: "type",
+      description:
+        "Project type. Indicates whether a project avoids or removes emissions, or both.",
+      group: "info",
+      type: "string",
+      options: {
+        list: types,
+      },
+    },
+    defineField({
       type: "array",
       name: "methodologies",
       of: [
@@ -146,10 +209,17 @@ export default defineType({
     defineField({
       name: "subcategory",
       description: "From our predefined ontology of subcategories",
+      group: "info",
       type: "string",
       options: {
         list: subcategories,
       },
+    }),
+    defineField({
+      name: "estAnnualMitigations",
+      description: "Estimated tonnes of carbon emissions mitigated per annum",
+      group: "info",
+      type: "number",
     }),
     {
       name: "region",
@@ -252,7 +322,8 @@ export default defineType({
     }),
     defineField({
       name: "hostedDocuments",
-      description: "PDF documents hosted in this CMS associated with this project",
+      description:
+        "PDF documents hosted in this CMS associated with this project",
       group: "media",
       type: "array",
       of: [{ type: "hostedFile" }],

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -315,7 +315,8 @@ export default defineType({
     }),
     defineField({
       name: "externalDocuments",
-      description: "External documents (e.g. PDFs, Word documents) associated with this project",
+      description:
+        "External documents (e.g. PDFs, Word documents) associated with this project",
       group: "media",
       type: "array",
       of: [{ type: "externalFile" }],

--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -315,10 +315,17 @@ export default defineType({
     }),
     defineField({
       name: "externalDocuments",
-      description: "External PDF documents associated with this project",
+      description: "External documents (e.g. PDFs, Word documents) associated with this project",
       group: "media",
       type: "array",
       of: [{ type: "externalFile" }],
+    }),
+    defineField({
+      name: "hostedMedia",
+      description: "Media hosted in this CMS and associated captions",
+      group: "media",
+      type: "array",
+      of: [{ type: "captionImage" }],
     }),
     defineField({
       name: "hostedDocuments",

--- a/carbon-projects/schemas/standard.ts
+++ b/carbon-projects/schemas/standard.ts
@@ -1,0 +1,36 @@
+import { defineType } from "sanity";
+
+export default defineType({
+  name: "standard",
+  title: "Standard",
+  description: "Information about a standard that applies to projects",
+  type: "document",
+  preview: {
+    select: {
+      name: "name",
+    },
+    prepare(selection) {
+      return {
+        title: selection.name || "",
+      };
+    },
+  },
+  fields: [
+    {
+      type: "string",
+      title: "Name",
+      name: "name",
+      validation: (r) => r.required(),
+    },
+    {
+      type: "string",
+      title: "Link",
+      name: "link",
+    },
+    {
+      type: "image",
+      title: "Logo",
+      name: "logo",
+    },
+  ],
+});


### PR DESCRIPTION
## Description

To support direct issuance documents being uploaded directly rather than referencing externally hosted documents from e.g. a registry

We may need other additional fields as the design solidifies so going to hold off on merging/deploying this