### PR TITLE
[carbon-projects] add UCR support

### DIFF
--- a/carbon-projects/schemas/project.ts
+++ b/carbon-projects/schemas/project.ts
@@ -21,6 +21,7 @@ const registries = [
   { title: "Carbonmark Direct Issuance", value: "CMARK" },
   { title: "Thailand Voluntary Emission Reduction", value: "TVER" },
   { title: "Regen Registry", value: "REGEN" },
+  { title: "Universal Carbon Registry", value: "UCR" },
 ];
 
 const subcategories = [


### PR DESCRIPTION
## Description

Add support for the **Universal Carbon Registry (UCR)** to the Registry dropdown in the carbon-projects Sanity CMS.

This mirrors the recent work to add Regen Registry support in #2437 — a single new entry in the `registries` array in `carbon-projects/schemas/project.ts`, storing the value `UCR`.

Closes #2441

## Note

Needs to be deployed to the CMS (`sanity deploy`) after merge, as with #2437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)