### PR TITLE
Adds CarbonClass and CarbonClass group schemas

### DIFF
--- a/carbon-projects/package.json
+++ b/carbon-projects/package.json
@@ -5,7 +5,7 @@
   "main": "package.json",
   "license": "UNLICENSED",
   "scripts": {
-    "dev": "sanity dev",
+    "dev": "sanity dev --host 0.0.0.0",
     "start": "sanity start",
     "build": "sanity build",
     "deploy": "sanity deploy",

--- a/carbon-projects/schemas/carbonClass.ts
+++ b/carbon-projects/schemas/carbonClass.ts
@@ -1,0 +1,50 @@
+import { defineField, defineType } from "sanity";
+
+export default defineType({
+  name: "carbonClass",
+  title: "Carbon Class",
+  description: "Metadata associated with a carbonClass",
+  type: "document",
+  preview: {
+    select: {
+      title: "name",
+      subtitle: "address",
+    },
+    prepare(selection) {
+      return {
+        title: selection.title,
+        subtitle: selection.subtitle,
+      };
+    },
+  },
+  fields: [
+    defineField({
+      name: "name",
+      description: "Name of the Carbon Class",
+      type: "string",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "address",
+      description: "Address of the Carbon Class on the base blockchain",
+      type: "string",
+      validation: (r) =>
+        r
+          .regex(/^0x[a-fA-F0-9]{40}$/, { name: "Invalid address format" })
+          .custom((val: string) => {
+            if (val.toLowerCase() !== val) {
+              return "Address must be in lowercase";
+            }
+            return true;
+          })
+          .required(),
+    }),
+    defineField({
+      type: "reference",
+      name: "group",
+      to: [{ type: "carbonClassGroup" }],
+      description: "The Group this Carbon Class belongs to",
+      validation: (r) => r.required(),
+    }),
+  ],
+});

--- a/carbon-projects/schemas/carbonClassGroup.ts
+++ b/carbon-projects/schemas/carbonClassGroup.ts
@@ -1,0 +1,32 @@
+import { defineField, defineType } from "sanity";
+
+export default defineType({
+  name: "carbonClassGroup",
+  title: "Carbon Class Group",
+  description: "Groups Carbon Classes",
+  type: "document",
+  preview: {
+    select: {
+      title: "name",
+    },
+    prepare(selection) {
+      return {
+        title: selection.title,
+      };
+    },
+  },
+  fields: [
+    defineField({
+      name: "name",
+      description: "Name of the Carbon Class Group",
+      type: "string",
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "description",
+      description: "Description of the Carbon Class Group",
+      type: "text",
+      validation: (r) => r.required(),
+    }),
+  ],
+});

--- a/carbon-projects/schemas/index.ts
+++ b/carbon-projects/schemas/index.ts
@@ -1,4 +1,6 @@
 import assessor from "./assessor";
+import carbonClass from "./carbonClass";
+import carbonClassGroup from "./carbonClassGroup";
 import country from "./country";
 import developer from "./developer";
 import indexContent from "./indexContent";
@@ -23,4 +25,6 @@ export const schemaTypes = [
   assessor,
   developer,
   standard,
+  carbonClass,
+  carbonClassGroup,
 ];


### PR DESCRIPTION
## Description

Adds the Carbon Class and Carbon Class Croup schemas to the sanity CMS.

Those entities would be queried by the dApp to display supplemental information about Carbon Classes.


###  A Carbon Claass Group:
<img width="1353" height="552" alt="image" src="https://github.com/user-attachments/assets/2d49e99e-3751-4d3c-ab69-a2ddf785f3c6" />

### A Carbon Class
<img width="1375" height="563" alt="image" src="https://github.com/user-attachments/assets/090d7cfd-b81e-4e46-a554-5e6aaecbb33f" />

## Related Ticket

NA

## How to Test
<!--
 Please provide a short description of how a reviewer can confirm the changes
-->

Done on a personal project. I can deploy and give access if necessary.

