### PR TITLE
fix lp check

### DIFF
--- a/base/components/AutoCompounder/NavLinks/styles.tsx
+++ b/base/components/AutoCompounder/NavLinks/styles.tsx
@@ -1,7 +1,7 @@
 import { Anchor } from "@klimadao/lib/components";
 import { styled } from "@mui/material";
 
-export const StyledNavLinks = styled(Anchor)(({ theme }) => ({
+export const StyledNavLinks = styled("div")(({ theme }) => ({
   gap: "4rem",
   display: "flex",
   alignItems: "center",

--- a/base/lib/constants.ts
+++ b/base/lib/constants.ts
@@ -146,7 +146,7 @@ export const BASE_LIQUIDITY_POOLS: { [key: string]: LiquidityPool } = {
 export const getLiquidityPools = (
   chain: Chain
 ): { [key: string]: LiquidityPool } => {
-  if (chain === base) {
+  if (chain.id === base.id) {
     return BASE_LIQUIDITY_POOLS;
   }
   return {};


### PR DESCRIPTION
This PR, checks the chain id matches rather than the full chain object. I noticed, the lps load correctly when a user isn't logged in, but as soon as you log in, you are just shown the spinner which never resolves.

After digging around, it seems that when return the liquidity pools, we check `chain === base`, but the rpc url is different in chain vs base when logged in, so returns false empty results. I've made the change to just compare the chain id to the base network id. 

I also made a change to a css element, as I was seeing an error about anchor tags cannot be a descendant of another anchor tag.